### PR TITLE
ci(vpn-tests): filter ignored tests by `vpn_` prefix

### DIFF
--- a/ci/Jenkinsfile.vpn-tests
+++ b/ci/Jenkinsfile.vpn-tests
@@ -52,7 +52,13 @@ pipeline {
                       sh label: 'Rust Core VPN E2E tests', script: '''
                         set +x
                         export PARAMETER_PATH=$(pwd)/parameters.json
-                        cargo test --package sf_core -- --ignored
+                        # Run only VPN-gated tests. By convention (see sf_core/README.md)
+                        # tests that require VPN access to a preprod account are marked
+                        # `#[ignore]` AND named with a `vpn_` prefix. The positional name
+                        # filter below excludes other ignored tests (e.g. stress benches,
+                        # parked feature E2Es) that share the `#[ignore]` attribute but
+                        # are not meant to run here.
+                        cargo test --package sf_core -- --ignored vpn_
                       '''
                     } finally {
                       sh label: 'Cleanup test PATs', script: '''

--- a/sf_core/src/token_cache/file_cache.rs
+++ b/sf_core/src/token_cache/file_cache.rs
@@ -986,7 +986,10 @@ mod tests {
         /// Run with:
         ///   cargo test -p sf_core -- stress_concurrent_lock --ignored --nocapture
         #[test]
-        #[ignore] // slow — run manually to validate locking reliability
+        // Slow — run manually to validate locking reliability. Deliberately NOT
+        // prefixed with `vpn_` so the Jenkins VPN-tests pipeline (which filters
+        // `--ignored vpn_`) does not pick it up. See sf_core/README.md.
+        #[ignore]
         fn stress_concurrent_lock() {
             const ITERATIONS: usize = 20;
             const STRESS_THREADS: usize = 100;


### PR DESCRIPTION
## Summary

The Jenkins VPN-tests pipeline runs `cargo test --package sf_core -- --ignored` to exercise tests that need a Snowflake preprod account. That filter is too broad — it pulls in **every** `#[ignore]`d test in `sf_core`, regardless of why it's ignored.

This was harmless when the only ignored `sf_core` tests were VPN-gated. But #851 added `stress_concurrent_lock` (a manual local benchmark for the file-lock implementation) under the same `#[ignore]` attribute, and the pipeline has been silently running it on every build for ~3 weeks. With 100 threads contending on a ~60 ms total retry budget, scheduler jitter on a loaded runner occasionally blows the budget — see [PR-1084 build #9](https://es-ci-legacy-mainvalidation-001.jenkinsdev1.us-west-2.aws-dev.app.snowflake.com/job/universal-driver-vpn-tests/job/PR-1084/9/) for the first visible flake (1/20 rounds failed).

## Fix

Add the `vpn_` positional name filter to the cargo invocation, matching the convention already documented in `sf_core/README.md`:

```diff
-cargo test --package sf_core -- --ignored
+cargo test --package sf_core -- --ignored vpn_
```

Every real VPN test in `sf_core` already follows the `vpn_` prefix convention (the 3 tests in `tests/e2e/authentication/native_okta.rs`), so no test renames are needed. Also clarifies the `#[ignore]` comment on `stress_concurrent_lock` so future contributors don't re-introduce the same conflation.

## Effect

| Test | Currently picked up by VPN job? | After this PR |
|---|---|---|
| `vpn_should_authenticate_using_native_okta` | ✅ (intended) | ✅ |
| `vpn_should_fail_native_okta_authentication_with_wrong_credentials` | ✅ (intended) | ✅ |
| `vpn_should_fail_native_okta_authentication_with_wrong_okta_url` | ✅ (intended) | ✅ |
| `should_authenticate_using_username_password_and_*` (4 tests, parked under SNOW-3252862, file header says *"Cannot run in CI"*) | ✅ (unintended) | ❌ |
| `stress_concurrent_lock` (manual local benchmark from #851) | ✅ (unintended, source of the flake) | ❌ |

## Test plan

- [ ] Jenkins `universal-driver-vpn-tests` job runs the 3 `vpn_*` native_okta tests and reports `running 3 tests` instead of `running 1 test` (which used to pick up only the unit-test stress test).
- [ ] No regression in `cargo test -p sf_core` from a developer machine (no behavior change there — only `--ignored vpn_` invocations are affected).


Made with [Cursor](https://cursor.com)