### PR TITLE
fix(odbc_tests): align replay numCols with recorded trace (SHOW TABLES = 23)

### DIFF
--- a/odbc_tests/tests/replay/datometry/exec_direct_getdata_14col_26rows/test.cpp
+++ b/odbc_tests/tests/replay/datometry/exec_direct_getdata_14col_26rows/test.cpp
@@ -79,8 +79,8 @@ TEST_CASE("Replay: exec_direct_getdata_14col_26rows", "[dtm]") {
     SQLSMALLINT numCols = 0;
     SQLRETURN ret = SQLNumResultCols(stmt0, &numCols);
     CHECK_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt0), OdbcMatchers::IsSuccess());
-    // Adapted: current Snowflake returns 22 cols (trace had 23)
-    CHECK(numCols == 22);
+    // Matches the recorded trace: SHOW TABLES returns 23 columns.
+    CHECK(numCols == 23);
   }
 
   // SQLDescribeCol col 1

--- a/odbc_tests/tests/replay/datometry/exec_direct_getdata_23col_1rows/test.cpp
+++ b/odbc_tests/tests/replay/datometry/exec_direct_getdata_23col_1rows/test.cpp
@@ -79,8 +79,8 @@ TEST_CASE("Replay: exec_direct_getdata_23col_1rows", "[dtm]") {
     SQLSMALLINT numCols = 0;
     SQLRETURN ret = SQLNumResultCols(stmt0, &numCols);
     CHECK_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt0), OdbcMatchers::IsSuccess());
-    // Adapted: current Snowflake returns 22 cols (trace had 23)
-    CHECK(numCols == 22);
+    // Matches the recorded trace: SHOW TABLES returns 23 columns.
+    CHECK(numCols == 23);
   }
 
   // SQLDescribeCol col 1


### PR DESCRIPTION
## Summary

Two Datometry replay tests are currently failing on `main` and on every PR that runs `odbc_reference_tests`:

- `replay_dtm_exec_direct_getdata_14col_26rows`
- `replay_dtm_exec_direct_getdata_23col_1rows`

Both fail at the same assertion:

```
../tests/replay/datometry/exec_direct_getdata_14col_26rows/test.cpp:83: FAILED:
  CHECK( numCols == 22 )
../tests/replay/datometry/exec_direct_getdata_23col_1rows/test.cpp:83: FAILED:
  CHECK( numCols == 22 )
```

## Root cause

These tests are auto-generated replays of recorded ODBC traces against `SHOW TABLES`. The recorded traces had **23 columns**. When the tests were initially merged, the Snowflake server was transiently returning **22 columns** for `SHOW TABLES`, and the assertions were hand-adapted to `numCols == 22` — see the comment that was previously in both files:

```cpp
// Adapted: current Snowflake returns 22 cols (trace had 23)
CHECK(numCols == 22);
```

The server has now flipped back to **23 columns** (matching the original recorded trace), so the hand-adapted assertion is wrong in the opposite direction.

## What this PR changes

Restores the assertions to `numCols == 23`, which matches:

1. The recorded trace these tests were generated from.
2. The current server behavior — confirmed by the symmetric failure on every recent CI run that hit the live account.

The tests already only verify per-column metadata for columns 1–21, so the extra column is benign — no other assertions need to change.

## Why this is safe

- 4 lines changed across 2 files; pure assertion updates inside `tests/replay/datometry/`.
- No production code touched.
- This is the value the test authors originally captured from a real ODBC trace; we're returning to ground truth, not picking a new arbitrary number.

## Impact

Unblocks `main` and every PR that runs `odbc_reference_tests` (currently red on `main` and on multiple in-flight PRs from different teams since ~2026-05-10 19:52 UTC).

If the server ever flips back to 22 columns again, this assertion will need to be revisited — at that point the right fix is probably to either re-record the trace or relax the assertion permanently rather than ping-pong the constant.

## Test plan

- [ ] Wait for `odbc_reference_tests (Linux x64)` and `odbc_reference_tests (Windows x64)` to go green on this PR.
- [ ] Confirm no other replay tests regress.


Made with [Cursor](https://cursor.com)