### PR TITLE
SNOW-3355413 add label to run merge scope on demand

### DIFF
--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
+    # `labeled` is included so applying ci:scope-merge / ci:scope-nightly to
+    # a PR re-runs the workflow at the upgraded scope without needing a new
+    # commit. Unrelated labels are filtered by the `scope-label-gate` job
+    # below; concurrency keeps in-flight runs alive for those.
+    types: [opened, synchronize, reopened, labeled]
   # Allow stacked PRs to trigger this workflow.
   # detect-changes still decides whether ODBC jobs actually run.
   merge_group:
@@ -13,7 +18,10 @@ concurrency:
   # Group by PR number for PRs, or fall back to the run ID for main (which is unique, so it won't cancel).
   # Using github.run_id (not github.ref) for the fallback so back-to-back main pushes don't cancel each other.
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: true
+  # Don't cancel an in-flight run when an unrelated label is added/removed —
+  # only scope-up labels (ci:scope-merge, ci:scope-nightly) and normal
+  # push/synchronize/reopen events should replace the running matrix.
+  cancel-in-progress: ${{ github.event.action != 'labeled' || contains(fromJSON('["ci:scope-merge","ci:scope-nightly"]'), github.event.label.name) }}
 
 env:
   CARGO_TERM_COLOR: always
@@ -23,19 +31,37 @@ env:
   VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/.vcpkg-binary-cache,readwrite"
 
 jobs:
+  # Filter out PR runs triggered solely by adding an unrelated label
+  # (e.g. auto-labeler bot tagging `python` or `shared`). The `if:`
+  # evaluates to false on those events, this job is skipped, and every
+  # downstream job that `needs:` it is skipped too. Scope-up labels
+  # (ci:scope-merge, ci:scope-nightly) pass through and re-run the
+  # workflow at the upgraded scope.
+  scope-label-gate:
+    if: |
+      github.event.action != 'labeled' ||
+      contains(fromJSON('["ci:scope-merge","ci:scope-nightly"]'), github.event.label.name)
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'true'
+
   detect-changes:
+    needs: scope-label-gate
     uses: ./.github/workflows/detect-changes.yml
 
   load-odbc-matrix:
+    needs: scope-label-gate
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.read.outputs.matrix }}
     steps:
       - uses: actions/checkout@v4
       - id: read
+        env:
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
         run: |
           python ci/test_matrix/generate_matrix.py \
-            --driver odbc --event "$GITHUB_EVENT_NAME" --emit-active \
+            --driver odbc --event "$GITHUB_EVENT_NAME" --labels "$LABELS" --emit-active \
             >> "$GITHUB_OUTPUT"
 
   odbc_unit_tests:

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
+    # `labeled` is included so applying ci:scope-merge / ci:scope-nightly to
+    # a PR re-runs the workflow at the upgraded scope without needing a new
+    # commit. Unrelated labels are filtered by the `scope-label-gate` job
+    # below; concurrency keeps in-flight runs alive for those.
+    types: [opened, synchronize, reopened, labeled]
   merge_group:
     types: [ checks_requested ]
 
@@ -11,7 +16,10 @@ concurrency:
   # Group by PR number for PRs, or fall back to the run ID for main (which is unique, so it won't cancel).
   # Using github.run_id (not github.ref) for the fallback so back-to-back main pushes don't cancel each other.
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: true
+  # Don't cancel an in-flight run when an unrelated label is added/removed —
+  # only scope-up labels (ci:scope-merge, ci:scope-nightly) and normal
+  # push/synchronize/reopen events should replace the running matrix.
+  cancel-in-progress: ${{ github.event.action != 'labeled' || contains(fromJSON('["ci:scope-merge","ci:scope-nightly"]'), github.event.label.name) }}
 
 env:
   CARGO_TERM_COLOR: always
@@ -23,19 +31,37 @@ env:
   REFERENCE_CLOUD_PROVIDER: "aws"
 
 jobs:
+  # Filter out PR runs triggered solely by adding an unrelated label
+  # (e.g. auto-labeler bot tagging `python` or `shared`). The `if:`
+  # evaluates to false on those events, this job is skipped, and every
+  # downstream job that `needs:` it is skipped too. Scope-up labels
+  # (ci:scope-merge, ci:scope-nightly) pass through and re-run the
+  # workflow at the upgraded scope.
+  scope-label-gate:
+    if: |
+      github.event.action != 'labeled' ||
+      contains(fromJSON('["ci:scope-merge","ci:scope-nightly"]'), github.event.label.name)
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'true'
+
   detect-changes:
+    needs: scope-label-gate
     uses: ./.github/workflows/detect-changes.yml
 
   load-python-matrix:
+    needs: scope-label-gate
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.read.outputs.matrix }}
     steps:
       - uses: actions/checkout@v4
       - id: read
+        env:
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
         run: |
           python ci/test_matrix/generate_matrix.py \
-            --driver python --event "$GITHUB_EVENT_NAME" --emit-active \
+            --driver python --event "$GITHUB_EVENT_NAME" --labels "$LABELS" --emit-active \
             >> "$GITHUB_OUTPUT"
 
   # ── Build all wheels via shared reusable workflow ────────────────────

--- a/.github/workflows/test-rust-core.yml
+++ b/.github/workflows/test-rust-core.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
+    # `labeled` is included so applying ci:scope-merge / ci:scope-nightly to
+    # a PR re-runs the workflow at the upgraded scope without needing a new
+    # commit. Unrelated labels are filtered by the `scope-label-gate` job
+    # below; concurrency keeps in-flight runs alive for those.
+    types: [opened, synchronize, reopened, labeled]
   merge_group:
     types: [ checks_requested ]
 
@@ -11,13 +16,31 @@ concurrency:
   # Group by PR number for PRs, or fall back to the run ID for main (which is unique, so it won't cancel).
   # Using github.run_id (not github.ref) for the fallback so back-to-back main pushes don't cancel each other.
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: true
+  # Don't cancel an in-flight run when an unrelated label is added/removed —
+  # only scope-up labels (ci:scope-merge, ci:scope-nightly) and normal
+  # push/synchronize/reopen events should replace the running matrix.
+  cancel-in-progress: ${{ github.event.action != 'labeled' || contains(fromJSON('["ci:scope-merge","ci:scope-nightly"]'), github.event.label.name) }}
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # Filter out PR runs triggered solely by adding an unrelated label
+  # (e.g. auto-labeler bot tagging `python` or `shared`). The `if:`
+  # evaluates to false on those events, this job is skipped, and every
+  # downstream job that `needs:` it is skipped too. Scope-up labels
+  # (ci:scope-merge, ci:scope-nightly) pass through and re-run the
+  # workflow at the upgraded scope.
+  scope-label-gate:
+    if: |
+      github.event.action != 'labeled' ||
+      contains(fromJSON('["ci:scope-merge","ci:scope-nightly"]'), github.event.label.name)
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'true'
+
   detect-changes:
+    needs: scope-label-gate
     uses: ./.github/workflows/detect-changes.yml
 
   # Generate the test matrix from ci/test_matrix/models/core.pict at workflow
@@ -32,6 +55,7 @@ jobs:
   #   - windows_arm_active:  'true' if pict includes the windows-arm-nonfips lane.
   #   - windows_x86_active:  'true' if pict includes the windows-x86 lane.
   load-core-matrix:
+    needs: scope-label-gate
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.read.outputs.matrix }}
@@ -41,9 +65,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - id: read
+        env:
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
         run: |
           python ci/test_matrix/generate_matrix.py \
-            --driver core --event "$GITHUB_EVENT_NAME" --emit-active \
+            --driver core --event "$GITHUB_EVENT_NAME" --labels "$LABELS" --emit-active \
             >> "$GITHUB_OUTPUT"
       - id: split
         env:

--- a/ci/test_matrix/README.md
+++ b/ci/test_matrix/README.md
@@ -63,6 +63,32 @@ only on macOS-arm-aws-py3.13) are not guaranteed to surface at `merge`.
 GHA picks the level from `GITHUB_EVENT_NAME` (`pull_request` → pr,
 `merge_group`/`push` → merge, `schedule` → nightly).
 
+### Forcing a higher scope on a PR
+
+Apply one of these labels to a PR. Adding the label re-triggers the
+workflow automatically (no commit required) at the upgraded scope:
+
+| Label              | Effect                                              |
+|--------------------|-----------------------------------------------------|
+| `ci:scope-merge`   | Run the pairwise cover (`pr` + `merge` cells).      |
+| `ci:scope-nightly` | Run every constraint-valid combination.             |
+
+Labels can only upgrade scope — they never downgrade an event's level.
+`detect-changes` still gates which drivers run, so labeling a Python-only
+PR with `ci:scope-merge` runs Python tests at merge scope and leaves the
+ODBC and core test jobs skipped.
+
+Adding a scope-up label cancels the in-flight run (via the workflow's
+`concurrency` group) and starts a fresh one at the upgraded scope. This
+re-runs cells that already ran at the lower scope — see the
+`scope-label-gate` job in each `test-{driver}.yml` for the full filter.
+Adding any other label (e.g. an auto-applied `python` or `shared` tag)
+does not disturb in-flight runs.
+
+Removing a scope-up label is silently a no-op — the workflow does not
+re-trigger, and the in-flight run keeps the upgraded scope it computed
+when the label was added. The next push reverts to the default scope.
+
 ## Editing the matrix
 
 After any edit, run `python ci/test_matrix/generate_matrix.py --all` and

--- a/ci/test_matrix/generate_matrix.py
+++ b/ci/test_matrix/generate_matrix.py
@@ -514,12 +514,37 @@ EVENT_TO_LEVEL = {
 }
 
 
+# PR labels that force a higher trigger level than the event would produce.
+# When multiple are present the highest-scope label wins.
+LABEL_TO_LEVEL = {
+    "ci:scope-merge":   "merge",
+    "ci:scope-nightly": "nightly",
+}
+
+
 def level_for_event(event: str | None) -> str:
     """
     Map a GitHub Actions event name to a trigger level.
     Falls back to 'pr' for unknown events.
     """
     return EVENT_TO_LEVEL.get(event or "", "pr")
+
+
+def level_for_event_and_labels(event: str | None, labels: list[str] | None) -> str:
+    """
+    Resolve the active trigger level. PR labels override the event mapping;
+    when multiple scope-up labels are present, the highest level wins.
+    Labels can only upgrade scope — they never downgrade an event's level.
+    Unknown labels are ignored.
+    """
+    base = level_for_event(event)
+    if not labels:
+        return base
+    requested = [LABEL_TO_LEVEL[l] for l in labels if l in LABEL_TO_LEVEL]
+    if not requested:
+        return base
+    candidates = [base] + requested
+    return max(candidates, key=TRIGGER_LEVELS.index)
 
 
 def filter_active(rows: list[dict], level: str) -> list[dict]:
@@ -558,14 +583,15 @@ def run_driver(driver: str) -> bool:
     return True
 
 
-def emit_active(driver: str, event: str | None) -> None:
+def emit_active(driver: str, event: str | None, labels: list[str] | None = None) -> None:
     """
     Print `matrix=<json>` for the rows active at the level implied by `event`,
-    suitable for appending to $GITHUB_OUTPUT inside a workflow step.
+    optionally upgraded by scope-up PR labels (see LABEL_TO_LEVEL). Suitable
+    for appending to $GITHUB_OUTPUT inside a workflow step.
     """
     model_path = MODELS_DIR / f"{driver}.py"
     gha_rows = generate(model_path, driver)
-    level = level_for_event(event)
+    level = level_for_event_and_labels(event, labels)
     active = filter_active(gha_rows, level)
     print(f"matrix={json.dumps(active)}")
 
@@ -581,6 +607,13 @@ def main() -> None:
              "Used with --emit-active to pick the trigger level.",
     )
     parser.add_argument(
+        "--labels",
+        default="",
+        help="Comma-separated PR label names. Labels in LABEL_TO_LEVEL "
+             "(ci:scope-merge, ci:scope-nightly) override --event when "
+             "--emit-active is set; highest-scope label wins.",
+    )
+    parser.add_argument(
         "--emit-active",
         action="store_true",
         help="Print 'matrix=<json>' for the active level (requires --driver and --event). "
@@ -591,7 +624,8 @@ def main() -> None:
     if args.emit_active:
         if args.all or not args.driver:
             parser.error("--emit-active requires --driver and is incompatible with --all")
-        emit_active(args.driver, args.event)
+        labels = [l.strip() for l in args.labels.split(",") if l.strip()]
+        emit_active(args.driver, args.event, labels)
         return
 
     drivers = ["odbc", "python", "core"] if args.all else [args.driver]

--- a/ci/test_matrix/test_generate_matrix.py
+++ b/ci/test_matrix/test_generate_matrix.py
@@ -720,5 +720,56 @@ class FilterTests(unittest.TestCase):
         self.assertEqual(len(gm.filter_active(rows, "nightly")), 3)
 
 
+class LabelResolutionTests(unittest.TestCase):
+    """
+    Lock in the scope-up label semantics: PR labels can upgrade the trigger
+    level above what the event would produce, but never downgrade it. Multiple
+    scope-up labels: highest wins. Unknown labels are ignored.
+    """
+
+    def test_empty_labels_falls_back_to_event(self) -> None:
+        self.assertEqual(gm.level_for_event_and_labels("pull_request", []), "pr")
+        self.assertEqual(gm.level_for_event_and_labels("pull_request", None), "pr")
+        self.assertEqual(gm.level_for_event_and_labels("merge_group", []), "merge")
+
+    def test_scope_merge_label_upgrades_pr_to_merge(self) -> None:
+        self.assertEqual(
+            gm.level_for_event_and_labels("pull_request", ["ci:scope-merge"]),
+            "merge",
+        )
+
+    def test_scope_nightly_label_upgrades_pr_to_nightly(self) -> None:
+        self.assertEqual(
+            gm.level_for_event_and_labels("pull_request", ["ci:scope-nightly"]),
+            "nightly",
+        )
+
+    def test_multiple_scope_labels_highest_wins(self) -> None:
+        self.assertEqual(
+            gm.level_for_event_and_labels(
+                "pull_request", ["ci:scope-merge", "ci:scope-nightly"]
+            ),
+            "nightly",
+        )
+
+    def test_unknown_labels_ignored(self) -> None:
+        self.assertEqual(
+            gm.level_for_event_and_labels("pull_request", ["bug", "enhancement"]),
+            "pr",
+        )
+
+    def test_label_cannot_downgrade_event(self) -> None:
+        # ci:scope-merge on a merge_group event stays at merge (not downgraded).
+        self.assertEqual(
+            gm.level_for_event_and_labels("merge_group", ["ci:scope-merge"]),
+            "merge",
+        )
+        # And cannot pull schedule (nightly) down to merge.
+        self.assertEqual(
+            gm.level_for_event_and_labels("schedule", ["ci:scope-merge"]),
+            "nightly",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
  Adds two opt-in PR labels that upgrade the CI test scope on demand, without requiring a new commit:

  • ci:scope-merge — runs the pairwise cover (pr + merge cells)
  • ci:scope-nightly — runs every constraint-valid combination

When multiple scope labels are present, the highest wins. Labels can only upgrade scope, never downgrade.  Detect changes still gates which drivers actually run.