### PR TITLE
ci(python): add flaky pytest marker and non-blocking CI job

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -600,11 +600,20 @@ jobs:
 
       - name: Run flaky tests
         working-directory: python
+        # Exit code 5 means "no tests collected" — expected when no tests are
+        # currently marked @pytest.mark.flaky. Treat it as success.
         run: |
           mkdir -p reports
+          set +e
           hatch run test.py3.13:flaky \
             --json-report --json-report-file=reports/flaky-${{ env.MATRIX_KEY }}.json \
             --junitxml=reports/flaky-${{ env.MATRIX_KEY }}.xml
+          status=$?
+          if [[ $status -eq 5 ]]; then
+            echo "::notice::No tests marked @pytest.mark.flaky — skipping."
+            exit 0
+          fi
+          exit $status
         env:
           PARAMETER_PATH: ${{ github.workspace }}/parameters.json
           REFERENCE_DRIVER_VERSION: ${{ env.PYTHON_REFERENCE_DRIVER_VERSION }}

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -533,6 +533,114 @@ jobs:
           name: results-reference-${{ env.MATRIX_KEY }}
           path: python/reports/*-${{ env.MATRIX_KEY }}.*
 
+  # Flaky tests — non-blocking, informational. Runs only tests marked
+  # @pytest.mark.flaky (excluded from every other job by the default
+  # `-m "not flaky"` in python/pyproject.toml addopts). Failures here do
+  # not gate merges and the job is intentionally omitted from python-status.
+  python_flaky_tests:
+    needs: [detect-changes, build_wheels]
+    if: github.event_name == 'push' || needs.detect-changes.outputs.run_python == 'true'
+    runs-on: ubuntu-latest
+    name: python_flaky_tests (ubuntu-latest, py3.13, aws)
+    continue-on-error: true
+    env:
+      MATRIX_KEY: flaky-ubuntu-latest-3.13-aws
+    steps:
+      - name: Set UV cache dir
+        shell: bash
+        run: echo "UV_CACHE_DIR=/tmp/.uv-cache" >> $GITHUB_ENV
+
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7.2.1
+        with:
+          version: "0.9.28"
+
+      - name: Restore uv cache
+        id: uv-cache-flaky
+        continue-on-error: true
+        uses: actions/cache/restore@v5
+        with:
+          path: /tmp/.uv-cache
+          key: uv-ubuntu-latest-3.13-test-${{ hashFiles('python/uv.lock', 'python/pyproject.toml') }}
+          restore-keys: |
+            uv-ubuntu-latest-3.13-test-
+            uv-ubuntu-latest-3.13-
+            uv-ubuntu-latest-
+
+      - name: Set up Python 3.13
+        run: uv python install 3.13
+
+      - name: Download wheel
+        uses: actions/download-artifact@v4
+        with:
+          name: manylinux_x86_64_py3.13
+          path: python/dist
+
+      - name: Decode secrets
+        run: ./scripts/decode_secrets.sh aws
+        env:
+          PARAMETERS_SECRET: ${{ secrets.PARAMETERS_SECRET }}
+        shell: bash
+
+      - name: Install Hatch
+        run: uv tool install hatch --with "virtualenv<21.0.0"
+
+      - name: Install snowflake ud driver from wheel
+        working-directory: python
+        run: |
+          WHEELS=(dist/*.whl)
+          if [[ ${#WHEELS[@]} -ne 1 ]]; then
+            echo "::error::Expected exactly 1 wheel, found ${#WHEELS[@]}"; ls -la dist/; exit 1
+          fi
+          export WHEEL_PATH="${WHEELS[0]}"
+          echo "Installing wheel: $WHEEL_PATH"
+          hatch run test.py3.13:install-wheel
+
+      - name: Run flaky tests
+        working-directory: python
+        run: |
+          mkdir -p reports
+          hatch run test.py3.13:flaky \
+            --json-report --json-report-file=reports/flaky-${{ env.MATRIX_KEY }}.json \
+            --junitxml=reports/flaky-${{ env.MATRIX_KEY }}.xml
+        env:
+          PARAMETER_PATH: ${{ github.workspace }}/parameters.json
+          REFERENCE_DRIVER_VERSION: ${{ env.PYTHON_REFERENCE_DRIVER_VERSION }}
+
+      - name: Cleanup test PATs
+        if: always()
+        continue-on-error: true
+        shell: bash
+        run: |
+          python -m pip install snowflake-connector-python -q
+          python scripts/cleanup_env.py \
+            --parameter-path "${{ github.workspace }}/parameters.json"
+
+      - name: Upload test results as GitHub artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: results-flaky-${{ env.MATRIX_KEY }}
+          path: python/reports/flaky-${{ env.MATRIX_KEY }}.*
+
+      - name: Prune uv cache
+        if: always()
+        shell: bash
+        run: uv cache prune --ci
+
+      - name: Save uv cache
+        if: always() && steps.uv-cache-flaky.outputs.cache-hit != 'true'
+        continue-on-error: true
+        timeout-minutes: 10
+        env:
+          ZSTD_NBTHREADS: '2'
+        uses: actions/cache/save@v5
+        with:
+          path: /tmp/.uv-cache
+          key: uv-ubuntu-latest-3.13-test-${{ hashFiles('python/uv.lock', 'python/pyproject.toml') }}
+
   # Compare results between connectors
   python_compare_results:
     needs: [detect-changes, python_tests, python_tests_reference]

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -609,15 +609,6 @@ jobs:
           PARAMETER_PATH: ${{ github.workspace }}/parameters.json
           REFERENCE_DRIVER_VERSION: ${{ env.PYTHON_REFERENCE_DRIVER_VERSION }}
 
-      - name: Cleanup test PATs
-        if: always()
-        continue-on-error: true
-        shell: bash
-        run: |
-          python -m pip install snowflake-connector-python -q
-          python scripts/cleanup_env.py \
-            --parameter-path "${{ github.workspace }}/parameters.json"
-
       - name: Upload test results as GitHub artifact
         if: always()
         uses: actions/upload-artifact@v4

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -135,6 +135,9 @@ addopts = [
     "-n", "auto",
     "--max-worker-restart=4",
     "--durations=0",
+    # Flaky tests are excluded by default; the python_flaky_tests CI job
+    # overrides this with `-m flaky` to run them in isolation.
+    "-m", "not flaky",
 ]
 # Default timeout for tests (2 minutes) - prevents hanging tests on CI
 timeout = 120
@@ -144,6 +147,7 @@ markers = [
     "slow: marks tests as slow (e.g., full sdist install with Rust compilation)",
     "skip_for_json_result_set(reason: str=''): skip when QUERY_RESULT_FORMAT=JSON (tests requiring Arrow precision)",
     "require_vpn: test requires VPN access (skipped outside Jenkins CI)",
+    "flaky: marks tests as flaky; skipped by default, run explicitly via the flaky CI job or `-m flaky` locally",
 ]
 log_cli = true
 log_cli_level = "INFO"
@@ -269,6 +273,9 @@ python = ["3.10", "3.11", "3.12", "3.13", "3.14"]
 # Install from wheel
 install-wheel = "uv pip install {env:WHEEL_PATH:dist/*.whl}"
 cov = "pytest tests/ --ignore=tests/packaging --ignore=tests/e2e/pandas --cov=src/snowflake --cov-report=xml --cov-report=html {args}"
+# Runs only tests marked @pytest.mark.flaky. `-m flaky` overrides the default
+# `-m "not flaky"` from [tool.pytest.ini_options].addopts.
+flaky = "pytest tests/ --ignore=tests/packaging --ignore=tests/e2e/pandas -m flaky --no-cov {args}"
 
 # Pandas-specific CI test environment
 [tool.hatch.envs.test-pandas]


### PR DESCRIPTION
## Summary
- Register a `flaky` pytest marker in `python/pyproject.toml` and exclude it from every existing pytest invocation via a new default `-m "not flaky"` in `addopts`, so the required `python_tests` job stays green and deterministic.
- Add a non-blocking `python_flaky_tests` GitHub Actions job that opts in with `-m flaky` on a single matrix cell (Linux x86_64, py3.13, AWS). The job is `continue-on-error: true` and is intentionally omitted from `python-status` `needs` so flaky failures do not gate merges.
- Add a `hatch run test.pyX.Y:flaky` script that the new job invokes; developers can also run `-m flaky` locally.

## Test plan
- [ ] `python_tests` (and all existing jobs) still pass — flaky tests are skipped by default.
- [ ] `python_flaky_tests` appears in the Actions run, is marked `continue-on-error`, and does not block `python-status`.
- [ ] Locally: `hatch run test.py3.13:pytest --markers | grep flaky` lists the new marker.
- [ ] Locally: adding a sample `@pytest.mark.flaky` test shows up as deselected in default runs and selected under `hatch run test.py3.13:flaky`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)