### PR TITLE
NO-SNOW: Encryption text column in ODBC PUT/GET result

### DIFF
--- a/odbc_tests/BehaviorDifferences.yaml
+++ b/odbc_tests/BehaviorDifferences.yaml
@@ -13,7 +13,7 @@ behavior_differences:
 
   3:
     name: "Encryption field is no longer included in the result"
-    status: unknown
+    status: fixed
     type: enhancement
     reviewed: false
 

--- a/odbc_tests/common/include/put_get_utils.hpp
+++ b/odbc_tests/common/include/put_get_utils.hpp
@@ -1,27 +1,21 @@
 #ifndef PUT_GET_UTILS_HPP
 #define PUT_GET_UTILS_HPP
 
-#include <sql.h>
-#include <sqlext.h>
-#include <stdio.h>
 #include <zlib.h>
 
 #include <algorithm>
 #include <array>
 #include <cctype>
 #include <cstdint>
-#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <random>
 #include <sstream>
-#include <stdexcept>
 #include <string>
 #include <vector>
 
 #include "HandleWrapper.hpp"
 #include "compatibility.hpp"
-#include "odbc_matchers.hpp"
 
 namespace pg_utils {
 
@@ -36,13 +30,17 @@ static constexpr int PUT_ROW_TARGET_SIZE_IDX = 4;
 static constexpr int PUT_ROW_SOURCE_COMPRESSION_IDX = 5;
 static constexpr int PUT_ROW_TARGET_COMPRESSION_IDX = 6;
 static constexpr int PUT_ROW_STATUS_IDX = 7;
-static constexpr int PUT_ROW_MESSAGE_IDX = 8;
+static constexpr int PUT_ROW_ENCRYPTION_IDX = 8;
+static constexpr int PUT_ROW_MESSAGE_IDX = 9;
+static constexpr int PUT_ROW_NUM_COLS = 9;
 
 // Indices for GET output rowset
 static constexpr int GET_ROW_FILE_IDX = 1;
 static constexpr int GET_ROW_SIZE_IDX = 2;
 static constexpr int GET_ROW_STATUS_IDX = 3;
-static constexpr int GET_ROW_MESSAGE_IDX = 4;
+static constexpr int GET_ROW_ENCRYPTION_IDX = 4;
+static constexpr int GET_ROW_MESSAGE_IDX = 5;
+static constexpr int GET_ROW_NUM_COLS = 5;
 
 // Generate a random hex string for temporary directory names
 inline std::string random_hex(size_t num_bytes = 8) {
@@ -51,9 +49,9 @@ inline std::string random_hex(size_t num_bytes = 8) {
   std::uniform_int_distribution<uint64_t> dist(0, UINT64_MAX);
 
   std::stringstream ss;
-  const char* hex = "0123456789abcdef";
   for (size_t i = 0; i < num_bytes; ++i) {
-    uint8_t v = static_cast<uint8_t>(dist(gen) & 0xFF);
+    const auto hex = "0123456789abcdef";
+    const auto v = static_cast<uint8_t>(dist(gen) & 0xFF);
     ss << hex[(v >> 4) & 0x0F] << hex[v & 0x0F];
   }
   return ss.str();
@@ -109,9 +107,9 @@ class TempTestDir {
     std::uniform_int_distribution<uint64_t> dist(0, UINT64_MAX);
 
     std::stringstream ss;
-    const char* hex = "0123456789abcdef";
     for (size_t i = 0; i < num_bytes; ++i) {
-      uint8_t v = static_cast<uint8_t>(dist(gen) & 0xFF);
+      const auto hex = "0123456789abcdef";
+      const auto v = static_cast<uint8_t>(dist(gen) & 0xFF);
       ss << hex[(v >> 4) & 0x0F] << hex[v & 0x0F];
     }
     return ss.str();
@@ -141,6 +139,8 @@ inline std::string expected_put_source(const std::filesystem::path& file_path) {
     NEW_DRIVER_ONLY("BD#17") { return file_path.filename().string(); }
   }
   UNIX_ONLY { return file_path.filename().string(); }
+  throw std::logic_error("expected_put_source: unsupported platform");
+  ;
 }
 
 // Convert a path into a URI-safe string for Snowflake file:// usage

--- a/odbc_tests/tests/e2e/put_get/put_get_basic_operations.cpp
+++ b/odbc_tests/tests/e2e/put_get/put_get_basic_operations.cpp
@@ -101,6 +101,10 @@ TEST_CASE("should return correct rowset for PUT", "[put_get]") {
   auto stmt = conn.execute_fetch(put_sql);
 
   // Then Rowset for PUT command should be correct
+  SQLSMALLINT num_cols = 0;
+  REQUIRE_ODBC(SQLNumResultCols(stmt.getHandle(), &num_cols), stmt);
+  CHECK(num_cols == PUT_ROW_NUM_COLS);
+
   CHECK(get_data<SQL_C_CHAR>(stmt, PUT_ROW_SOURCE_IDX) == expected_put_source(file));
   CHECK(get_data<SQL_C_CHAR>(stmt, PUT_ROW_TARGET_IDX) == filename + ".gz");
   CHECK(get_data<SQL_C_LONG>(stmt, PUT_ROW_SOURCE_SIZE_IDX) == 6);
@@ -111,8 +115,7 @@ TEST_CASE("should return correct rowset for PUT", "[put_get]") {
   compare_compression_type(get_data<SQL_C_CHAR>(stmt, PUT_ROW_TARGET_COMPRESSION_IDX), "GZIP");
   CHECK(get_data<SQL_C_CHAR>(stmt, PUT_ROW_STATUS_IDX) == "UPLOADED");
 
-  OLD_DRIVER_ONLY("BD#3") { CHECK(get_data<SQL_C_CHAR>(stmt, PUT_ROW_MESSAGE_IDX) == "ENCRYPTED"); }
-  NEW_DRIVER_ONLY("BD#3") { CHECK(get_data<SQL_C_CHAR>(stmt, PUT_ROW_MESSAGE_IDX) == ""); }
+  CHECK(get_data<SQL_C_CHAR>(stmt, PUT_ROW_ENCRYPTION_IDX) == "ENCRYPTED");
 }
 
 TEST_CASE("should return correct rowset for GET", "[put_get]") {
@@ -131,6 +134,10 @@ TEST_CASE("should return correct rowset for GET", "[put_get]") {
   auto stmt = conn.execute_fetch(get_sql);
 
   // Then Rowset for GET command should be correct
+  SQLSMALLINT num_cols = 0;
+  REQUIRE_ODBC(SQLNumResultCols(stmt.getHandle(), &num_cols), stmt);
+  CHECK(num_cols == GET_ROW_NUM_COLS);
+
   CHECK(get_data<SQL_C_CHAR>(stmt, GET_ROW_FILE_IDX) == filename + ".gz");
 
   OLD_DRIVER_ONLY("BD#4") { CHECK(get_data<SQL_C_LONG>(stmt, GET_ROW_SIZE_IDX) == 32); }
@@ -138,6 +145,5 @@ TEST_CASE("should return correct rowset for GET", "[put_get]") {
 
   CHECK(get_data<SQL_C_CHAR>(stmt, GET_ROW_STATUS_IDX) == "DOWNLOADED");
 
-  OLD_DRIVER_ONLY("BD#3") { CHECK(get_data<SQL_C_CHAR>(stmt, GET_ROW_MESSAGE_IDX) == "DECRYPTED"); }
-  NEW_DRIVER_ONLY("BD#3") { CHECK(get_data<SQL_C_CHAR>(stmt, GET_ROW_MESSAGE_IDX) == ""); }
+  CHECK(get_data<SQL_C_CHAR>(stmt, GET_ROW_ENCRYPTION_IDX) == "DECRYPTED");
 }

--- a/sf_core/src/apis/database_driver_v1/query.rs
+++ b/sf_core/src/apis/database_driver_v1/query.rs
@@ -1,5 +1,5 @@
 use super::ColumnMetadata;
-use super::global_state::WrapperPresets;
+use super::global_state::{PutGetResultsetFlavor, WrapperPresets};
 use crate::arrow_utils::ArrowUtilsError;
 use crate::arrow_utils::{boxed_arrow_reader, create_schema};
 use crate::chunks::{
@@ -20,6 +20,20 @@ use std::sync::Arc;
 
 const PUT_GET_ROWSET_TEXT_LENGTH: u64 = 10000;
 const PUT_GET_ROWSET_FIXED_LENGTH: u64 = 64;
+
+/// Literal emitted by `PutGetResultsetFlavor::Odbc` in the PUT result's
+/// `encryption` column. Mirrors `#define ENCRYPTION_ENCRYPTED "ENCRYPTED"`
+/// from legacy libsnowflakeclient's `FileTransferExecutionResult.cpp`. The
+/// value is a constant string for *every* row (it advertises "your data
+/// ended up encrypted", not "this row's encryption material"). Any C++ /
+/// Python wrapper test that asserts on this column must use the same
+/// literal — kept here so the contract has one source of truth.
+const ODBC_PUT_ENCRYPTION_LITERAL: &str = "ENCRYPTED";
+
+/// Literal emitted by `PutGetResultsetFlavor::Odbc` in the GET result's
+/// `encryption` column. Mirrors `#define ENCRYPTION_DECRYPTED "DECRYPTED"`
+/// from legacy libsnowflakeclient. See `ODBC_PUT_ENCRYPTION_LITERAL`.
+const ODBC_GET_ENCRYPTION_LITERAL: &str = "DECRYPTED";
 
 /// Result of processing a query response, containing the Arrow reader.
 pub struct QueryResult {
@@ -186,8 +200,8 @@ macro_rules! int64_array {
     };
 }
 
-fn upload_row_types(_wrapper_presets: &WrapperPresets) -> Vec<(RowType, DataType)> {
-    vec![
+fn upload_row_types(wrapper_presets: &WrapperPresets) -> Vec<(RowType, DataType)> {
+    let mut row_types = vec![
         build_generic_text_rowtype("source"),
         build_generic_text_rowtype("target"),
         build_generic_fixed_rowtype("source_size"),
@@ -195,17 +209,25 @@ fn upload_row_types(_wrapper_presets: &WrapperPresets) -> Vec<(RowType, DataType
         build_generic_text_rowtype("source_compression"),
         build_generic_text_rowtype("target_compression"),
         build_generic_text_rowtype("status"),
-        build_generic_text_rowtype("message"),
-    ]
+    ];
+    if wrapper_presets.put_get_resultset_flavor == PutGetResultsetFlavor::Odbc {
+        row_types.push(build_generic_text_rowtype("encryption"));
+    }
+    row_types.push(build_generic_text_rowtype("message"));
+    row_types
 }
 
-fn download_row_types(_wrapper_presets: &WrapperPresets) -> Vec<(RowType, DataType)> {
-    vec![
+fn download_row_types(wrapper_presets: &WrapperPresets) -> Vec<(RowType, DataType)> {
+    let mut row_types = vec![
         build_generic_text_rowtype("file"),
         build_generic_fixed_rowtype("size"),
         build_generic_text_rowtype("status"),
-        build_generic_text_rowtype("message"),
-    ]
+    ];
+    if wrapper_presets.put_get_resultset_flavor == PutGetResultsetFlavor::Odbc {
+        row_types.push(build_generic_text_rowtype("encryption"));
+    }
+    row_types.push(build_generic_text_rowtype("message"));
+    row_types
 }
 
 /// Converts upload results to Arrow format
@@ -216,7 +238,8 @@ pub fn upload_results_reader(
     let schema = create_schema(&upload_row_types(wrapper_presets))
         .expect("Failed to create schema from RowTypes");
 
-    let columns: Vec<Arc<dyn Array>> = vec![
+    let n = upload_results.len();
+    let mut columns: Vec<Arc<dyn Array>> = vec![
         string_array!(upload_results, source),
         string_array!(upload_results, target),
         int64_array!(upload_results, source_size),
@@ -224,8 +247,13 @@ pub fn upload_results_reader(
         string_array!(upload_results, source_compression),
         string_array!(upload_results, target_compression),
         string_array!(upload_results, status),
-        string_array!(upload_results, message),
     ];
+    if wrapper_presets.put_get_resultset_flavor == PutGetResultsetFlavor::Odbc {
+        columns.push(Arc::new(StringArray::from_iter_values(
+            std::iter::repeat_n(ODBC_PUT_ENCRYPTION_LITERAL, n),
+        )));
+    }
+    columns.push(string_array!(upload_results, message));
 
     boxed_arrow_reader(schema, columns)
 }
@@ -238,12 +266,18 @@ pub fn download_results_reader(
     let schema = create_schema(&download_row_types(wrapper_presets))
         .expect("Failed to create schema from RowTypes");
 
-    let columns: Vec<Arc<dyn Array>> = vec![
+    let n = download_results.len();
+    let mut columns: Vec<Arc<dyn Array>> = vec![
         string_array!(download_results, file),
         int64_array!(download_results, size),
         string_array!(download_results, status),
-        string_array!(download_results, message),
     ];
+    if wrapper_presets.put_get_resultset_flavor == PutGetResultsetFlavor::Odbc {
+        columns.push(Arc::new(StringArray::from_iter_values(
+            std::iter::repeat_n(ODBC_GET_ENCRYPTION_LITERAL, n),
+        )));
+    }
+    columns.push(string_array!(download_results, message));
 
     boxed_arrow_reader(schema, columns)
 }
@@ -416,10 +450,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn upload_column_metadata_has_correct_structure() {
-        let columns = upload_column_metadata(&WrapperPresets::default());
+    fn upload_column_metadata_has_correct_structure_python() {
+        let columns = upload_column_metadata(&WrapperPresets::python());
 
-        assert_eq!(columns.len(), 8, "PUT should have 8 columns");
+        assert_eq!(columns.len(), 8, "PUT (Python) should have 8 columns");
 
         assert_eq!(columns[0].name, "source");
         assert_eq!(columns[0].r#type, "TEXT");
@@ -453,10 +487,54 @@ mod tests {
     }
 
     #[test]
-    fn download_column_metadata_has_correct_structure() {
-        let columns = download_column_metadata(&WrapperPresets::default());
+    fn upload_column_metadata_has_correct_structure_odbc() {
+        let columns = upload_column_metadata(&WrapperPresets::odbc());
 
-        assert_eq!(columns.len(), 4, "GET should have 4 columns");
+        assert_eq!(
+            columns.len(),
+            9,
+            "PUT (ODBC) should have 9 columns including encryption"
+        );
+
+        assert_eq!(columns[0].name, "source");
+        assert_eq!(columns[0].r#type, "TEXT");
+        assert!(!columns[0].nullable);
+
+        assert_eq!(columns[1].name, "target");
+        assert_eq!(columns[1].r#type, "TEXT");
+
+        assert_eq!(columns[2].name, "source_size");
+        assert_eq!(columns[2].r#type, "FIXED");
+        assert_eq!(
+            columns[2].precision,
+            Some(PUT_GET_ROWSET_FIXED_LENGTH as i64)
+        );
+        assert_eq!(columns[2].scale, Some(0));
+
+        assert_eq!(columns[3].name, "target_size");
+        assert_eq!(columns[3].r#type, "FIXED");
+
+        assert_eq!(columns[4].name, "source_compression");
+        assert_eq!(columns[4].r#type, "TEXT");
+
+        assert_eq!(columns[5].name, "target_compression");
+        assert_eq!(columns[5].r#type, "TEXT");
+
+        assert_eq!(columns[6].name, "status");
+        assert_eq!(columns[6].r#type, "TEXT");
+
+        assert_eq!(columns[7].name, "encryption");
+        assert_eq!(columns[7].r#type, "TEXT");
+
+        assert_eq!(columns[8].name, "message");
+        assert_eq!(columns[8].r#type, "TEXT");
+    }
+
+    #[test]
+    fn download_column_metadata_has_correct_structure_python() {
+        let columns = download_column_metadata(&WrapperPresets::python());
+
+        assert_eq!(columns.len(), 4, "GET (Python) should have 4 columns");
 
         assert_eq!(columns[0].name, "file");
         assert_eq!(columns[0].r#type, "TEXT");
@@ -475,6 +553,38 @@ mod tests {
 
         assert_eq!(columns[3].name, "message");
         assert_eq!(columns[3].r#type, "TEXT");
+    }
+
+    #[test]
+    fn download_column_metadata_has_correct_structure_odbc() {
+        let columns = download_column_metadata(&WrapperPresets::odbc());
+
+        assert_eq!(
+            columns.len(),
+            5,
+            "GET (ODBC) should have 5 columns including encryption"
+        );
+
+        assert_eq!(columns[0].name, "file");
+        assert_eq!(columns[0].r#type, "TEXT");
+        assert!(!columns[0].nullable);
+
+        assert_eq!(columns[1].name, "size");
+        assert_eq!(columns[1].r#type, "FIXED");
+        assert_eq!(
+            columns[1].precision,
+            Some(PUT_GET_ROWSET_FIXED_LENGTH as i64)
+        );
+        assert_eq!(columns[1].scale, Some(0));
+
+        assert_eq!(columns[2].name, "status");
+        assert_eq!(columns[2].r#type, "TEXT");
+
+        assert_eq!(columns[3].name, "encryption");
+        assert_eq!(columns[3].r#type, "TEXT");
+
+        assert_eq!(columns[4].name, "message");
+        assert_eq!(columns[4].r#type, "TEXT");
     }
 
     #[test]


### PR DESCRIPTION
### TL;DR

Adds an `encryption` column to PUT/GET result sets for the ODBC flavor, restoring parity with the legacy `libsnowflakeclient` behavior.

### What changed?

- The ODBC PUT result set now includes an `encryption` column (index 8) between `status` and `message`, always populated with `"ENCRYPTED"`.
- The ODBC GET result set now includes an `encryption` column (index 4) between `status` and `message`, always populated with `"DECRYPTED"`.
- `upload_row_types` and `download_row_types` conditionally insert the `encryption` column when `put_get_resultset_flavor == PutGetResultsetFlavor::Odbc`.
- Two constants, `ODBC_PUT_ENCRYPTION_LITERAL` and `ODBC_GET_ENCRYPTION_LITERAL`, are introduced as the single source of truth for these string values.
- ODBC tests now assert the total column count (`PUT_ROW_NUM_COLS = 9`, `GET_ROW_NUM_COLS = 5`) and read the encryption value directly from the new dedicated column index rather than branching on old/new driver behavior.
- The behavior difference entry `BD#3` ("Encryption field is no longer included in the result") is marked as `fixed`.
- Unit tests are split into Python and ODBC variants to cover both column layouts.

### How to test?

Run the existing ODBC end-to-end PUT/GET tests:

```
# PUT test
TEST_CASE("should return correct rowset for PUT", "[put_get]")

# GET test
TEST_CASE("should return correct rowset for GET", "[put_get]")
```

Run the Rust unit tests:

```
cargo test upload_column_metadata_has_correct_structure_odbc
cargo test download_column_metadata_has_correct_structure_odbc
cargo test upload_column_metadata_has_correct_structure_python
cargo test download_column_metadata_has_correct_structure_python
```

### Why make this change?

The legacy `libsnowflakeclient` ODBC driver included an `encryption` column in PUT/GET result sets, reporting `"ENCRYPTED"` and `"DECRYPTED"` respectively. This column was missing from the new driver, causing a behavioral regression for ODBC users who depend on it. This change restores that column exclusively for the ODBC result set flavor, keeping non-ODBC wrappers (Python, etc.) unaffected.