### PR TITLE
NO-SNOW: Put/get flags prep in core

### DIFF
--- a/sf_core/src/apis/database_driver_v1/global_state.rs
+++ b/sf_core/src/apis/database_driver_v1/global_state.rs
@@ -15,6 +15,7 @@ use crate::token_cache::{KeyringTokenCache, TokenCacheError};
 
 /// Which shape the PUT/GET result set should take.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum PutGetResultsetFlavor {
     #[default]
     Python,
@@ -26,6 +27,7 @@ pub enum PutGetResultsetFlavor {
 /// compile-time / init-time differences between wrappers so that shared Rust
 /// code can branch on them without hard-coding wrapper knowledge everywhere.
 #[derive(Debug, Clone, Default)]
+#[non_exhaustive]
 pub struct WrapperPresets {
     pub put_get_resultset_flavor: PutGetResultsetFlavor,
 }

--- a/sf_core/src/apis/database_driver_v1/query.rs
+++ b/sf_core/src/apis/database_driver_v1/query.rs
@@ -186,7 +186,8 @@ macro_rules! int64_array {
     };
 }
 
-fn upload_row_types(_wrapper_presets: &WrapperPresets) -> Vec<(RowType, DataType)> {
+#[allow(unused_variables)]
+fn upload_row_types(wrapper_presets: &WrapperPresets) -> Vec<(RowType, DataType)> {
     vec![
         build_generic_text_rowtype("source"),
         build_generic_text_rowtype("target"),
@@ -199,7 +200,8 @@ fn upload_row_types(_wrapper_presets: &WrapperPresets) -> Vec<(RowType, DataType
     ]
 }
 
-fn download_row_types(_wrapper_presets: &WrapperPresets) -> Vec<(RowType, DataType)> {
+#[allow(unused_variables)]
+fn download_row_types(wrapper_presets: &WrapperPresets) -> Vec<(RowType, DataType)> {
     vec![
         build_generic_text_rowtype("file"),
         build_generic_fixed_rowtype("size"),


### PR DESCRIPTION
### TL;DR

Added `#[non_exhaustive]` attributes to `PutGetResultsetFlavor` and `WrapperPresets`, and renamed prefixed-underscore parameters in `upload_row_types` and `download_row_types`.

### What changed?

`PutGetResultsetFlavor` and `WrapperPresets` are now marked with `#[non_exhaustive]`, preventing external crates from exhaustively matching or constructing these types without going through provided APIs. This allows future variants or fields to be added without breaking downstream consumers.

The `_wrapper_presets` parameters in `upload_row_types` and `download_row_types` were renamed to `wrapper_presets` (with `#[allow(unused_variables)]` added) to prepare these functions for future use of the parameter without triggering compiler warnings in the interim.

### How to test?

Verify that existing code that constructs or matches on `PutGetResultsetFlavor` and `WrapperPresets` still compiles correctly. Confirm that no new compiler warnings are introduced related to unused variables in `upload_row_types` and `download_row_types`.

### Why make this change?

Marking these types as `#[non_exhaustive]` improves forward compatibility by ensuring that adding new variants or fields in the future won't be a breaking change for downstream consumers. Renaming the underscore-prefixed parameters signals that they are intended to be used in upcoming changes, while suppressing unused variable warnings in the meantime.