### PR TITLE
NO-SNOW: Skip message in ODBC when file not put

### DIFF
--- a/odbc_tests/common/include/put_get_utils.hpp
+++ b/odbc_tests/common/include/put_get_utils.hpp
@@ -34,6 +34,12 @@ static constexpr int PUT_ROW_ENCRYPTION_IDX = 8;
 static constexpr int PUT_ROW_MESSAGE_IDX = 9;
 static constexpr int PUT_ROW_NUM_COLS = 9;
 
+// Literal emitted in the PUT result's `message` column when the upload
+// outcome is SKIPPED (overwrite=false + file exists). Mirrors
+// `ODBC_PUT_MESSAGE_SKIPPED` in `sf_core::apis::database_driver_v1` and the
+// legacy libsnowflakeclient `MESSAGE_SKIPPED` macro.
+inline constexpr auto PUT_ROW_MESSAGE_SKIPPED = "File with same name already exists. SKIPPED";
+
 // Indices for GET output rowset
 static constexpr int GET_ROW_FILE_IDX = 1;
 static constexpr int GET_ROW_SIZE_IDX = 2;

--- a/odbc_tests/tests/e2e/put_get/put_get_basic_operations.cpp
+++ b/odbc_tests/tests/e2e/put_get/put_get_basic_operations.cpp
@@ -2,7 +2,6 @@
 #include <filesystem>
 #include <fstream>
 #include <string>
-#include <vector>
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -116,6 +115,7 @@ TEST_CASE("should return correct rowset for PUT", "[put_get]") {
   CHECK(get_data<SQL_C_CHAR>(stmt, PUT_ROW_STATUS_IDX) == "UPLOADED");
 
   CHECK(get_data<SQL_C_CHAR>(stmt, PUT_ROW_ENCRYPTION_IDX) == "ENCRYPTED");
+  CHECK(get_data<SQL_C_CHAR>(stmt, PUT_ROW_MESSAGE_IDX).empty());
 }
 
 TEST_CASE("should return correct rowset for GET", "[put_get]") {

--- a/odbc_tests/tests/e2e/put_get/put_get_overwrite.cpp
+++ b/odbc_tests/tests/e2e/put_get/put_get_overwrite.cpp
@@ -3,8 +3,6 @@
 #include <fstream>
 #include <random>
 #include <string>
-#include <tuple>
-#include <vector>
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -73,10 +71,12 @@ TEST_CASE("should not overwrite file when OVERWRITE is set to false", "[put_get]
   auto stmt_update = conn.execute_fetch("PUT 'file://" + as_file_uri(updated) + "' @" + stage + " OVERWRITE=FALSE");
   std::string src_update = get_data<SQL_C_CHAR>(stmt_update, PUT_ROW_SOURCE_IDX);
   std::string status_update = get_data<SQL_C_CHAR>(stmt_update, PUT_ROW_STATUS_IDX);
+  std::string message_update = get_data<SQL_C_CHAR>(stmt_update, PUT_ROW_MESSAGE_IDX);
 
   // Then SKIPPED status is returned
   CHECK(src_update == expected_put_source(updated));
   CHECK(status_update == "SKIPPED");
+  CHECK(message_update == PUT_ROW_MESSAGE_SKIPPED);
 
   // And File was not overwritten
   auto stmt_check = conn.execute_fetch("SELECT $1, $2, $3 FROM @" + stage);

--- a/sf_core/src/apis/database_driver_v1/mod.rs
+++ b/sf_core/src/apis/database_driver_v1/mod.rs
@@ -26,7 +26,7 @@ pub use async_query_registry::AsyncQueryRegistry;
 pub use connection::{Connection, ConnectionInfo, RefreshContext, with_valid_session};
 pub use database::FetchChunkInput;
 pub use error::ApiError;
-pub use global_state::{DatabaseDriverV1, DriverProviders, WrapperPresets};
+pub use global_state::{DatabaseDriverV1, DriverProviders, PutGetResultsetFlavor, WrapperPresets};
 pub use result_set::{
     ChunkData, ChunkDataWithDescriptor, ColumnMetadata, ExecuteQueryResult, InlineData,
     ResultSetDescriptor, ResultSetInfo,

--- a/sf_core/src/apis/database_driver_v1/query.rs
+++ b/sf_core/src/apis/database_driver_v1/query.rs
@@ -39,11 +39,12 @@ const ODBC_GET_ENCRYPTION_LITERAL: &str = "DECRYPTED";
 pub(super) async fn perform_put_get_transfer(
     command: &str,
     data: &query_response::Data,
+    wrapper_presets: &WrapperPresets,
 ) -> Result<RowsetData, QueryResponseProcessingError> {
     match command {
         "UPLOAD" => {
             let file_upload_data = data
-                .to_file_upload_data()
+                .to_file_upload_data(wrapper_presets.put_get_resultset_flavor.clone())
                 .context(FileTransferPreparationSnafu)?;
             let upload_results = upload_files(&file_upload_data)
                 .await

--- a/sf_core/src/apis/database_driver_v1/statement.rs
+++ b/sf_core/src/apis/database_driver_v1/statement.rs
@@ -330,7 +330,7 @@ impl DatabaseDriverV1 {
         }
 
         let rowset_data = match data.command.as_deref() {
-            Some(command) => perform_put_get_transfer(command, &data)
+            Some(command) => perform_put_get_transfer(command, &data, &self.wrapper_presets)
                 .await
                 .context(QueryResponseProcessingSnafu)?,
             None => data.into_rowset_data(),
@@ -425,7 +425,7 @@ impl DatabaseDriverV1 {
         }
 
         let rowset_data = match data.command.as_deref() {
-            Some(command) => perform_put_get_transfer(command, &data)
+            Some(command) => perform_put_get_transfer(command, &data, &self.wrapper_presets)
                 .await
                 .context(QueryResponseProcessingSnafu)?,
             None => data.into_rowset_data(),

--- a/sf_core/src/file_manager/mod.rs
+++ b/sf_core/src/file_manager/mod.rs
@@ -10,6 +10,7 @@ pub use self::types::*;
 pub use azure_transfer::download_from_azure;
 pub use gcs_transfer::download_from_gcs;
 
+use crate::apis::database_driver_v1::PutGetResultsetFlavor;
 use crate::compression::{CompressionError, compress_data};
 use crate::compression_types::{CompressionType, CompressionTypeError, try_guess_compression_type};
 use azure_transfer::{AzureDownloadError, AzureUploadError, upload_to_azure_or_skip};
@@ -22,6 +23,14 @@ use snafu::{Location, OptionExt, ResultExt, Snafu};
 use std::fs::File;
 use std::io::{Read, Write};
 use std::path::Path;
+
+/// Message string emitted in the PUT result's `message` column when the
+/// upload outcome is `Skipped` under `PutGetResultsetFlavor::Odbc`. Mirrors
+/// `#define MESSAGE_SKIPPED "File with same name already exists. SKIPPED"`
+/// from legacy libsnowflakeclient's `FileTransferExecutionResult.cpp`. The
+/// `Python` flavor leaves the `message` column empty for skipped uploads,
+/// matching the historical universal-driver behaviour.
+const ODBC_PUT_MESSAGE_SKIPPED: &str = "File with same name already exists. SKIPPED";
 
 pub async fn upload_files(data: &UploadData) -> Result<Vec<UploadResult>, FileManagerError> {
     let file_locations =
@@ -47,6 +56,7 @@ pub async fn upload_files(data: &UploadData) -> Result<Vec<UploadResult>, FileMa
             auto_compress: data.auto_compress,
             source_compression: data.source_compression.clone(),
             overwrite: data.overwrite,
+            flavor: data.flavor.clone(),
         };
 
         let result = upload_single_file(single_upload_data).await?;
@@ -91,9 +101,10 @@ pub async fn upload_single_file(data: SingleUploadData) -> Result<UploadResult, 
         .context(AzureUploadSnafu)?,
     };
 
-    // TODO: Right now empty message is hardcoded, because any error in the upload process will
-    // result in an error before this point and an ERROR status is never returned.
-    // We should adjust this after we have more tests in different wrappers to ensure error handling is consistent.
+    // TODO: Right now the message column is only populated for the `Skipped` outcome under
+    // the ODBC wrapper preset. Any failure in the upload process today returns an error before
+    // this point, so an `ERROR` status is never produced. Revisit when error handling is
+    // unified across wrappers.
     Ok(UploadResult {
         source: file_metadata.source,
         target: file_metadata.target,
@@ -107,9 +118,21 @@ pub async fn upload_single_file(data: SingleUploadData) -> Result<UploadResult, 
             .target_compression
             .get_snowflake_representation()
             .to_string(),
+        message: upload_result_message(status, &data.flavor).to_string(),
         status: status.to_string(),
-        message: "".to_string(),
     })
+}
+
+/// Returns the `message` column value for a completed upload, gated on the
+/// active wrapper flavor. Legacy ODBC always populates the message with
+/// `ODBC_PUT_MESSAGE_SKIPPED` for skipped uploads (overwrite=false +
+/// target already exists); every other (flavor, status) combination uses
+/// an empty string.
+fn upload_result_message(status: UploadStatus, flavor: &PutGetResultsetFlavor) -> &'static str {
+    match (status, flavor) {
+        (UploadStatus::Skipped, PutGetResultsetFlavor::Odbc) => ODBC_PUT_MESSAGE_SKIPPED,
+        _ => "",
+    }
 }
 
 /// Sets file metadata, compresses the file if needed, and optionally encrypts the data.
@@ -353,4 +376,52 @@ pub enum FileManagerError {
         #[snafu(implicit)]
         location: Location,
     },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn upload_result_message_odbc_skipped_uses_legacy_literal() {
+        assert_eq!(
+            upload_result_message(UploadStatus::Skipped, &PutGetResultsetFlavor::Odbc),
+            ODBC_PUT_MESSAGE_SKIPPED,
+        );
+    }
+
+    #[test]
+    fn upload_result_message_python_skipped_is_empty() {
+        assert_eq!(
+            upload_result_message(UploadStatus::Skipped, &PutGetResultsetFlavor::Python),
+            "",
+        );
+    }
+
+    #[test]
+    fn upload_result_message_odbc_uploaded_is_empty() {
+        assert_eq!(
+            upload_result_message(UploadStatus::Uploaded, &PutGetResultsetFlavor::Odbc),
+            "",
+        );
+    }
+
+    #[test]
+    fn upload_result_message_python_uploaded_is_empty() {
+        assert_eq!(
+            upload_result_message(UploadStatus::Uploaded, &PutGetResultsetFlavor::Python),
+            "",
+        );
+    }
+
+    #[test]
+    fn odbc_put_message_skipped_matches_legacy_libsnowflakeclient() {
+        // The exact string is part of the wrapper contract — every ODBC
+        // application that parses the `message` column will key off this
+        // value verbatim. Pinning it in a test prevents silent rewording.
+        assert_eq!(
+            ODBC_PUT_MESSAGE_SKIPPED,
+            "File with same name already exists. SKIPPED",
+        );
+    }
 }

--- a/sf_core/src/file_manager/types.rs
+++ b/sf_core/src/file_manager/types.rs
@@ -1,3 +1,4 @@
+use crate::apis::database_driver_v1::PutGetResultsetFlavor;
 use crate::compression_types::CompressionType;
 use crate::sensitive::SensitiveString;
 use serde::{Deserialize, Serialize};
@@ -28,6 +29,10 @@ pub struct UploadData {
     pub auto_compress: bool,
     pub source_compression: SourceCompressionParam,
     pub overwrite: bool,
+    /// Wrapper-specific shape of the PUT result set. Forwarded into each
+    /// `SingleUploadData` so that `upload_single_file` can populate the
+    /// `message` column according to the active wrapper's contract.
+    pub flavor: PutGetResultsetFlavor,
 }
 
 pub struct SingleUploadData {
@@ -38,6 +43,7 @@ pub struct SingleUploadData {
     pub auto_compress: bool,
     pub source_compression: SourceCompressionParam,
     pub overwrite: bool,
+    pub flavor: PutGetResultsetFlavor,
 }
 
 #[derive(Debug)]

--- a/sf_core/src/rest/snowflake/query_response.rs
+++ b/sf_core/src/rest/snowflake/query_response.rs
@@ -1,3 +1,4 @@
+use crate::apis::database_driver_v1::PutGetResultsetFlavor;
 use crate::chunks::ChunkDownloadData;
 use crate::file_manager::SourceCompressionParam;
 use crate::{file_manager, query_types};
@@ -300,7 +301,15 @@ pub struct EncryptionMaterial {
 impl Data {
     /// Copies the fields necessary for file transfer.
     /// Encryption material is optional — SSE stages omit it from the response.
-    pub fn to_file_upload_data(&self) -> Result<file_manager::UploadData, QueryResponseError> {
+    ///
+    /// `flavor` selects the wrapper-specific shape of the resulting PUT
+    /// result set; it is forwarded into `SingleUploadData` so that
+    /// `file_manager::upload_single_file` can populate the `message` column
+    /// per `BehaviorDifferences.yaml` BD#3.
+    pub fn to_file_upload_data(
+        &self,
+        flavor: PutGetResultsetFlavor,
+    ) -> Result<file_manager::UploadData, QueryResponseError> {
         let src_locations = self.src_locations.as_ref().context(MissingParameterSnafu {
             parameter: "source locations",
         })?;
@@ -380,6 +389,7 @@ impl Data {
             auto_compress,
             source_compression,
             overwrite,
+            flavor,
         })
     }
 
@@ -1189,7 +1199,9 @@ mod tests {
     fn upload_encryption_material_null_returns_none() {
         let json = make_upload_json(r#""encryptionMaterial": null,"#);
         let data: Data = serde_json::from_str(&json).unwrap();
-        let upload = data.to_file_upload_data().unwrap();
+        let upload = data
+            .to_file_upload_data(PutGetResultsetFlavor::default())
+            .unwrap();
         assert!(upload.encryption_material.is_none());
     }
 
@@ -1197,7 +1209,9 @@ mod tests {
     fn upload_encryption_material_absent_returns_none() {
         let json = make_upload_json("");
         let data: Data = serde_json::from_str(&json).unwrap();
-        let upload = data.to_file_upload_data().unwrap();
+        let upload = data
+            .to_file_upload_data(PutGetResultsetFlavor::default())
+            .unwrap();
         assert!(upload.encryption_material.is_none());
     }
 
@@ -1205,7 +1219,9 @@ mod tests {
     fn upload_encryption_material_empty_array_returns_none() {
         let json = make_upload_json(r#""encryptionMaterial": [],"#);
         let data: Data = serde_json::from_str(&json).unwrap();
-        let upload = data.to_file_upload_data().unwrap();
+        let upload = data
+            .to_file_upload_data(PutGetResultsetFlavor::default())
+            .unwrap();
         assert!(upload.encryption_material.is_none());
     }
 
@@ -1215,7 +1231,9 @@ mod tests {
             r#""encryptionMaterial": {"queryStageMasterKey": "a2V5","queryId": "qid-1","smkId": "42"},"#,
         );
         let data: Data = serde_json::from_str(&json).unwrap();
-        let upload = data.to_file_upload_data().unwrap();
+        let upload = data
+            .to_file_upload_data(PutGetResultsetFlavor::default())
+            .unwrap();
         assert!(upload.encryption_material.is_some());
     }
 
@@ -1225,7 +1243,9 @@ mod tests {
             r#""encryptionMaterial": [{"queryStageMasterKey": "a2V5","queryId": "qid-1","smkId": "42"}],"#,
         );
         let data: Data = serde_json::from_str(&json).unwrap();
-        let upload = data.to_file_upload_data().unwrap();
+        let upload = data
+            .to_file_upload_data(PutGetResultsetFlavor::default())
+            .unwrap();
         assert!(upload.encryption_material.is_some());
     }
 
@@ -1238,13 +1258,33 @@ mod tests {
             ],"#,
         );
         let data: Data = serde_json::from_str(&json).unwrap();
-        let result = data.to_file_upload_data();
+        let result = data.to_file_upload_data(PutGetResultsetFlavor::default());
         assert!(result.is_err());
         let err_msg = result.unwrap_err().to_string();
         assert!(
             err_msg.contains("Expected exactly one encryption material"),
             "Error should mention the constraint: {err_msg}"
         );
+    }
+
+    #[test]
+    fn upload_data_forwards_flavor_python() {
+        let json = make_upload_json("");
+        let data: Data = serde_json::from_str(&json).unwrap();
+        let upload = data
+            .to_file_upload_data(PutGetResultsetFlavor::Python)
+            .unwrap();
+        assert_eq!(upload.flavor, PutGetResultsetFlavor::Python);
+    }
+
+    #[test]
+    fn upload_data_forwards_flavor_odbc() {
+        let json = make_upload_json("");
+        let data: Data = serde_json::from_str(&json).unwrap();
+        let upload = data
+            .to_file_upload_data(PutGetResultsetFlavor::Odbc)
+            .unwrap();
+        assert_eq!(upload.flavor, PutGetResultsetFlavor::Odbc);
     }
 
     #[test]


### PR DESCRIPTION
### TL;DR

Populate the `message` column in PUT result sets with the legacy ODBC skipped-file literal when `overwrite=false` and the target file already exists.

### What changed?

A new `PutGetResultsetFlavor` type is now threaded through the file upload pipeline — from `WrapperPresets` through `to_file_upload_data`, into `UploadData` and `SingleUploadData`, and finally consumed in `upload_single_file`. A new helper `upload_result_message` uses the flavor to decide what to write into the `message` column of the upload result:

- **ODBC flavor + Skipped status** → `"File with same name already exists. SKIPPED"` (matching the legacy `libsnowflakeclient` `MESSAGE_SKIPPED` macro)
- **All other (flavor, status) combinations** → empty string

The constant `ODBC_PUT_MESSAGE_SKIPPED` is defined in both the Rust core and the ODBC test headers so both sides of the contract are pinned to the same literal.

E2E tests now assert that a successful upload produces an empty `message` column, and that a skipped upload (OVERWRITE=FALSE on an existing file) produces the expected ODBC message string.

### How to test?

- Run the existing unit tests in `sf_core::file_manager` — the new `upload_result_message` tests cover all (flavor, status) combinations and pin the exact string value.
- Run the ODBC E2E tests under `put_get`:
  - `should return correct rowset for PUT` — verifies the `message` column is empty on a successful upload.
  - `should not overwrite file when OVERWRITE is set to false` — verifies the `message` column equals `PUT_ROW_MESSAGE_SKIPPED` when a file is skipped.

### Why make this change?

Legacy ODBC applications that parse the PUT result set's `message` column rely on the exact string `"File with same name already exists. SKIPPED"` to detect skipped uploads. The universal driver was previously returning an empty string for all outcomes, breaking that contract. This change restores the expected ODBC behavior while keeping the Python flavor's message column empty, matching its historical behavior.