### PR TITLE
feat(odbc): accept legacy SQL_DATE / SQL_TIME bindparam codes as aliases

### DIFF
--- a/odbc/src/conversion/param_binding.rs
+++ b/odbc/src/conversion/param_binding.rs
@@ -203,14 +203,32 @@ fn make_converter(binding: &ParameterBinding) -> Result<Box<dyn ParamConverter>,
             snowflake_type: SnowflakeBinary { len: 0 },
         })),
 
-        sql::SqlDataType::DATE => Ok(Box::new(JsonParamConverter {
+        // ODBC 3.x SQL_TYPE_DATE (=91) and its ODBC 2.x predecessor SQL_DATE
+        // (=9, exposed in `odbc-sys` as `SqlDataType::DATETIME` because the
+        // header value is shared with the datetime-header code) route to the
+        // same converter. Per ODBC Appendix G, ODBC 3.x drivers must accept
+        // either spelling and treat them as identical at the API boundary.
+        sql::SqlDataType::DATE | sql::SqlDataType::DATETIME => Ok(Box::new(JsonParamConverter {
             snowflake_type: SnowflakeDate,
         })),
 
-        sql::SqlDataType::TIME => Ok(Box::new(JsonParamConverter {
-            snowflake_type: SnowflakeTime { scale: 9 },
-        })),
+        // ODBC 3.x SQL_TYPE_TIME (=92) and its ODBC 2.x predecessor SQL_TIME
+        // (=10, exposed in `odbc-sys` as `EXT_TIME_OR_INTERVAL` because the
+        // header value is shared with the interval-header code) route to the
+        // same converter. Bare value 10 is unambiguously SQL_TIME at the
+        // SQLBindParameter boundary: the interval subtypes use codes
+        // 101-113 and are matched by their own guarded arms below.
+        sql::SqlDataType::TIME | sql::SqlDataType::EXT_TIME_OR_INTERVAL => {
+            Ok(Box::new(JsonParamConverter {
+                snowflake_type: SnowflakeTime { scale: 9 },
+            }))
+        }
 
+        // ODBC 3.x SQL_TYPE_TIMESTAMP (=93) and its ODBC 2.x predecessor
+        // SQL_TIMESTAMP (=11, exposed as `EXT_TIMESTAMP`) route to the same
+        // converter (already covered before this PR; documented here for
+        // symmetry with the new DATE / TIME alias arms above).
+        //
         // SQL_TYPE_TIMESTAMP (93) routing depends on the optional Snowflake
         // vendor opt-in. Default (no opt-in) maps to TIMESTAMP_NTZ for
         // backward compatibility with Tableau/Excel/Power BI; explicit LTZ

--- a/odbc_tests/tests/e2e/types/c_date_conversion_to_sql_date.cpp
+++ b/odbc_tests/tests/e2e/types/c_date_conversion_to_sql_date.cpp
@@ -1,4 +1,14 @@
+// ODBC E2E: SQL_C_TYPE_DATE bound via SQLBindParameter to a DATE target.
+//
+// Per ODBC Appendix G ("Driver Guidelines for Backward Compatibility"),
+// the ODBC 3.x date code SQL_TYPE_DATE (91) and its ODBC 2.x predecessor
+// SQL_DATE (9) must be accepted as identical at the SQLBindParameter
+// boundary. Each TEST_CASE below is parametrized over both spellings
+// using Catch2 GENERATE so the alias contract is pinned for every
+// scenario.
+
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
 
 #include "Connection.hpp"
 #include "SchemaFixtures.hpp"
@@ -6,12 +16,15 @@
 #include "odbc_cast.hpp"
 #include "odbc_matchers.hpp"
 
-TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_DATE to SQL_TYPE_DATE and read back",
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_DATE to DATE target and read back",
                  "[c_date][conversion][sql_date]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_DATE, SQL_TYPE_DATE);
+  CAPTURE(sql_type);
+
   // Given Snowflake client is logged in
   conn.execute("CREATE TEMPORARY TABLE t (col DATE)");
 
-  // When SQL_C_TYPE_DATE 2026-04-13 is bound to SQL_TYPE_DATE and inserted
+  // When SQL_C_TYPE_DATE 2026-04-13 is bound to the DATE target and inserted
   auto stmt = conn.createStatement();
   SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO t VALUES (?)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
@@ -20,7 +33,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_DATE to SQL_TYPE_DAT
   val.month = 4;
   val.day = 13;
   SQLLEN ind = sizeof(val);
-  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_DATE, SQL_TYPE_DATE, 0, 0, &val, sizeof(val),
+  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_DATE, sql_type, 0, 0, &val, sizeof(val),
                          &ind);
   REQUIRE_ODBC(ret, stmt);
   ret = SQLExecute(stmt.getHandle());
@@ -34,8 +47,11 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_DATE to SQL_TYPE_DAT
   CHECK(result.day == 13);
 }
 
-TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_DATE with NULL indicator to SQL_TYPE_DATE",
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_DATE with NULL indicator to DATE target",
                  "[c_date][conversion][sql_date]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_DATE, SQL_TYPE_DATE);
+  CAPTURE(sql_type);
+
   // Given Snowflake client is logged in
   conn.execute("CREATE TEMPORARY TABLE t (col DATE)");
 
@@ -44,7 +60,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_DATE with NULL indic
   SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO t VALUES (?)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
   SQLLEN ind = SQL_NULL_DATA;
-  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_DATE, SQL_TYPE_DATE, 0, 0, nullptr, 0, &ind);
+  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_DATE, sql_type, 0, 0, nullptr, 0, &ind);
   REQUIRE_ODBC(ret, stmt);
   ret = SQLExecute(stmt.getHandle());
   REQUIRE_ODBC(ret, stmt);

--- a/odbc_tests/tests/e2e/types/c_date_conversion_to_sql_date.cpp
+++ b/odbc_tests/tests/e2e/types/c_date_conversion_to_sql_date.cpp
@@ -33,8 +33,8 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_DATE to DATE target 
   val.month = 4;
   val.day = 13;
   SQLLEN ind = sizeof(val);
-  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_DATE, sql_type, 0, 0, &val, sizeof(val),
-                         &ind);
+  ret =
+      SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_DATE, sql_type, 0, 0, &val, sizeof(val), &ind);
   REQUIRE_ODBC(ret, stmt);
   ret = SQLExecute(stmt.getHandle());
   REQUIRE_ODBC(ret, stmt);

--- a/odbc_tests/tests/e2e/types/c_date_conversion_to_sql_timestamp.cpp
+++ b/odbc_tests/tests/e2e/types/c_date_conversion_to_sql_timestamp.cpp
@@ -1,12 +1,19 @@
-// ODBC E2E: SQL_C_TYPE_DATE bound via SQLBindParameter to ODBC 3.x
-// SQL_TYPE_TIMESTAMP across all three Snowflake variants (TIMESTAMP_NTZ,
-// TIMESTAMP_LTZ, TIMESTAMP_TZ).
+// ODBC E2E: SQL_C_TYPE_DATE bound via SQLBindParameter to a TIMESTAMP target
+// across all three Snowflake variants (TIMESTAMP_NTZ, TIMESTAMP_LTZ,
+// TIMESTAMP_TZ).
 //
 // Per ODBC Appendix D ("C to SQL: Date"), binding a date to a timestamp
 // target sets the time portion to 00:00:00.000000000. These tests verify
 // the round-trip preserves Y/M/D and produces a zeroed time portion.
+//
+// Per ODBC Appendix G ("Driver Guidelines for Backward Compatibility"),
+// the ODBC 3.x code SQL_TYPE_TIMESTAMP (93) and its ODBC 2.x predecessor
+// SQL_TIMESTAMP (11) must be accepted as identical at the SQLBindParameter
+// boundary. Each TEST_CASE below is parametrized over both spellings using
+// Catch2 GENERATE so the alias contract is pinned for every scenario.
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
 
 #include "Connection.hpp"
 #include "SchemaFixtures.hpp"
@@ -16,17 +23,19 @@
 
 namespace {
 
-void bind_date_and_execute(StatementHandleWrapper& stmt, SQL_DATE_STRUCT& val, SQLLEN& ind) {
-  SQLRETURN ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_DATE, SQL_TYPE_TIMESTAMP, 0, 0,
-                                   &val, sizeof(val), &ind);
+void bind_date_and_execute(StatementHandleWrapper& stmt, SQLSMALLINT target_sql_type, SQL_DATE_STRUCT& val,
+                           SQLLEN& ind) {
+  SQLRETURN ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_DATE, target_sql_type, 0, 0, &val,
+                                   sizeof(val), &ind);
   REQUIRE_ODBC(ret, stmt);
   ret = SQLExecute(stmt.getHandle());
   REQUIRE_ODBC(ret, stmt);
 }
 
-SQLRETURN bind_date_and_try_execute(StatementHandleWrapper& stmt, SQL_DATE_STRUCT& val, SQLLEN& ind) {
-  SQLRETURN ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_DATE, SQL_TYPE_TIMESTAMP, 0, 0,
-                                   &val, sizeof(val), &ind);
+SQLRETURN bind_date_and_try_execute(StatementHandleWrapper& stmt, SQLSMALLINT target_sql_type, SQL_DATE_STRUCT& val,
+                                    SQLLEN& ind) {
+  SQLRETURN ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_DATE, target_sql_type, 0, 0, &val,
+                                   sizeof(val), &ind);
   REQUIRE_ODBC(ret, stmt);
   return SQLExecute(stmt.getHandle());
 }
@@ -39,17 +48,20 @@ SQLRETURN bind_date_and_try_execute(StatementHandleWrapper& stmt, SQL_DATE_STRUC
 
 TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_DATE to TIMESTAMP_NTZ at midnight",
                  "[c_date][conversion][sql_timestamp]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_TIMESTAMP, SQL_TYPE_TIMESTAMP);
+  CAPTURE(sql_type);
+
   // Given a TIMESTAMP_NTZ column
   conn.execute("ALTER SESSION SET TIMEZONE = 'UTC'");
   conn.execute("CREATE TEMPORARY TABLE t (col TIMESTAMP_NTZ)");
 
-  // When SQL_C_TYPE_DATE 2026-04-13 is bound to SQL_TYPE_TIMESTAMP and inserted
+  // When SQL_C_TYPE_DATE 2026-04-13 is bound to the TIMESTAMP target and inserted
   auto stmt = conn.createStatement();
   SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO t VALUES (?)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
   SQL_DATE_STRUCT val = {2026, 4, 13};
   SQLLEN ind = sizeof(val);
-  bind_date_and_execute(stmt, val, ind);
+  bind_date_and_execute(stmt, sql_type, val, ind);
 
   // Then the stored value has the bound date and a zeroed time component
   auto fetch_stmt = conn.execute_fetch("SELECT col FROM t");
@@ -69,17 +81,20 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_DATE to TIMESTAMP_NT
 
 TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_DATE to TIMESTAMP_LTZ at midnight UTC",
                  "[c_date][conversion][sql_timestamp]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_TIMESTAMP, SQL_TYPE_TIMESTAMP);
+  CAPTURE(sql_type);
+
   // Given a TIMESTAMP_LTZ column with a known session timezone
   conn.execute("ALTER SESSION SET TIMEZONE = 'UTC'");
   conn.execute("CREATE TEMPORARY TABLE t (col TIMESTAMP_LTZ)");
 
-  // When SQL_C_TYPE_DATE 2026-04-13 is bound to SQL_TYPE_TIMESTAMP and inserted
+  // When SQL_C_TYPE_DATE 2026-04-13 is bound to the TIMESTAMP target and inserted
   auto stmt = conn.createStatement();
   SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO t VALUES (?)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
   SQL_DATE_STRUCT val = {2026, 4, 13};
   SQLLEN ind = sizeof(val);
-  bind_date_and_execute(stmt, val, ind);
+  bind_date_and_execute(stmt, sql_type, val, ind);
 
   // Then the stored value has the bound date and midnight UTC
   auto fetch_stmt = conn.execute_fetch("SELECT col FROM t");
@@ -99,17 +114,20 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_DATE to TIMESTAMP_LT
 
 TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_DATE to TIMESTAMP_TZ at midnight UTC",
                  "[c_date][conversion][sql_timestamp]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_TIMESTAMP, SQL_TYPE_TIMESTAMP);
+  CAPTURE(sql_type);
+
   // Given a TIMESTAMP_TZ column with a known session timezone
   conn.execute("ALTER SESSION SET TIMEZONE = 'UTC'");
   conn.execute("CREATE TEMPORARY TABLE t (col TIMESTAMP_TZ)");
 
-  // When SQL_C_TYPE_DATE 2026-04-13 is bound to SQL_TYPE_TIMESTAMP and inserted
+  // When SQL_C_TYPE_DATE 2026-04-13 is bound to the TIMESTAMP target and inserted
   auto stmt = conn.createStatement();
   SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO t VALUES (?)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
   SQL_DATE_STRUCT val = {2026, 4, 13};
   SQLLEN ind = sizeof(val);
-  bind_date_and_execute(stmt, val, ind);
+  bind_date_and_execute(stmt, sql_type, val, ind);
 
   // Then the stored value has the bound date and midnight UTC
   auto fetch_stmt = conn.execute_fetch("SELECT col FROM t");
@@ -127,8 +145,11 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_DATE to TIMESTAMP_TZ
 // Edge cases
 // ============================================================================
 
-TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_DATE leap day 2024-02-29 to SQL_TYPE_TIMESTAMP",
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_DATE leap day 2024-02-29 to TIMESTAMP target",
                  "[c_date][conversion][sql_timestamp]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_TIMESTAMP, SQL_TYPE_TIMESTAMP);
+  CAPTURE(sql_type);
+
   // TIMEZONE=UTC is required because the legacy 3.16.0 driver routes DATE →
   // TIMESTAMP through a TZ-aware path; without pinning TZ the legacy driver
   // would shift the day by the session's UTC offset.
@@ -142,7 +163,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_DATE leap day 2024-0
   REQUIRE_ODBC(ret, stmt);
   SQL_DATE_STRUCT val = {2024, 2, 29};
   SQLLEN ind = sizeof(val);
-  bind_date_and_execute(stmt, val, ind);
+  bind_date_and_execute(stmt, sql_type, val, ind);
 
   // Then the leap day is preserved
   auto fetch_stmt = conn.execute_fetch("SELECT col FROM t");
@@ -156,8 +177,11 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_DATE leap day 2024-0
   CHECK(result.fraction == 0);
 }
 
-TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_DATE epoch 1970-01-01 to SQL_TYPE_TIMESTAMP",
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_DATE epoch 1970-01-01 to TIMESTAMP target",
                  "[c_date][conversion][sql_timestamp]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_TIMESTAMP, SQL_TYPE_TIMESTAMP);
+  CAPTURE(sql_type);
+
   // See the leap-day test above for the TIMEZONE=UTC rationale.
   conn.execute("ALTER SESSION SET TIMEZONE = 'UTC'");
   // Given a TIMESTAMP_NTZ column with a known session timezone
@@ -169,7 +193,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_DATE epoch 1970-01-0
   REQUIRE_ODBC(ret, stmt);
   SQL_DATE_STRUCT val = {1970, 1, 1};
   SQLLEN ind = sizeof(val);
-  bind_date_and_execute(stmt, val, ind);
+  bind_date_and_execute(stmt, sql_type, val, ind);
 
   // Then the epoch date is preserved at midnight
   auto fetch_stmt = conn.execute_fetch("SELECT col FROM t");
@@ -183,8 +207,11 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_DATE epoch 1970-01-0
   CHECK(result.fraction == 0);
 }
 
-TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_DATE with NULL indicator to SQL_TYPE_TIMESTAMP",
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_DATE with NULL indicator to TIMESTAMP target",
                  "[c_date][conversion][sql_timestamp]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_TIMESTAMP, SQL_TYPE_TIMESTAMP);
+  CAPTURE(sql_type);
+
   // Given a TIMESTAMP_NTZ column
   conn.execute("CREATE TEMPORARY TABLE t (col TIMESTAMP_NTZ)");
 
@@ -193,8 +220,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_DATE with NULL indic
   SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO t VALUES (?)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
   SQLLEN ind = SQL_NULL_DATA;
-  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_DATE, SQL_TYPE_TIMESTAMP, 0, 0, nullptr, 0,
-                         &ind);
+  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_DATE, sql_type, 0, 0, nullptr, 0, &ind);
   REQUIRE_ODBC(ret, stmt);
   ret = SQLExecute(stmt.getHandle());
   REQUIRE_ODBC(ret, stmt);
@@ -214,8 +240,11 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_DATE with NULL indic
 // used for narrowing conversions.
 // ============================================================================
 
-TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_DATE with month=13 bound to SQL_TYPE_TIMESTAMP",
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_DATE with month=13 bound to TIMESTAMP target",
                  "[c_date][conversion][sql_timestamp][invalid]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_TIMESTAMP, SQL_TYPE_TIMESTAMP);
+  CAPTURE(sql_type);
+
   // Given a TIMESTAMP_NTZ column
   conn.execute("CREATE TEMPORARY TABLE t (col TIMESTAMP_NTZ)");
 
@@ -225,14 +254,17 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_DATE with month=13
   REQUIRE_ODBC(ret, stmt);
   SQL_DATE_STRUCT val = {2024, 13, 1};
   SQLLEN ind = sizeof(val);
-  ret = bind_date_and_try_execute(stmt, val, ind);
+  ret = bind_date_and_try_execute(stmt, sql_type, val, ind);
 
   // Then SQLExecute fails with SQLSTATE 22007
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::IsError() && OdbcMatchers::HasSqlState("22007"));
 }
 
-TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_DATE with month=0 bound to SQL_TYPE_TIMESTAMP",
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_DATE with month=0 bound to TIMESTAMP target",
                  "[c_date][conversion][sql_timestamp][invalid]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_TIMESTAMP, SQL_TYPE_TIMESTAMP);
+  CAPTURE(sql_type);
+
   // Given a TIMESTAMP_NTZ column
   conn.execute("CREATE TEMPORARY TABLE t (col TIMESTAMP_NTZ)");
 
@@ -242,14 +274,17 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_DATE with month=0 
   REQUIRE_ODBC(ret, stmt);
   SQL_DATE_STRUCT val = {2024, 0, 15};
   SQLLEN ind = sizeof(val);
-  ret = bind_date_and_try_execute(stmt, val, ind);
+  ret = bind_date_and_try_execute(stmt, sql_type, val, ind);
 
   // Then SQLExecute fails with SQLSTATE 22007
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::IsError() && OdbcMatchers::HasSqlState("22007"));
 }
 
-TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_DATE with day=32 bound to SQL_TYPE_TIMESTAMP",
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_DATE with day=32 bound to TIMESTAMP target",
                  "[c_date][conversion][sql_timestamp][invalid]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_TIMESTAMP, SQL_TYPE_TIMESTAMP);
+  CAPTURE(sql_type);
+
   // Given a TIMESTAMP_NTZ column
   conn.execute("CREATE TEMPORARY TABLE t (col TIMESTAMP_NTZ)");
 
@@ -259,14 +294,17 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_DATE with day=32 b
   REQUIRE_ODBC(ret, stmt);
   SQL_DATE_STRUCT val = {2024, 1, 32};
   SQLLEN ind = sizeof(val);
-  ret = bind_date_and_try_execute(stmt, val, ind);
+  ret = bind_date_and_try_execute(stmt, sql_type, val, ind);
 
   // Then SQLExecute fails with SQLSTATE 22007
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::IsError() && OdbcMatchers::HasSqlState("22007"));
 }
 
-TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_DATE with day=0 bound to SQL_TYPE_TIMESTAMP",
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_DATE with day=0 bound to TIMESTAMP target",
                  "[c_date][conversion][sql_timestamp][invalid]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_TIMESTAMP, SQL_TYPE_TIMESTAMP);
+  CAPTURE(sql_type);
+
   // Given a TIMESTAMP_NTZ column
   conn.execute("CREATE TEMPORARY TABLE t (col TIMESTAMP_NTZ)");
 
@@ -276,15 +314,18 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_DATE with day=0 bo
   REQUIRE_ODBC(ret, stmt);
   SQL_DATE_STRUCT val = {2024, 1, 0};
   SQLLEN ind = sizeof(val);
-  ret = bind_date_and_try_execute(stmt, val, ind);
+  ret = bind_date_and_try_execute(stmt, sql_type, val, ind);
 
   // Then SQLExecute fails with SQLSTATE 22007
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::IsError() && OdbcMatchers::HasSqlState("22007"));
 }
 
 TEST_CASE_METHOD(ConnSchemaFixture,
-                 "should reject SQL_C_TYPE_DATE with non-leap-year Feb 29 bound to SQL_TYPE_TIMESTAMP",
+                 "should reject SQL_C_TYPE_DATE with non-leap-year Feb 29 bound to TIMESTAMP target",
                  "[c_date][conversion][sql_timestamp][invalid]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_TIMESTAMP, SQL_TYPE_TIMESTAMP);
+  CAPTURE(sql_type);
+
   // Given a TIMESTAMP_NTZ column
   conn.execute("CREATE TEMPORARY TABLE t (col TIMESTAMP_NTZ)");
 
@@ -294,7 +335,7 @@ TEST_CASE_METHOD(ConnSchemaFixture,
   REQUIRE_ODBC(ret, stmt);
   SQL_DATE_STRUCT val = {2023, 2, 29};
   SQLLEN ind = sizeof(val);
-  ret = bind_date_and_try_execute(stmt, val, ind);
+  ret = bind_date_and_try_execute(stmt, sql_type, val, ind);
 
   // Then SQLExecute fails with SQLSTATE 22007
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::IsError() && OdbcMatchers::HasSqlState("22007"));

--- a/odbc_tests/tests/e2e/types/c_date_conversion_to_sql_timestamp.cpp
+++ b/odbc_tests/tests/e2e/types/c_date_conversion_to_sql_timestamp.cpp
@@ -320,8 +320,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_DATE with day=0 bo
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::IsError() && OdbcMatchers::HasSqlState("22007"));
 }
 
-TEST_CASE_METHOD(ConnSchemaFixture,
-                 "should reject SQL_C_TYPE_DATE with non-leap-year Feb 29 bound to TIMESTAMP target",
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_DATE with non-leap-year Feb 29 bound to TIMESTAMP target",
                  "[c_date][conversion][sql_timestamp][invalid]") {
   const SQLSMALLINT sql_type = GENERATE(SQL_TIMESTAMP, SQL_TYPE_TIMESTAMP);
   CAPTURE(sql_type);

--- a/odbc_tests/tests/e2e/types/c_numeric_incompatible_to_sql_date.cpp
+++ b/odbc_tests/tests/e2e/types/c_numeric_incompatible_to_sql_date.cpp
@@ -1,13 +1,22 @@
-// Tests that binding numeric and bit C types to SQL_TYPE_DATE returns an error,
-// as these conversions are not listed in the ODBC spec conversion table
-// (Appendix D, "C to SQL: Date"). Only SQL_C_CHAR, SQL_C_WCHAR,
-// SQL_C_TYPE_DATE, and SQL_C_TYPE_TIMESTAMP may be bound to SQL_TYPE_DATE.
+// Tests that binding numeric and bit C types to a DATE target returns an
+// error, as these conversions are not listed in the ODBC spec conversion
+// table (Appendix D, "C to SQL: Date"). Only SQL_C_CHAR, SQL_C_WCHAR,
+// SQL_C_TYPE_DATE, and SQL_C_TYPE_TIMESTAMP may be bound to a DATE target.
+//
+// Per ODBC Appendix G ("Driver Guidelines for Backward Compatibility"),
+// the ODBC 3.x code SQL_TYPE_DATE (91) and its ODBC 2.x predecessor
+// SQL_DATE (9) must be accepted as identical at the SQLBindParameter
+// boundary, including for the negative path tested here — both spellings
+// must reject the same set of incompatible C source types in the same
+// way. Each TEST_CASE below is parametrized over both spellings using
+// Catch2 GENERATE.
 
 #include <sql.h>
 #include <sqlext.h>
 #include <sqltypes.h>
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
 
 #include "Connection.hpp"
 #include "SchemaFixtures.hpp"
@@ -15,76 +24,91 @@
 #include "odbc_cast.hpp"
 #include "odbc_matchers.hpp"
 
-TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_SLONG bound to SQL_TYPE_DATE",
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_SLONG bound to DATE target",
                  "[c_numeric][incompatible][sql_date]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_DATE, SQL_TYPE_DATE);
+  CAPTURE(sql_type);
+
   // Given Snowflake client is logged in
   conn.execute("CREATE TEMPORARY TABLE t (col DATE)");
 
   SQLINTEGER val = 20250115;
   SQLLEN ind = 0;
 
-  // When SQL_C_SLONG is bound to SQL_TYPE_DATE and executed
+  // When SQL_C_SLONG is bound to the DATE target and executed
   auto stmt = conn.createStatement();
   SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO t VALUES (?)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // Then the driver rejects the incompatible conversion with an error
-  check_incompatible_bindparam(stmt, SQL_C_SLONG, SQL_TYPE_DATE, &val, 0, &ind);
+  check_incompatible_bindparam(stmt, SQL_C_SLONG, sql_type, &val, 0, &ind);
 }
 
-TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_DOUBLE bound to SQL_TYPE_DATE",
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_DOUBLE bound to DATE target",
                  "[c_numeric][incompatible][sql_date]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_DATE, SQL_TYPE_DATE);
+  CAPTURE(sql_type);
+
   // Given Snowflake client is logged in
   conn.execute("CREATE TEMPORARY TABLE t (col DATE)");
 
   SQLDOUBLE val = 20250115.0;
   SQLLEN ind = 0;
 
-  // When SQL_C_DOUBLE is bound to SQL_TYPE_DATE and executed
+  // When SQL_C_DOUBLE is bound to the DATE target and executed
   auto stmt = conn.createStatement();
   SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO t VALUES (?)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // Then the driver rejects the incompatible conversion with an error
-  check_incompatible_bindparam(stmt, SQL_C_DOUBLE, SQL_TYPE_DATE, &val, 0, &ind);
+  check_incompatible_bindparam(stmt, SQL_C_DOUBLE, sql_type, &val, 0, &ind);
 }
 
-TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_FLOAT bound to SQL_TYPE_DATE",
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_FLOAT bound to DATE target",
                  "[c_numeric][incompatible][sql_date]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_DATE, SQL_TYPE_DATE);
+  CAPTURE(sql_type);
+
   // Given Snowflake client is logged in
   conn.execute("CREATE TEMPORARY TABLE t (col DATE)");
 
   SQLREAL val = 20250115.0f;
   SQLLEN ind = 0;
 
-  // When SQL_C_FLOAT is bound to SQL_TYPE_DATE and executed
+  // When SQL_C_FLOAT is bound to the DATE target and executed
   auto stmt = conn.createStatement();
   SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO t VALUES (?)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // Then the driver rejects the incompatible conversion with an error
-  check_incompatible_bindparam(stmt, SQL_C_FLOAT, SQL_TYPE_DATE, &val, 0, &ind);
+  check_incompatible_bindparam(stmt, SQL_C_FLOAT, sql_type, &val, 0, &ind);
 }
 
-TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_BIT bound to SQL_TYPE_DATE",
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_BIT bound to DATE target",
                  "[c_numeric][incompatible][sql_date]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_DATE, SQL_TYPE_DATE);
+  CAPTURE(sql_type);
+
   // Given Snowflake client is logged in
   conn.execute("CREATE TEMPORARY TABLE t (col DATE)");
 
   SQLCHAR val = 1;
   SQLLEN ind = 0;
 
-  // When SQL_C_BIT is bound to SQL_TYPE_DATE and executed
+  // When SQL_C_BIT is bound to the DATE target and executed
   auto stmt = conn.createStatement();
   SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO t VALUES (?)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // Then the driver rejects the incompatible conversion with an error
-  check_incompatible_bindparam(stmt, SQL_C_BIT, SQL_TYPE_DATE, &val, 0, &ind);
+  check_incompatible_bindparam(stmt, SQL_C_BIT, sql_type, &val, 0, &ind);
 }
 
-TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_NUMERIC bound to SQL_TYPE_DATE",
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_NUMERIC bound to DATE target",
                  "[c_numeric][incompatible][sql_date]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_DATE, SQL_TYPE_DATE);
+  CAPTURE(sql_type);
+
   // Given Snowflake client is logged in
   conn.execute("CREATE TEMPORARY TABLE t (col DATE)");
 
@@ -95,28 +119,31 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_NUMERIC bound to SQL_TY
   set_numeric_magnitude(ns, 20250115);
   SQLLEN ind = sizeof(ns);
 
-  // When SQL_C_NUMERIC is bound to SQL_TYPE_DATE and executed
+  // When SQL_C_NUMERIC is bound to the DATE target and executed
   auto stmt = conn.createStatement();
   SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO t VALUES (?)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // Then the driver rejects the incompatible conversion with an error
-  check_incompatible_bindparam(stmt, SQL_C_NUMERIC, SQL_TYPE_DATE, &ns, sizeof(ns), &ind);
+  check_incompatible_bindparam(stmt, SQL_C_NUMERIC, sql_type, &ns, sizeof(ns), &ind);
 }
 
-TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_SBIGINT bound to SQL_TYPE_DATE",
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_SBIGINT bound to DATE target",
                  "[c_numeric][incompatible][sql_date]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_DATE, SQL_TYPE_DATE);
+  CAPTURE(sql_type);
+
   // Given Snowflake client is logged in
   conn.execute("CREATE TEMPORARY TABLE t (col DATE)");
 
   SQLBIGINT val = 20250115;
   SQLLEN ind = 0;
 
-  // When SQL_C_SBIGINT is bound to SQL_TYPE_DATE and executed
+  // When SQL_C_SBIGINT is bound to the DATE target and executed
   auto stmt = conn.createStatement();
   SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO t VALUES (?)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // Then the driver rejects the incompatible conversion with an error
-  check_incompatible_bindparam(stmt, SQL_C_SBIGINT, SQL_TYPE_DATE, &val, 0, &ind);
+  check_incompatible_bindparam(stmt, SQL_C_SBIGINT, sql_type, &val, 0, &ind);
 }

--- a/odbc_tests/tests/e2e/types/c_numeric_incompatible_to_sql_time.cpp
+++ b/odbc_tests/tests/e2e/types/c_numeric_incompatible_to_sql_time.cpp
@@ -1,13 +1,22 @@
-// Tests that binding numeric and bit C types to SQL_TYPE_TIME returns an error,
-// as these conversions are not listed in the ODBC spec conversion table
-// (Appendix D, "C to SQL: Time"). Only SQL_C_CHAR, SQL_C_WCHAR,
-// SQL_C_TYPE_TIME, and SQL_C_TYPE_TIMESTAMP may be bound to SQL_TYPE_TIME.
+// Tests that binding numeric and bit C types to a TIME target returns an
+// error, as these conversions are not listed in the ODBC spec conversion
+// table (Appendix D, "C to SQL: Time"). Only SQL_C_CHAR, SQL_C_WCHAR,
+// SQL_C_TYPE_TIME, and SQL_C_TYPE_TIMESTAMP may be bound to a TIME target.
+//
+// Per ODBC Appendix G ("Driver Guidelines for Backward Compatibility"),
+// the ODBC 3.x code SQL_TYPE_TIME (92) and its ODBC 2.x predecessor
+// SQL_TIME (10) must be accepted as identical at the SQLBindParameter
+// boundary, including for the negative path tested here — both spellings
+// must reject the same set of incompatible C source types in the same
+// way. Each TEST_CASE below is parametrized over both spellings using
+// Catch2 GENERATE.
 
 #include <sql.h>
 #include <sqlext.h>
 #include <sqltypes.h>
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
 
 #include "Connection.hpp"
 #include "SchemaFixtures.hpp"
@@ -15,76 +24,91 @@
 #include "odbc_cast.hpp"
 #include "odbc_matchers.hpp"
 
-TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_SLONG bound to SQL_TYPE_TIME",
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_SLONG bound to TIME target",
                  "[c_numeric][incompatible][sql_time]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_TIME, SQL_TYPE_TIME);
+  CAPTURE(sql_type);
+
   // Given Snowflake client is logged in
   conn.execute("CREATE TEMPORARY TABLE t (col TIME)");
 
   SQLINTEGER val = 123045;
   SQLLEN ind = 0;
 
-  // When SQL_C_SLONG is bound to SQL_TYPE_TIME and executed
+  // When SQL_C_SLONG is bound to the TIME target and executed
   auto stmt = conn.createStatement();
   SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO t VALUES (?)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // Then the driver rejects the incompatible conversion with an error
-  check_incompatible_bindparam(stmt, SQL_C_SLONG, SQL_TYPE_TIME, &val, 0, &ind);
+  check_incompatible_bindparam(stmt, SQL_C_SLONG, sql_type, &val, 0, &ind);
 }
 
-TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_DOUBLE bound to SQL_TYPE_TIME",
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_DOUBLE bound to TIME target",
                  "[c_numeric][incompatible][sql_time]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_TIME, SQL_TYPE_TIME);
+  CAPTURE(sql_type);
+
   // Given Snowflake client is logged in
   conn.execute("CREATE TEMPORARY TABLE t (col TIME)");
 
   SQLDOUBLE val = 123045.0;
   SQLLEN ind = 0;
 
-  // When SQL_C_DOUBLE is bound to SQL_TYPE_TIME and executed
+  // When SQL_C_DOUBLE is bound to the TIME target and executed
   auto stmt = conn.createStatement();
   SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO t VALUES (?)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // Then the driver rejects the incompatible conversion with an error
-  check_incompatible_bindparam(stmt, SQL_C_DOUBLE, SQL_TYPE_TIME, &val, 0, &ind);
+  check_incompatible_bindparam(stmt, SQL_C_DOUBLE, sql_type, &val, 0, &ind);
 }
 
-TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_FLOAT bound to SQL_TYPE_TIME",
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_FLOAT bound to TIME target",
                  "[c_numeric][incompatible][sql_time]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_TIME, SQL_TYPE_TIME);
+  CAPTURE(sql_type);
+
   // Given Snowflake client is logged in
   conn.execute("CREATE TEMPORARY TABLE t (col TIME)");
 
   SQLREAL val = 123045.0f;
   SQLLEN ind = 0;
 
-  // When SQL_C_FLOAT is bound to SQL_TYPE_TIME and executed
+  // When SQL_C_FLOAT is bound to the TIME target and executed
   auto stmt = conn.createStatement();
   SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO t VALUES (?)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // Then the driver rejects the incompatible conversion with an error
-  check_incompatible_bindparam(stmt, SQL_C_FLOAT, SQL_TYPE_TIME, &val, 0, &ind);
+  check_incompatible_bindparam(stmt, SQL_C_FLOAT, sql_type, &val, 0, &ind);
 }
 
-TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_BIT bound to SQL_TYPE_TIME",
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_BIT bound to TIME target",
                  "[c_numeric][incompatible][sql_time]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_TIME, SQL_TYPE_TIME);
+  CAPTURE(sql_type);
+
   // Given Snowflake client is logged in
   conn.execute("CREATE TEMPORARY TABLE t (col TIME)");
 
   SQLCHAR val = 1;
   SQLLEN ind = 0;
 
-  // When SQL_C_BIT is bound to SQL_TYPE_TIME and executed
+  // When SQL_C_BIT is bound to the TIME target and executed
   auto stmt = conn.createStatement();
   SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO t VALUES (?)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // Then the driver rejects the incompatible conversion with an error
-  check_incompatible_bindparam(stmt, SQL_C_BIT, SQL_TYPE_TIME, &val, 0, &ind);
+  check_incompatible_bindparam(stmt, SQL_C_BIT, sql_type, &val, 0, &ind);
 }
 
-TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_NUMERIC bound to SQL_TYPE_TIME",
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_NUMERIC bound to TIME target",
                  "[c_numeric][incompatible][sql_time]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_TIME, SQL_TYPE_TIME);
+  CAPTURE(sql_type);
+
   // Given Snowflake client is logged in
   conn.execute("CREATE TEMPORARY TABLE t (col TIME)");
 
@@ -95,28 +119,31 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_NUMERIC bound to SQL_TY
   set_numeric_magnitude(ns, 123045);
   SQLLEN ind = sizeof(ns);
 
-  // When SQL_C_NUMERIC is bound to SQL_TYPE_TIME and executed
+  // When SQL_C_NUMERIC is bound to the TIME target and executed
   auto stmt = conn.createStatement();
   SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO t VALUES (?)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // Then the driver rejects the incompatible conversion with an error
-  check_incompatible_bindparam(stmt, SQL_C_NUMERIC, SQL_TYPE_TIME, &ns, sizeof(ns), &ind);
+  check_incompatible_bindparam(stmt, SQL_C_NUMERIC, sql_type, &ns, sizeof(ns), &ind);
 }
 
-TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_SBIGINT bound to SQL_TYPE_TIME",
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_SBIGINT bound to TIME target",
                  "[c_numeric][incompatible][sql_time]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_TIME, SQL_TYPE_TIME);
+  CAPTURE(sql_type);
+
   // Given Snowflake client is logged in
   conn.execute("CREATE TEMPORARY TABLE t (col TIME)");
 
   SQLBIGINT val = 123045;
   SQLLEN ind = 0;
 
-  // When SQL_C_SBIGINT is bound to SQL_TYPE_TIME and executed
+  // When SQL_C_SBIGINT is bound to the TIME target and executed
   auto stmt = conn.createStatement();
   SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO t VALUES (?)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // Then the driver rejects the incompatible conversion with an error
-  check_incompatible_bindparam(stmt, SQL_C_SBIGINT, SQL_TYPE_TIME, &val, 0, &ind);
+  check_incompatible_bindparam(stmt, SQL_C_SBIGINT, sql_type, &val, 0, &ind);
 }

--- a/odbc_tests/tests/e2e/types/c_numeric_incompatible_to_sql_timestamp.cpp
+++ b/odbc_tests/tests/e2e/types/c_numeric_incompatible_to_sql_timestamp.cpp
@@ -1,13 +1,23 @@
-// Tests that binding numeric and bit C types to SQL_TYPE_TIMESTAMP returns an error,
-// as these conversions are not listed in the ODBC spec conversion table
-// (Appendix D, "C to SQL: Timestamp"). Only SQL_C_CHAR, SQL_C_WCHAR,
-// SQL_C_TYPE_DATE, and SQL_C_TYPE_TIMESTAMP may be bound to SQL_TYPE_TIMESTAMP.
+// Tests that binding numeric and bit C types to a TIMESTAMP target returns
+// an error, as these conversions are not listed in the ODBC spec
+// conversion table (Appendix D, "C to SQL: Timestamp"). Only SQL_C_CHAR,
+// SQL_C_WCHAR, SQL_C_TYPE_DATE, and SQL_C_TYPE_TIMESTAMP may be bound to a
+// TIMESTAMP target.
+//
+// Per ODBC Appendix G ("Driver Guidelines for Backward Compatibility"),
+// the ODBC 3.x code SQL_TYPE_TIMESTAMP (93) and its ODBC 2.x predecessor
+// SQL_TIMESTAMP (11) must be accepted as identical at the SQLBindParameter
+// boundary, including for the negative path tested here — both spellings
+// must reject the same set of incompatible C source types in the same
+// way. Each TEST_CASE below is parametrized over both spellings using
+// Catch2 GENERATE.
 
 #include <sql.h>
 #include <sqlext.h>
 #include <sqltypes.h>
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
 
 #include "Connection.hpp"
 #include "SchemaFixtures.hpp"
@@ -15,76 +25,91 @@
 #include "odbc_cast.hpp"
 #include "odbc_matchers.hpp"
 
-TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_SLONG bound to SQL_TYPE_TIMESTAMP",
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_SLONG bound to TIMESTAMP target",
                  "[c_numeric][incompatible][sql_timestamp]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_TIMESTAMP, SQL_TYPE_TIMESTAMP);
+  CAPTURE(sql_type);
+
   // Given Snowflake client is logged in
   conn.execute("CREATE TEMPORARY TABLE t (col TIMESTAMP)");
 
   SQLINTEGER val = 20250115;
   SQLLEN ind = 0;
 
-  // When SQL_C_SLONG is bound to SQL_TYPE_TIMESTAMP and executed
+  // When SQL_C_SLONG is bound to the TIMESTAMP target and executed
   auto stmt = conn.createStatement();
   SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO t VALUES (?)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // Then the driver rejects the incompatible conversion with an error
-  check_incompatible_bindparam(stmt, SQL_C_SLONG, SQL_TYPE_TIMESTAMP, &val, 0, &ind);
+  check_incompatible_bindparam(stmt, SQL_C_SLONG, sql_type, &val, 0, &ind);
 }
 
-TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_DOUBLE bound to SQL_TYPE_TIMESTAMP",
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_DOUBLE bound to TIMESTAMP target",
                  "[c_numeric][incompatible][sql_timestamp]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_TIMESTAMP, SQL_TYPE_TIMESTAMP);
+  CAPTURE(sql_type);
+
   // Given Snowflake client is logged in
   conn.execute("CREATE TEMPORARY TABLE t (col TIMESTAMP)");
 
   SQLDOUBLE val = 20250115.0;
   SQLLEN ind = 0;
 
-  // When SQL_C_DOUBLE is bound to SQL_TYPE_TIMESTAMP and executed
+  // When SQL_C_DOUBLE is bound to the TIMESTAMP target and executed
   auto stmt = conn.createStatement();
   SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO t VALUES (?)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // Then the driver rejects the incompatible conversion with an error
-  check_incompatible_bindparam(stmt, SQL_C_DOUBLE, SQL_TYPE_TIMESTAMP, &val, 0, &ind);
+  check_incompatible_bindparam(stmt, SQL_C_DOUBLE, sql_type, &val, 0, &ind);
 }
 
-TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_FLOAT bound to SQL_TYPE_TIMESTAMP",
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_FLOAT bound to TIMESTAMP target",
                  "[c_numeric][incompatible][sql_timestamp]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_TIMESTAMP, SQL_TYPE_TIMESTAMP);
+  CAPTURE(sql_type);
+
   // Given Snowflake client is logged in
   conn.execute("CREATE TEMPORARY TABLE t (col TIMESTAMP)");
 
   SQLREAL val = 20250115.0f;
   SQLLEN ind = 0;
 
-  // When SQL_C_FLOAT is bound to SQL_TYPE_TIMESTAMP and executed
+  // When SQL_C_FLOAT is bound to the TIMESTAMP target and executed
   auto stmt = conn.createStatement();
   SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO t VALUES (?)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // Then the driver rejects the incompatible conversion with an error
-  check_incompatible_bindparam(stmt, SQL_C_FLOAT, SQL_TYPE_TIMESTAMP, &val, 0, &ind);
+  check_incompatible_bindparam(stmt, SQL_C_FLOAT, sql_type, &val, 0, &ind);
 }
 
-TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_BIT bound to SQL_TYPE_TIMESTAMP",
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_BIT bound to TIMESTAMP target",
                  "[c_numeric][incompatible][sql_timestamp]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_TIMESTAMP, SQL_TYPE_TIMESTAMP);
+  CAPTURE(sql_type);
+
   // Given Snowflake client is logged in
   conn.execute("CREATE TEMPORARY TABLE t (col TIMESTAMP)");
 
   SQLCHAR val = 1;
   SQLLEN ind = 0;
 
-  // When SQL_C_BIT is bound to SQL_TYPE_TIMESTAMP and executed
+  // When SQL_C_BIT is bound to the TIMESTAMP target and executed
   auto stmt = conn.createStatement();
   SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO t VALUES (?)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // Then the driver rejects the incompatible conversion with an error
-  check_incompatible_bindparam(stmt, SQL_C_BIT, SQL_TYPE_TIMESTAMP, &val, 0, &ind);
+  check_incompatible_bindparam(stmt, SQL_C_BIT, sql_type, &val, 0, &ind);
 }
 
-TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_NUMERIC bound to SQL_TYPE_TIMESTAMP",
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_NUMERIC bound to TIMESTAMP target",
                  "[c_numeric][incompatible][sql_timestamp]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_TIMESTAMP, SQL_TYPE_TIMESTAMP);
+  CAPTURE(sql_type);
+
   // Given Snowflake client is logged in
   conn.execute("CREATE TEMPORARY TABLE t (col TIMESTAMP)");
 
@@ -95,28 +120,31 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_NUMERIC bound to SQL_TY
   set_numeric_magnitude(ns, 20250115);
   SQLLEN ind = sizeof(ns);
 
-  // When SQL_C_NUMERIC is bound to SQL_TYPE_TIMESTAMP and executed
+  // When SQL_C_NUMERIC is bound to the TIMESTAMP target and executed
   auto stmt = conn.createStatement();
   SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO t VALUES (?)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // Then the driver rejects the incompatible conversion with an error
-  check_incompatible_bindparam(stmt, SQL_C_NUMERIC, SQL_TYPE_TIMESTAMP, &ns, sizeof(ns), &ind);
+  check_incompatible_bindparam(stmt, SQL_C_NUMERIC, sql_type, &ns, sizeof(ns), &ind);
 }
 
-TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_SBIGINT bound to SQL_TYPE_TIMESTAMP",
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_SBIGINT bound to TIMESTAMP target",
                  "[c_numeric][incompatible][sql_timestamp]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_TIMESTAMP, SQL_TYPE_TIMESTAMP);
+  CAPTURE(sql_type);
+
   // Given Snowflake client is logged in
   conn.execute("CREATE TEMPORARY TABLE t (col TIMESTAMP)");
 
   SQLBIGINT val = 20250115;
   SQLLEN ind = 0;
 
-  // When SQL_C_SBIGINT is bound to SQL_TYPE_TIMESTAMP and executed
+  // When SQL_C_SBIGINT is bound to the TIMESTAMP target and executed
   auto stmt = conn.createStatement();
   SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO t VALUES (?)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // Then the driver rejects the incompatible conversion with an error
-  check_incompatible_bindparam(stmt, SQL_C_SBIGINT, SQL_TYPE_TIMESTAMP, &val, 0, &ind);
+  check_incompatible_bindparam(stmt, SQL_C_SBIGINT, sql_type, &val, 0, &ind);
 }

--- a/odbc_tests/tests/e2e/types/c_time_conversion_to_sql_time.cpp
+++ b/odbc_tests/tests/e2e/types/c_time_conversion_to_sql_time.cpp
@@ -33,8 +33,8 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIME to TIME target 
   val.minute = 30;
   val.second = 45;
   SQLLEN ind = sizeof(val);
-  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_TIME, sql_type, 0, 0, &val, sizeof(val),
-                         &ind);
+  ret =
+      SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_TIME, sql_type, 0, 0, &val, sizeof(val), &ind);
   REQUIRE_ODBC(ret, stmt);
   ret = SQLExecute(stmt.getHandle());
   REQUIRE_ODBC(ret, stmt);

--- a/odbc_tests/tests/e2e/types/c_time_conversion_to_sql_time.cpp
+++ b/odbc_tests/tests/e2e/types/c_time_conversion_to_sql_time.cpp
@@ -1,4 +1,14 @@
+// ODBC E2E: SQL_C_TYPE_TIME bound via SQLBindParameter to a TIME target.
+//
+// Per ODBC Appendix G ("Driver Guidelines for Backward Compatibility"),
+// the ODBC 3.x time code SQL_TYPE_TIME (92) and its ODBC 2.x predecessor
+// SQL_TIME (10) must be accepted as identical at the SQLBindParameter
+// boundary. Each TEST_CASE below is parametrized over both spellings
+// using Catch2 GENERATE so the alias contract is pinned for every
+// scenario.
+
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
 
 #include "Connection.hpp"
 #include "SchemaFixtures.hpp"
@@ -6,12 +16,15 @@
 #include "odbc_cast.hpp"
 #include "odbc_matchers.hpp"
 
-TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIME to SQL_TYPE_TIME and read back",
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIME to TIME target and read back",
                  "[c_time][conversion][sql_time]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_TIME, SQL_TYPE_TIME);
+  CAPTURE(sql_type);
+
   // Given Snowflake client is logged in
   conn.execute("CREATE TEMPORARY TABLE t (col TIME)");
 
-  // When SQL_C_TYPE_TIME 14:30:45 is bound to SQL_TYPE_TIME and inserted
+  // When SQL_C_TYPE_TIME 14:30:45 is bound to the TIME target and inserted
   auto stmt = conn.createStatement();
   SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO t VALUES (?)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
@@ -20,7 +33,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIME to SQL_TYPE_TIM
   val.minute = 30;
   val.second = 45;
   SQLLEN ind = sizeof(val);
-  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_TIME, SQL_TYPE_TIME, 0, 0, &val, sizeof(val),
+  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_TIME, sql_type, 0, 0, &val, sizeof(val),
                          &ind);
   REQUIRE_ODBC(ret, stmt);
   ret = SQLExecute(stmt.getHandle());
@@ -34,8 +47,11 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIME to SQL_TYPE_TIM
   CHECK(time.second == 45);
 }
 
-TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIME with NULL indicator to SQL_TYPE_TIME",
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIME with NULL indicator to TIME target",
                  "[c_time][conversion][sql_time]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_TIME, SQL_TYPE_TIME);
+  CAPTURE(sql_type);
+
   // Given Snowflake client is logged in
   conn.execute("CREATE TEMPORARY TABLE t (col TIME)");
 
@@ -44,7 +60,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIME with NULL indic
   SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO t VALUES (?)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
   SQLLEN ind = SQL_NULL_DATA;
-  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_TIME, SQL_TYPE_TIME, 0, 0, nullptr, 0, &ind);
+  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_TIME, sql_type, 0, 0, nullptr, 0, &ind);
   REQUIRE_ODBC(ret, stmt);
   ret = SQLExecute(stmt.getHandle());
   REQUIRE_ODBC(ret, stmt);

--- a/odbc_tests/tests/e2e/types/c_time_conversion_to_sql_timestamp.cpp
+++ b/odbc_tests/tests/e2e/types/c_time_conversion_to_sql_timestamp.cpp
@@ -1,5 +1,5 @@
-// ODBC E2E: SQL_C_TYPE_TIME bound via SQLBindParameter to ODBC 3.x
-// SQL_TYPE_TIMESTAMP across all three Snowflake variants.
+// ODBC E2E: SQL_C_TYPE_TIME bound via SQLBindParameter to a TIMESTAMP target
+// across all three Snowflake variants.
 //
 // Per ODBC Appendix D ("C to SQL: Time"): "The date fields of the
 // timestamp structure are set to the current date, and the fractional
@@ -9,10 +9,17 @@
 // To stay deterministic across midnight rollover, the date assertion
 // captures the local date both before and after the bind and accepts
 // any value within that window.
+//
+// Per ODBC Appendix G ("Driver Guidelines for Backward Compatibility"),
+// the ODBC 3.x code SQL_TYPE_TIMESTAMP (93) and its ODBC 2.x predecessor
+// SQL_TIMESTAMP (11) must be accepted as identical at the SQLBindParameter
+// boundary. Each TEST_CASE below is parametrized over both spellings using
+// Catch2 GENERATE so the alias contract is pinned for every scenario.
 
 #include <ctime>
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
 
 #include "Connection.hpp"
 #include "SchemaFixtures.hpp"
@@ -51,17 +58,19 @@ bool ymd_gte(const LocalYmd& a, const SQL_TIMESTAMP_STRUCT& b) {
   return a.day >= b.day;
 }
 
-void bind_time_and_execute(StatementHandleWrapper& stmt, SQL_TIME_STRUCT& val, SQLLEN& ind) {
-  SQLRETURN ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_TIME, SQL_TYPE_TIMESTAMP, 0, 0,
-                                   &val, sizeof(val), &ind);
+void bind_time_and_execute(StatementHandleWrapper& stmt, SQLSMALLINT target_sql_type, SQL_TIME_STRUCT& val,
+                           SQLLEN& ind) {
+  SQLRETURN ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_TIME, target_sql_type, 0, 0, &val,
+                                   sizeof(val), &ind);
   REQUIRE_ODBC(ret, stmt);
   ret = SQLExecute(stmt.getHandle());
   REQUIRE_ODBC(ret, stmt);
 }
 
-SQLRETURN bind_time_and_try_execute(StatementHandleWrapper& stmt, SQL_TIME_STRUCT& val, SQLLEN& ind) {
-  SQLRETURN ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_TIME, SQL_TYPE_TIMESTAMP, 0, 0,
-                                   &val, sizeof(val), &ind);
+SQLRETURN bind_time_and_try_execute(StatementHandleWrapper& stmt, SQLSMALLINT target_sql_type, SQL_TIME_STRUCT& val,
+                                    SQLLEN& ind) {
+  SQLRETURN ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_TIME, target_sql_type, 0, 0, &val,
+                                   sizeof(val), &ind);
   REQUIRE_ODBC(ret, stmt);
   return SQLExecute(stmt.getHandle());
 }
@@ -74,18 +83,21 @@ SQLRETURN bind_time_and_try_execute(StatementHandleWrapper& stmt, SQL_TIME_STRUC
 
 TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIME to TIMESTAMP_NTZ with current local date",
                  "[c_time][conversion][sql_timestamp]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_TIMESTAMP, SQL_TYPE_TIMESTAMP);
+  CAPTURE(sql_type);
+
   // Given a TIMESTAMP_NTZ column
   conn.execute("ALTER SESSION SET TIMEZONE = 'UTC'");
   conn.execute("CREATE TEMPORARY TABLE t (col TIMESTAMP_NTZ)");
 
-  // When SQL_C_TYPE_TIME 14:30:45 is bound to SQL_TYPE_TIMESTAMP and inserted
+  // When SQL_C_TYPE_TIME 14:30:45 is bound to the TIMESTAMP target and inserted
   auto stmt = conn.createStatement();
   SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO t VALUES (?)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
   SQL_TIME_STRUCT val = {14, 30, 45};
   SQLLEN ind = sizeof(val);
   LocalYmd today_before = local_today();
-  bind_time_and_execute(stmt, val, ind);
+  bind_time_and_execute(stmt, sql_type, val, ind);
   LocalYmd today_after = local_today();
 
   // Then the time round-trips exactly the fraction is zero and the date falls within the local clock window at bind
@@ -109,6 +121,9 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIME to TIMESTAMP_NT
 
 TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIME to TIMESTAMP_LTZ with current local date",
                  "[c_time][conversion][sql_timestamp]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_TIMESTAMP, SQL_TYPE_TIMESTAMP);
+  CAPTURE(sql_type);
+
   // Given a TIMESTAMP_LTZ column with a known session timezone
   conn.execute("ALTER SESSION SET TIMEZONE = 'UTC'");
   conn.execute("CREATE TEMPORARY TABLE t (col TIMESTAMP_LTZ)");
@@ -119,7 +134,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIME to TIMESTAMP_LT
   REQUIRE_ODBC(ret, stmt);
   SQL_TIME_STRUCT val = {14, 30, 45};
   SQLLEN ind = sizeof(val);
-  bind_time_and_execute(stmt, val, ind);
+  bind_time_and_execute(stmt, sql_type, val, ind);
 
   // Then the bind succeeds and the time component round-trips
   auto fetch_stmt = conn.execute_fetch("SELECT col FROM t");
@@ -136,6 +151,9 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIME to TIMESTAMP_LT
 
 TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIME to TIMESTAMP_TZ with current local date",
                  "[c_time][conversion][sql_timestamp]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_TIMESTAMP, SQL_TYPE_TIMESTAMP);
+  CAPTURE(sql_type);
+
   // Given a TIMESTAMP_TZ column with a known session timezone
   conn.execute("ALTER SESSION SET TIMEZONE = 'UTC'");
   conn.execute("CREATE TEMPORARY TABLE t (col TIMESTAMP_TZ)");
@@ -146,7 +164,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIME to TIMESTAMP_TZ
   REQUIRE_ODBC(ret, stmt);
   SQL_TIME_STRUCT val = {14, 30, 45};
   SQLLEN ind = sizeof(val);
-  bind_time_and_execute(stmt, val, ind);
+  bind_time_and_execute(stmt, sql_type, val, ind);
 
   // Then the bind succeeds and the time component round-trips
   auto fetch_stmt = conn.execute_fetch("SELECT col FROM t");
@@ -161,8 +179,11 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIME to TIMESTAMP_TZ
 // NULL indicator
 // ============================================================================
 
-TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIME with NULL indicator to SQL_TYPE_TIMESTAMP",
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIME with NULL indicator to TIMESTAMP target",
                  "[c_time][conversion][sql_timestamp]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_TIMESTAMP, SQL_TYPE_TIMESTAMP);
+  CAPTURE(sql_type);
+
   // Given a TIMESTAMP_NTZ column
   conn.execute("CREATE TEMPORARY TABLE t (col TIMESTAMP_NTZ)");
 
@@ -171,8 +192,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIME with NULL indic
   SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO t VALUES (?)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
   SQLLEN ind = SQL_NULL_DATA;
-  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_TIME, SQL_TYPE_TIMESTAMP, 0, 0, nullptr, 0,
-                         &ind);
+  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_TIME, sql_type, 0, 0, nullptr, 0, &ind);
   REQUIRE_ODBC(ret, stmt);
   ret = SQLExecute(stmt.getHandle());
   REQUIRE_ODBC(ret, stmt);
@@ -190,8 +210,11 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIME with NULL indic
 // second not in 0..59) must surface SQL_ERROR with SQLSTATE 22007.
 // ============================================================================
 
-TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_TIME with hour=24 bound to SQL_TYPE_TIMESTAMP",
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_TIME with hour=24 bound to TIMESTAMP target",
                  "[c_time][conversion][sql_timestamp][invalid]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_TIMESTAMP, SQL_TYPE_TIMESTAMP);
+  CAPTURE(sql_type);
+
   // Given a TIMESTAMP_NTZ column
   conn.execute("CREATE TEMPORARY TABLE t (col TIMESTAMP_NTZ)");
 
@@ -201,14 +224,17 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_TIME with hour=24 
   REQUIRE_ODBC(ret, stmt);
   SQL_TIME_STRUCT val = {24, 0, 0};
   SQLLEN ind = sizeof(val);
-  ret = bind_time_and_try_execute(stmt, val, ind);
+  ret = bind_time_and_try_execute(stmt, sql_type, val, ind);
 
   // Then SQLExecute fails with SQLSTATE 22007
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::IsError() && OdbcMatchers::HasSqlState("22007"));
 }
 
-TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_TIME with minute=60 bound to SQL_TYPE_TIMESTAMP",
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_TIME with minute=60 bound to TIMESTAMP target",
                  "[c_time][conversion][sql_timestamp][invalid]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_TIMESTAMP, SQL_TYPE_TIMESTAMP);
+  CAPTURE(sql_type);
+
   // Given a TIMESTAMP_NTZ column
   conn.execute("CREATE TEMPORARY TABLE t (col TIMESTAMP_NTZ)");
 
@@ -218,7 +244,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_TIME with minute=6
   REQUIRE_ODBC(ret, stmt);
   SQL_TIME_STRUCT val = {12, 60, 0};
   SQLLEN ind = sizeof(val);
-  ret = bind_time_and_try_execute(stmt, val, ind);
+  ret = bind_time_and_try_execute(stmt, sql_type, val, ind);
 
   // Then SQLExecute fails with SQLSTATE 22007
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::IsError() && OdbcMatchers::HasSqlState("22007"));

--- a/odbc_tests/tests/e2e/types/c_timestamp_conversion_to_sql_date.cpp
+++ b/odbc_tests/tests/e2e/types/c_timestamp_conversion_to_sql_date.cpp
@@ -1,5 +1,4 @@
-// ODBC E2E: SQL_C_TYPE_TIMESTAMP bound via SQLBindParameter to ODBC 3.x
-// SQL_TYPE_DATE.
+// ODBC E2E: SQL_C_TYPE_TIMESTAMP bound via SQLBindParameter to a DATE target.
 //
 // Per ODBC Appendix D ("Converting Data from C to SQL Data Types"), binding
 // a TIMESTAMP source to a DATE target succeeds only when the discarded time
@@ -7,8 +6,15 @@
 // driver must return SQL_ERROR with SQLSTATE 22008 ("Datetime field
 // overflow"). These tests cover both the happy path (zero time) and the
 // spec-mandated overflow cases.
+//
+// Per ODBC Appendix G ("Driver Guidelines for Backward Compatibility"),
+// the ODBC 3.x code SQL_TYPE_DATE (91) and its ODBC 2.x predecessor
+// SQL_DATE (9) must be accepted as identical at the SQLBindParameter
+// boundary. Each TEST_CASE below is parametrized over both spellings using
+// Catch2 GENERATE so the alias contract is pinned for every scenario.
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
 
 #include "Connection.hpp"
 #include "SchemaFixtures.hpp"
@@ -18,8 +24,9 @@
 
 namespace {
 
-void bind_timestamp_and_execute(StatementHandleWrapper& stmt, SQL_TIMESTAMP_STRUCT& val, SQLLEN& ind) {
-  SQLRETURN ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_TIMESTAMP, SQL_TYPE_DATE, 0, 0,
+void bind_timestamp_and_execute(StatementHandleWrapper& stmt, SQLSMALLINT target_sql_type,
+                                SQL_TIMESTAMP_STRUCT& val, SQLLEN& ind) {
+  SQLRETURN ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_TIMESTAMP, target_sql_type, 0, 0,
                                    &val, sizeof(val), &ind);
   REQUIRE_ODBC(ret, stmt);
   ret = SQLExecute(stmt.getHandle());
@@ -29,8 +36,9 @@ void bind_timestamp_and_execute(StatementHandleWrapper& stmt, SQL_TIMESTAMP_STRU
 // Like bind_timestamp_and_execute but returns the SQLExecute return code so
 // the caller can assert on the diagnostic SQLSTATE instead of REQUIRE'ing
 // success.
-SQLRETURN bind_timestamp_and_try_execute(StatementHandleWrapper& stmt, SQL_TIMESTAMP_STRUCT& val, SQLLEN& ind) {
-  SQLRETURN ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_TIMESTAMP, SQL_TYPE_DATE, 0, 0,
+SQLRETURN bind_timestamp_and_try_execute(StatementHandleWrapper& stmt, SQLSMALLINT target_sql_type,
+                                         SQL_TIMESTAMP_STRUCT& val, SQLLEN& ind) {
+  SQLRETURN ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_TIMESTAMP, target_sql_type, 0, 0,
                                    &val, sizeof(val), &ind);
   REQUIRE_ODBC(ret, stmt);
   return SQLExecute(stmt.getHandle());
@@ -42,8 +50,11 @@ SQLRETURN bind_timestamp_and_try_execute(StatementHandleWrapper& stmt, SQL_TIMES
 // SQL_C_TYPE_TIMESTAMP → DATE — happy paths (time portion = 00:00:00.0)
 // ============================================================================
 
-TEST_CASE_METHOD(ConnSchemaFixture, "should bind midnight SQL_C_TYPE_TIMESTAMP to SQL_TYPE_DATE without info loss",
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind midnight SQL_C_TYPE_TIMESTAMP to DATE target without info loss",
                  "[c_timestamp][conversion][sql_date]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_DATE, SQL_TYPE_DATE);
+  CAPTURE(sql_type);
+
   // Given a DATE column
   conn.execute("CREATE TEMPORARY TABLE t (col DATE)");
 
@@ -53,7 +64,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should bind midnight SQL_C_TYPE_TIMESTAMP t
   REQUIRE_ODBC(ret, stmt);
   SQL_TIMESTAMP_STRUCT val = {2026, 4, 13, 0, 0, 0, 0};
   SQLLEN ind = sizeof(val);
-  bind_timestamp_and_execute(stmt, val, ind);
+  bind_timestamp_and_execute(stmt, sql_type, val, ind);
 
   // Then the date round-trips exactly
   auto fetch_stmt = conn.execute_fetch("SELECT col FROM t");
@@ -63,8 +74,11 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should bind midnight SQL_C_TYPE_TIMESTAMP t
   CHECK(result.day == 13);
 }
 
-TEST_CASE_METHOD(ConnSchemaFixture, "should bind leap-day SQL_C_TYPE_TIMESTAMP at midnight to SQL_TYPE_DATE",
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind leap-day SQL_C_TYPE_TIMESTAMP at midnight to DATE target",
                  "[c_timestamp][conversion][sql_date]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_DATE, SQL_TYPE_DATE);
+  CAPTURE(sql_type);
+
   // Given a DATE column
   conn.execute("CREATE TEMPORARY TABLE t (col DATE)");
 
@@ -74,7 +88,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should bind leap-day SQL_C_TYPE_TIMESTAMP a
   REQUIRE_ODBC(ret, stmt);
   SQL_TIMESTAMP_STRUCT val = {2024, 2, 29, 0, 0, 0, 0};
   SQLLEN ind = sizeof(val);
-  bind_timestamp_and_execute(stmt, val, ind);
+  bind_timestamp_and_execute(stmt, sql_type, val, ind);
 
   // Then the leap date is preserved
   auto fetch_stmt = conn.execute_fetch("SELECT col FROM t");
@@ -84,8 +98,11 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should bind leap-day SQL_C_TYPE_TIMESTAMP a
   CHECK(result.day == 29);
 }
 
-TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIMESTAMP with NULL indicator to SQL_TYPE_DATE",
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIMESTAMP with NULL indicator to DATE target",
                  "[c_timestamp][conversion][sql_date]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_DATE, SQL_TYPE_DATE);
+  CAPTURE(sql_type);
+
   // Given a DATE column
   conn.execute("CREATE TEMPORARY TABLE t (col DATE)");
 
@@ -94,7 +111,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIMESTAMP with NULL 
   SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO t VALUES (?)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
   SQLLEN ind = SQL_NULL_DATA;
-  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_TIMESTAMP, SQL_TYPE_DATE, 0, 0, nullptr, 0,
+  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_TIMESTAMP, sql_type, 0, 0, nullptr, 0,
                          &ind);
   REQUIRE_ODBC(ret, stmt);
   ret = SQLExecute(stmt.getHandle());
@@ -112,8 +129,11 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIMESTAMP with NULL 
 // portion is non-zero. The driver must NOT silently truncate or round.
 // ============================================================================
 
-TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_TIMESTAMP with non-zero time bound to SQL_TYPE_DATE",
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_TIMESTAMP with non-zero time bound to DATE target",
                  "[c_timestamp][conversion][sql_date]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_DATE, SQL_TYPE_DATE);
+  CAPTURE(sql_type);
+
   // Given a DATE column
   conn.execute("CREATE TEMPORARY TABLE t (col DATE)");
 
@@ -123,14 +143,17 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_TIMESTAMP with non
   REQUIRE_ODBC(ret, stmt);
   SQL_TIMESTAMP_STRUCT val = {2026, 4, 13, 14, 30, 45, 0};
   SQLLEN ind = sizeof(val);
-  ret = bind_timestamp_and_try_execute(stmt, val, ind);
+  ret = bind_timestamp_and_try_execute(stmt, sql_type, val, ind);
 
   // Then SQLExecute fails with SQLSTATE 22008
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::IsError() && OdbcMatchers::HasSqlState("22008"));
 }
 
-TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_TIMESTAMP with non-zero fraction bound to SQL_TYPE_DATE",
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_TIMESTAMP with non-zero fraction bound to DATE target",
                  "[c_timestamp][conversion][sql_date]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_DATE, SQL_TYPE_DATE);
+  CAPTURE(sql_type);
+
   // Given a DATE column
   conn.execute("CREATE TEMPORARY TABLE t (col DATE)");
 
@@ -140,15 +163,18 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_TIMESTAMP with non
   REQUIRE_ODBC(ret, stmt);
   SQL_TIMESTAMP_STRUCT val = {2026, 4, 13, 0, 0, 0, 1};
   SQLLEN ind = sizeof(val);
-  ret = bind_timestamp_and_try_execute(stmt, val, ind);
+  ret = bind_timestamp_and_try_execute(stmt, sql_type, val, ind);
 
   // Then SQLExecute fails with SQLSTATE 22008
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::IsError() && OdbcMatchers::HasSqlState("22008"));
 }
 
 TEST_CASE_METHOD(ConnSchemaFixture,
-                 "should reject end-of-day SQL_C_TYPE_TIMESTAMP bound to SQL_TYPE_DATE (no rollover)",
+                 "should reject end-of-day SQL_C_TYPE_TIMESTAMP bound to DATE target (no rollover)",
                  "[c_timestamp][conversion][sql_date]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_DATE, SQL_TYPE_DATE);
+  CAPTURE(sql_type);
+
   // Given a DATE column
   conn.execute("CREATE TEMPORARY TABLE t (col DATE)");
 
@@ -158,7 +184,7 @@ TEST_CASE_METHOD(ConnSchemaFixture,
   REQUIRE_ODBC(ret, stmt);
   SQL_TIMESTAMP_STRUCT val = {2026, 4, 13, 23, 59, 59, 0};
   SQLLEN ind = sizeof(val);
-  ret = bind_timestamp_and_try_execute(stmt, val, ind);
+  ret = bind_timestamp_and_try_execute(stmt, sql_type, val, ind);
 
   // Then SQLExecute fails with SQLSTATE 22008
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::IsError() && OdbcMatchers::HasSqlState("22008"));
@@ -175,8 +201,11 @@ TEST_CASE_METHOD(ConnSchemaFixture,
 // layer; these e2e tests pin the same contract end-to-end.
 // ============================================================================
 
-TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_TIMESTAMP with month=13 bound to SQL_TYPE_DATE",
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_TIMESTAMP with month=13 bound to DATE target",
                  "[c_timestamp][conversion][sql_date][invalid]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_DATE, SQL_TYPE_DATE);
+  CAPTURE(sql_type);
+
   // Given a DATE column
   conn.execute("CREATE TEMPORARY TABLE t (col DATE)");
 
@@ -186,14 +215,17 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_TIMESTAMP with mon
   REQUIRE_ODBC(ret, stmt);
   SQL_TIMESTAMP_STRUCT val = {2024, 13, 1, 0, 0, 0, 0};
   SQLLEN ind = sizeof(val);
-  ret = bind_timestamp_and_try_execute(stmt, val, ind);
+  ret = bind_timestamp_and_try_execute(stmt, sql_type, val, ind);
 
   // Then SQLExecute fails with SQLSTATE 22007
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::IsError() && OdbcMatchers::HasSqlState("22007"));
 }
 
-TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_TIMESTAMP with day=32 bound to SQL_TYPE_DATE",
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_TIMESTAMP with day=32 bound to DATE target",
                  "[c_timestamp][conversion][sql_date][invalid]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_DATE, SQL_TYPE_DATE);
+  CAPTURE(sql_type);
+
   // Given a DATE column
   conn.execute("CREATE TEMPORARY TABLE t (col DATE)");
 
@@ -203,7 +235,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_TIMESTAMP with day
   REQUIRE_ODBC(ret, stmt);
   SQL_TIMESTAMP_STRUCT val = {2024, 1, 32, 0, 0, 0, 0};
   SQLLEN ind = sizeof(val);
-  ret = bind_timestamp_and_try_execute(stmt, val, ind);
+  ret = bind_timestamp_and_try_execute(stmt, sql_type, val, ind);
 
   // Then SQLExecute fails with SQLSTATE 22007
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::IsError() && OdbcMatchers::HasSqlState("22007"));
@@ -211,8 +243,12 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_TIMESTAMP with day
 
 TEST_CASE_METHOD(
     ConnSchemaFixture,
-    "should prefer SQLSTATE 22007 over 22008 when SQL_C_TYPE_TIMESTAMP has invalid month and non-zero time",
+    "should prefer SQLSTATE 22007 over 22008 when SQL_C_TYPE_TIMESTAMP has invalid month and non-zero time bound "
+    "to DATE target",
     "[c_timestamp][conversion][sql_date][invalid]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_DATE, SQL_TYPE_DATE);
+  CAPTURE(sql_type);
+
   // Given a DATE column
   conn.execute("CREATE TEMPORARY TABLE t (col DATE)");
 
@@ -222,7 +258,7 @@ TEST_CASE_METHOD(
   REQUIRE_ODBC(ret, stmt);
   SQL_TIMESTAMP_STRUCT val = {2024, 13, 1, 14, 30, 45, 500000000};
   SQLLEN ind = sizeof(val);
-  ret = bind_timestamp_and_try_execute(stmt, val, ind);
+  ret = bind_timestamp_and_try_execute(stmt, sql_type, val, ind);
 
   // Then SQLExecute fails with SQLSTATE 22007 not 22008
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::IsError() && OdbcMatchers::HasSqlState("22007"));

--- a/odbc_tests/tests/e2e/types/c_timestamp_conversion_to_sql_date.cpp
+++ b/odbc_tests/tests/e2e/types/c_timestamp_conversion_to_sql_date.cpp
@@ -24,8 +24,8 @@
 
 namespace {
 
-void bind_timestamp_and_execute(StatementHandleWrapper& stmt, SQLSMALLINT target_sql_type,
-                                SQL_TIMESTAMP_STRUCT& val, SQLLEN& ind) {
+void bind_timestamp_and_execute(StatementHandleWrapper& stmt, SQLSMALLINT target_sql_type, SQL_TIMESTAMP_STRUCT& val,
+                                SQLLEN& ind) {
   SQLRETURN ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_TIMESTAMP, target_sql_type, 0, 0,
                                    &val, sizeof(val), &ind);
   REQUIRE_ODBC(ret, stmt);
@@ -111,8 +111,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIMESTAMP with NULL 
   SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO t VALUES (?)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
   SQLLEN ind = SQL_NULL_DATA;
-  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_TIMESTAMP, sql_type, 0, 0, nullptr, 0,
-                         &ind);
+  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_TIMESTAMP, sql_type, 0, 0, nullptr, 0, &ind);
   REQUIRE_ODBC(ret, stmt);
   ret = SQLExecute(stmt.getHandle());
   REQUIRE_ODBC(ret, stmt);
@@ -169,8 +168,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_TIMESTAMP with non
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::IsError() && OdbcMatchers::HasSqlState("22008"));
 }
 
-TEST_CASE_METHOD(ConnSchemaFixture,
-                 "should reject end-of-day SQL_C_TYPE_TIMESTAMP bound to DATE target (no rollover)",
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject end-of-day SQL_C_TYPE_TIMESTAMP bound to DATE target (no rollover)",
                  "[c_timestamp][conversion][sql_date]") {
   const SQLSMALLINT sql_type = GENERATE(SQL_DATE, SQL_TYPE_DATE);
   CAPTURE(sql_type);

--- a/odbc_tests/tests/e2e/types/c_timestamp_conversion_to_sql_time.cpp
+++ b/odbc_tests/tests/e2e/types/c_timestamp_conversion_to_sql_time.cpp
@@ -25,8 +25,8 @@
 
 namespace {
 
-void bind_timestamp_and_execute(StatementHandleWrapper& stmt, SQLSMALLINT target_sql_type,
-                                SQL_TIMESTAMP_STRUCT& val, SQLLEN& ind) {
+void bind_timestamp_and_execute(StatementHandleWrapper& stmt, SQLSMALLINT target_sql_type, SQL_TIMESTAMP_STRUCT& val,
+                                SQLLEN& ind) {
   SQLRETURN ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_TIMESTAMP, target_sql_type, 0, 0,
                                    &val, sizeof(val), &ind);
   REQUIRE_ODBC(ret, stmt);
@@ -180,8 +180,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIMESTAMP with NULL 
   SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO t VALUES (?)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
   SQLLEN ind = SQL_NULL_DATA;
-  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_TIMESTAMP, sql_type, 0, 0, nullptr, 0,
-                         &ind);
+  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_TIMESTAMP, sql_type, 0, 0, nullptr, 0, &ind);
   REQUIRE_ODBC(ret, stmt);
   ret = SQLExecute(stmt.getHandle());
   REQUIRE_ODBC(ret, stmt);

--- a/odbc_tests/tests/e2e/types/c_timestamp_conversion_to_sql_time.cpp
+++ b/odbc_tests/tests/e2e/types/c_timestamp_conversion_to_sql_time.cpp
@@ -1,5 +1,4 @@
-// ODBC E2E: SQL_C_TYPE_TIMESTAMP bound via SQLBindParameter to ODBC 3.x
-// SQL_TYPE_TIME.
+// ODBC E2E: SQL_C_TYPE_TIMESTAMP bound via SQLBindParameter to a TIME target.
 //
 // Per ODBC Appendix D ("Converting Data from C to SQL Data Types"), binding
 // a TIMESTAMP source to a TIME target silently discards the date fields and
@@ -8,8 +7,15 @@
 // SQL_ERROR with SQLSTATE 22008 ("Datetime field overflow"). These tests
 // cover both the happy path (zero fraction) and the spec-mandated overflow
 // case.
+//
+// Per ODBC Appendix G ("Driver Guidelines for Backward Compatibility"),
+// the ODBC 3.x code SQL_TYPE_TIME (92) and its ODBC 2.x predecessor
+// SQL_TIME (10) must be accepted as identical at the SQLBindParameter
+// boundary. Each TEST_CASE below is parametrized over both spellings using
+// Catch2 GENERATE so the alias contract is pinned for every scenario.
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
 
 #include "Connection.hpp"
 #include "SchemaFixtures.hpp"
@@ -19,8 +25,9 @@
 
 namespace {
 
-void bind_timestamp_and_execute(StatementHandleWrapper& stmt, SQL_TIMESTAMP_STRUCT& val, SQLLEN& ind) {
-  SQLRETURN ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_TIMESTAMP, SQL_TYPE_TIME, 0, 0,
+void bind_timestamp_and_execute(StatementHandleWrapper& stmt, SQLSMALLINT target_sql_type,
+                                SQL_TIMESTAMP_STRUCT& val, SQLLEN& ind) {
+  SQLRETURN ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_TIMESTAMP, target_sql_type, 0, 0,
                                    &val, sizeof(val), &ind);
   REQUIRE_ODBC(ret, stmt);
   ret = SQLExecute(stmt.getHandle());
@@ -30,8 +37,9 @@ void bind_timestamp_and_execute(StatementHandleWrapper& stmt, SQL_TIMESTAMP_STRU
 // Like bind_timestamp_and_execute but returns the SQLExecute return code so
 // the caller can assert on the diagnostic SQLSTATE instead of REQUIRE'ing
 // success.
-SQLRETURN bind_timestamp_and_try_execute(StatementHandleWrapper& stmt, SQL_TIMESTAMP_STRUCT& val, SQLLEN& ind) {
-  SQLRETURN ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_TIMESTAMP, SQL_TYPE_TIME, 0, 0,
+SQLRETURN bind_timestamp_and_try_execute(StatementHandleWrapper& stmt, SQLSMALLINT target_sql_type,
+                                         SQL_TIMESTAMP_STRUCT& val, SQLLEN& ind) {
+  SQLRETURN ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_TIMESTAMP, target_sql_type, 0, 0,
                                    &val, sizeof(val), &ind);
   REQUIRE_ODBC(ret, stmt);
   return SQLExecute(stmt.getHandle());
@@ -43,8 +51,11 @@ SQLRETURN bind_timestamp_and_try_execute(StatementHandleWrapper& stmt, SQL_TIMES
 // SQL_C_TYPE_TIMESTAMP → TIME — happy paths
 // ============================================================================
 
-TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIMESTAMP to SQL_TYPE_TIME and discard date component",
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIMESTAMP to TIME target and discard date component",
                  "[c_timestamp][conversion][sql_time]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_TIME, SQL_TYPE_TIME);
+  CAPTURE(sql_type);
+
   // Given a TIME column
   conn.execute("CREATE TEMPORARY TABLE t (col TIME)");
 
@@ -54,7 +65,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIMESTAMP to SQL_TYP
   REQUIRE_ODBC(ret, stmt);
   SQL_TIMESTAMP_STRUCT val = {2026, 4, 13, 14, 30, 45, 0};
   SQLLEN ind = sizeof(val);
-  bind_timestamp_and_execute(stmt, val, ind);
+  bind_timestamp_and_execute(stmt, sql_type, val, ind);
 
   // Then only the time is preserved and the date is silently discarded
   auto fetch_stmt = conn.execute_fetch("SELECT col FROM t");
@@ -64,8 +75,11 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIMESTAMP to SQL_TYP
   CHECK(result.second == 45);
 }
 
-TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_TIMESTAMP with non-zero fraction bound to SQL_TYPE_TIME",
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_TIMESTAMP with non-zero fraction bound to TIME target",
                  "[c_timestamp][conversion][sql_time]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_TIME, SQL_TYPE_TIME);
+  CAPTURE(sql_type);
+
   // Given a TIME column
   conn.execute("CREATE TEMPORARY TABLE t (col TIME)");
 
@@ -75,14 +89,17 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_TIMESTAMP with non
   REQUIRE_ODBC(ret, stmt);
   SQL_TIMESTAMP_STRUCT val = {2026, 4, 13, 14, 30, 45, 500000000};
   SQLLEN ind = sizeof(val);
-  ret = bind_timestamp_and_try_execute(stmt, val, ind);
+  ret = bind_timestamp_and_try_execute(stmt, sql_type, val, ind);
 
   // Then SQLExecute fails with SQLSTATE 22008
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::IsError() && OdbcMatchers::HasSqlState("22008"));
 }
 
-TEST_CASE_METHOD(ConnSchemaFixture, "should bind midnight SQL_C_TYPE_TIMESTAMP to SQL_TYPE_TIME",
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind midnight SQL_C_TYPE_TIMESTAMP to TIME target",
                  "[c_timestamp][conversion][sql_time]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_TIME, SQL_TYPE_TIME);
+  CAPTURE(sql_type);
+
   // Given a TIME column
   conn.execute("CREATE TEMPORARY TABLE t (col TIME)");
 
@@ -92,7 +109,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should bind midnight SQL_C_TYPE_TIMESTAMP t
   REQUIRE_ODBC(ret, stmt);
   SQL_TIMESTAMP_STRUCT val = {2026, 4, 13, 0, 0, 0, 0};
   SQLLEN ind = sizeof(val);
-  bind_timestamp_and_execute(stmt, val, ind);
+  bind_timestamp_and_execute(stmt, sql_type, val, ind);
 
   // Then the stored value is the zero time
   auto fetch_stmt = conn.execute_fetch("SELECT col FROM t");
@@ -102,8 +119,11 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should bind midnight SQL_C_TYPE_TIMESTAMP t
   CHECK(result.second == 0);
 }
 
-TEST_CASE_METHOD(ConnSchemaFixture, "should bind end-of-day SQL_C_TYPE_TIMESTAMP to SQL_TYPE_TIME",
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind end-of-day SQL_C_TYPE_TIMESTAMP to TIME target",
                  "[c_timestamp][conversion][sql_time]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_TIME, SQL_TYPE_TIME);
+  CAPTURE(sql_type);
+
   // Given a TIME column
   conn.execute("CREATE TEMPORARY TABLE t (col TIME)");
 
@@ -113,7 +133,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should bind end-of-day SQL_C_TYPE_TIMESTAMP
   REQUIRE_ODBC(ret, stmt);
   SQL_TIMESTAMP_STRUCT val = {2026, 4, 13, 23, 59, 59, 0};
   SQLLEN ind = sizeof(val);
-  bind_timestamp_and_execute(stmt, val, ind);
+  bind_timestamp_and_execute(stmt, sql_type, val, ind);
 
   // Then the upper-bound time is preserved
   auto fetch_stmt = conn.execute_fetch("SELECT col FROM t");
@@ -123,8 +143,11 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should bind end-of-day SQL_C_TYPE_TIMESTAMP
   CHECK(result.second == 59);
 }
 
-TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIMESTAMP at epoch date to SQL_TYPE_TIME",
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIMESTAMP at epoch date to TIME target",
                  "[c_timestamp][conversion][sql_time]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_TIME, SQL_TYPE_TIME);
+  CAPTURE(sql_type);
+
   // Given a TIME column
   conn.execute("CREATE TEMPORARY TABLE t (col TIME)");
 
@@ -134,7 +157,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIMESTAMP at epoch d
   REQUIRE_ODBC(ret, stmt);
   SQL_TIMESTAMP_STRUCT val = {1970, 1, 1, 12, 0, 0, 0};
   SQLLEN ind = sizeof(val);
-  bind_timestamp_and_execute(stmt, val, ind);
+  bind_timestamp_and_execute(stmt, sql_type, val, ind);
 
   // Then only the time matters and the epoch date is irrelevant
   auto fetch_stmt = conn.execute_fetch("SELECT col FROM t");
@@ -144,8 +167,11 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIMESTAMP at epoch d
   CHECK(result.second == 0);
 }
 
-TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIMESTAMP with NULL indicator to SQL_TYPE_TIME",
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIMESTAMP with NULL indicator to TIME target",
                  "[c_timestamp][conversion][sql_time]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_TIME, SQL_TYPE_TIME);
+  CAPTURE(sql_type);
+
   // Given a TIME column
   conn.execute("CREATE TEMPORARY TABLE t (col TIME)");
 
@@ -154,7 +180,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIMESTAMP with NULL 
   SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO t VALUES (?)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
   SQLLEN ind = SQL_NULL_DATA;
-  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_TIMESTAMP, SQL_TYPE_TIME, 0, 0, nullptr, 0,
+  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_TIMESTAMP, sql_type, 0, 0, nullptr, 0,
                          &ind);
   REQUIRE_ODBC(ret, stmt);
   ret = SQLExecute(stmt.getHandle());
@@ -176,8 +202,11 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIMESTAMP with NULL 
 // layer; these e2e tests pin the same contract end-to-end.
 // ============================================================================
 
-TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_TIMESTAMP with hour=24 bound to SQL_TYPE_TIME",
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_TIMESTAMP with hour=24 bound to TIME target",
                  "[c_timestamp][conversion][sql_time][invalid]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_TIME, SQL_TYPE_TIME);
+  CAPTURE(sql_type);
+
   // Given a TIME column
   conn.execute("CREATE TEMPORARY TABLE t (col TIME)");
 
@@ -187,14 +216,17 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_TIMESTAMP with hou
   REQUIRE_ODBC(ret, stmt);
   SQL_TIMESTAMP_STRUCT val = {2026, 4, 13, 24, 0, 0, 0};
   SQLLEN ind = sizeof(val);
-  ret = bind_timestamp_and_try_execute(stmt, val, ind);
+  ret = bind_timestamp_and_try_execute(stmt, sql_type, val, ind);
 
   // Then SQLExecute fails with SQLSTATE 22007
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::IsError() && OdbcMatchers::HasSqlState("22007"));
 }
 
-TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_TIMESTAMP with minute=60 bound to SQL_TYPE_TIME",
+TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_TIMESTAMP with minute=60 bound to TIME target",
                  "[c_timestamp][conversion][sql_time][invalid]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_TIME, SQL_TYPE_TIME);
+  CAPTURE(sql_type);
+
   // Given a TIME column
   conn.execute("CREATE TEMPORARY TABLE t (col TIME)");
 
@@ -204,15 +236,18 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should reject SQL_C_TYPE_TIMESTAMP with min
   REQUIRE_ODBC(ret, stmt);
   SQL_TIMESTAMP_STRUCT val = {2026, 4, 13, 12, 60, 0, 0};
   SQLLEN ind = sizeof(val);
-  ret = bind_timestamp_and_try_execute(stmt, val, ind);
+  ret = bind_timestamp_and_try_execute(stmt, sql_type, val, ind);
 
   // Then SQLExecute fails with SQLSTATE 22007
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::IsError() && OdbcMatchers::HasSqlState("22007"));
 }
 
 TEST_CASE_METHOD(ConnSchemaFixture,
-                 "should reject SQL_C_TYPE_TIMESTAMP with out-of-range fraction bound to SQL_TYPE_TIME",
+                 "should reject SQL_C_TYPE_TIMESTAMP with out-of-range fraction bound to TIME target",
                  "[c_timestamp][conversion][sql_time][invalid]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_TIME, SQL_TYPE_TIME);
+  CAPTURE(sql_type);
+
   // Given a TIME column
   conn.execute("CREATE TEMPORARY TABLE t (col TIME)");
 
@@ -222,7 +257,7 @@ TEST_CASE_METHOD(ConnSchemaFixture,
   REQUIRE_ODBC(ret, stmt);
   SQL_TIMESTAMP_STRUCT val = {2026, 4, 13, 12, 0, 0, 3000000000U};
   SQLLEN ind = sizeof(val);
-  ret = bind_timestamp_and_try_execute(stmt, val, ind);
+  ret = bind_timestamp_and_try_execute(stmt, sql_type, val, ind);
 
   // Then SQLExecute fails with SQLSTATE 22007
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::IsError() && OdbcMatchers::HasSqlState("22007"));
@@ -230,8 +265,12 @@ TEST_CASE_METHOD(ConnSchemaFixture,
 
 TEST_CASE_METHOD(
     ConnSchemaFixture,
-    "should prefer SQLSTATE 22007 over 22008 when SQL_C_TYPE_TIMESTAMP has invalid hour and non-zero fraction",
+    "should prefer SQLSTATE 22007 over 22008 when SQL_C_TYPE_TIMESTAMP has invalid hour and non-zero fraction bound "
+    "to TIME target",
     "[c_timestamp][conversion][sql_time][invalid]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_TIME, SQL_TYPE_TIME);
+  CAPTURE(sql_type);
+
   // Given a TIME column
   conn.execute("CREATE TEMPORARY TABLE t (col TIME)");
 
@@ -241,7 +280,7 @@ TEST_CASE_METHOD(
   REQUIRE_ODBC(ret, stmt);
   SQL_TIMESTAMP_STRUCT val = {2026, 4, 13, 25, 0, 0, 500000000};
   SQLLEN ind = sizeof(val);
-  ret = bind_timestamp_and_try_execute(stmt, val, ind);
+  ret = bind_timestamp_and_try_execute(stmt, sql_type, val, ind);
 
   // Then SQLExecute fails with SQLSTATE 22007 not 22008
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::IsError() && OdbcMatchers::HasSqlState("22007"));

--- a/odbc_tests/tests/e2e/types/c_timestamp_conversion_to_sql_timestamp.cpp
+++ b/odbc_tests/tests/e2e/types/c_timestamp_conversion_to_sql_timestamp.cpp
@@ -39,8 +39,8 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIMESTAMP to TIMESTA
   val.second = 45;
   val.fraction = 0;
   SQLLEN ind = sizeof(val);
-  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_TIMESTAMP, sql_type, 0, 0, &val,
-                         sizeof(val), &ind);
+  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_TIMESTAMP, sql_type, 0, 0, &val, sizeof(val),
+                         &ind);
   REQUIRE_ODBC(ret, stmt);
   ret = SQLExecute(stmt.getHandle());
   REQUIRE_ODBC(ret, stmt);
@@ -69,8 +69,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIMESTAMP with NULL 
   SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO t VALUES (?)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
   SQLLEN ind = SQL_NULL_DATA;
-  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_TIMESTAMP, sql_type, 0, 0, nullptr, 0,
-                         &ind);
+  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_TIMESTAMP, sql_type, 0, 0, nullptr, 0, &ind);
   REQUIRE_ODBC(ret, stmt);
   ret = SQLExecute(stmt.getHandle());
   REQUIRE_ODBC(ret, stmt);

--- a/odbc_tests/tests/e2e/types/c_timestamp_conversion_to_sql_timestamp.cpp
+++ b/odbc_tests/tests/e2e/types/c_timestamp_conversion_to_sql_timestamp.cpp
@@ -1,4 +1,15 @@
+// ODBC E2E: SQL_C_TYPE_TIMESTAMP bound via SQLBindParameter to a TIMESTAMP
+// target.
+//
+// Per ODBC Appendix G ("Driver Guidelines for Backward Compatibility"),
+// the ODBC 3.x code SQL_TYPE_TIMESTAMP (93) and its ODBC 2.x predecessor
+// SQL_TIMESTAMP (11) must be accepted as identical at the SQLBindParameter
+// boundary. Each TEST_CASE below is parametrized over both spellings
+// using Catch2 GENERATE so the alias contract is pinned for every
+// scenario.
+
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
 
 #include "Connection.hpp"
 #include "SchemaFixtures.hpp"
@@ -6,8 +17,11 @@
 #include "odbc_cast.hpp"
 #include "odbc_matchers.hpp"
 
-TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIMESTAMP to SQL_TYPE_TIMESTAMP and read back",
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIMESTAMP to TIMESTAMP target and read back",
                  "[c_timestamp][conversion][sql_timestamp]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_TIMESTAMP, SQL_TYPE_TIMESTAMP);
+  CAPTURE(sql_type);
+
   // Given Snowflake client is logged in
   conn.execute("ALTER SESSION SET TIMEZONE = 'UTC'");
   conn.execute("CREATE TEMPORARY TABLE t (col TIMESTAMP_NTZ)");
@@ -25,7 +39,7 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIMESTAMP to SQL_TYP
   val.second = 45;
   val.fraction = 0;
   SQLLEN ind = sizeof(val);
-  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_TIMESTAMP, SQL_TYPE_TIMESTAMP, 0, 0, &val,
+  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_TIMESTAMP, sql_type, 0, 0, &val,
                          sizeof(val), &ind);
   REQUIRE_ODBC(ret, stmt);
   ret = SQLExecute(stmt.getHandle());
@@ -42,8 +56,11 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIMESTAMP to SQL_TYP
   CHECK(result.second == 45);
 }
 
-TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIMESTAMP with NULL indicator to SQL_TYPE_TIMESTAMP",
+TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIMESTAMP with NULL indicator to TIMESTAMP target",
                  "[c_timestamp][conversion][sql_timestamp]") {
+  const SQLSMALLINT sql_type = GENERATE(SQL_TIMESTAMP, SQL_TYPE_TIMESTAMP);
+  CAPTURE(sql_type);
+
   // Given Snowflake client is logged in
   conn.execute("CREATE TEMPORARY TABLE t (col TIMESTAMP_NTZ)");
 
@@ -52,8 +69,8 @@ TEST_CASE_METHOD(ConnSchemaFixture, "should bind SQL_C_TYPE_TIMESTAMP with NULL 
   SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO t VALUES (?)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
   SQLLEN ind = SQL_NULL_DATA;
-  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_TIMESTAMP, SQL_TYPE_TIMESTAMP, 0, 0, nullptr,
-                         0, &ind);
+  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_TIMESTAMP, sql_type, 0, 0, nullptr, 0,
+                         &ind);
   REQUIRE_ODBC(ret, stmt);
   ret = SQLExecute(stmt.getHandle());
   REQUIRE_ODBC(ret, stmt);


### PR DESCRIPTION
## Summary

SQLBindParameter previously rejected the deprecated ODBC 2.x temporal codes `SQL_DATE` (=9) and `SQL_TIME` (=10) at the dispatcher in `odbc/src/conversion/param_binding.rs`, falling through to the unsupported-type branch with an HY004-style error. The modern ODBC 3.x spelling (`SQL_TYPE_DATE` / `SQL_TYPE_TIME`) worked. The third deprecated code `SQL_TIMESTAMP` (=11) was already aliased to `SQL_TYPE_TIMESTAMP` before this change.

Per ODBC Appendix G (\"Driver Guidelines for Backward Compatibility\"), ODBC 3.x drivers must accept either spelling and treat them as identical at the API boundary. This was previously visible as the three pairs of differently-coloured rows for DATE / TIME / TIMESTAMP in the SQLBindParameter conversion matrix on the reports site: the modern rows were green where supported, and the deprecated rows were red across the board.

### What changes

**Driver** (`odbc/src/conversion/param_binding.rs`):
- Add `sql::SqlDataType::DATETIME` (=9, the `odbc-sys` alias for the deprecated `SQL_DATE`) to the existing `DATE` arm.
- Add `sql::SqlDataType::EXT_TIME_OR_INTERVAL` (=10, the `odbc-sys` alias for the deprecated `SQL_TIME`) to the `TIME` arm.
- The `TIMESTAMP` arm gets a clarifying comment for symmetry; behavior unchanged (already aliased).

The header-value collisions (9 doubles as `SQL_DATETIME`, 10 doubles as `SQL_INTERVAL`) are resolved at the C-runtime header level. At the `SQLBindParameter` boundary the bare numeric value is unambiguously the ODBC 2.x SQL code — the interval subtypes use codes 101-113 and are matched by their own guarded match arms below.

**Tests** — parametrize the e2e SQLBindParameter tests for date / time / timestamp targets over both legacy and modern SQL type codes using Catch2 `GENERATE`. Each TEST_CASE now runs twice (once per spelling), pinning the alias contract for happy-path round trips, NULL indicators, invalid-struct-field rejection (22007), narrowing-conversion overflow (22008), and the negative path (incompatible numeric / bit C source rejection):

| Source C type → Target SQL type | File | Parametrized over |
|---|---|---|
| \`SQL_C_TYPE_DATE\` → DATE | \`c_date_conversion_to_sql_date.cpp\` | \`SQL_DATE\` \| \`SQL_TYPE_DATE\` |
| \`SQL_C_TYPE_DATE\` → TIMESTAMP | \`c_date_conversion_to_sql_timestamp.cpp\` | \`SQL_TIMESTAMP\` \| \`SQL_TYPE_TIMESTAMP\` |
| \`SQL_C_TYPE_TIME\` → TIME | \`c_time_conversion_to_sql_time.cpp\` | \`SQL_TIME\` \| \`SQL_TYPE_TIME\` |
| \`SQL_C_TYPE_TIME\` → TIMESTAMP | \`c_time_conversion_to_sql_timestamp.cpp\` | \`SQL_TIMESTAMP\` \| \`SQL_TYPE_TIMESTAMP\` |
| \`SQL_C_TYPE_TIMESTAMP\` → DATE | \`c_timestamp_conversion_to_sql_date.cpp\` | \`SQL_DATE\` \| \`SQL_TYPE_DATE\` |
| \`SQL_C_TYPE_TIMESTAMP\` → TIME | \`c_timestamp_conversion_to_sql_time.cpp\` | \`SQL_TIME\` \| \`SQL_TYPE_TIME\` |
| \`SQL_C_TYPE_TIMESTAMP\` → TIMESTAMP | \`c_timestamp_conversion_to_sql_timestamp.cpp\` | \`SQL_TIMESTAMP\` \| \`SQL_TYPE_TIMESTAMP\` |
| numeric / bit (incompatible) → DATE | \`c_numeric_incompatible_to_sql_date.cpp\` | \`SQL_DATE\` \| \`SQL_TYPE_DATE\` |
| numeric / bit (incompatible) → TIME | \`c_numeric_incompatible_to_sql_time.cpp\` | \`SQL_TIME\` \| \`SQL_TYPE_TIME\` |
| numeric / bit (incompatible) → TIMESTAMP | \`c_numeric_incompatible_to_sql_timestamp.cpp\` | \`SQL_TIMESTAMP\` \| \`SQL_TYPE_TIMESTAMP\` |

The existing conversion-matrix harness in \`odbc_tests/tests/conversion_matrix/bindparam_to_{date,time,timestamp,timestamp_ltz,timestamp_tz}.cpp\` already iterates over both spellings, so the next matrix snapshot picks up the new coverage automatically.

## Test plan

- [x] \`cargo test -p odbc --lib conversion::param_binding\` — 208 passed locally.
- [x] \`cmake --build cmake-build --target e2e_types_<each>\` for all 10 modified targets — all build & link cleanly locally.
- [ ] CI: full e2e suite on the parametrized targets (each test now runs twice; failure messages include \`CAPTURE(sql_type)\` so the failing spelling is easy to identify).
- [ ] Next conversion-matrix snapshot run shows the deprecated \`SQL_DATE\` / \`SQL_TIME\` rows transitioning from \"not implemented (red)\" to the same coverage state as their modern counterparts, with no regression in \`SQL_TYPE_DATE\` / \`SQL_TYPE_TIME\` / either \`SQL_TIMESTAMP\` row.

Made with [Cursor](https://cursor.com)