### PR TITLE
Linting & Formatting setup

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -67,6 +67,14 @@ jobs:
         run: |
           pip install pre-commit hatch "virtualenv<21.0.0"
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install Node.js dependencies
+        run: cd nodejs && npm install
+
       # NOTE: no pre-commit hook cache. Every hook in .pre-commit-config.yaml
       # uses `language: system` (cargo, clang-format, gradlew, etc.), so
       # pre-commit doesn't manage virtualenvs or clone hook repos — the only

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,6 +70,13 @@ repos:
         pass_filenames: false
         files: ^jdbc/
         language: system
+    -   id: nodejs-code-format
+        name: Node.js code formatting & linting
+        description: Auto-format with oxfmt and lint with oxlint
+        entry: bash -c 'cd nodejs && npm run fmt:fix && npm run lint:check'
+        pass_filenames: false
+        files: ^nodejs/
+        language: system
     -   id: behavior-differences-validator
         name: Behavioral Differences format check
         description: Validate BehaviorDifferences.yaml schema (status, type, required fields)

--- a/nodejs/.oxfmtrc.json
+++ b/nodejs/.oxfmtrc.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "./node_modules/oxfmt/configuration_schema.json",
+  "singleQuote": true,
+  "tabWidth": 2,
+  "endOfLine": "lf",
+  "printWidth": 100,
+  "sortPackageJson": false
+}

--- a/nodejs/.oxlintrc.json
+++ b/nodejs/.oxlintrc.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "rules": {
+    "eqeqeq": ["error", "always", { "null": "ignore" }],
+    "no-async-promise-executor": "error",
+    "no-console": ["error", { "allow": ["warn", "error"] }],
+    "no-empty": "error",
+    "no-prototype-builtins": "error",
+    "no-redeclare": "error",
+    "no-undef": "off",
+    "no-unused-vars": ["error", { "caughtErrors": "none" }],
+    "no-var": "error",
+    "prefer-const": "error",
+    "unicorn/no-new-array": "off"
+  },
+  "ignorePatterns": ["dist/**/*.js"]
+}

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -19,12 +19,18 @@
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
+    "lint:check": "oxlint . --max-warnings=0",
+    "lint:fix": "oxlint --fix .",
+    "fmt:check": "oxfmt --check .",
+    "fmt:fix": "oxfmt --write .",
     "test:unit": "vitest run --project unit",
     "test:e2e": "vitest run --project e2e"
   },
   "devDependencies": {
     "@types/node": "^25.6.2",
     "@vitest/coverage-v8": "^4.1.5",
+    "oxfmt": "^0.48.0",
+    "oxlint": "^1.43.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.5"
   }

--- a/nodejs/src/index.ts
+++ b/nodejs/src/index.ts
@@ -1,1 +1,2 @@
 // TODO
+export {};

--- a/nodejs/tests/e2e/create-connection.test.ts
+++ b/nodejs/tests/e2e/create-connection.test.ts
@@ -1,5 +1,5 @@
-import { describe, it } from "vitest";
+import { describe, it } from 'vitest';
 
-describe("snowflake.createConnection", () => {
-  it.todo("works");
+describe('snowflake.createConnection', () => {
+  it.todo('works');
 });

--- a/nodejs/tests/unit/global-config.test.ts
+++ b/nodejs/tests/unit/global-config.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
+import { describe, it } from 'vitest';
 
-describe("Global Config", () => {
-  it.todo("works");
+describe('Global Config', () => {
+  it.todo('works');
 });

--- a/nodejs/vitest.config.ts
+++ b/nodejs/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vitest/config";
+import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
@@ -12,18 +12,18 @@ export default defineConfig({
       {
         extends: true,
         test: {
-          name: { label: "unit", color: "cyan" },
-          environment: "node",
-          include: ["tests/unit/**/*.test.ts"],
+          name: { label: 'unit', color: 'cyan' },
+          environment: 'node',
+          include: ['tests/unit/**/*.test.ts'],
           testTimeout: 1_000,
         },
       },
       {
         extends: true,
         test: {
-          name: { label: "e2e", color: "magenta" },
-          environment: "node",
-          include: ["tests/e2e/**/*.test.ts"],
+          name: { label: 'e2e', color: 'magenta' },
+          environment: 'node',
+          include: ['tests/e2e/**/*.test.ts'],
           testTimeout: 30_000,
           hookTimeout: 30_000,
         },


### PR DESCRIPTION
## Summary
- Add oxlint (linter) and oxfmt (formatter) to the Node.js package with config files (`.oxlintrc.json`, `.oxfmtrc.json`)
- Add `lint:check`, `lint:fix`, `fmt:check`, `fmt:fix` npm scripts
- Add a pre-commit hook that auto-formats and lints `nodejs/` files
- Apply formatting fixes: double quotes → single quotes across existing files

## Context
Sets up the linting & formatting foundation for the Node.js package, mirroring the existing pre-commit patterns used by other packages in this repo.

## Test plan
- Verified `npm run fmt:check` and `npm run lint:check` pass with no warnings
- Pre-commit hook runs formatting and linting on `nodejs/` file changes