### PR TITLE
NO-SNOW: Return pre-decryption size in ODBC resultset

### DIFF
--- a/odbc_tests/BehaviorDifferences.yaml
+++ b/odbc_tests/BehaviorDifferences.yaml
@@ -19,9 +19,9 @@ behavior_differences:
 
   4:
     name: "GET rowset metadata contains file size after decryption instead of file size before decryption"
-    status: unknown
+    status: fixed
     type: bug
-    reviewed: false
+    reviewed: true
 
   5:
     name: "Header of a gzip-compressed file does not contain filename"

--- a/odbc_tests/tests/e2e/put_get/put_get_basic_operations.cpp
+++ b/odbc_tests/tests/e2e/put_get/put_get_basic_operations.cpp
@@ -140,8 +140,7 @@ TEST_CASE("should return correct rowset for GET", "[put_get]") {
 
   CHECK(get_data<SQL_C_CHAR>(stmt, GET_ROW_FILE_IDX) == filename + ".gz");
 
-  OLD_DRIVER_ONLY("BD#4") { CHECK(get_data<SQL_C_LONG>(stmt, GET_ROW_SIZE_IDX) == 32); }
-  NEW_DRIVER_ONLY("BD#4") { CHECK(get_data<SQL_C_LONG>(stmt, GET_ROW_SIZE_IDX) == 26); }
+  CHECK(get_data<SQL_C_LONG>(stmt, GET_ROW_SIZE_IDX) == 32);
 
   CHECK(get_data<SQL_C_CHAR>(stmt, GET_ROW_STATUS_IDX) == "DOWNLOADED");
 

--- a/sf_core/src/apis/database_driver_v1/query.rs
+++ b/sf_core/src/apis/database_driver_v1/query.rs
@@ -52,13 +52,15 @@ pub(super) async fn perform_put_get_transfer(
             Ok(RowsetData::Upload(upload_results))
         }
         "DOWNLOAD" => {
-            let file_download_data = data.to_file_download_data().map_err(|e| {
-                if e.to_string().contains("source locations") {
-                    RemoteFileNotFoundSnafu.build()
-                } else {
-                    FileTransferPreparationSnafu.into_error(e)
-                }
-            })?;
+            let file_download_data = data
+                .to_file_download_data(&wrapper_presets.put_get_resultset_flavor)
+                .map_err(|e| {
+                    if e.to_string().contains("source locations") {
+                        RemoteFileNotFoundSnafu.build()
+                    } else {
+                        FileTransferPreparationSnafu.into_error(e)
+                    }
+                })?;
             let download_results = download_files(file_download_data)
                 .await
                 .context(FileDownloadSnafu)?;

--- a/sf_core/src/file_manager/azure_transfer.rs
+++ b/sf_core/src/file_manager/azure_transfer.rs
@@ -1,6 +1,6 @@
 use super::types::{
-    CloudCredentials, EncryptedFileMetadata, EncryptionData, MaterialDescription, PreparedUpload,
-    StageInfo, UploadStatus, build_encryption_metadata_json, percent_encode_path,
+    CloudCredentials, DownloadResponse, EncryptedFileMetadata, EncryptionData, MaterialDescription,
+    PreparedUpload, StageInfo, UploadStatus, build_encryption_metadata_json, percent_encode_path,
 };
 use crate::config::retry::{BackoffConfig, Jitter, RetryPolicy};
 use crate::http::retry::{HttpContext, HttpError, execute_with_retry as http_execute_with_retry};
@@ -38,10 +38,16 @@ pub async fn upload_to_azure_or_skip(
 
 /// Downloads a file from Azure Blob Storage and returns data with optional encryption metadata.
 /// For SSE stages the metadata headers will be absent and `None` is returned.
+///
+/// `cloud_byte_count` reflects the on-cloud (pre-decryption) byte count of
+/// the blob — taken from the collected body length, which equals the
+/// Azure `Content-Length` (i.e. the stored blob size) for non-streamed
+/// responses. This is the wire byte count, not the decrypted/decoded
+/// size of the original file.
 pub async fn download_from_azure(
     stage_info: &StageInfo,
     filename: &str,
-) -> Result<(Vec<u8>, Option<String>, Option<EncryptedFileMetadata>), AzureDownloadError> {
+) -> Result<DownloadResponse, AzureDownloadError> {
     let client = create_azure_client()?;
     let key = format!("{}{filename}", stage_info.key_prefix);
     let (url, sas_token) = resolve_url_and_token(stage_info, &key)?;
@@ -82,8 +88,14 @@ pub async fn download_from_azure(
             detail: sanitize_sas(e.to_string()),
         })?
         .to_vec();
+    let cloud_byte_count = data.len() as i64;
 
-    Ok((data, digest, file_metadata))
+    Ok(DownloadResponse {
+        data,
+        digest,
+        file_metadata,
+        cloud_byte_count,
+    })
 }
 
 /// Check if a blob exists in Azure via HEAD request.

--- a/sf_core/src/file_manager/gcs_transfer.rs
+++ b/sf_core/src/file_manager/gcs_transfer.rs
@@ -1,6 +1,6 @@
 use super::types::{
-    CloudCredentials, EncryptedFileMetadata, MaterialDescription, PreparedUpload, StageInfo,
-    UploadStatus, build_encryption_metadata_json, percent_encode_path,
+    CloudCredentials, DownloadResponse, EncryptedFileMetadata, MaterialDescription, PreparedUpload,
+    StageInfo, UploadStatus, build_encryption_metadata_json, percent_encode_path,
 };
 use crate::config::retry::{BackoffConfig, Jitter, RetryPolicy};
 use crate::http::retry::{HttpContext, HttpError, execute_with_retry as http_execute_with_retry};
@@ -38,10 +38,16 @@ pub async fn upload_to_gcs_or_skip(
 
 /// Downloads a file from GCS and returns data with optional encryption metadata.
 /// For SSE stages the metadata headers will be absent and `None` is returned.
+///
+/// `cloud_byte_count` reflects the on-cloud (pre-decryption) byte count of
+/// the object — taken from the collected body length, which equals the
+/// GCS `Content-Length` (i.e. the stored object size) for non-streamed
+/// responses. This is the wire byte count, not the decrypted/decoded
+/// size of the original file.
 pub async fn download_from_gcs(
     stage_info: &StageInfo,
     filename: &str,
-) -> Result<(Vec<u8>, Option<String>, Option<EncryptedFileMetadata>), GcsDownloadError> {
+) -> Result<DownloadResponse, GcsDownloadError> {
     let client = create_gcs_client()?;
     let key = format!("{}{filename}", stage_info.key_prefix);
     let (url, token) = resolve_url_and_token(stage_info, &key)?;
@@ -104,8 +110,14 @@ pub async fn download_from_gcs(
         .await
         .map_err(|source| GcsRequestError::Http { source })?
         .to_vec();
+    let cloud_byte_count = data.len() as i64;
 
-    Ok((data, digest, file_metadata))
+    Ok(DownloadResponse {
+        data,
+        digest,
+        file_metadata,
+        cloud_byte_count,
+    })
 }
 
 /// Check if a file exists in GCS via HEAD request.

--- a/sf_core/src/file_manager/mod.rs
+++ b/sf_core/src/file_manager/mod.rs
@@ -223,6 +223,7 @@ pub async fn download_files(
             local_location: data.local_location.clone(),
             stage_info: data.stage_info.clone(),
             encryption_material,
+            flavor: data.flavor.clone(),
         };
 
         let result = download_single_file(single_download_data).await?;
@@ -235,7 +236,12 @@ pub async fn download_files(
 pub async fn download_single_file(
     data: SingleDownloadData,
 ) -> Result<DownloadResult, FileManagerError> {
-    let (raw_data, digest, file_metadata) = match data.stage_info.location_type {
+    let DownloadResponse {
+        data: raw_data,
+        digest,
+        file_metadata,
+        cloud_byte_count,
+    } = match data.stage_info.location_type {
         LocationType::S3 => download_from_s3(&data.stage_info, data.src_location.as_str())
             .await
             .context(S3DownloadSnafu)?,
@@ -276,10 +282,25 @@ pub async fn download_single_file(
 
     Ok(DownloadResult {
         file: data.src_location,
-        size: output_data.len() as i64,
+        size: download_result_size(cloud_byte_count, output_data.len() as i64, &data.flavor),
         status: "DOWNLOADED".to_string(),
         message: "".to_string(),
     })
+}
+
+/// Returns the `size` column value for a completed download, gated on the
+/// active wrapper flavor. Legacy ODBC reports the on-cloud
+/// (pre-decryption) byte count via `srcFileSize`; Python keeps reporting
+/// the post-decryption buffer length.
+fn download_result_size(
+    cloud_byte_count: i64,
+    output_byte_len: i64,
+    flavor: &PutGetResultsetFlavor,
+) -> i64 {
+    match flavor {
+        PutGetResultsetFlavor::Odbc => cloud_byte_count,
+        _ => output_byte_len,
+    }
 }
 
 // Error types for file manager operations
@@ -423,5 +444,56 @@ mod tests {
             ODBC_PUT_MESSAGE_SKIPPED,
             "File with same name already exists. SKIPPED",
         );
+    }
+
+    // BD#4 — `download_single_file` must report the on-cloud
+    // (pre-decryption) byte count under `Odbc` (matching legacy
+    // libsnowflakeclient `srcFileSize`) and the post-decryption buffer
+    // length under `Python` (current UD-Python contract).
+    #[test]
+    fn download_result_size_odbc_uses_cloud_byte_count() {
+        let cloud_byte_count = 32;
+        let output_byte_len = 26;
+        assert_eq!(
+            download_result_size(
+                cloud_byte_count,
+                output_byte_len,
+                &PutGetResultsetFlavor::Odbc
+            ),
+            cloud_byte_count,
+        );
+    }
+
+    #[test]
+    fn download_result_size_python_uses_output_length() {
+        let cloud_byte_count = 32;
+        let output_byte_len = 26;
+        assert_eq!(
+            download_result_size(
+                cloud_byte_count,
+                output_byte_len,
+                &PutGetResultsetFlavor::Python,
+            ),
+            output_byte_len,
+        );
+    }
+
+    #[test]
+    fn download_result_size_sse_branches_collapse_to_same_value() {
+        // For SSE stages (no client-side encryption) the cloud byte
+        // count and the post-decryption buffer length are identical, so
+        // both wrapper flavors must report exactly `n`.
+        for n in [0, 1, 1000] {
+            assert_eq!(
+                download_result_size(n, n, &PutGetResultsetFlavor::Odbc),
+                n,
+                "Odbc flavor must report n={n} when cloud == output",
+            );
+            assert_eq!(
+                download_result_size(n, n, &PutGetResultsetFlavor::Python),
+                n,
+                "Python flavor must report n={n} when cloud == output",
+            );
+        }
     }
 }

--- a/sf_core/src/file_manager/s3_transfer.rs
+++ b/sf_core/src/file_manager/s3_transfer.rs
@@ -1,5 +1,6 @@
 use super::types::{
-    EncryptedFileMetadata, MaterialDescription, PreparedUpload, StageInfo, UploadStatus,
+    DownloadResponse, EncryptedFileMetadata, MaterialDescription, PreparedUpload, StageInfo,
+    UploadStatus,
 };
 use crate::config::retry::{BackoffConfig, Jitter, RetryPolicy};
 use snafu::{Location, ResultExt, Snafu};
@@ -113,10 +114,14 @@ async fn upload_to_s3(
 
 /// Downloads a file from S3 and returns the data with optional encryption metadata.
 /// For SSE stages the metadata headers will be absent and `None` is returned.
+///
+/// `cloud_byte_count` reflects the on-cloud (pre-decryption) byte count of
+/// the blob — taken from the collected body length, which equals the S3
+/// `Content-Length` for non-streamed responses.
 pub async fn download_from_s3(
     stage_info: &StageInfo,
     filename: &str,
-) -> Result<(Vec<u8>, Option<String>, Option<EncryptedFileMetadata>), DownloadFileError> {
+) -> Result<DownloadResponse, DownloadFileError> {
     let s3_client = create_s3_client(stage_info, SNOWFLAKE_DOWNLOAD_PROVIDER).await?;
     let s3_key = format!("{}{filename}", stage_info.key_prefix);
 
@@ -164,8 +169,14 @@ pub async fn download_from_s3(
         .context(download_file_error::ByteStreamSnafu)?
         .into_bytes()
         .to_vec();
+    let cloud_byte_count = data.len() as i64;
 
-    Ok((data, digest, file_metadata))
+    Ok(DownloadResponse {
+        data,
+        digest,
+        file_metadata,
+        cloud_byte_count,
+    })
 }
 
 /// Returns a retry policy tuned for S3 file-transfer operations.

--- a/sf_core/src/file_manager/types.rs
+++ b/sf_core/src/file_manager/types.rs
@@ -52,6 +52,12 @@ pub struct DownloadData {
     pub local_location: String,
     pub stage_info: StageInfo,
     pub encryption_materials: Vec<Option<EncryptionMaterial>>,
+    /// Wrapper-specific shape of the GET result set. Forwarded into each
+    /// `SingleDownloadData` so that `download_single_file` can populate the
+    /// `size` column according to the active wrapper's contract (cloud
+    /// pre-decryption byte count for ODBC vs. post-decryption length for
+    /// Python).
+    pub flavor: PutGetResultsetFlavor,
 }
 
 #[derive(Debug)]
@@ -60,6 +66,24 @@ pub struct SingleDownloadData {
     pub local_location: String,
     pub stage_info: StageInfo,
     pub encryption_material: Option<EncryptionMaterial>,
+    pub flavor: PutGetResultsetFlavor,
+}
+
+/// Bytes plus metadata returned by the cloud transfer layer for a single
+/// downloaded blob.
+///
+/// `cloud_byte_count` is the on-cloud (pre-decryption) byte count of the
+/// blob — typically the value reported by the storage layer's
+/// `Content-Length` header. For `PutGetResultsetFlavor::Odbc` it becomes
+/// the value of the GET result's `size` column (legacy `srcFileSize`
+/// parity); for `Python` we keep reporting the post-decryption buffer
+/// length out of `download_single_file`.
+#[derive(Debug)]
+pub struct DownloadResponse {
+    pub data: Vec<u8>,
+    pub digest: Option<String>,
+    pub file_metadata: Option<EncryptedFileMetadata>,
+    pub cloud_byte_count: i64,
 }
 
 #[derive(Debug, Clone)]

--- a/sf_core/src/rest/snowflake/query_response.rs
+++ b/sf_core/src/rest/snowflake/query_response.rs
@@ -394,7 +394,17 @@ impl Data {
     }
 
     /// Encryption material is optional — SSE stages omit it from the response.
-    pub fn to_file_download_data(&self) -> Result<file_manager::DownloadData, QueryResponseError> {
+    ///
+    /// `flavor` selects the wrapper-specific shape of the resulting GET
+    /// result set; it is forwarded into `SingleDownloadData` so that
+    /// `file_manager::download_single_file` can populate the `size`
+    /// column per `BehaviorDifferences.yaml` BD#4. Taken by reference so
+    /// callers don't have to clone — the single `clone` happens at the
+    /// `DownloadData` storage point below.
+    pub fn to_file_download_data(
+        &self,
+        flavor: &PutGetResultsetFlavor,
+    ) -> Result<file_manager::DownloadData, QueryResponseError> {
         let src_locations = self
             .src_locations
             .as_ref()
@@ -451,6 +461,7 @@ impl Data {
             local_location,
             stage_info,
             encryption_materials,
+            flavor: flavor.clone(),
         })
     }
 
@@ -1289,6 +1300,38 @@ mod tests {
             .to_file_upload_data(PutGetResultsetFlavor::Odbc)
             .unwrap();
         assert_eq!(upload.flavor, PutGetResultsetFlavor::Odbc);
+    }
+
+    fn make_download_json() -> String {
+        r#"{
+            "src_locations": ["path/to/file.csv.gz"],
+            "stageInfo": {
+                "locationType": "GCS",
+                "location": "bucket/prefix/",
+                "creds": {"GCS_ACCESS_TOKEN": "fake"},
+                "region": "us-central1"
+            },
+            "localLocation": "/tmp/dl"
+        }"#
+        .to_string()
+    }
+
+    #[test]
+    fn download_data_forwards_flavor_python() {
+        let data: Data = serde_json::from_str(&make_download_json()).unwrap();
+        let download = data
+            .to_file_download_data(&PutGetResultsetFlavor::Python)
+            .unwrap();
+        assert_eq!(download.flavor, PutGetResultsetFlavor::Python);
+    }
+
+    #[test]
+    fn download_data_forwards_flavor_odbc() {
+        let data: Data = serde_json::from_str(&make_download_json()).unwrap();
+        let download = data
+            .to_file_download_data(&PutGetResultsetFlavor::Odbc)
+            .unwrap();
+        assert_eq!(download.flavor, PutGetResultsetFlavor::Odbc);
     }
 
     #[test]

--- a/sf_core/tests/integration/http/azure_retry.rs
+++ b/sf_core/tests/integration/http/azure_retry.rs
@@ -66,10 +66,17 @@ async fn azure_download_success_returns_data_and_metadata() {
     let stage = azure_stage(&server.uri());
     let result = sf_core::file_manager::download_from_azure(&stage, "file.csv").await;
 
-    let (data, digest, metadata) = result.expect("download should succeed");
-    assert_eq!(data, b"encrypted-data");
-    assert_eq!(digest, Some("test-digest".to_string()));
-    let metadata = metadata.expect("encryption metadata should be present");
+    let response = result.expect("download should succeed");
+    assert_eq!(response.data, b"encrypted-data");
+    assert_eq!(response.digest, Some("test-digest".to_string()));
+    assert_eq!(
+        response.cloud_byte_count,
+        b"encrypted-data".len() as i64,
+        "cloud_byte_count should equal the body length"
+    );
+    let metadata = response
+        .file_metadata
+        .expect("encryption metadata should be present");
     assert_eq!(metadata.encrypted_key, "dGVzdC1rZXk=");
     assert_eq!(metadata.iv, "dGVzdC1pdg==");
     assert_eq!(metadata.material_desc.query_id, "test-query");


### PR DESCRIPTION
### TL;DR

Fixes BD#4: GET rowset `size` column now reports the on-cloud (pre-decryption) byte count for ODBC, matching legacy `libsnowflakeclient` behavior.

### What changed?

Each cloud download function (S3, GCS, Azure) now returns a `DownloadResponse` struct instead of a bare tuple. This struct carries the raw bytes, digest, encryption metadata, and a new `cloud_byte_count` field representing the wire byte count of the blob before decryption.

A `PutGetResultsetFlavor` is threaded from `to_file_download_data` through `DownloadData` and `SingleDownloadData` into `download_single_file`. A new `download_result_size` function uses this flavor to select which byte count to report in the GET result's `size` column: ODBC reports `cloud_byte_count` (pre-decryption, matching legacy `srcFileSize`), while Python continues to report the post-decryption buffer length.

The ODBC end-to-end test for GET rowset metadata is updated to assert a single expected size of `32` (the on-cloud byte count), removing the old `OLD_DRIVER_ONLY`/`NEW_DRIVER_ONLY` split. BD#4 in `BehaviorDifferences.yaml` is marked `fixed`.

### How to test?

- Run the ODBC end-to-end test `should return correct rowset for GET` and confirm it passes with the size asserting `32`.
- Run the new unit tests in `file_manager/mod.rs`:
  - `download_result_size_odbc_uses_cloud_byte_count`
  - `download_result_size_python_uses_output_length`
  - `download_result_size_sse_branches_collapse_to_same_value`
- Run the new `query_response` tests `download_data_forwards_flavor_python` and `download_data_forwards_flavor_odbc` to confirm flavor propagation.
- Run the Azure integration test `azure_download_success_returns_data_and_metadata` to confirm `cloud_byte_count` equals the body length.

### Why make this change?

The legacy ODBC driver (`libsnowflakeclient`) reported the pre-decryption (on-cloud) file size in the GET result's `size` column. The new driver was incorrectly reporting the post-decryption size, causing a mismatch. This fix restores parity with the legacy behavior for ODBC while leaving the Python driver's behavior unchanged.