### PR TITLE
NO-SNOW: consolidate PAT cleanup into single post-test job

### DIFF
--- a/.github/workflows/test-jdbc.yml
+++ b/.github/workflows/test-jdbc.yml
@@ -144,6 +144,26 @@ jobs:
             ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-jdbc-${{ hashFiles('jdbc/**/*.gradle*', 'jdbc/**/gradle-wrapper.properties') }}
 
+  cleanup_jdbc:
+    needs: [detect-changes, jdbc_tests]
+    if: always() && needs.jdbc_tests.result != 'skipped'
+    runs-on: ubuntu-latest
+    name: cleanup_jdbc
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Decode secrets
+        run: ./scripts/decode_secrets.sh
+        env:
+          PARAMETERS_SECRET: ${{ secrets.PARAMETERS_SECRET }}
+
+      - name: Cleanup test PATs
+        continue-on-error: true
+        run: |
+          python -m pip install snowflake-connector-python -q
+          python scripts/cleanup_env.py \
+            --parameter-path "${{ github.workspace }}/parameters.json"
+
   jdbc_tests_reference:
     needs: detect-changes
     if: github.event_name == 'push' || needs.detect-changes.outputs.run_jdbc_reference == 'true'
@@ -225,7 +245,7 @@ jobs:
           key: ${{ runner.os }}-gradle-jdbc-reference-${{ hashFiles('jdbc/**/*.gradle*', 'jdbc/**/gradle-wrapper.properties') }}
 
   jdbc-status:
-    needs: [detect-changes, jdbc_tests, jdbc_tests_reference]
+    needs: [detect-changes, jdbc_tests, cleanup_jdbc, jdbc_tests_reference]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -756,15 +756,6 @@ jobs:
           DRIVER_TYPE: NEW
           QUERY_RESULT_FORMAT: ${{ matrix.result_format == 'json' && 'JSON' || '' }}
 
-      - name: Cleanup test PATs
-        if: always()
-        continue-on-error: true
-        shell: bash
-        run: |
-          python -m pip install snowflake-connector-python -q
-          python scripts/cleanup_env.py \
-            --parameter-path "${{ github.workspace }}/parameters.json"
-
       - name: Cleanup orphaned test schemas
         if: always() && runner.os == 'Linux'
         run: |
@@ -833,6 +824,31 @@ jobs:
         with:
           path: ~/Library/Caches/Homebrew
           key: macos-brew-odbc-tests-v1
+
+  cleanup_odbc:
+    needs: [detect-changes, odbc_tests]
+    if: always() && needs.odbc_tests.result != 'skipped'
+    strategy:
+      fail-fast: false
+      matrix:
+        cloud_provider: [aws, gcp, azure]
+    runs-on: ubuntu-latest
+    name: cleanup_odbc (${{ matrix.cloud_provider }})
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Decode secrets
+        run: ./scripts/decode_secrets.sh ${{ matrix.cloud_provider }}
+        env:
+          PARAMETERS_SECRET: ${{ secrets.PARAMETERS_SECRET }}
+        shell: bash
+
+      - name: Cleanup test PATs
+        continue-on-error: true
+        run: |
+          python -m pip install snowflake-connector-python -q
+          python scripts/cleanup_env.py \
+            --parameter-path "${{ github.workspace }}/parameters.json"
 
   build_msi:
     needs: detect-changes
@@ -1159,7 +1175,7 @@ jobs:
           path: build/snowflake_odbc_ud-*.dmg
 
   odbc-status:
-    needs: [detect-changes, odbc_unit_tests, odbc_tests_reference, build_odbc_driver, odbc_tests, build_msi, build_dmg]
+    needs: [detect-changes, odbc_unit_tests, odbc_tests_reference, build_odbc_driver, odbc_tests, cleanup_odbc, build_msi, build_dmg]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -381,15 +381,6 @@ jobs:
           PARAMETER_PATH: ${{ github.workspace }}\parameters.json
           REFERENCE_DRIVER_VERSION: ${{ env.PYTHON_REFERENCE_DRIVER_VERSION }}
 
-      - name: Cleanup test PATs
-        if: always()
-        continue-on-error: true
-        shell: bash
-        run: |
-          python -m pip install snowflake-connector-python -q
-          python scripts/cleanup_env.py \
-            --parameter-path "${{ github.workspace }}/parameters.json"
-
       - name: Upload test results as GitHub artifact
         uses: actions/upload-artifact@v4
         with:
@@ -444,6 +435,31 @@ jobs:
           shared-key: sdist-test
           registry-cache-hit: ${{ steps.rust-cache.outputs.registry-cache-hit }}
           target-cache-hit: ${{ steps.rust-cache.outputs.target-cache-hit }}
+
+  cleanup_python:
+    needs: [detect-changes, python_tests]
+    if: always() && needs.python_tests.result != 'skipped'
+    strategy:
+      fail-fast: false
+      matrix:
+        cloud_provider: [aws, gcp, azure]
+    runs-on: ubuntu-latest
+    name: cleanup_python (${{ matrix.cloud_provider }})
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Decode secrets
+        run: ./scripts/decode_secrets.sh ${{ matrix.cloud_provider }}
+        env:
+          PARAMETERS_SECRET: ${{ secrets.PARAMETERS_SECRET }}
+        shell: bash
+
+      - name: Cleanup test PATs
+        continue-on-error: true
+        run: |
+          python -m pip install snowflake-connector-python -q
+          python scripts/cleanup_env.py \
+            --parameter-path "${{ github.workspace }}/parameters.json"
 
   # Integration tests only with reference connector (for comparison)
   python_tests_reference:
@@ -574,7 +590,7 @@ jobs:
             --fail-on-regressions 0 | tee -a $GITHUB_STEP_SUMMARY
 
   python-status:
-    needs: [detect-changes, build_wheels, packaging_tests, python_tests, python_tests_reference, python_compare_results]
+    needs: [detect-changes, build_wheels, packaging_tests, python_tests, cleanup_python, python_tests_reference, python_compare_results]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test-rust-core.yml
+++ b/.github/workflows/test-rust-core.yml
@@ -240,14 +240,6 @@ jobs:
             echo "(this is expected if the build failed before any test executed)"
           fi
 
-      - name: Cleanup test PATs
-        if: always()
-        continue-on-error: true
-        run: |
-          python -m pip install snowflake-connector-python -q
-          python scripts/cleanup_env.py \
-            --parameter-path $(pwd)/parameters.json
-
       # NOTE: profraw/profdata cleanup and llvm-cov-target/ removal happen inside
       # the cargo-cache action's slim step (with slim-mode: aggressive below).
       # Workspace test binaries are also stripped — they're rebuilt from cached
@@ -456,19 +448,6 @@ jobs:
           path: C:\vcpkg\installed\arm64-windows-static-md
           key: windows-11-arm-vcpkg-openssl-static-md-${{ env.VCPKG_VER }}
 
-      - name: Cleanup test PATs
-        if: always()
-        continue-on-error: true
-        shell: bash
-        env:
-          OPENSSL_DIR: C:\vcpkg\installed\arm64-windows-static-md
-          OPENSSL_LIB_DIR: C:\vcpkg\installed\arm64-windows-static-md\lib
-          OPENSSL_STATIC: "1"
-        run: |
-          python -m pip install --no-binary cryptography snowflake-connector-python -q
-          python scripts/cleanup_env.py \
-            --parameter-path "${{ github.workspace }}/parameters.json"
-
       - name: Save Rust cache
         if: always()
         # timeout-minutes is enforced here because it isn't supported on
@@ -594,15 +573,6 @@ jobs:
           set PARAMETER_PATH=${{ github.workspace }}\parameters.json
           cargo nextest run --package sf_core --no-default-features --features protobuf --target i686-pc-windows-msvc --no-fail-fast
 
-      - name: Cleanup test PATs
-        if: always()
-        continue-on-error: true
-        shell: bash
-        run: |
-          python -m pip install snowflake-connector-python -q
-          python scripts/cleanup_test_pats.py \
-            --parameter-path "${{ github.workspace }}/parameters.json"
-
       - name: Save Rust cache
         if: always()
         uses: ./.github/actions/cargo-cache
@@ -612,8 +582,29 @@ jobs:
           registry-cache-hit: ${{ steps.rust-cache.outputs.registry-cache-hit }}
           target-cache-hit: ${{ steps.rust-cache.outputs.target-cache-hit }}
 
+  cleanup_rust_core:
+    needs: [detect-changes, test, test_windows_arm64_nonfips, test_windows_x86]
+    if: always() && (needs.test.result != 'skipped' || needs.test_windows_arm64_nonfips.result != 'skipped' || needs.test_windows_x86.result != 'skipped')
+    runs-on: ubuntu-latest
+    name: cleanup_rust_core
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Decode secrets
+        run: ./scripts/decode_secrets.sh
+        env:
+          PARAMETERS_SECRET: ${{ secrets.PARAMETERS_SECRET }}
+        shell: bash
+
+      - name: Cleanup test PATs
+        continue-on-error: true
+        run: |
+          python -m pip install snowflake-connector-python -q
+          python scripts/cleanup_env.py \
+            --parameter-path "${{ github.workspace }}/parameters.json"
+
   rust-core-status:
-    needs: [detect-changes, format, clippy, build-without-protobuf, test, test_windows_arm64_nonfips, test_windows_x86]
+    needs: [detect-changes, format, clippy, build-without-protobuf, test, test_windows_arm64_nonfips, test_windows_x86, cleanup_rust_core]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/python/tests/e2e/authentication/test_pat.py
+++ b/python/tests/e2e/authentication/test_pat.py
@@ -26,7 +26,7 @@ def _ci_build_tag() -> str:
     return "LOCAL_0"
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="session")
 def pat_token(connection_factory):
     pat_token = PAT(connection_factory)
     try:


### PR DESCRIPTION
Each test matrix cell was running cleanup_env.py independently, creating redundant Snowflake API calls and unnecessary compute minutes. Replace with one cleanup job per workflow that runs after all test jobs complete.

Also widens the Python pat_token fixture from scope="class" to scope="session" to limit PAT creation to one per worker process.

Fixes a bug in test-rust-core.yml where test_windows_x86 referenced the non-existent script cleanup_test_pats.py instead of cleanup_env.py.