### PR TITLE
chore(odbc_tests): tag LOB string tests as `[flaky]`

### DIFF
--- a/odbc_tests/tests/e2e/types/string_lob.cpp
+++ b/odbc_tests/tests/e2e/types/string_lob.cpp
@@ -42,7 +42,7 @@ static std::string generate_random_ascii_string(std::mt19937& gen, size_t length
 // ============================================================================
 
 TEST_CASE_METHOD(ConnSchemaFixture, "should handle LOB string at maximum 128 MB limit with increased LOB size",
-                 "[datatype][string][lob]") {
+                 "[datatype][string][lob][flaky]") {
   // Corner case: string at maximum LOB limit (128 MB) - requires Increased LOB Size feature
   // Given Snowflake client is logged in
 
@@ -94,7 +94,8 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should handle LOB string at maximum 128 MB 
   CHECK(retrieved_value == lob_string);
 }
 
-TEST_CASE_METHOD(ConnSchemaFixture, "should handle LOB string at historical 16 MB limit", "[datatype][string][lob]") {
+TEST_CASE_METHOD(ConnSchemaFixture, "should handle LOB string at historical 16 MB limit",
+                 "[datatype][string][lob][flaky]") {
   // Corner case: string at the historical LOB limit (16 MB = 16,777,216 bytes)
   // Given Snowflake client is logged in
 


### PR DESCRIPTION
## Summary

The two `e2e_types_string_lob` test cases push 16 MB and 128 MB string literals through the bind+fetch path end-to-end and take ~20 s / ~110 s respectively under normal CI load. They depend on a single staged-data upload + fetch round-trip, so any transient network blip or server slowness flips them red without any real driver-side regression.

They were also the only e2e tests in the default `odbc_reference_tests` set that behave like flaky tests (slow + network-bound + non-deterministic timing) but were missing the `[flaky]` tag. Adding it brings them in line with the rest of the flaky-test convention.

## How the tag works

`odbc_tests/CMakeLists.txt:56` registers Catch2 tests with `catch_discover_tests(... ADD_TAGS_AS_LABELS)`, which lifts every tag into a CTest label. The PR-merge workflows already invoke `ctest -LE flaky` (label exclude) — see `scripts/odbc/run_tests_unix.sh` / `run_tests_windows.ps1` — so this single one-line change immediately drops the LOB tests from the default set without any workflow edits.

## Effect

- `odbc_reference_tests (Linux x64)`: skips LOB tests (~130 s saved).
- `odbc_reference_tests (Windows x64)`: skips LOB tests (~130 s saved).
- Tests still build and can be invoked manually with `ctest -L lob` or `ctest -L flaky` for stress / release validation runs.

## Test plan

- [ ] After merge, observe LOB tests no longer in the default `odbc_reference_tests` matrix.
- [ ] Manual `ctest -L lob` run still picks up both tests when needed.


Made with [Cursor](https://cursor.com)