### PR TITLE
SNOW-2314157: add OAuth core integration tests with wiremock fixtures

### DIFF
--- a/sf_core/src/apis/database_driver_v1/connection.rs
+++ b/sf_core/src/apis/database_driver_v1/connection.rs
@@ -254,8 +254,22 @@ impl DatabaseDriverV1 {
                         ..
                     }
                 );
+                // OAuth Authorization Code uses the same token cache to
+                // (a) short-circuit the interactive flow with a cached
+                // access token, (b) exchange a cached refresh token, and
+                // (c) drive 390303/390318 refresh-on-failure eviction
+                // (analysis_feature_oauth.md §3.2 / §7 / §8). Client
+                // Credentials intentionally never persists tokens
+                // (analysis §14 #12) and the legacy pre-acquired
+                // `OAUTH` flow forwards a caller-supplied token, so
+                // neither needs the cache wired here.
+                let oauth_caching_requested = matches!(
+                    &login_parameters.login_method,
+                    LoginMethod::OAuthAuthorizationCode(cfg)
+                        if cfg.client_store_temporary_credential
+                );
 
-                let token_cache = if mfa_caching_requested {
+                let token_cache = if mfa_caching_requested || oauth_caching_requested {
                     Some(self.token_cache().context(TokenCacheInitializationSnafu)?)
                 } else {
                     None

--- a/sf_core/src/config/connection_config.rs
+++ b/sf_core/src/config/connection_config.rs
@@ -12,7 +12,8 @@ use url::Url;
 use crate::config::ParamStore;
 use crate::config::param_names::*;
 use crate::config::rest_parameters::{
-    ClientInfo, DEFAULT_AUTHENTICATION_TIMEOUT_SECS, LoginMethod, LoginParameters, NativeOktaConfig,
+    ClientInfo, DEFAULT_AUTHENTICATION_TIMEOUT_SECS, LoginMethod, LoginParameters,
+    NativeOktaConfig, OAuthAuthorizationCodeConfig, OAuthClientCredentialsConfig,
 };
 use crate::config::settings::Setting;
 use crate::config::{
@@ -69,6 +70,17 @@ pub enum AuthConfig {
         user: String,
         authentication_timeout_secs: u64,
     },
+    /// Legacy pre-acquired OAuth access token (`AUTHENTICATOR=OAUTH` +
+    /// raw `token=`). Forwarded unchanged to Snowflake (analysis
+    /// `analysis_feature_oauth.md` §6 / §10.1).
+    OAuthAccessToken {
+        user: String,
+        token: SensitiveString,
+    },
+    /// OAuth 2.0 Authorization Code (with PKCE) flow (analysis §3).
+    OAuthAuthorizationCode(OAuthAuthorizationCodeConfig),
+    /// OAuth 2.0 Client Credentials flow, external IdP only (analysis §4).
+    OAuthClientCredentials(OAuthClientCredentialsConfig),
 }
 
 #[derive(Debug)]
@@ -336,6 +348,132 @@ fn parse_authentication_timeout(settings: &ParamStore) -> u64 {
         .unwrap_or(DEFAULT_AUTHENTICATION_TIMEOUT_SECS)
 }
 
+/// Read a boolean parameter that wrappers may submit as a typed bool,
+/// a string (`"true"`/`"1"`), or an int (`0`/`1`). Mirrors
+/// `LoginMethod::get_flexible_bool` so OAuth knobs behave identically
+/// regardless of which path constructed the auth config.
+fn get_flexible_bool(settings: &ParamStore, key: crate::config::ParamKey) -> bool {
+    settings
+        .get_bool(key)
+        .or_else(|| {
+            settings
+                .get_string(key)
+                .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
+        })
+        .or_else(|| settings.get_int(key).map(|v| v != 0))
+        .unwrap_or(false)
+}
+
+fn parse_optional_url(
+    settings: &ParamStore,
+    key: crate::config::ParamKey,
+) -> Result<Option<Url>, ConfigError> {
+    let Some(raw) = non_empty_string(settings, key) else {
+        return Ok(None);
+    };
+    let url = Url::parse(&raw).map_err(|e| {
+        InvalidParameterValueSnafu {
+            parameter: String::from(key),
+            value: raw,
+            explanation: format!("Could not parse URL: {e}"),
+        }
+        .build()
+    })?;
+    Ok(Some(url))
+}
+
+fn parse_required_url(
+    settings: &ParamStore,
+    key: crate::config::ParamKey,
+) -> Result<Url, ConfigError> {
+    let raw = non_empty_string(settings, key).context(MissingParameterSnafu {
+        parameter: String::from(key),
+    })?;
+    Url::parse(&raw).map_err(|e| {
+        InvalidParameterValueSnafu {
+            parameter: String::from(key),
+            value: raw,
+            explanation: format!("Could not parse URL: {e}"),
+        }
+        .build()
+    })
+}
+
+fn build_oauth_authorization_code_config(
+    settings: &ParamStore,
+) -> Result<OAuthAuthorizationCodeConfig, ConfigError> {
+    let username = non_empty_string(settings, USER).context(MissingParameterSnafu {
+        parameter: String::from(USER),
+    })?;
+    // For Snowflake-as-IdP we let the AC provider substitute
+    // LOCAL_APPLICATION at flow time when client_id/client_secret are
+    // empty (analysis §1, §9). Rest of the config is taken straight
+    // from settings.
+    let client_id = non_empty_string(settings, OAUTH_CLIENT_ID).unwrap_or_default();
+    let client_secret = non_empty_string(settings, OAUTH_CLIENT_SECRET).unwrap_or_default();
+    let authorization_url = parse_optional_url(settings, OAUTH_AUTHORIZATION_URL)?;
+    let token_url = parse_optional_url(settings, OAUTH_TOKEN_REQUEST_URL)?;
+    let redirect_uri = parse_optional_url(settings, OAUTH_REDIRECT_URI)?;
+    let scope = non_empty_string(settings, OAUTH_SCOPE);
+    let enable_single_use_refresh_tokens =
+        get_flexible_bool(settings, OAUTH_ENABLE_SINGLE_USE_REFRESH_TOKENS);
+    let disable_pkce = get_flexible_bool(settings, OAUTH_DISABLE_PKCE);
+    let enable_dpop = get_flexible_bool(settings, OAUTH_ENABLE_DPOP);
+    let client_store_temporary_credential =
+        get_flexible_bool(settings, CLIENT_STORE_TEMPORARY_CREDENTIAL);
+    let authentication_timeout_secs = settings
+        .get_int(AUTHENTICATION_TIMEOUT)
+        .and_then(|v| u64::try_from(v).ok())
+        .unwrap_or(DEFAULT_AUTHENTICATION_TIMEOUT_SECS);
+
+    Ok(OAuthAuthorizationCodeConfig {
+        username,
+        client_id,
+        client_secret: client_secret.into(),
+        authorization_url,
+        token_url,
+        redirect_uri,
+        scope,
+        enable_single_use_refresh_tokens,
+        disable_pkce,
+        enable_dpop,
+        client_store_temporary_credential,
+        authentication_timeout_secs,
+    })
+}
+
+fn build_oauth_client_credentials_config(
+    settings: &ParamStore,
+) -> Result<OAuthClientCredentialsConfig, ConfigError> {
+    let username = non_empty_string(settings, USER).context(MissingParameterSnafu {
+        parameter: String::from(USER),
+    })?;
+    let client_id = non_empty_string(settings, OAUTH_CLIENT_ID).context(MissingParameterSnafu {
+        parameter: String::from(OAUTH_CLIENT_ID),
+    })?;
+    let client_secret =
+        non_empty_string(settings, OAUTH_CLIENT_SECRET).context(MissingParameterSnafu {
+            parameter: String::from(OAUTH_CLIENT_SECRET),
+        })?;
+    let token_url = parse_required_url(settings, OAUTH_TOKEN_REQUEST_URL)?;
+    let scope = non_empty_string(settings, OAUTH_SCOPE);
+    let enable_dpop = get_flexible_bool(settings, OAUTH_ENABLE_DPOP);
+    let authentication_timeout_secs = settings
+        .get_int(AUTHENTICATION_TIMEOUT)
+        .and_then(|v| u64::try_from(v).ok())
+        .unwrap_or(DEFAULT_AUTHENTICATION_TIMEOUT_SECS);
+
+    Ok(OAuthClientCredentialsConfig {
+        username,
+        client_id,
+        client_secret: client_secret.into(),
+        token_url,
+        scope,
+        enable_dpop,
+        authentication_timeout_secs,
+    })
+}
+
 fn build_auth_config(settings: &ParamStore) -> Result<AuthConfig, ConfigError> {
     let authenticator = settings.get_string(AUTHENTICATOR).unwrap_or_default();
     let auth_upper = authenticator.to_ascii_uppercase();
@@ -391,6 +529,32 @@ fn build_auth_config(settings: &ParamStore) -> Result<AuthConfig, ConfigError> {
                     parameter: String::from(TOKEN),
                 })?,
         }),
+        // ─── OAuth: legacy pre-acquired access token ─────────────────────
+        // analysis_feature_oauth.md §6 — `AUTHENTICATOR=OAUTH` + raw
+        // `token=`. Forwarded unchanged to Snowflake; LOGIN_NAME is
+        // always set (gotcha §14 #10).
+        "OAUTH" => Ok(AuthConfig::OAuthAccessToken {
+            user: non_empty_string(settings, USER).context(MissingParameterSnafu {
+                parameter: String::from(USER),
+            })?,
+            token: settings.get_sensitive_string(TOKEN).context(MissingParameterSnafu {
+                parameter: String::from(TOKEN),
+            })?,
+        }),
+        // ─── OAuth: Authorization Code (with PKCE) ───────────────────────
+        // analysis_feature_oauth.md §3, §9. Snowflake-as-IdP defaults
+        // (LOCAL_APPLICATION substitution + default endpoints) are
+        // applied at flow time.
+        "OAUTH_AUTHORIZATION_CODE" => Ok(AuthConfig::OAuthAuthorizationCode(
+            build_oauth_authorization_code_config(settings)?,
+        )),
+        // ─── OAuth: Client Credentials (external IdP only) ───────────────
+        // analysis_feature_oauth.md §4. client_id/client_secret/token_url
+        // are mandatory because Snowflake's GS does not issue tokens for
+        // grant_type=client_credentials.
+        "OAUTH_CLIENT_CREDENTIALS" => Ok(AuthConfig::OAuthClientCredentials(
+            build_oauth_client_credentials_config(settings)?,
+        )),
         _ if auth_upper.starts_with("HTTPS://") => {
             let okta_url = Url::parse(&authenticator).map_err(|_| {
                 InvalidParameterValueSnafu {
@@ -528,6 +692,37 @@ fn login_method_from_auth_config(auth: &AuthConfig) -> LoginMethod {
             username: user.clone(),
             authentication_timeout_secs: *authentication_timeout_secs,
         },
+        AuthConfig::OAuthAccessToken { user, token } => LoginMethod::OAuthAccessToken {
+            username: user.clone(),
+            token: token.clone(),
+        },
+        AuthConfig::OAuthAuthorizationCode(cfg) => {
+            LoginMethod::OAuthAuthorizationCode(OAuthAuthorizationCodeConfig {
+                username: cfg.username.clone(),
+                client_id: cfg.client_id.clone(),
+                client_secret: cfg.client_secret.clone(),
+                authorization_url: cfg.authorization_url.clone(),
+                token_url: cfg.token_url.clone(),
+                redirect_uri: cfg.redirect_uri.clone(),
+                scope: cfg.scope.clone(),
+                enable_single_use_refresh_tokens: cfg.enable_single_use_refresh_tokens,
+                disable_pkce: cfg.disable_pkce,
+                enable_dpop: cfg.enable_dpop,
+                client_store_temporary_credential: cfg.client_store_temporary_credential,
+                authentication_timeout_secs: cfg.authentication_timeout_secs,
+            })
+        }
+        AuthConfig::OAuthClientCredentials(cfg) => {
+            LoginMethod::OAuthClientCredentials(OAuthClientCredentialsConfig {
+                username: cfg.username.clone(),
+                client_id: cfg.client_id.clone(),
+                client_secret: cfg.client_secret.clone(),
+                token_url: cfg.token_url.clone(),
+                scope: cfg.scope.clone(),
+                enable_dpop: cfg.enable_dpop,
+                authentication_timeout_secs: cfg.authentication_timeout_secs,
+            })
+        }
     }
 }
 
@@ -648,6 +843,71 @@ pub fn validate_settings(settings: &ParamStore) -> Vec<ValidationIssue> {
                     severity: ValidationSeverity::Error,
                     parameter: TOKEN.into(),
                     message: "Missing required parameter 'token' for PAT authentication".into(),
+                    code: ValidationCode::MissingRequired,
+                });
+            }
+        }
+        "OAUTH" => {
+            // Legacy OAuth (analysis_feature_oauth.md §6) forwards a
+            // pre-acquired access token verbatim; the only required
+            // payload-side parameter is `token`. user/account are
+            // already validated above.
+            if settings.get_string(TOKEN).is_none_or(|s| s.is_empty()) {
+                issues.push(ValidationIssue {
+                    severity: ValidationSeverity::Error,
+                    parameter: TOKEN.into(),
+                    message: "Missing required parameter 'token' for OAuth authentication".into(),
+                    code: ValidationCode::MissingRequired,
+                });
+            }
+        }
+        "OAUTH_AUTHORIZATION_CODE" => {
+            // AC flow (analysis_feature_oauth.md §3) defaults to
+            // Snowflake-as-IdP when client_id/secret are absent, so we
+            // only require user here. URL-shape validation is performed
+            // by `LoginMethod::from_settings` at build time.
+        }
+        "OAUTH_CLIENT_CREDENTIALS" => {
+            // CC flow (analysis_feature_oauth.md §4) is external-IdP
+            // only: client_id, client_secret, and oauth_token_request_url
+            // must be provided up-front (Snowflake's GS does not mint
+            // CC tokens).
+            if settings
+                .get_string(OAUTH_CLIENT_ID)
+                .is_none_or(|s| s.is_empty())
+            {
+                issues.push(ValidationIssue {
+                    severity: ValidationSeverity::Error,
+                    parameter: OAUTH_CLIENT_ID.into(),
+                    message: "Missing required parameter 'oauth_client_id' for OAuth client \
+                              credentials authentication"
+                        .into(),
+                    code: ValidationCode::MissingRequired,
+                });
+            }
+            if settings
+                .get_string(OAUTH_CLIENT_SECRET)
+                .is_none_or(|s| s.is_empty())
+            {
+                issues.push(ValidationIssue {
+                    severity: ValidationSeverity::Error,
+                    parameter: OAUTH_CLIENT_SECRET.into(),
+                    message: "Missing required parameter 'oauth_client_secret' for OAuth client \
+                              credentials authentication"
+                        .into(),
+                    code: ValidationCode::MissingRequired,
+                });
+            }
+            if settings
+                .get_string(OAUTH_TOKEN_REQUEST_URL)
+                .is_none_or(|s| s.is_empty())
+            {
+                issues.push(ValidationIssue {
+                    severity: ValidationSeverity::Error,
+                    parameter: OAUTH_TOKEN_REQUEST_URL.into(),
+                    message: "Missing required parameter 'oauth_token_request_url' for OAuth \
+                              client credentials authentication"
+                        .into(),
                     code: ValidationCode::MissingRequired,
                 });
             }
@@ -1432,7 +1692,10 @@ mod tests {
         let settings = settings_from(&[
             ("account", Setting::String("acct".into())),
             ("user", Setting::String("u".into())),
-            ("authenticator", Setting::String("OAUTH".into())),
+            (
+                "authenticator",
+                Setting::String("BOGUS_AUTHENTICATOR".into()),
+            ),
         ]);
         let issues = validate_settings(&settings);
         let auth_issues: Vec<_> = issues
@@ -1470,7 +1733,10 @@ mod tests {
         let settings = settings_from(&[
             ("account", Setting::String("acct".into())),
             ("user", Setting::String("u".into())),
-            ("authenticator", Setting::String("OAUTH".into())),
+            (
+                "authenticator",
+                Setting::String("BOGUS_AUTHENTICATOR".into()),
+            ),
             ("host", Setting::String("h.com".into())),
         ]);
 

--- a/sf_core/tests/common/mocks/mod.rs
+++ b/sf_core/tests/common/mocks/mod.rs
@@ -6,6 +6,7 @@
 pub mod auth;
 pub mod external_browser;
 pub mod mfa;
+pub mod oauth;
 pub mod okta;
 pub mod password;
 pub mod put_get;

--- a/sf_core/tests/common/mocks/oauth.rs
+++ b/sf_core/tests/common/mocks/oauth.rs
@@ -1,0 +1,304 @@
+//! OAuth 2.0 authentication mock helpers.
+//!
+//! Each function returns a `wiremock::Mock` for one logical step in the
+//! OAuth Authorization Code (AC), Client Credentials (CC), or legacy
+//! pre-acquired-token flow. These mirror the behavioral fixtures shipped
+//! with the ODBC driver under
+//! `Tests/UnitTests/UnitOAuthTest/wiremock/{idp_responses,snowflake_responses}`
+//! and the cross-driver expectations catalogued in
+//! `analysis_feature_oauth.md` (notably §3.5, §4, §6, §7.4, §8, §10.1,
+//! §13). The caller mounts them via `MockServerWithTls::mount`.
+//!
+//! Conventions:
+//! * IdP token endpoint is at `POST /oauth/token-request` (the Snowflake
+//!   default, analysis §9). External-IdP scenarios still hit this path
+//!   because the harness routes the configured `oauth_token_request_url`
+//!   to the same wiremock server.
+//! * Snowflake login mocks match on `data.AUTHENTICATOR == "OAUTH"`
+//!   (analysis §10.1: `AUTHENTICATOR` is always uppercase `OAUTH`, never
+//!   the user-supplied authenticator string verbatim — gotcha §14 #5).
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use serde_json::json;
+use wiremock::matchers::{body_partial_json, body_string_contains, method, path_regex};
+use wiremock::{Mock, Respond, ResponseTemplate};
+
+// ─── IdP token endpoint — success variants ──────────────────────────────────
+
+/// Successful AC token exchange (`grant_type=authorization_code`).
+///
+/// Mirrors ODBC's `idp_auth_successful.json` (the canonical AC happy
+/// path). Returns `access_token`, `refresh_token`, `token_type` and
+/// `expires_in` so callers can also exercise the refresh-token rotation
+/// persistence path (analysis §7.4).
+pub fn idp_token_endpoint_success_authorization_code() -> Mock {
+    Mock::given(method("POST"))
+        .and(path_regex(r"/oauth/token-request"))
+        .and(body_string_contains("grant_type=authorization_code"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "access_token": "ac-access-token-success",
+            "refresh_token": "ac-refresh-token-success",
+            "token_type": "Bearer",
+            "expires_in": 600,
+            "refresh_token_expires_in": 86399
+        })))
+}
+
+/// AC token exchange whose body asserts `enable_single_use_refresh_tokens=true`.
+///
+/// Mirrors ODBC's `idp_auth_successful_with_single_use_refresh_token.json`
+/// (analysis §7.4). The wiremock body matcher only fires when the
+/// driver actually included the flag, so a missing flag fails the test
+/// with a 404 from wiremock and the OAuth flow surfaces a token-exchange
+/// error.
+pub fn idp_token_endpoint_success_with_single_use_refresh_token() -> Mock {
+    Mock::given(method("POST"))
+        .and(path_regex(r"/oauth/token-request"))
+        .and(body_string_contains("grant_type=authorization_code"))
+        .and(body_string_contains(
+            "enable_single_use_refresh_tokens=true",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "access_token": "ac-access-token-single-use",
+            "refresh_token": "ac-refresh-token-rotated",
+            "token_type": "Bearer",
+            "expires_in": 600
+        })))
+}
+
+/// Successful CC token exchange (`grant_type=client_credentials`).
+///
+/// Mirrors ODBC's `idp_client_successful.json`. CC tokens are
+/// intentionally never cached (analysis §14 #12), so this fixture does
+/// not include a `refresh_token`.
+pub fn idp_token_endpoint_success_client_credentials() -> Mock {
+    Mock::given(method("POST"))
+        .and(path_regex(r"/oauth/token-request"))
+        .and(body_string_contains("grant_type=client_credentials"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "access_token": "cc-access-token-success",
+            "token_type": "Bearer",
+            "expires_in": 900
+        })))
+}
+
+/// Successful refresh-token exchange (`grant_type=refresh_token`).
+///
+/// Mirrors ODBC's `idp_refresh_successful.json`. Returns a fresh access
+/// token AND a rotated refresh token so callers can also assert the
+/// rotated RT is persisted to the cache (analysis §7.4 #1/#2/#5/#6).
+pub fn idp_token_endpoint_success_refresh() -> Mock {
+    Mock::given(method("POST"))
+        .and(path_regex(r"/oauth/token-request"))
+        .and(body_string_contains("grant_type=refresh_token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "access_token": "ac-access-token-refreshed",
+            "refresh_token": "ac-refresh-token-rotated",
+            "token_type": "Bearer",
+            "expires_in": 599
+        })))
+}
+
+// ─── IdP token endpoint — error variants ────────────────────────────────────
+
+/// IdP returns 400 with an `invalid_scope` body. Mirrors ODBC's
+/// `idp_auth_invalid_scope.json`. The OAuth flow should surface
+/// `OAuthError::IdpError { error: "invalid_scope", .. }` (analysis §13).
+pub fn idp_token_endpoint_invalid_scope() -> Mock {
+    Mock::given(method("POST"))
+        .and(path_regex(r"/oauth/token-request"))
+        .respond_with(ResponseTemplate::new(400).set_body_json(json!({
+            "error": "invalid_scope",
+            "error_description": "One or more scopes are not configured for the authorization server resource."
+        })))
+}
+
+/// 200 OK with an empty/missing `access_token` — mirrors ODBC's
+/// `idp_auth_missing_access_token.json` (the field is present but
+/// empty, which our flow treats as missing — analysis §13). The flow
+/// surfaces `OAuthError::MissingAccessToken`.
+pub fn idp_token_endpoint_missing_access_token() -> Mock {
+    Mock::given(method("POST"))
+        .and(path_regex(r"/oauth/token-request"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "access_token": "",
+            "refresh_token": "rt-but-no-at",
+            "token_type": "Bearer",
+            "expires_in": 600
+        })))
+}
+
+/// IdP returns a generic 500 (no parseable body). Mirrors ODBC's
+/// `idp_auth_token_request_error.json` and `idp_client_token_request_error.json`.
+/// The flow surfaces `OAuthError::TokenExchange { status: 500, .. }`.
+pub fn idp_token_endpoint_token_request_error() -> Mock {
+    Mock::given(method("POST"))
+        .and(path_regex(r"/oauth/token-request"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("Internal Server Error from IdP"))
+}
+
+/// IdP returns 400 with an explicit `invalid_token` IdP-side error (the
+/// body's `access_token` field is empty so even if the body were 200,
+/// `MissingAccessToken` would fire). Mirrors ODBC's
+/// `idp_auth_invalid_access_token.json` semantics — the IdP signals that
+/// the token it would have minted is itself invalid.
+pub fn idp_token_endpoint_invalid_access_token() -> Mock {
+    Mock::given(method("POST"))
+        .and(path_regex(r"/oauth/token-request"))
+        .respond_with(ResponseTemplate::new(400).set_body_json(json!({
+            "error": "invalid_token",
+            "error_description": "Identity Provider rejected the access token"
+        })))
+}
+
+/// Refresh-token exchange fails with `invalid_grant`. Mirrors ODBC's
+/// `idp_refresh_failed.json`. After this fires the OAuth flow evicts the
+/// cached refresh token and falls back to the full interactive flow
+/// (analysis §7.4 / §8 / §13).
+pub fn idp_token_endpoint_refresh_failed() -> Mock {
+    Mock::given(method("POST"))
+        .and(path_regex(r"/oauth/token-request"))
+        .and(body_string_contains("grant_type=refresh_token"))
+        .respond_with(ResponseTemplate::new(400).set_body_json(json!({
+            "error": "invalid_grant",
+            "error_description": "Refresh token expired or revoked"
+        })))
+}
+
+// ─── Snowflake login endpoint — OAuth variants ──────────────────────────────
+
+/// Successful Snowflake login for OAuth, asserting the request body
+/// carries `AUTHENTICATOR=OAUTH` *and* the supplied `expected_token`
+/// value in `data.TOKEN` (analysis §10.1). The `expected_token` echo
+/// lets callers prove that a specific cached / freshly-acquired access
+/// token was actually forwarded to GS — particularly useful for the
+/// cached-AT short-circuit assertion.
+pub fn snowflake_login_success_oauth(expected_token: &str) -> Mock {
+    Mock::given(method("POST"))
+        .and(path_regex(r"/session/v1/login-request"))
+        .and(body_partial_json(json!({
+            "data": {
+                "AUTHENTICATOR": "OAUTH",
+                "TOKEN": expected_token
+            }
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "success": true,
+            "data": {
+                "token": "mock_session_token_oauth",
+                "masterToken": "mock_master_token_oauth",
+                "sessionId": 12345,
+                "validityInSeconds": 3600,
+                "masterValidityInSeconds": 14400
+            }
+        })))
+}
+
+/// Snowflake login returns `390303` (`OAUTH_ACCESS_TOKEN_INVALID`).
+/// Mirrors the cross-driver eviction trigger in analysis §8 — drivers
+/// remove the cached access token and replay the login.
+pub fn snowflake_login_oauth_access_token_invalid_390303() -> Mock {
+    Mock::given(method("POST"))
+        .and(path_regex(r"/session/v1/login-request"))
+        .and(body_partial_json(json!({
+            "data": {
+                "AUTHENTICATOR": "OAUTH"
+            }
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "success": false,
+            "code": "390303",
+            "message": "OAuth access token is invalid."
+        })))
+}
+
+/// Snowflake login returns `390318` (`OAUTH_ACCESS_TOKEN_EXPIRED`).
+/// Same eviction-and-replay semantics as 390303 (analysis §8).
+pub fn snowflake_login_oauth_access_token_expired_390318() -> Mock {
+    Mock::given(method("POST"))
+        .and(path_regex(r"/session/v1/login-request"))
+        .and(body_partial_json(json!({
+            "data": {
+                "AUTHENTICATOR": "OAUTH"
+            }
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "success": false,
+            "code": "390318",
+            "message": "OAuth access token has expired."
+        })))
+}
+
+/// Refresh-on-failure fixture: the first matching OAuth login returns
+/// the supplied Snowflake error `code` (`390303` or `390318`);
+/// subsequent matching OAuth logins succeed. Returning both responses
+/// from a single counter-backed responder (instead of two
+/// `up_to_n_times`-gated mocks) sidesteps wiremock's mount-ordering
+/// ambiguity when two equal-priority mocks match the same request —
+/// see `analysis_feature_oauth.md` §8 / §14 #9 for the cross-driver
+/// expectation that the eviction always runs exactly once before the
+/// retry succeeds.
+///
+/// The retry success body uses distinct token values
+/// (`mock_session_token_oauth_retry`, `mock_master_token_oauth_retry`)
+/// so test assertions can unambiguously distinguish the retry leg from
+/// the initial failed leg.
+pub fn snowflake_login_oauth_then_success(code: &str) -> Mock {
+    let message = match code {
+        "390303" => "OAuth access token is invalid.",
+        "390318" => "OAuth access token has expired.",
+        _ => "OAuth access token error.",
+    };
+    Mock::given(method("POST"))
+        .and(path_regex(r"/session/v1/login-request"))
+        .and(body_partial_json(json!({
+            "data": {
+                "AUTHENTICATOR": "OAUTH"
+            }
+        })))
+        .respond_with(ThenSuccessResponder::new(code, message))
+}
+
+/// Counter-backed responder that returns a failing OAuth login (JSON
+/// body with `success=false` and the supplied Snowflake error `code`)
+/// on the first match, and a success body on every subsequent match.
+struct ThenSuccessResponder {
+    calls: AtomicUsize,
+    failure_code: String,
+    failure_message: String,
+}
+
+impl ThenSuccessResponder {
+    fn new(code: &str, message: &str) -> Self {
+        Self {
+            calls: AtomicUsize::new(0),
+            failure_code: code.to_string(),
+            failure_message: message.to_string(),
+        }
+    }
+}
+
+impl Respond for ThenSuccessResponder {
+    fn respond(&self, _req: &wiremock::Request) -> ResponseTemplate {
+        let n = self.calls.fetch_add(1, Ordering::SeqCst);
+        if n == 0 {
+            ResponseTemplate::new(200).set_body_json(json!({
+                "success": false,
+                "code": self.failure_code,
+                "message": self.failure_message,
+            }))
+        } else {
+            ResponseTemplate::new(200).set_body_json(json!({
+                "success": true,
+                "data": {
+                    "token": "mock_session_token_oauth_retry",
+                    "masterToken": "mock_master_token_oauth_retry",
+                    "sessionId": 12345,
+                    "validityInSeconds": 3600,
+                    "masterValidityInSeconds": 14400,
+                }
+            }))
+        }
+    }
+}

--- a/sf_core/tests/integration/authentication/mod.rs
+++ b/sf_core/tests/integration/authentication/mod.rs
@@ -1,5 +1,6 @@
 pub mod external_browser;
 pub mod native_okta;
+pub mod oauth;
 pub mod os_details;
 pub mod private_key_auth;
 pub mod spcs_token;

--- a/sf_core/tests/integration/authentication/oauth.rs
+++ b/sf_core/tests/integration/authentication/oauth.rs
@@ -1,0 +1,671 @@
+//! Wiremock-driven integration tests for the OAuth login pipeline.
+//!
+//! Exercises the three OAuth-shaped login methods that the universal
+//! driver exposes today:
+//!
+//! * legacy pre-acquired access token (`AUTHENTICATOR=OAUTH`, raw `token=`),
+//! * authorization code with PKCE and token caching (AC), and
+//! * client credentials (CC).
+//!
+//! The behavioral spec lives in `analysis_feature_oauth.md`. Cross-driver
+//! conventions referenced in this module:
+//!
+//! * §6 / §10.1 — legacy `OAUTH` body shape.
+//! * §3.2 / §7   — AC cache short-circuit + refresh-token exchange.
+//! * §8 / §14 #9 — refresh-on-failure for `390303` / `390318`.
+//! * §4 / §14 #12 — CC tokens are intentionally never cached.
+//! * §13         — IdP-error / missing-access-token surface area.
+//!
+//! Approach (per the integration-test plan): the AC interactive leg
+//! would otherwise hang on the loopback redirect, so happy-path tests
+//! pre-seed `KeyringTokenCache` with a cached access token (and / or
+//! refresh token) so `acquire_authorization_code` short-circuits before
+//! the loopback ever binds. Tests that intentionally exercise the
+//! interactive leg are gated by `#[ignore]`.
+//!
+//! Cache hygiene: each test uses a unique username and removes the
+//! tokens it seeded as part of teardown (mirroring
+//! `user_password_mfa_token_cache.rs`).
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::common::mocks::oauth;
+use crate::common::snowflake_test_client::SnowflakeTestClient;
+use crate::common::tls_proxy::MockServerWithTls;
+use sf_core::token_cache::{KeyringTokenCache, TokenCache, TokenType};
+
+// =============================================================================
+// Test Fixture
+// =============================================================================
+
+/// Reduces boilerplate for OAuth integration tests.  Holds a wiremock
+/// server, a configured [`SnowflakeTestClient`], a [`KeyringTokenCache`]
+/// handle, and the host used as the token-cache key (always `127.0.0.1`
+/// for the wiremock-backed flow because that's what
+/// `host_from_token_url` extracts from the configured `oauth_token_request_url`).
+///
+/// On `Drop` the fixture removes every token type it could conceivably
+/// have seeded, scoped to the unique username — avoids cross-test
+/// pollution if a test panics before its explicit teardown.
+struct OAuthTestFixture {
+    mock: MockServerWithTls,
+    client: SnowflakeTestClient,
+    cache: KeyringTokenCache,
+    /// Host used as the token-cache key (always `127.0.0.1` for the
+    /// wiremock-backed flow, which is what `host_from_token_url`
+    /// extracts from the configured `oauth_token_request_url`).
+    cache_host: String,
+    user: String,
+}
+
+impl OAuthTestFixture {
+    /// Build a fixture configured for the OAuth Authorization Code flow.
+    /// The wiremock server hosts both the IdP token endpoint
+    /// (`/oauth/token-request`) and the Snowflake login endpoint
+    /// (`/session/v1/login-request`).
+    fn with_authorization_code(user: &str) -> Self {
+        let mock = MockServerWithTls::start();
+        let token_url = format!("{}/oauth/token-request", mock.http_url());
+        let auth_url = format!("{}/oauth/authorize", mock.http_url());
+
+        let client = SnowflakeTestClient::with_int_tests_params(Some(&mock.http_url()));
+        client.set_connection_option("authenticator", "OAUTH_AUTHORIZATION_CODE");
+        client.set_connection_option("user", user);
+        client.set_connection_option("oauth_client_id", "test-oauth-client-id");
+        client.set_connection_option("oauth_client_secret", "test-oauth-client-secret"); // pragma: allowlist secret
+        client.set_connection_option("oauth_token_request_url", &token_url);
+        client.set_connection_option("oauth_authorization_url", &auth_url);
+        client.set_connection_option("oauth_scope", "session:role:test_role");
+        client.set_connection_option("client_store_temporary_credential", "true");
+
+        let cache = KeyringTokenCache::new().expect("token cache should be available");
+        let cache_host = host_from(&mock.http_url());
+
+        Self {
+            mock,
+            client,
+            cache,
+            cache_host,
+            user: user.to_string(),
+        }
+    }
+
+    /// Build a fixture configured for the OAuth Client Credentials flow.
+    fn with_client_credentials(user: &str) -> Self {
+        let mock = MockServerWithTls::start();
+        let token_url = format!("{}/oauth/token-request", mock.http_url());
+
+        let client = SnowflakeTestClient::with_int_tests_params(Some(&mock.http_url()));
+        client.set_connection_option("authenticator", "OAUTH_CLIENT_CREDENTIALS");
+        client.set_connection_option("user", user);
+        client.set_connection_option("oauth_client_id", "test-oauth-client-id");
+        client.set_connection_option("oauth_client_secret", "test-oauth-client-secret"); // pragma: allowlist secret
+        client.set_connection_option("oauth_token_request_url", &token_url);
+        client.set_connection_option("oauth_scope", "session:role:test_role");
+
+        let cache = KeyringTokenCache::new().expect("token cache should be available");
+        let cache_host = host_from(&mock.http_url());
+
+        Self {
+            mock,
+            client,
+            cache,
+            cache_host,
+            user: user.to_string(),
+        }
+    }
+
+    /// Build a fixture configured for the legacy pre-acquired token
+    /// flow (`AUTHENTICATOR=OAUTH` + raw `token=`).
+    fn with_legacy_oauth(user: &str, token: &str) -> Self {
+        let mock = MockServerWithTls::start();
+
+        let client = SnowflakeTestClient::with_int_tests_params(Some(&mock.http_url()));
+        client.set_connection_option("authenticator", "OAUTH");
+        client.set_connection_option("user", user);
+        client.set_connection_option("token", token);
+
+        let cache = KeyringTokenCache::new().expect("token cache should be available");
+        let cache_host = host_from(&mock.http_url());
+
+        Self {
+            mock,
+            client,
+            cache,
+            cache_host,
+            user: user.to_string(),
+        }
+    }
+
+    /// Set an arbitrary connection option, returning `&self` for chaining.
+    fn set_oauth_options(&self, options: &[(&str, &str)]) -> &Self {
+        for (k, v) in options {
+            self.client.set_connection_option(k, v);
+        }
+        self
+    }
+
+    fn seed_access_token(&self, value: &str) {
+        self.cache
+            .add_token(
+                &self.cache_host,
+                &self.user,
+                TokenType::OAuthAccessToken,
+                value,
+            )
+            .expect("seed OAuth access token");
+    }
+
+    fn seed_refresh_token(&self, value: &str) {
+        self.cache
+            .add_token(
+                &self.cache_host,
+                &self.user,
+                TokenType::OAuthRefreshToken,
+                value,
+            )
+            .expect("seed OAuth refresh token");
+    }
+
+    fn cached_access_token(&self) -> Option<String> {
+        self.cache
+            .get_token(&self.cache_host, &self.user, TokenType::OAuthAccessToken)
+            .expect("get OAuth access token")
+    }
+
+    fn cached_refresh_token(&self) -> Option<String> {
+        self.cache
+            .get_token(&self.cache_host, &self.user, TokenType::OAuthRefreshToken)
+            .expect("get OAuth refresh token")
+    }
+
+    fn connect(&self) -> Result<(), String> {
+        self.client.connect()
+    }
+
+    fn assert_success(result: Result<(), String>, context: &str) {
+        assert!(result.is_ok(), "Expected {context}, got: {result:?}");
+    }
+
+    fn assert_error(result: Result<(), String>, patterns: &[&str], context: &str) {
+        let error = result.expect_err(&format!("Expected {context} to fail"));
+        let matches = patterns.iter().any(|p| error.contains(p));
+        assert!(matches, "Expected {context}, got: {error}");
+    }
+}
+
+impl Drop for OAuthTestFixture {
+    fn drop(&mut self) {
+        // Remove every token type we could plausibly have seeded so a
+        // panicking test does not pollute the OS keyring (mirrors
+        // `user_password_mfa_token_cache.rs`).
+        for &tt in &[
+            TokenType::OAuthAccessToken,
+            TokenType::OAuthRefreshToken,
+            TokenType::DpopBundledAccessToken,
+        ] {
+            let _ = self.cache.remove_token(&self.cache_host, &self.user, tt);
+        }
+    }
+}
+
+/// Extract the bare host (no port) from a URL string. Mirrors
+/// `host_from_token_url` in `sf_core::rest::snowflake::oauth::token`,
+/// which the production code uses to derive the cache key (analysis
+/// §7.3).
+fn host_from(url: &str) -> String {
+    url::Url::parse(url)
+        .expect("valid mock URL")
+        .host_str()
+        .expect("mock URL must have a host")
+        .to_string()
+}
+
+/// Build a unique username scoped to the running test, so concurrent
+/// runs of the suite do not race on the OS keyring (mirrors the
+/// uniqueness convention in `user_password_mfa_token_cache.rs`).
+fn unique_user(prefix: &str) -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    format!("{prefix}_{nanos}")
+}
+
+fn count_token_endpoint_requests(mock: &MockServerWithTls) -> usize {
+    mock.received_requests()
+        .iter()
+        .filter(|r| r.url.path() == "/oauth/token-request" && r.method.as_str() == "POST")
+        .count()
+}
+
+fn token_endpoint_bodies(mock: &MockServerWithTls) -> Vec<String> {
+    mock.received_requests()
+        .iter()
+        .filter(|r| r.url.path() == "/oauth/token-request" && r.method.as_str() == "POST")
+        .map(|r| String::from_utf8_lossy(&r.body).to_string())
+        .collect()
+}
+
+// =============================================================================
+// Legacy `AUTHENTICATOR=OAUTH` + raw `token=`
+// =============================================================================
+
+#[test]
+fn should_login_with_legacy_oauth_using_pre_acquired_token() {
+    // Given Wiremock is running and a fixture is configured with the
+    // legacy OAUTH authenticator and a pre-acquired access token
+    let user = unique_user("oauth_legacy_ok");
+    let token = "legacy-pre-acquired-access-token";
+    let fixture = OAuthTestFixture::with_legacy_oauth(&user, token);
+    fixture
+        .mock
+        .mount(oauth::snowflake_login_success_oauth(token));
+
+    // When Trying to Connect
+    let result = fixture.connect();
+
+    // Then Login is successful
+    OAuthTestFixture::assert_success(result, "legacy OAUTH login to succeed");
+    // And the IdP token endpoint must NOT have been hit (legacy flow
+    // forwards the caller-supplied token unchanged — analysis §6).
+    assert_eq!(
+        count_token_endpoint_requests(&fixture.mock),
+        0,
+        "legacy OAUTH must not call the IdP token endpoint"
+    );
+}
+
+#[test]
+fn should_fail_legacy_oauth_when_snowflake_returns_390303() {
+    // Given Wiremock is running with a Snowflake login that returns 390303
+    let user = unique_user("oauth_legacy_390303");
+    let fixture = OAuthTestFixture::with_legacy_oauth(&user, "legacy-bad-token");
+    fixture
+        .mock
+        .mount(oauth::snowflake_login_oauth_access_token_invalid_390303());
+
+    // When Trying to Connect
+    let result = fixture.connect();
+
+    // Then Connection fails with a login error (legacy flow has no
+    // cache to evict, so the error is surfaced unchanged — analysis
+    // §6 / §8).
+    OAuthTestFixture::assert_error(
+        result,
+        &["390303", "OAuth", "login", "auth"],
+        "legacy OAUTH 390303 failure",
+    );
+}
+
+// =============================================================================
+// Authorization Code — cache short-circuit (preferred happy path)
+// =============================================================================
+
+#[test]
+fn should_login_with_authorization_code_using_cached_access_token() {
+    // Given Wiremock is running and an OAuth access token is already
+    // cached for the user (so the AC flow short-circuits before binding
+    // the loopback — analysis §3.2)
+    let user = unique_user("oauth_ac_cached_at");
+    let cached_at = "ac-cached-access-token-canary";
+    let fixture = OAuthTestFixture::with_authorization_code(&user);
+    fixture.seed_access_token(cached_at);
+    fixture
+        .mock
+        .mount(oauth::snowflake_login_success_oauth(cached_at));
+
+    // When Trying to Connect
+    let result = fixture.connect();
+
+    // Then Login is successful and no IdP token request was issued
+    OAuthTestFixture::assert_success(result, "AC cached-AT login to succeed");
+    assert_eq!(
+        count_token_endpoint_requests(&fixture.mock),
+        0,
+        "cached-AT short-circuit must NOT call the IdP token endpoint"
+    );
+}
+
+#[test]
+fn should_login_with_authorization_code_using_cached_refresh_token() {
+    // Given Wiremock is running with the IdP refresh-token endpoint
+    // mounted, only a refresh token is cached for the user, and the
+    // Snowflake login accepts the refreshed access token
+    let user = unique_user("oauth_ac_cached_rt");
+    let fixture = OAuthTestFixture::with_authorization_code(&user);
+    fixture.seed_refresh_token("ac-cached-refresh-token");
+    fixture
+        .mock
+        .mount(oauth::idp_token_endpoint_success_refresh());
+    fixture.mock.mount(oauth::snowflake_login_success_oauth(
+        "ac-access-token-refreshed",
+    ));
+
+    // When Trying to Connect
+    let result = fixture.connect();
+
+    // Then Login is successful, the IdP refresh endpoint was hit
+    // exactly once, and the rotated tokens replaced the cached values
+    // (analysis §7.4).
+    OAuthTestFixture::assert_success(result, "AC cached-RT login to succeed");
+    assert_eq!(
+        count_token_endpoint_requests(&fixture.mock),
+        1,
+        "expected exactly one IdP refresh request"
+    );
+    let stored_at = fixture.cached_access_token();
+    assert_eq!(
+        stored_at.as_deref(),
+        Some("ac-access-token-refreshed"),
+        "fresh access token must be persisted to the cache"
+    );
+    let stored_rt = fixture.cached_refresh_token();
+    assert_eq!(
+        stored_rt.as_deref(),
+        Some("ac-refresh-token-rotated"),
+        "rotated refresh token must replace the cached one"
+    );
+}
+
+// =============================================================================
+// Authorization Code — refresh-on-failure (390303 / 390318)
+// =============================================================================
+
+#[test]
+fn should_evict_cached_at_and_retry_via_refresh_token_on_390303() {
+    // Given Wiremock returns 390303 once, then accepts the retry, the
+    // IdP refresh endpoint is mounted, and both AT + RT are pre-seeded
+    let user = unique_user("oauth_ac_390303");
+    let stale_at = "ac-stale-access-token";
+    let fixture = OAuthTestFixture::with_authorization_code(&user);
+    fixture.seed_access_token(stale_at);
+    fixture.seed_refresh_token("ac-cached-refresh-token");
+    fixture
+        .mock
+        .mount(oauth::snowflake_login_oauth_then_success("390303"));
+    fixture
+        .mock
+        .mount(oauth::idp_token_endpoint_success_refresh());
+
+    // When Trying to Connect
+    let result = fixture.connect();
+
+    // Then Login eventually succeeds (after eviction + refresh +
+    // retry — analysis §8 / §14 #9), and the originally seeded AT is
+    // no longer present in the cache.
+    OAuthTestFixture::assert_success(result, "AC 390303 retry to succeed");
+    let stored_at = fixture.cached_access_token();
+    assert_ne!(
+        stored_at.as_deref(),
+        Some(stale_at),
+        "stale access token must be evicted after 390303"
+    );
+    assert_eq!(
+        stored_at.as_deref(),
+        Some("ac-access-token-refreshed"),
+        "fresh access token must be persisted after the retry"
+    );
+}
+
+#[test]
+fn should_evict_cached_at_and_retry_via_refresh_token_on_390318() {
+    // Given Wiremock returns 390318 once, then accepts the retry, the
+    // IdP refresh endpoint is mounted, and both AT + RT are pre-seeded
+    let user = unique_user("oauth_ac_390318");
+    let stale_at = "ac-expired-access-token";
+    let fixture = OAuthTestFixture::with_authorization_code(&user);
+    fixture.seed_access_token(stale_at);
+    fixture.seed_refresh_token("ac-cached-refresh-token");
+    fixture
+        .mock
+        .mount(oauth::snowflake_login_oauth_then_success("390318"));
+    fixture
+        .mock
+        .mount(oauth::idp_token_endpoint_success_refresh());
+
+    // When Trying to Connect
+    let result = fixture.connect();
+
+    // Then Login eventually succeeds and the seeded AT was evicted
+    OAuthTestFixture::assert_success(result, "AC 390318 retry to succeed");
+    let stored_at = fixture.cached_access_token();
+    assert_ne!(
+        stored_at.as_deref(),
+        Some(stale_at),
+        "expired access token must be evicted after 390318"
+    );
+    assert_eq!(
+        stored_at.as_deref(),
+        Some("ac-access-token-refreshed"),
+        "fresh access token must be persisted after the retry"
+    );
+}
+
+// =============================================================================
+// Authorization Code — single-use refresh tokens (analysis §7.4)
+// =============================================================================
+
+#[test]
+fn should_omit_single_use_refresh_flag_from_refresh_grant_body() {
+    // Given the AC fixture has `oauth_enable_single_use_refresh_tokens=true`
+    // configured, only a refresh token is cached, and the IdP refresh +
+    // Snowflake login mocks are mounted
+    let user = unique_user("oauth_ac_single_use_rt");
+    let fixture = OAuthTestFixture::with_authorization_code(&user);
+    fixture.set_oauth_options(&[("oauth_enable_single_use_refresh_tokens", "true")]);
+    fixture.seed_refresh_token("ac-cached-refresh-token");
+    fixture
+        .mock
+        .mount(oauth::idp_token_endpoint_success_refresh());
+    fixture.mock.mount(oauth::snowflake_login_success_oauth(
+        "ac-access-token-refreshed",
+    ));
+
+    // When Trying to Connect
+    let result = fixture.connect();
+
+    // Then Login succeeds and the refresh-grant body did NOT carry the
+    // single-use flag (the flag is only meaningful on the AC token
+    // exchange — `authorization_code.rs` adds it to that grant only,
+    // analysis §7.4).
+    OAuthTestFixture::assert_success(result, "single-use refresh grant to succeed");
+    let bodies = token_endpoint_bodies(&fixture.mock);
+    assert_eq!(bodies.len(), 1, "expected exactly one IdP token request");
+    assert!(
+        bodies[0].contains("grant_type=refresh_token"),
+        "refresh grant must carry grant_type=refresh_token, got: {body}",
+        body = bodies[0]
+    );
+    assert!(
+        !bodies[0].contains("enable_single_use_refresh_tokens"),
+        "refresh grant must NOT include the single-use flag, got: {body}",
+        body = bodies[0]
+    );
+}
+
+// =============================================================================
+// Authorization Code — IdP error responses
+// =============================================================================
+
+#[test]
+fn should_evict_refresh_token_when_idp_returns_invalid_grant() {
+    // Given a refresh token is cached, the IdP refuses with
+    // `invalid_grant`, and the AC `authentication_timeout` is short
+    // enough to surface BrowserTimeout fast when the flow falls
+    // through to the interactive leg.
+    let user = unique_user("oauth_ac_invalid_grant");
+    let fixture = OAuthTestFixture::with_authorization_code(&user);
+    fixture.set_oauth_options(&[("authentication_timeout", "1")]);
+    fixture.seed_refresh_token("ac-cached-refresh-token");
+    fixture
+        .mock
+        .mount(oauth::idp_token_endpoint_refresh_failed());
+
+    // When Trying to Connect
+    let result = fixture.connect();
+
+    // Then Connection fails (interactive leg times out without a
+    // browser) and the refresh token is evicted from the cache. Per
+    // `authorization_code.rs`, an IdP refresh-exchange failure evicts
+    // the cached refresh token before falling through to the
+    // interactive leg (analysis §7.4 / §13).
+    OAuthTestFixture::assert_error(
+        result,
+        &[
+            "BrowserTimeout",
+            "OAuthFlow",
+            "OAuth",
+            "timed out",
+            "timeout",
+        ],
+        "AC interactive leg to time out after refresh failure",
+    );
+    let stored_rt = fixture.cached_refresh_token();
+    assert!(
+        stored_rt.is_none(),
+        "refresh token must be evicted after invalid_grant; cache still holds {stored_rt:?}"
+    );
+}
+
+// =============================================================================
+// Client Credentials — happy path + error paths
+// =============================================================================
+
+#[test]
+fn should_login_with_client_credentials_using_external_idp() {
+    // Given the CC fixture is wired with mock IdP token endpoint and
+    // Snowflake login mocks
+    let user = unique_user("oauth_cc_ok");
+    let fixture = OAuthTestFixture::with_client_credentials(&user);
+    fixture
+        .mock
+        .mount(oauth::idp_token_endpoint_success_client_credentials());
+    fixture.mock.mount(oauth::snowflake_login_success_oauth(
+        "cc-access-token-success",
+    ));
+
+    // When Trying to Connect
+    let result = fixture.connect();
+
+    // Then Login is successful and CC tokens are NOT cached
+    // (analysis §14 #12).
+    OAuthTestFixture::assert_success(result, "CC happy path to succeed");
+    assert!(
+        fixture.cached_access_token().is_none(),
+        "CC must not cache access tokens (analysis §14 #12)"
+    );
+    assert!(
+        fixture.cached_refresh_token().is_none(),
+        "CC must not cache refresh tokens (analysis §14 #12)"
+    );
+}
+
+#[test]
+fn should_fail_client_credentials_when_idp_returns_500() {
+    // Given the CC fixture is wired with an IdP that returns 500
+    let user = unique_user("oauth_cc_500");
+    let fixture = OAuthTestFixture::with_client_credentials(&user);
+    fixture
+        .mock
+        .mount(oauth::idp_token_endpoint_token_request_error());
+
+    // When Trying to Connect
+    let result = fixture.connect();
+
+    // Then Connection fails with a transport / token-exchange error and
+    // the cache is untouched (CC never writes to it — analysis §14 #12)
+    OAuthTestFixture::assert_error(
+        result,
+        &["TokenExchange", "OAuth", "500", "OAuthFlow"],
+        "CC IdP 500 error",
+    );
+    assert!(
+        fixture.cached_access_token().is_none(),
+        "CC IdP failure must not have written anything to the cache"
+    );
+}
+
+#[test]
+fn should_fail_client_credentials_when_idp_returns_invalid_scope() {
+    // Given the CC fixture is wired with an IdP that returns
+    // `invalid_scope`
+    let user = unique_user("oauth_cc_invalid_scope");
+    let fixture = OAuthTestFixture::with_client_credentials(&user);
+    fixture
+        .mock
+        .mount(oauth::idp_token_endpoint_invalid_scope());
+
+    // When Trying to Connect
+    let result = fixture.connect();
+
+    // Then Connection fails with a redacted IdP-error message that
+    // names the OAuth error code but never echoes the client secret
+    // (analysis §11 / §13). The error class is `OAuthFlow → IdpError`.
+    let err = result.expect_err("CC invalid_scope must fail");
+    let pattern_hit = [
+        "IdpError",
+        "invalid_scope",
+        "Identity Provider",
+        "OAuthFlow",
+    ]
+    .iter()
+    .any(|p| err.contains(p));
+    assert!(pattern_hit, "expected IdP error message, got: {err}");
+    assert!(
+        !err.contains("test-oauth-client-secret"),
+        "client secret must never appear in an OAuth error: {err}"
+    );
+}
+
+#[test]
+fn should_fail_client_credentials_when_idp_response_is_missing_access_token() {
+    // Given the CC fixture is wired with an IdP that returns 200 but no
+    // `access_token`
+    let user = unique_user("oauth_cc_missing_at");
+    let fixture = OAuthTestFixture::with_client_credentials(&user);
+    fixture
+        .mock
+        .mount(oauth::idp_token_endpoint_missing_access_token());
+
+    // When Trying to Connect
+    let result = fixture.connect();
+
+    // Then Connection fails with `MissingAccessToken` (analysis §13 —
+    // empty access tokens are treated as missing to avoid forwarding
+    // a useless Bearer token to GS).
+    OAuthTestFixture::assert_error(
+        result,
+        &["MissingAccessToken", "access_token", "OAuthFlow", "OAuth"],
+        "CC missing access_token error",
+    );
+}
+
+// =============================================================================
+// Authorization Code — interactive leg (documented + ignored)
+// =============================================================================
+
+/// Documents the interactive AC leg shape: the loopback listener binds
+/// and the test would otherwise hang indefinitely waiting on a real
+/// browser. Marked `#[ignore]` so it does not run in CI by default —
+/// the unit-level coverage in `authorization_code.rs` already drives
+/// the loopback synthetically (`loopback_redirect_with`,
+/// `dpop_nonce_retry_happens_exactly_once_with_nonce_claim`,
+/// `enable_single_use_refresh_tokens_appears_in_body_only_when_enabled`),
+/// so this is left as a manual reproducer.
+#[test]
+#[ignore = "drives the AC interactive leg; requires manual browser interaction"]
+fn should_drive_ac_interactive_leg_when_no_tokens_cached() {
+    let user = unique_user("oauth_ac_interactive");
+    let fixture = OAuthTestFixture::with_authorization_code(&user);
+    fixture
+        .mock
+        .mount(oauth::idp_token_endpoint_success_authorization_code());
+    fixture.mock.mount(oauth::snowflake_login_success_oauth(
+        "ac-access-token-success",
+    ));
+
+    // No tokens seeded — the flow will bind the loopback and wait for
+    // a browser redirect, which a human needs to drive manually.
+    let _ = fixture.connect();
+}


### PR DESCRIPTION
Co-authored-by: Cursor <cursoragent@cursor.com>