### PR TITLE
NO-SNOW: JSON->Arrow conversion for GEOGRAPHY and GEOMETRY types

### DIFF
--- a/python/tests/e2e/types/test_geography.py
+++ b/python/tests/e2e/types/test_geography.py
@@ -18,9 +18,6 @@ from ...conftest import with_paramstyle
 from .utils import assert_geojson, assert_sequential_values, assert_type
 
 
-pytestmark = pytest.mark.skip_for_json_result_set(reason="GEOGRAPHY type is not supported in JSON result format")
-
-
 # =============================================================================
 # WKT TEST VALUES
 # =============================================================================

--- a/python/tests/e2e/types/test_geometry.py
+++ b/python/tests/e2e/types/test_geometry.py
@@ -18,9 +18,6 @@ from ...conftest import with_paramstyle
 from .utils import assert_geojson, assert_sequential_values, assert_type
 
 
-pytestmark = pytest.mark.skip_for_json_result_set(reason="GEOMETRY type is not supported in JSON result format")
-
-
 # =============================================================================
 # WKT TEST VALUES
 # =============================================================================

--- a/sf_core/src/arrow_utils.rs
+++ b/sf_core/src/arrow_utils.rs
@@ -1,5 +1,5 @@
 pub use crate::chunks::convert_string_rowset_to_arrow_reader;
-use crate::query_types::RowType;
+use crate::query_types::{GeoRepresentation, RowType};
 use arrow::array::Array;
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::error::ArrowError;
@@ -249,19 +249,28 @@ pub fn create_field_with_type(
             )
             .with_metadata(metadata))
         }
-        RowType::Geography { name, nullable } => {
-            let mut metadata = HashMap::new();
-            metadata.insert("logicalType".to_string(), "GEOGRAPHY".to_string());
-            Ok(
-                Field::new(name, data_type.unwrap_or(DataType::Utf8), *nullable)
-                    .with_metadata(metadata),
-            )
+        RowType::Geography {
+            name,
+            nullable,
+            representation,
         }
-        RowType::Geometry { name, nullable } => {
+        | RowType::Geometry {
+            name,
+            nullable,
+            representation,
+        } => {
+            // The Python Arrow converter only recognises TEXT / BINARY logical types for
+            // geo data, so mirror what the server sends in native Arrow chunks (a TEXT
+            // column for GeoJSON/WKT/EWKT, a BINARY column for WKB/EWKB) rather than
+            // exposing GEOGRAPHY/GEOMETRY as a distinct logical type.
+            let (logical_type, default_dt) = match representation {
+                GeoRepresentation::Text => ("TEXT", DataType::Utf8),
+                GeoRepresentation::Binary => ("BINARY", DataType::Binary),
+            };
             let mut metadata = HashMap::new();
-            metadata.insert("logicalType".to_string(), "GEOMETRY".to_string());
+            metadata.insert("logicalType".to_string(), logical_type.to_string());
             Ok(
-                Field::new(name, data_type.unwrap_or(DataType::Utf8), *nullable)
+                Field::new(name, data_type.unwrap_or(default_dt), *nullable)
                     .with_metadata(metadata),
             )
         }

--- a/sf_core/src/chunks/json_parser.rs
+++ b/sf_core/src/chunks/json_parser.rs
@@ -320,10 +320,17 @@ impl ColumnBuilder {
             | RowType::Variant { .. }
             | RowType::Object { .. }
             | RowType::Array { .. }
-            | RowType::Geography { .. }
-            | RowType::Geometry { .. }
             | RowType::Vector { .. } => ColumnBuilder::Text {
                 builder: arrow::array::StringBuilder::with_capacity(capacity, capacity * 8),
+            },
+            RowType::Geography { representation, .. }
+            | RowType::Geometry { representation, .. } => match representation {
+                crate::query_types::GeoRepresentation::Text => ColumnBuilder::Text {
+                    builder: arrow::array::StringBuilder::with_capacity(capacity, capacity * 8),
+                },
+                crate::query_types::GeoRepresentation::Binary => ColumnBuilder::Binary {
+                    builder: arrow::array::BinaryBuilder::with_capacity(capacity, capacity * 16),
+                },
             },
             RowType::Boolean { .. } => ColumnBuilder::Boolean {
                 builder: arrow::array::BooleanBuilder::with_capacity(capacity),

--- a/sf_core/src/query_types.rs
+++ b/sf_core/src/query_types.rs
@@ -81,15 +81,35 @@ pub enum RowType {
     Geography {
         name: String,
         nullable: bool,
+        /// Underlying representation chosen by the server based on
+        /// `GEOGRAPHY_OUTPUT_FORMAT` (text for GeoJSON/WKT/EWKT, binary for WKB/EWKB).
+        representation: GeoRepresentation,
     },
     Geometry {
         name: String,
         nullable: bool,
+        /// Underlying representation chosen by the server based on
+        /// `GEOMETRY_OUTPUT_FORMAT` (text for GeoJSON/WKT/EWKT, binary for WKB/EWKB).
+        representation: GeoRepresentation,
     },
     Vector {
         name: String,
         nullable: bool,
     },
+}
+
+/// Underlying storage representation for GEOGRAPHY / GEOMETRY columns.
+/// Values in JSON result format arrive as UTF-8 strings when the output format
+/// produces text (GeoJSON/WKT/EWKT), and as hex-encoded strings when the format
+/// produces binary (WKB/EWKB).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GeoRepresentation {
+    /// Textual output: GeoJSON object (returned by Snowflake as `type=object`),
+    /// or WKT/EWKT strings (returned as `type=text`).
+    Text,
+    /// Binary output: WKB/EWKB, returned as hex-encoded strings with
+    /// `type=binary` — decoded into Arrow `Binary` by the JSON parser.
+    Binary,
 }
 
 impl RowType {
@@ -228,17 +248,19 @@ impl RowType {
         }
     }
 
-    pub fn geography(name: &str, nullable: bool) -> Self {
+    pub fn geography(name: &str, nullable: bool, representation: GeoRepresentation) -> Self {
         RowType::Geography {
             name: name.to_string(),
             nullable,
+            representation,
         }
     }
 
-    pub fn geometry(name: &str, nullable: bool) -> Self {
+    pub fn geometry(name: &str, nullable: bool, representation: GeoRepresentation) -> Self {
         RowType::Geometry {
             name: name.to_string(),
             nullable,
+            representation,
         }
     }
 

--- a/sf_core/src/rest/snowflake/query_response.rs
+++ b/sf_core/src/rest/snowflake/query_response.rs
@@ -564,6 +564,18 @@ pub enum RowsetData<'a> {
     NoData,
 }
 
+/// Selects the storage representation for a `GEOGRAPHY` / `GEOMETRY` column
+/// based on the underlying `type` field the server sends. The server routes
+/// text output formats (GeoJSON → `object`, WKT/EWKT → `text`) and binary
+/// output formats (WKB/EWKB → `binary`) through this field.
+fn geo_representation(underlying_type: &str) -> query_types::GeoRepresentation {
+    if underlying_type.eq_ignore_ascii_case("binary") {
+        query_types::GeoRepresentation::Binary
+    } else {
+        query_types::GeoRepresentation::Text
+    }
+}
+
 impl TryFrom<&RowType> for query_types::RowType {
     type Error = QueryResponseError;
 
@@ -678,8 +690,16 @@ impl TryFrom<&RowType> for query_types::RowType {
                     &name, nullable, precision, scale,
                 ))
             }
-            "GEOGRAPHY" => Ok(query_types::RowType::geography(&name, nullable)),
-            "GEOMETRY" => Ok(query_types::RowType::geometry(&name, nullable)),
+            "GEOGRAPHY" => Ok(query_types::RowType::geography(
+                &name,
+                nullable,
+                geo_representation(&value.type_),
+            )),
+            "GEOMETRY" => Ok(query_types::RowType::geometry(
+                &name,
+                nullable,
+                geo_representation(&value.type_),
+            )),
             "VECTOR" => Ok(query_types::RowType::vector(&name, nullable)),
             other => InvalidFormatSnafu {
                 message: format!("Unsupported column type '{other}' for column '{name}'"),
@@ -1229,6 +1249,78 @@ mod tests {
         ));
     }
 
+    /// Server sends `type=text` + `extTypeName=GEOGRAPHY` for WKT / EWKT output.
+    #[test]
+    fn test_geography_text_representation_from_text_underlying_type() {
+        let row_type = RowType {
+            name: "geo_col".to_string(),
+            type_: "text".to_string(),
+            nullable: true,
+            scale: None,
+            precision: None,
+            length: Some(134_217_728),
+            byte_length: Some(134_217_728),
+            ext_type_name: Some("GEOGRAPHY".to_string()),
+            _fields: None,
+        };
+        let result: crate::query_types::RowType = (&row_type).try_into().unwrap();
+        assert!(matches!(
+            result,
+            crate::query_types::RowType::Geography {
+                representation: crate::query_types::GeoRepresentation::Text,
+                ..
+            }
+        ));
+    }
+
+    /// Server sends `type=object` + `extTypeName=GEOGRAPHY` for GeoJSON output.
+    #[test]
+    fn test_geography_object_underlying_type_maps_to_text_representation() {
+        let row_type = RowType {
+            name: "geo_col".to_string(),
+            type_: "object".to_string(),
+            nullable: true,
+            scale: None,
+            precision: None,
+            length: None,
+            byte_length: None,
+            ext_type_name: Some("GEOGRAPHY".to_string()),
+            _fields: None,
+        };
+        let result: crate::query_types::RowType = (&row_type).try_into().unwrap();
+        assert!(matches!(
+            result,
+            crate::query_types::RowType::Geography {
+                representation: crate::query_types::GeoRepresentation::Text,
+                ..
+            }
+        ));
+    }
+
+    /// Server sends `type=binary` + `extTypeName=GEOGRAPHY` for WKB / EWKB output.
+    #[test]
+    fn test_geography_binary_representation_from_binary_underlying_type() {
+        let row_type = RowType {
+            name: "geo_col".to_string(),
+            type_: "binary".to_string(),
+            nullable: true,
+            scale: None,
+            precision: None,
+            length: Some(67_108_864),
+            byte_length: Some(67_108_864),
+            ext_type_name: Some("GEOGRAPHY".to_string()),
+            _fields: None,
+        };
+        let result: crate::query_types::RowType = (&row_type).try_into().unwrap();
+        assert!(matches!(
+            result,
+            crate::query_types::RowType::Geography {
+                representation: crate::query_types::GeoRepresentation::Binary,
+                ..
+            }
+        ));
+    }
+
     #[test]
     fn test_geometry_type_is_supported() {
         let row_type = RowType {
@@ -1385,6 +1477,7 @@ mod tests {
             crate::query_types::RowType::Geography {
                 ref name,
                 nullable: true,
+                ..
             } if name == "geo_col"
         ));
     }


### PR DESCRIPTION
## Summary

Convert GEOGRAPHY / GEOMETRY cells arriving in JSON result format to Arrow `Utf8` / `Binary` columns with `logicalType=TEXT` / `BINARY` — the same shape the server produces in native Arrow chunks — instead of emitting `logicalType=GEOGRAPHY` / `GEOMETRY`, which the Python nanoarrow-cpp converter does not recognise and aborts on.

The server encodes the output format in the underlying `type` field (with `extTypeName=GEOGRAPHY` / `GEOMETRY` on top):

| `GEOGRAPHY_OUTPUT_FORMAT` / `GEOMETRY_OUTPUT_FORMAT` | Server `type` | Arrow representation |
| --- | --- | --- |
| `GeoJSON`                                           | `object` | `Utf8` |
| `WKT`, `EWKT`                                       | `text`   | `Utf8` |
| `WKB`, `EWKB`                                       | `binary` | `Binary` (cell is hex-encoded) |

## Changes

- **`sf_core::query_types`** — `RowType::Geography` / `Geometry` now carry a `GeoRepresentation { Text, Binary }` discriminant so the JSON parser can pick the right child builder.
- **`sf_core::rest::snowflake::query_response`** — map the server's underlying `type` field (`object` / `text` → Text, `binary` → Binary) onto `GeoRepresentation` at parse time.
- **`sf_core::arrow_utils`** — emit `logicalType=TEXT` + `Utf8` or `logicalType=BINARY` + `Binary` for geo columns, matching the server's Arrow-format output.
- **`sf_core::chunks::json_parser`** — route `RowType::Geography` / `Geometry` to the `Text` / `Binary` column builder based on representation.
- **`python/tests/e2e/types/test_geography.py`** and **`test_geometry.py`** — drop the module-level `skip_for_json_result_set`.

`cursor.description` still exposes the column as `GEOGRAPHY` / `GEOMETRY` because `ColumnMetadata.type` is populated from `extTypeName` independently of `RowType`.

## Test plan

- [x] `cargo test -p sf_core --lib` — 709 passed (+3 new: text / binary / object underlying-type mappings)
- [x] Python GEOGRAPHY + GEOMETRY e2e in Arrow format (`QUERY_RESULT_FORMAT` unset) — 29 passed
- [x] Python GEOGRAPHY + GEOMETRY e2e in JSON format (`QUERY_RESULT_FORMAT=JSON`) — 29 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)