### PR TITLE
fix(ci): disable LTO for sf_mini_core_static on AIX

### DIFF
--- a/scripts/package_minicore.sh
+++ b/scripts/package_minicore.sh
@@ -103,7 +103,11 @@ if [[ "$PLATFORM" == aix-* ]]; then
 fi
 
 echo "=== Building static library version ==="
-"${STATIC_LTO_OVERRIDE[@]}" $CARGO_CMD build --release --package sf_mini_core_static --target $PLATFORM_TARGET
+# `${ARR[@]+"${ARR[@]}"}` expands to nothing when ARR is empty, but to the
+# array elements otherwise. Required because the script runs under `set -u`
+# and bash < 4.4 (notably macOS's bash 3.2) treats `"${EMPTY[@]}"` as an
+# unbound-variable reference instead of an empty expansion.
+${STATIC_LTO_OVERRIDE[@]+"${STATIC_LTO_OVERRIDE[@]}"} $CARGO_CMD build --release --package sf_mini_core_static --target $PLATFORM_TARGET
 
 # Determine dynamic library extension based on platform
 case "$PLATFORM" in

--- a/scripts/package_minicore.sh
+++ b/scripts/package_minicore.sh
@@ -81,8 +81,29 @@ cbindgen --config sf_mini_core/cbindgen.toml --crate sf_mini_core > $BUILD_DIR/s
 echo "=== Building dynamic library version ==="
 $CARGO_CMD build --release --package sf_mini_core --target $PLATFORM_TARGET 
 
+# AIX: the Rust toolchain on `powerpc64-ibm-aix` (tier-3) emits LLVM bitcode
+# in an archive section the AIX linker driver can't locate, so any LTO
+# (thin or fat) on a `staticlib` crate fails with:
+#
+#   error: failed to get bitcode from object file for LTO
+#       (could not find requested section)
+#
+# The cdylib build above succeeds because Rust links it directly without
+# needing the bitcode passed through to a downstream consumer's linker.
+# Disable LTO only for the staticlib build on AIX as a workaround until
+# upstream Rust/LLVM fixes the bitcode packaging on AIX. Other targets
+# keep the workspace default (`lto = "thin"` from the root Cargo.toml).
+#
+# Functional impact: `sf_mini_core` is a single-function stub with no
+# dependencies, so the lost cross-language LTO is negligible — the static
+# `.a` is at most a few percent larger and effectively the same speed.
+STATIC_LTO_OVERRIDE=()
+if [[ "$PLATFORM" == aix-* ]]; then
+    STATIC_LTO_OVERRIDE=(env CARGO_PROFILE_RELEASE_LTO=off)
+fi
+
 echo "=== Building static library version ==="
-$CARGO_CMD build --release --package sf_mini_core_static --target $PLATFORM_TARGET
+"${STATIC_LTO_OVERRIDE[@]}" $CARGO_CMD build --release --package sf_mini_core_static --target $PLATFORM_TARGET
 
 # Determine dynamic library extension based on platform
 case "$PLATFORM" in


### PR DESCRIPTION
## Summary

The `Universal driver build matrix` Jenkins job has been **UNSTABLE on every visible build of `main`** (build #2 through build #31, all red) because the `aix-ppc64` matrix entry fails with:

```
error: failed to get bitcode from object file for LTO
    (could not find requested section)
error: could not compile `sf_mini_core_static` (lib) due to 1 previous error
```

This blanks out the Jenkins check on every PR with no signal value, since the same failure reproduces on `main` and isn't caused by any individual change. Fixing it restores the Jenkins check as a meaningful PR signal.

## Root cause

- `sf_mini_core_static` is a `staticlib` that re-exports `sf_mini_core`'s symbols.
- The workspace default is `[profile.release] lto = "thin"`.
- The `cdylib` build (`sf_mini_core`) on AIX succeeds — Rust links the dylib itself, never has to hand bitcode to a downstream linker.
- The `staticlib` build has to embed LLVM bitcode in the `.a` archive section so a downstream LTO-aware linker can pick it up. On the tier-3 `powerpc64-ibm-aix` target, `rustc` emits the bitcode in a section the AIX linker driver can't locate, and aborts with the error above.
- The error reproduces with both `lto = "thin"` and `lto = "fat"`. It's a Rust/LLVM-on-AIX bitcode-packaging bug, not an LTO-flavor choice on our side.

## Fix

Set `CARGO_PROFILE_RELEASE_LTO=off` **only** when building `sf_mini_core_static` and **only** when the target is AIX. Every other crate / target / step keeps the workspace `lto = "thin"` default. The cdylib path is unaffected on every platform.

```bash
STATIC_LTO_OVERRIDE=()
if [[ "$PLATFORM" == aix-* ]]; then
    STATIC_LTO_OVERRIDE=(env CARGO_PROFILE_RELEASE_LTO=off)
fi

echo "=== Building static library version ==="
"${STATIC_LTO_OVERRIDE[@]}" $CARGO_CMD build --release --package sf_mini_core_static --target $PLATFORM_TARGET
```

## Why not switch the workspace to `lto = "thin"` everywhere?

Because we already are. The workspace root `Cargo.toml` has `[profile.release] lto = "thin"`. The bug is specifically in how `staticlib` archives package the bitcode for downstream LTO on AIX, and switching from `"thin"` to `"fat"` (or vice-versa) doesn't change the section layout the AIX linker can't read.

## Functional impact on the driver

**Negligible.** `sf_mini_core` is a 49-line stub crate with **no dependencies** that exports a single function (`sf_core_full_version`) returning a static null-terminated version string:

```rust
#[unsafe(no_mangle)]
pub extern "C" fn sf_core_full_version() -> *const c_char {
    static VERSION: &str = "0.0.1\0";
    VERSION.as_ptr() as *const c_char
}
```

Losing cross-language LTO between this crate and a downstream C/C++ consumer means:

- The AIX static `.a` is at most a few percent larger.
- Runtime performance is effectively unchanged — the function is one indirect load of a static constant.

The dylib variant (`sf_mini_core` cdylib) keeps `lto = "thin"` on every platform including AIX, so all dynamic-link consumers still get the existing optimisations.

## Scope

- Only touches `scripts/package_minicore.sh`.
- Only the `staticlib` step on `aix-*` is affected; every other platform and the cdylib step everywhere are unchanged.

## Follow-up

This is a **workaround**, not a permanent fix. Should be revisited once `rustc` / `lld` correctly emit the LTO bitcode section on `powerpc64-ibm-aix` upstream — at that point this conditional can be reverted and AIX picks up `lto = "thin"` like every other target.

## Test plan

- [ ] Jenkins `Universal driver build matrix` on this PR turns green (`SUCCESS` instead of `UNSTABLE`).
- [ ] The AIX `sf_mini_core_static` build artifact (`libsf_mini_core_static.a`) is produced and packaged into the AIX archive (`sf_mini_core_aix-ppc64_*_SNAPSHOT_*.tar.gz`).
- [ ] No regression on non-AIX targets — every other matrix entry still passes.
- [ ] (Optional) On a downstream consumer of the AIX static lib, confirm `sf_core_full_version()` still returns `"0.0.1"` and links cleanly without the LTO-bitcode error.

Made with [Cursor](https://cursor.com)