### PR TITLE
test(python): reduce per-test overhead in integ/e2e suites

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -149,7 +149,7 @@ markers = [
     "require_vpn: test requires VPN access (skipped outside Jenkins CI)",
     "flaky: marks tests as flaky; skipped by default, run explicitly via the flaky CI job or `-m flaky` locally",
 ]
-log_cli = true
+log_cli = false
 log_cli_level = "INFO"
 log_cli_format = "%(asctime)s [%(levelname)8s] %(message)s (%(pathname)s:%(lineno)s)"
 log_cli_date_format = "%Y-%m-%d %H:%M:%S"

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -16,12 +16,11 @@ from snowflake.connector.cursor import DictCursor
 from .compatibility import IS_UNIVERSAL_DRIVER
 from .connector_factory import ConnectorFactory, create_connection_with_adapter
 from .private_key_helper import get_test_private_key_path
+from .wiremock_client import WiremockClient
 
 
 # Type alias for a single row returned from cursor
 Row = tuple[Any, ...]
-
-_MIN_XDIST_WORKERS = 8
 
 
 def pytest_configure(config):
@@ -41,8 +40,7 @@ def pytest_configure(config):
 
 
 def pytest_xdist_auto_num_workers(config):
-    num_cpus = os.cpu_count() or _MIN_XDIST_WORKERS
-    return max(num_cpus, _MIN_XDIST_WORKERS)
+    return os.cpu_count() or 1
 
 
 @pytest.mark.optionalhook
@@ -71,16 +69,31 @@ def with_paramstyle(style: str):
     return pytest.mark.parametrize("connection", [style], indirect=True)
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def connection(request, connector_adapter):
-    """Create a test connection using the configured connector adapter.
+    """Module-scoped test connection; shared across tests in the same module.
 
-    Use ``@with_paramstyle(...)`` to enable parameter binding on the
-    connection.  When the decorator is absent the connection has no
-    paramstyle set.
+    Use ``@with_paramstyle(...)`` to enable parameter binding. When a paramstyle
+    is supplied via indirect parametrize, a distinct instance is created per
+    paramstyle so tests with different paramstyles don't collide.
+
+    Tests that mutate connection state (close, autocommit, commit/rollback,
+    set_autocommit, etc.) must use ``function_connection`` instead — this
+    fixture is reused across tests in a module and must remain untouched.
     """
     paramstyle = getattr(request, "param", None)
     with create_connection_with_adapter(connector_adapter, paramstyle=paramstyle) as conn:
+        yield conn
+
+
+@pytest.fixture
+def function_connection(connector_adapter):
+    """Function-scoped connection for tests that mutate connection state.
+
+    Required for tests that call ``close()``, ``autocommit()``, ``commit()``,
+    ``rollback()``, or similar methods that invalidate the session.
+    """
+    with create_connection_with_adapter(connector_adapter) as conn:
         yield conn
 
 
@@ -202,6 +215,27 @@ def int_test_connection_factory(connector_adapter):
         return create_connection_with_adapter(connector_adapter, **integration_params)
 
     return _create_connection
+
+
+@pytest.fixture(scope="session")
+def _wiremock_session():
+    """Start one Wiremock JVM per xdist worker and reuse it across tests."""
+    client = WiremockClient().start()
+    try:
+        yield client
+    finally:
+        client.stop()
+
+
+@pytest.fixture
+def wiremock(_wiremock_session):
+    """Per-test Wiremock handle backed by a session-scoped JVM.
+
+    Mappings and captured requests are cleared before each test; the JVM itself
+    stays up, saving ~1–3 s of startup per test.
+    """
+    _wiremock_session.reset()
+    return _wiremock_session
 
 
 def pytest_runtest_setup(item):

--- a/python/tests/e2e/pandas/conftest.py
+++ b/python/tests/e2e/pandas/conftest.py
@@ -1,0 +1,27 @@
+"""Shared fixtures for pandas tests."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_arrow_number_to_decimal(connection):
+    """Reset the ``arrow_number_to_decimal`` flag between tests.
+
+    Several tests flip ``connection.arrow_number_to_decimal = True`` to get
+    lossless Decimal columns for high-precision NUMBER(p,s) values. With the
+    module-scoped ``connection`` fixture the flag persists across tests in
+    the same module, turning every later NUMBER column into Decimal and
+    failing ``is_float_dtype`` assertions. Reset to the default (False) after
+    each test so the shared connection stays untainted.
+    """
+    yield
+    try:
+        connection.arrow_number_to_decimal = False
+    except Exception:
+        pass
+    try:
+        connection.arrow_number_to_decimal_setter = False
+    except Exception:
+        pass

--- a/python/tests/e2e/session/test_close.py
+++ b/python/tests/e2e/session/test_close.py
@@ -17,7 +17,6 @@ import warnings
 import pytest
 
 from tests.private_key_helper import get_test_private_key_path
-from tests.wiremock_client import WiremockClient
 
 
 def assert_logout_request_format(logout_request: dict) -> None:
@@ -48,84 +47,82 @@ class TestLogoutPythonWrapper:
     # 3. "And Connection close metrics are recorded in telemetry" is empty — telemetry
     #    recording is not yet implemented (SNOW-2912513).
     def test_should_send_logout_when_server_session_keep_alive_is_none_and_auto_detection_false(
-        self, int_test_connection_factory
+        self, int_test_connection_factory, wiremock
     ):
         """Verify that logout is sent when auto-detection is disabled."""
-        with WiremockClient().start() as wiremock:
-            # Setup Wiremock mappings
-            wiremock.add_mapping("auth/login_success_jwt.json")
-            wiremock.add_mapping("session/logout_success.json")
+        # Setup Wiremock mappings
+        wiremock.add_mapping("auth/login_success_jwt.json")
+        wiremock.add_mapping("session/logout_success.json")
 
-            # Capture warnings
-            with warnings.catch_warnings(record=True) as captured_warnings:
-                warnings.simplefilter("always")
+        # Capture warnings
+        with warnings.catch_warnings(record=True) as captured_warnings:
+            warnings.simplefilter("always")
 
-                # Given Snowflake Python client is created with server_session_keep_alive set to none
-                server_session_keep_alive_param = None
+            # Given Snowflake Python client is created with server_session_keep_alive set to none
+            server_session_keep_alive_param = None
 
-                # And enable_server_session_keep_alive_auto_detection is set to false
-                conn = int_test_connection_factory(
-                    server_url=wiremock.http_url(),
-                    server_session_keep_alive=server_session_keep_alive_param,
-                    enable_server_session_keep_alive_auto_detection=False,
-                )
-
-                # When Client closes connection
-                conn.close()
-
-            # Then Auto-detection is not performed
-            assert conn.is_closed(), "Connection closed: auto-detection was not invoked to prevent logout"
-
-            # And Logout request is sent
-            logout_requests = wiremock.get_logout_requests()
-
-            assert len(logout_requests) == 1, (
-                f"Should send logout request with auto_detection=False, got {len(logout_requests)} requests"
+            # And enable_server_session_keep_alive_auto_detection is set to false
+            conn = int_test_connection_factory(
+                server_url=wiremock.http_url(),
+                server_session_keep_alive=server_session_keep_alive_param,
+                enable_server_session_keep_alive_auto_detection=False,
             )
 
-            assert_logout_request_format(logout_requests[0])
+            # When Client closes connection
+            conn.close()
 
-            # And Connection close metrics are recorded in telemetry
-            pass  # TODO(SNOW-2912513): telemetry not yet implemented — step unverified
+        # Then Auto-detection is not performed
+        assert conn.is_closed(), "Connection closed: auto-detection was not invoked to prevent logout"
 
-            # And No deprecation warning is emitted
-            deprecation_warnings = [
-                w for w in captured_warnings if issubclass(w.category, (FutureWarning, DeprecationWarning))
-            ]
-            assert len(deprecation_warnings) == 0, (
-                f"Should not emit deprecation warning, got: {[str(w.message) for w in deprecation_warnings]}"
-            )
+        # And Logout request is sent
+        logout_requests = wiremock.get_logout_requests()
 
-            assert conn.is_closed()
+        assert len(logout_requests) == 1, (
+            f"Should send logout request with auto_detection=False, got {len(logout_requests)} requests"
+        )
+
+        assert_logout_request_format(logout_requests[0])
+
+        # And Connection close metrics are recorded in telemetry
+        pass  # TODO(SNOW-2912513): telemetry not yet implemented — step unverified
+
+        # And No deprecation warning is emitted
+        deprecation_warnings = [
+            w for w in captured_warnings if issubclass(w.category, (FutureWarning, DeprecationWarning))
+        ]
+        assert len(deprecation_warnings) == 0, (
+            f"Should not emit deprecation warning, got: {[str(w.message) for w in deprecation_warnings]}"
+        )
+
+        assert conn.is_closed()
 
     @pytest.mark.skip_reference(reason="core_proxy fixture imports _internal")
     def test_should_pass_correct_parameters_when_server_session_keep_alive_is_none_and_auto_detection_true(
-        self, int_test_connection_factory, core_proxy
+        self, int_test_connection_factory, core_proxy, wiremock
     ):
         """Verify Python wrapper passes None keep-alive and True auto-detection to Core.
 
         Phase 2 (SNOW-2314152) truth table: server_session_keep_alive=None + enable_auto_detection=True
         → no Phase 2 (SNOW-2314152) remap (only False + True triggers remap) → Core receives None + True.
         """
-        with WiremockClient().start() as wiremock:
-            wiremock.add_mapping("auth/login_success_jwt.json")
-            wiremock.add_mapping("session/logout_success.json")
+        wiremock.add_mapping("auth/login_success_jwt.json")
+        wiremock.add_mapping("session/logout_success.json")
 
-            with warnings.catch_warnings(record=True) as captured_warnings:
-                warnings.simplefilter("always")
+        with warnings.catch_warnings(record=True) as captured_warnings:
+            warnings.simplefilter("always")
 
-                # Given Snowflake Python client is created with server_session_keep_alive set to none
-                server_session_keep_alive_param = None
+            # Given Snowflake Python client is created with server_session_keep_alive set to none
+            server_session_keep_alive_param = None
 
-                # And enable_server_session_keep_alive_auto_detection is set to true
-                conn = int_test_connection_factory(
-                    server_url=wiremock.http_url(),
-                    server_session_keep_alive=server_session_keep_alive_param,
-                    enable_server_session_keep_alive_auto_detection=True,
-                )
+            # And enable_server_session_keep_alive_auto_detection is set to true
+            conn = int_test_connection_factory(
+                server_url=wiremock.http_url(),
+                server_session_keep_alive=server_session_keep_alive_param,
+                enable_server_session_keep_alive_auto_detection=True,
+            )
 
-            # When Client closes connection
-            conn.close()
+        # When Client closes connection
+        conn.close()
 
         # Then server_session_keep_alive none is passed to Core
         options = core_proxy.get_options_sent()
@@ -145,7 +142,7 @@ class TestLogoutPythonWrapper:
 
     @pytest.mark.skip_reference(reason="core_proxy fixture imports _internal")
     def test_should_remap_server_session_keep_alive_false_to_none_when_auto_detection_defaults_to_true(
-        self, int_test_connection_factory, core_proxy
+        self, int_test_connection_factory, core_proxy, wiremock
     ):
         """Verify Python wrapper remaps False keep-alive to None when auto-detection is True (default).
 
@@ -153,75 +150,73 @@ class TestLogoutPythonWrapper:
         → Phase 2 (SNOW-2314152) remap: False + True → None so Core checks registry (legacy Python behavior).
         Default True is required for Phase 2 backward compat (SNOW-2314152).
         """
-        with WiremockClient().start() as wiremock:
-            wiremock.add_mapping("auth/login_success_jwt.json")
-            wiremock.add_mapping("session/logout_success.json")
+        wiremock.add_mapping("auth/login_success_jwt.json")
+        wiremock.add_mapping("session/logout_success.json")
 
-            # Given Snowflake Python client is created with server_session_keep_alive set to false
-            with warnings.catch_warnings(record=True) as captured_warnings:
-                warnings.simplefilter("always")
-                conn = int_test_connection_factory(
-                    server_url=wiremock.http_url(),
-                    server_session_keep_alive=False,
-                )
-
-            # When Client closes connection
-            conn.close()
-
-            # Then server_session_keep_alive false is remapped to none
-            options = core_proxy.get_options_sent()
-            assert "server_session_keep_alive" not in options, (
-                "False + auto_detection=True (default) → remap → None → not sent to Core"
+        # Given Snowflake Python client is created with server_session_keep_alive set to false
+        with warnings.catch_warnings(record=True) as captured_warnings:
+            warnings.simplefilter("always")
+            conn = int_test_connection_factory(
+                server_url=wiremock.http_url(),
+                server_session_keep_alive=False,
             )
 
-            future_warnings = [w for w in captured_warnings if issubclass(w.category, FutureWarning)]
+        # When Client closes connection
+        conn.close()
 
-            # And Deprecation warning is emitted
-            assert any("server_session_keep_alive=False" in str(w.message) for w in future_warnings), (
-                f"Expected FutureWarning about server_session_keep_alive=False, "
-                f"got: {[str(w.message) for w in captured_warnings]}"
-            )
+        # Then server_session_keep_alive false is remapped to none
+        options = core_proxy.get_options_sent()
+        assert "server_session_keep_alive" not in options, (
+            "False + auto_detection=True (default) → remap → None → not sent to Core"
+        )
 
-            # And Warning mentions that false will force logout in Phase 3 (SNOW-2314152)
-            assert any("always logout" in str(w.message) for w in future_warnings), (
-                f"Warning should mention Phase 3 (SNOW-2314152) 'always logout' behavior, "
-                f"got: {[str(w.message) for w in future_warnings]}"
-            )
+        future_warnings = [w for w in captured_warnings if issubclass(w.category, FutureWarning)]
 
-            # Verify logout was actually sent to Core (False = explicit logout)
-            logout_requests = wiremock.get_logout_requests()
-            assert len(logout_requests) == 1, (
-                f"server_session_keep_alive=False should send exactly one logout request, got {len(logout_requests)}"
-            )
+        # And Deprecation warning is emitted
+        assert any("server_session_keep_alive=False" in str(w.message) for w in future_warnings), (
+            f"Expected FutureWarning about server_session_keep_alive=False, "
+            f"got: {[str(w.message) for w in captured_warnings]}"
+        )
+
+        # And Warning mentions that false will force logout in Phase 3 (SNOW-2314152)
+        assert any("always logout" in str(w.message) for w in future_warnings), (
+            f"Warning should mention Phase 3 (SNOW-2314152) 'always logout' behavior, "
+            f"got: {[str(w.message) for w in future_warnings]}"
+        )
+
+        # Verify logout was actually sent to Core (False = explicit logout)
+        logout_requests = wiremock.get_logout_requests()
+        assert len(logout_requests) == 1, (
+            f"server_session_keep_alive=False should send exactly one logout request, got {len(logout_requests)}"
+        )
 
     @pytest.mark.skip_reference(reason="core_proxy fixture imports _internal")
     def test_should_pass_server_session_keep_alive_false_to_core_when_auto_detection_explicitly_disabled(
-        self, int_test_connection_factory, core_proxy
+        self, int_test_connection_factory, core_proxy, wiremock
     ):
         """Verify Python wrapper passes False to Core when auto_detection is explicitly disabled.
 
         False + auto_detection=False (explicit) → no Phase 2 (SNOW-2314152) remap → Core receives False (force logout).
         No deprecation warning: user opted out of auto-detection consciously.
         """
-        with WiremockClient().start() as wiremock:
-            wiremock.add_mapping("auth/login_success_jwt.json")
-            wiremock.add_mapping("session/logout_success.json")
+        wiremock.add_mapping("auth/login_success_jwt.json")
+        wiremock.add_mapping("session/logout_success.json")
 
-            with warnings.catch_warnings(record=True) as captured_warnings:
-                warnings.simplefilter("always")
+        with warnings.catch_warnings(record=True) as captured_warnings:
+            warnings.simplefilter("always")
 
-                # Given Snowflake Python client is created with server_session_keep_alive set to false
-                server_session_keep_alive_param = False
+            # Given Snowflake Python client is created with server_session_keep_alive set to false
+            server_session_keep_alive_param = False
 
-                # And enable_server_session_keep_alive_auto_detection is set to false
-                conn = int_test_connection_factory(
-                    server_url=wiremock.http_url(),
-                    server_session_keep_alive=server_session_keep_alive_param,
-                    enable_server_session_keep_alive_auto_detection=False,
-                )
+            # And enable_server_session_keep_alive_auto_detection is set to false
+            conn = int_test_connection_factory(
+                server_url=wiremock.http_url(),
+                server_session_keep_alive=server_session_keep_alive_param,
+                enable_server_session_keep_alive_auto_detection=False,
+            )
 
-            # When Client closes connection
-            conn.close()
+        # When Client closes connection
+        conn.close()
 
         # Then server_session_keep_alive false is passed to Core
         options = core_proxy.get_options_sent()
@@ -245,149 +240,145 @@ class TestLogoutPythonWrapper:
         ids=["auto_detection_true", "auto_detection_false"],
     )
     def test_should_skip_logout_when_server_session_keep_alive_is_true_regardless_of_auto_detection(
-        self, int_test_connection_factory, core_proxy, auto_detection: bool
+        self, int_test_connection_factory, core_proxy, auto_detection: bool, wiremock
     ) -> None:
         """Verify no logout is sent when server_session_keep_alive=True, regardless of auto_detection.
 
         Phase 2 (SNOW-2314152) truth table: True + any auto_detection → no logout, no deprecation.
         Core receives server_session_keep_alive=True and skips the logout request.
         """
-        with WiremockClient().start() as wiremock:
-            wiremock.add_mapping("auth/login_success_jwt.json")
+        wiremock.add_mapping("auth/login_success_jwt.json")
 
-            with warnings.catch_warnings(record=True) as captured_warnings:
-                warnings.simplefilter("always")
+        with warnings.catch_warnings(record=True) as captured_warnings:
+            warnings.simplefilter("always")
 
-                # Given Snowflake Python client is created with server_session_keep_alive set to true
-                server_session_keep_alive_param = True
+            # Given Snowflake Python client is created with server_session_keep_alive set to true
+            server_session_keep_alive_param = True
 
-                # And enable_server_session_keep_alive_auto_detection is set to <auto_detection>
-                conn = int_test_connection_factory(
-                    server_url=wiremock.http_url(),
-                    server_session_keep_alive=server_session_keep_alive_param,
-                    enable_server_session_keep_alive_auto_detection=auto_detection,
-                )
-
-                # When Connection is closed
-                conn.close()
-
-            # Then No logout request is sent
-            logout_requests = wiremock.get_logout_requests()
-            assert len(logout_requests) == 0, (
-                f"Expected no logout when server_session_keep_alive=True "
-                f"(auto_detection={auto_detection}), got {len(logout_requests)} requests"
+            # And enable_server_session_keep_alive_auto_detection is set to <auto_detection>
+            conn = int_test_connection_factory(
+                server_url=wiremock.http_url(),
+                server_session_keep_alive=server_session_keep_alive_param,
+                enable_server_session_keep_alive_auto_detection=auto_detection,
             )
-
-            # And server_session_keep_alive true is passed to Core
-            options = core_proxy.get_options_sent()
-            assert options.get("server_session_keep_alive") is True, (
-                f"Expected server_session_keep_alive=True passed to Core, "
-                f"got {options.get('server_session_keep_alive')!r}"
-            )
-
-            # And No deprecation warning is emitted
-            deprecation_warnings = [
-                w for w in captured_warnings if issubclass(w.category, (FutureWarning, DeprecationWarning))
-            ]
-            assert len(deprecation_warnings) == 0, (
-                f"server_session_keep_alive=True should not emit deprecation warning, "
-                f"got: {[str(w.message) for w in deprecation_warnings]}"
-            )
-
-    @pytest.mark.skip_reference(reason="core_proxy fixture imports _internal")
-    def test_should_use_python_default_15_second_timeout_and_3_max_retries(self, int_test_connection_factory):
-        """Verify default logout uses 15s timeout and 3 max attempts (Core defaults)."""
-        with WiremockClient().start() as wiremock:
-            wiremock.add_mapping("auth/login_success_jwt.json")
-            wiremock.add_mapping("session/logout_500_always.json")
-
-            # Given Snowflake Python client is created with default timeout configuration
-            conn = int_test_connection_factory(server_url=wiremock.http_url())
 
             # When Connection is closed
-            start = time.monotonic()
-            conn.close()  # BestEffort — won't raise despite 500s
-            elapsed = time.monotonic() - start
+            conn.close()
 
-            # Then Logout completes within 15 seconds
-            DEFAULT_LOGOUT_TIMEOUT = 15
-            SCHEDULING_TOLERANCE = 2  # backoff jitter + OS scheduling overhead
-            assert elapsed < DEFAULT_LOGOUT_TIMEOUT + SCHEDULING_TOLERANCE, (
-                f"Expected completion within {DEFAULT_LOGOUT_TIMEOUT}s + {SCHEDULING_TOLERANCE}s tolerance, "
-                f"took {elapsed:.1f}s"
-            )
+        # Then No logout request is sent
+        logout_requests = wiremock.get_logout_requests()
+        assert len(logout_requests) == 0, (
+            f"Expected no logout when server_session_keep_alive=True "
+            f"(auto_detection={auto_detection}), got {len(logout_requests)} requests"
+        )
 
-            # And Logout retries up to 3 times on failure
-            logout_requests = wiremock.get_logout_requests()
-            assert len(logout_requests) == 3, f"Expected 3 attempts (default max_attempts), got {len(logout_requests)}"
+        # And server_session_keep_alive true is passed to Core
+        options = core_proxy.get_options_sent()
+        assert options.get("server_session_keep_alive") is True, (
+            f"Expected server_session_keep_alive=True passed to Core, got {options.get('server_session_keep_alive')!r}"
+        )
+
+        # And No deprecation warning is emitted
+        deprecation_warnings = [
+            w for w in captured_warnings if issubclass(w.category, (FutureWarning, DeprecationWarning))
+        ]
+        assert len(deprecation_warnings) == 0, (
+            f"server_session_keep_alive=True should not emit deprecation warning, "
+            f"got: {[str(w.message) for w in deprecation_warnings]}"
+        )
+
+    @pytest.mark.skip_reference(reason="core_proxy fixture imports _internal")
+    def test_should_use_python_default_15_second_timeout_and_3_max_retries(self, int_test_connection_factory, wiremock):
+        """Verify default logout uses 15s timeout and 3 max attempts (Core defaults)."""
+        wiremock.add_mapping("auth/login_success_jwt.json")
+        wiremock.add_mapping("session/logout_500_always.json")
+
+        # Given Snowflake Python client is created with default timeout configuration
+        conn = int_test_connection_factory(server_url=wiremock.http_url())
+
+        # When Connection is closed
+        start = time.monotonic()
+        conn.close()  # BestEffort — won't raise despite 500s
+        elapsed = time.monotonic() - start
+
+        # Then Logout completes within 15 seconds
+        DEFAULT_LOGOUT_TIMEOUT = 15
+        SCHEDULING_TOLERANCE = 2  # backoff jitter + OS scheduling overhead
+        assert elapsed < DEFAULT_LOGOUT_TIMEOUT + SCHEDULING_TOLERANCE, (
+            f"Expected completion within {DEFAULT_LOGOUT_TIMEOUT}s + {SCHEDULING_TOLERANCE}s tolerance, "
+            f"took {elapsed:.1f}s"
+        )
+
+        # And Logout retries up to 3 times on failure
+        logout_requests = wiremock.get_logout_requests()
+        assert len(logout_requests) == 3, f"Expected 3 attempts (default max_attempts), got {len(logout_requests)}"
 
     @pytest.mark.skip_reference(reason="core_proxy fixture imports _internal")
     def test_should_use_best_effort_error_handling_strategy_by_default(
-        self, int_test_connection_factory, core_proxy, tmp_path
+        self, int_test_connection_factory, core_proxy, tmp_path, wiremock
     ):
         """Verify close() does not raise when server returns 500 on all logout attempts.
 
         Best-effort strategy: close() succeeds even if logout fails.
         All retries (max_attempts=3) are exhausted, then Core reports WARN and returns ok.
         """
-        with WiremockClient().start() as wiremock:
-            wiremock.add_mapping("auth/login_success_jwt.json")
+        wiremock.add_mapping("auth/login_success_jwt.json")
 
-            # Given Snowflake Python client is created with default parameters
-            conn = int_test_connection_factory(server_url=wiremock.http_url())
+        # Given Snowflake Python client is created with default parameters
+        conn = int_test_connection_factory(server_url=wiremock.http_url())
 
-            # And Server will return 500 Internal Server Error on logout on all attempts
-            wiremock.add_mapping("session/logout_500_always.json")
+        # And Server will return 500 Internal Server Error on logout on all attempts
+        wiremock.add_mapping("session/logout_500_always.json")
 
-            # Capture Core logs to a temp file. We use a file instead of pytest caplog
-            # because the Rust→Python FFI log bridge (sf_core_init_logger callback in
-            # c_api.py) writes to the snowflake.connector._core logger which has
-            # propagate=False and NullHandler by default — caplog can't intercept it
-            # without reconfiguring propagation. A FileHandler on the logger directly
-            # captures the FFI-bridged logs.
-            log_file = tmp_path / "core.log"
-            core_logger = logging.getLogger("snowflake.connector._core")
-            handler = logging.FileHandler(str(log_file))
-            handler.setLevel(logging.WARNING)
-            handler.setFormatter(logging.Formatter("%(levelname)s %(message)s"))
-            core_logger.addHandler(handler)
-            original_level = core_logger.level
-            core_logger.setLevel(logging.WARNING)
+        # Capture Core logs to a temp file. We use a file instead of pytest caplog
+        # because the Rust→Python FFI log bridge (sf_core_init_logger callback in
+        # c_api.py) writes to the snowflake.connector._core logger which has
+        # propagate=False and NullHandler by default — caplog can't intercept it
+        # without reconfiguring propagation. A FileHandler on the logger directly
+        # captures the FFI-bridged logs.
+        log_file = tmp_path / "core.log"
+        core_logger = logging.getLogger("snowflake.connector._core")
+        handler = logging.FileHandler(str(log_file))
+        handler.setLevel(logging.WARNING)
+        handler.setFormatter(logging.Formatter("%(levelname)s %(message)s"))
+        core_logger.addHandler(handler)
+        original_level = core_logger.level
+        core_logger.setLevel(logging.WARNING)
 
-            try:
-                # When Connection is closed
-                conn.close()  # Must NOT raise with best-effort strategy
-            finally:
-                core_logger.removeHandler(handler)
-                core_logger.setLevel(original_level)
-                handler.close()
+        try:
+            # When Connection is closed
+            conn.close()  # Must NOT raise with best-effort strategy
+        finally:
+            core_logger.removeHandler(handler)
+            core_logger.setLevel(original_level)
+            handler.close()
 
-            # Then Logout attempts are bounded by the default retry limit
-            logout_requests = wiremock.get_logout_requests()
-            assert len(logout_requests) <= 3, (
-                f"Expected at most 3 logout attempts (default max_attempts), got {len(logout_requests)}"
-            )
+        # Then Logout attempts are bounded by the default retry limit
+        logout_requests = wiremock.get_logout_requests()
+        assert len(logout_requests) <= 3, (
+            f"Expected at most 3 logout attempts (default max_attempts), got {len(logout_requests)}"
+        )
 
-            # And No further requests are sent after retry limit is reached
-            assert len(logout_requests) == 3, (
-                f"Expected exactly {3} attempts (limit hit, no more sent). Got {len(logout_requests)}"
-            )
+        # And No further requests are sent after retry limit is reached
+        assert len(logout_requests) == 3, (
+            f"Expected exactly {3} attempts (limit hit, no more sent). Got {len(logout_requests)}"
+        )
 
-            # And Error is logged as WARN
-            log_content = log_file.read_text()
-            assert "WARNING" in log_content and "Logout failed" in log_content, (
-                f"Expected WARNING log with 'Logout failed' from Core.\nCaptured:\n{log_content}"
-            )
+        # And Error is logged as WARN
+        log_content = log_file.read_text()
+        assert "WARNING" in log_content and "Logout failed" in log_content, (
+            f"Expected WARNING log with 'Logout failed' from Core.\nCaptured:\n{log_content}"
+        )
 
-            # And close() method does not raise exception
-            pass  # proven by conn.close() completing without exception in the try block above
+        # And close() method does not raise exception
+        pass  # proven by conn.close() completing without exception in the try block above
 
-            # And Connection cleanup succeeds
-            assert conn.is_closed()
+        # And Connection cleanup succeeds
+        assert conn.is_closed()
 
-            # And Error handling strategy is best-effort by default
-            options = core_proxy.get_options_sent()
-            assert options.get("logout_error_strategy") == "best_effort", "Default error strategy should be BEST_EFFORT"
+        # And Error handling strategy is best-effort by default
+        options = core_proxy.get_options_sent()
+        assert options.get("logout_error_strategy") == "best_effort", "Default error strategy should be BEST_EFFORT"
 
 
 class TestLogoutRetryBehavior:
@@ -399,59 +390,57 @@ class TestLogoutRetryBehavior:
 
     @pytest.mark.skip_reference(reason="Old connector (v4.3.0) does not retry logout on 503")
     def test_should_retry_logout_on_transient_failure_when_close_called_with_default_retry(
-        self, int_test_connection_factory
+        self, int_test_connection_factory, wiremock
     ):
         """Verify close() retries a failed logout and sends two requests on transient 503."""
-        with WiremockClient().start() as wiremock:
-            wiremock.add_mapping("auth/login_success_jwt.json")
+        wiremock.add_mapping("auth/login_success_jwt.json")
 
-            # Given Snowflake Python client is logged in
-            conn = int_test_connection_factory(server_url=wiremock.http_url())
+        # Given Snowflake Python client is logged in
+        conn = int_test_connection_factory(server_url=wiremock.http_url())
 
-            # And Server will return 503 on first logout attempt then succeed
-            wiremock.add_mapping("session/logout_503_then_success.json")
+        # And Server will return 503 on first logout attempt then succeed
+        wiremock.add_mapping("session/logout_503_then_success.json")
 
-            # When close() is called with default parameters
-            conn.close()
+        # When close() is called with default parameters
+        conn.close()
 
-            # Then Logout succeeds after retry
-            assert conn.is_closed(), "Connection should be closed after successful retry"
+        # Then Logout succeeds after retry
+        assert conn.is_closed(), "Connection should be closed after successful retry"
 
-            # And Two logout requests were sent to server
-            logout_requests = wiremock.get_logout_requests()
-            assert len(logout_requests) == 2, (
-                f"Expected 2 logout requests (1 failure + 1 success), got {len(logout_requests)}"
-            )
+        # And Two logout requests were sent to server
+        logout_requests = wiremock.get_logout_requests()
+        assert len(logout_requests) == 2, (
+            f"Expected 2 logout requests (1 failure + 1 success), got {len(logout_requests)}"
+        )
 
     def test_should_not_retry_logout_on_transient_failure_when_close_called_with_retry_false(
-        self, int_test_connection_factory
+        self, int_test_connection_factory, wiremock
     ):
         """Verify close(retry=False) sends exactly one logout request and does not retry."""
-        with WiremockClient().start() as wiremock:
-            wiremock.add_mapping("auth/login_success_jwt.json")
+        wiremock.add_mapping("auth/login_success_jwt.json")
 
-            # Given Snowflake Python client is logged in
-            conn = int_test_connection_factory(server_url=wiremock.http_url())
+        # Given Snowflake Python client is logged in
+        conn = int_test_connection_factory(server_url=wiremock.http_url())
 
-            # And Server will return 503 on first logout attempt then succeed
-            wiremock.add_mapping("session/logout_503_then_success.json")
+        # And Server will return 503 on first logout attempt then succeed
+        wiremock.add_mapping("session/logout_503_then_success.json")
 
-            # When close(retry=False) is called
-            conn.close(retry=False)
+        # When close(retry=False) is called
+        conn.close(retry=False)
 
-            # Then Logout is not retried
-            logout_requests = wiremock.get_logout_requests()
-            assert len(logout_requests) == 1, (
-                f"retry=False should prevent retries despite 503, got {len(logout_requests)} requests"
-            )
+        # Then Logout is not retried
+        logout_requests = wiremock.get_logout_requests()
+        assert len(logout_requests) == 1, (
+            f"retry=False should prevent retries despite 503, got {len(logout_requests)} requests"
+        )
 
-            # And Only one logout request was sent to server
-            assert_logout_request_format(logout_requests[0])
+        # And Only one logout request was sent to server
+        assert_logout_request_format(logout_requests[0])
 
-            # And Error is handled according to best-effort strategy
-            assert conn.is_closed(), (
-                "Connection should be closed: best-effort strategy suppresses error from single failed attempt"
-            )
+        # And Error is handled according to best-effort strategy
+        assert conn.is_closed(), (
+            "Connection should be closed: best-effort strategy suppresses error from single failed attempt"
+        )
 
 
 _SIGABRT = -6
@@ -487,69 +476,68 @@ class TestAutoCleanup:
 
     # test_should_have_auto_cleanup_enabled_by_default moved to integ (uses core_mock)
 
-    def test_should_unregister_atexit_handler_when_close_called_explicitly(self, int_test_connection_factory):
+    def test_should_unregister_atexit_handler_when_close_called_explicitly(self, int_test_connection_factory, wiremock):
         """Verify close() unregisters atexit handler so process exit doesn't trigger second close."""
-        with WiremockClient().start() as wiremock:
-            wiremock.add_mapping("auth/login_success_jwt.json")
-            wiremock.add_mapping("session/logout_success.json")
+        wiremock.add_mapping("auth/login_success_jwt.json")
+        wiremock.add_mapping("session/logout_success.json")
 
-            wiremock_url = wiremock.http_url()
-            private_key_path = get_test_private_key_path()
+        wiremock_url = wiremock.http_url()
+        private_key_path = get_test_private_key_path()
 
-            # Given Snowflake Python client is created with auto_cleanup enabled
-            subprocess_code = textwrap.dedent(f"""\
-                import atexit
-                from snowflake.connector.connection import Connection
-                conn = Connection(
-                    user="test_user",
-                    account="test_account",
-                    database="test_database",
-                    schema="test_schema",
-                    warehouse="test_warehouse",
-                    role="test_role",
-                    server_url="{wiremock_url}",
-                    authenticator="SNOWFLAKE_JWT",
-                    private_key_file=r"{private_key_path}",
-                    auto_cleanup=True,
-                    enable_server_session_keep_alive_auto_detection=False,
-                )
-                # And atexit handler is registered at connection init
-                assert conn.auto_cleanup is True, "auto_cleanup must be True for atexit.register to fire"
-                print("ATEXIT_REGISTERED")
-                # When close() is called explicitly
-                orig = atexit.unregister
-                def _spy(f): orig(f); print("ATEXIT_UNREGISTERED")
-                atexit.unregister = _spy
-                conn.close()
-                print("CLOSE_CALLED")
-            """)
-
+        # Given Snowflake Python client is created with auto_cleanup enabled
+        subprocess_code = textwrap.dedent(f"""\
+            import atexit
+            from snowflake.connector.connection import Connection
+            conn = Connection(
+                user="test_user",
+                account="test_account",
+                database="test_database",
+                schema="test_schema",
+                warehouse="test_warehouse",
+                role="test_role",
+                server_url="{wiremock_url}",
+                authenticator="SNOWFLAKE_JWT",
+                private_key_file=r"{private_key_path}",
+                auto_cleanup=True,
+                enable_server_session_keep_alive_auto_detection=False,
+            )
             # And atexit handler is registered at connection init
-            result = subprocess.run(
-                [sys.executable, "-c", subprocess_code],
-                capture_output=True,
-                text=True,
-                timeout=120,
-            )
-            _assert_subprocess_ok(result)
-            assert "ATEXIT_REGISTERED" in result.stdout, "Subprocess must confirm atexit registration"
-
+            assert conn.auto_cleanup is True, "auto_cleanup must be True for atexit.register to fire"
+            print("ATEXIT_REGISTERED")
             # When close() is called explicitly
-            assert "CLOSE_CALLED" in result.stdout, "Subprocess must confirm close() was called"
+            orig = atexit.unregister
+            def _spy(f): orig(f); print("ATEXIT_UNREGISTERED")
+            atexit.unregister = _spy
+            conn.close()
+            print("CLOSE_CALLED")
+        """)
 
-            # Then atexit handler is unregistered
-            assert "ATEXIT_UNREGISTERED" in result.stdout, "conn.close() must call atexit.unregister()"
-            logout_requests = wiremock.get_logout_requests()
+        # And atexit handler is registered at connection init
+        result = subprocess.run(
+            [sys.executable, "-c", subprocess_code],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        _assert_subprocess_ok(result)
+        assert "ATEXIT_REGISTERED" in result.stdout, "Subprocess must confirm atexit registration"
 
-            # And Subsequent process exit will not trigger second close
-            assert len(logout_requests) == 1, (
-                f"Expected exactly 1 logout (from close()), not 2 (close + atexit). "
-                f"Got {len(logout_requests)}: unregister failed or atexit fired despite close()."
-            )
+        # When close() is called explicitly
+        assert "CLOSE_CALLED" in result.stdout, "Subprocess must confirm close() was called"
+
+        # Then atexit handler is unregistered
+        assert "ATEXIT_UNREGISTERED" in result.stdout, "conn.close() must call atexit.unregister()"
+        logout_requests = wiremock.get_logout_requests()
+
+        # And Subsequent process exit will not trigger second close
+        assert len(logout_requests) == 1, (
+            f"Expected exactly 1 logout (from close()), not 2 (close + atexit). "
+            f"Got {len(logout_requests)}: unregister failed or atexit fired despite close()."
+        )
 
     # This test spawns 2 subprocesses × 120s timeout each (240s worst case).
     # CI timeout must be >= 300s.
-    def test_should_call_close_with_retry_false_from_atexit_handler(self, int_test_connection_factory):
+    def test_should_call_close_with_retry_false_from_atexit_handler(self, int_test_connection_factory, wiremock):
         """Verify atexit handler calls close(retry=False), no retries, exceptions suppressed."""
         private_key_path = get_test_private_key_path()
 
@@ -574,144 +562,74 @@ class TestAutoCleanup:
         # Phase A: process exits with leaked connection; first logout attempt returns 503, second
         # attempt returns 200. With retry=False, the 503 is never retried (len==1). This
         # distinguishes retry=False (len==1) from retry=True (len==2: 503 + retry 200).
-        with WiremockClient().start() as wiremock:
-            wiremock.add_mapping("auth/login_success_jwt.json")
-            wiremock.add_mapping("session/logout_503_then_success.json")
+        wiremock.add_mapping("auth/login_success_jwt.json")
+        wiremock.add_mapping("session/logout_503_then_success.json")
 
-            # Given Snowflake Python client is created with auto_cleanup enabled
-            subprocess_code = _build_subprocess_code(wiremock.http_url())
+        # Given Snowflake Python client is created with auto_cleanup enabled
+        subprocess_code = _build_subprocess_code(wiremock.http_url())
 
-            # And Connection was not closed explicitly
-            assert "conn.close()" not in subprocess_code
+        # And Connection was not closed explicitly
+        assert "conn.close()" not in subprocess_code
 
-            # When Process exits
-            result = subprocess.run(
-                [sys.executable, "-c", subprocess_code],
-                capture_output=True,
-                text=True,
-                timeout=120,
-            )
-            _assert_subprocess_ok(result)
+        # When Process exits
+        result = subprocess.run(
+            [sys.executable, "-c", subprocess_code],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        _assert_subprocess_ok(result)
 
-            # Then atexit handler calls close(retry=False)
-            logout_requests = wiremock.get_logout_requests()
+        # Then atexit handler calls close(retry=False)
+        logout_requests = wiremock.get_logout_requests()
 
-            # 503 is retried under retry=True (→ len==2) but not under retry=False (→ len==1).
-            # And No retries are attempted during atexit close
-            assert len(logout_requests) == 1, (
-                f"retry=False: 503 must not be retried (retry=True would push count to 2), "
-                f"got {len(logout_requests)} requests"
-            )
+        # 503 is retried under retry=True (→ len==2) but not under retry=False (→ len==1).
+        # And No retries are attempted during atexit close
+        assert len(logout_requests) == 1, (
+            f"retry=False: 503 must not be retried (retry=True would push count to 2), "
+            f"got {len(logout_requests)} requests"
+        )
 
-            # And Session is logged out if conditions allow
-            assert_logout_request_format(logout_requests[0])
+        # And Session is logged out if conditions allow
+        assert_logout_request_format(logout_requests[0])
 
-        # Phase B: server error — atexit handler must not crash the process
-        with WiremockClient().start() as wiremock2:
-            wiremock2.add_mapping("auth/login_success_jwt.json")
-            wiremock2.add_mapping("session/logout_500_always.json")
+        # Phase B: server error — atexit handler must not crash the process. Reset state on
+        # the shared wiremock so Phase A's captured requests and mappings don't bleed in.
+        wiremock.reset()
+        wiremock.add_mapping("auth/login_success_jwt.json")
+        wiremock.add_mapping("session/logout_500_always.json")
 
-            # And All exceptions during atexit close are suppressed
-            subprocess_code_b = _build_subprocess_code(wiremock2.http_url())
-            result_b = subprocess.run(
-                [sys.executable, "-c", subprocess_code_b],
-                capture_output=True,
-                text=True,
-                timeout=120,
-            )
-            _assert_subprocess_ok(result_b)
-            assert len(wiremock2.get_logout_requests()) >= 1, (
-                "Phase B must reach the logout endpoint to prove exception suppression"
-            )
+        # And All exceptions during atexit close are suppressed
+        subprocess_code_b = _build_subprocess_code(wiremock.http_url())
+        result_b = subprocess.run(
+            [sys.executable, "-c", subprocess_code_b],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        _assert_subprocess_ok(result_b)
+        assert len(wiremock.get_logout_requests()) >= 1, (
+            "Phase B must reach the logout endpoint to prove exception suppression"
+        )
 
     def test_should_emit_deprecation_warning_only_once_when_multiple_auto_cleanup_handlers_run_during_process_exit(
-        self, int_test_connection_factory
+        self, int_test_connection_factory, wiremock
     ):
         """Verify warning deduplication: 10 leaked connections emit only 1 FutureWarning."""
-        with WiremockClient().start() as wiremock:
-            wiremock.add_mapping("auth/login_success_jwt.json")
-            # logout_503_then_success: first request → 503, then 200.
-            # Proves retry=False: the 503 is not retried (total stays 10, not 11+).
-            wiremock.add_mapping("session/logout_503_then_success.json")
+        wiremock.add_mapping("auth/login_success_jwt.json")
+        # logout_503_then_success: first request → 503, then 200.
+        # Proves retry=False: the 503 is not retried (total stays 10, not 11+).
+        wiremock.add_mapping("session/logout_503_then_success.json")
 
-            wiremock_url = wiremock.http_url()
-            private_key_path = get_test_private_key_path()
+        wiremock_url = wiremock.http_url()
+        private_key_path = get_test_private_key_path()
 
-            # Given A separate Python subprocess is spawned
-            subprocess_code = textwrap.dedent(f"""\
-                import sys
-                from snowflake.connector.connection import Connection
-                connections = []
-                for i in range(10):
-                    conn = Connection(
-                        user="test_user",
-                        account="test_account",
-                        database="test_database",
-                        schema="test_schema",
-                        warehouse="test_warehouse",
-                        role="test_role",
-                        server_url="{wiremock_url}",
-                        authenticator="SNOWFLAKE_JWT",
-                        private_key_file=r"{private_key_path}",
-                        auto_cleanup=True,
-                        enable_server_session_keep_alive_auto_detection=False,
-                    )
-                    connections.append(conn)
-            """)
-
-            # And 10 Snowflake clients are created with auto_cleanup enabled
-            assert subprocess_code.count("auto_cleanup=True") == 1
-
-            # And None of the connections are explicitly closed
-            assert "conn.close()" not in subprocess_code
-
-            # When The subprocess exits
-            result = subprocess.run(
-                [sys.executable, "-c", subprocess_code],
-                capture_output=True,
-                text=True,
-                timeout=120,
-            )
-            # Then Auto-cleanup is triggered for all 10 leaked connections
-            logout_requests = wiremock.get_logout_requests()
-            assert len(logout_requests) == 10, (
-                f"Expected 10 logout requests (one per leaked connection), got {len(logout_requests)}"
-            )
-
-            # retry=False → 503 is not retried → total stays at 10 (step above) and the 503
-            # is visible in the journal. retry=True → 503 would trigger a retry → 11+ total.
-            # Both (a) total==10 and (b) one got 503 together prove retry=False was used.
-            # And Each auto-cleanup close is invoked with retry false
-            responses_503 = [r for r in logout_requests if r.get("response", {}).get("status") == 503]
-            assert len(responses_503) == 1, (
-                f"Expected exactly 1 connection to receive 503 (retry=False: not retried). "
-                f"Got {len(responses_503)} 503 responses out of {len(logout_requests)} total. "
-                f"If retry=True, the 503 retry would push total to 11+."
-            )
-
-            # And Deprecation warning is emitted only once per process
-            warning_text = "Auto-cleanup at exit will be disabled"
-            warning_count = result.stderr.count(warning_text)
-            assert warning_count == 1, (
-                f"FutureWarning should be emitted exactly once per process (deduplication), "
-                f"got {warning_count} occurrences.\nstderr:\n{result.stderr}"
-            )
-
-    def test_should_not_register_atexit_handler_when_auto_cleanup_explicitly_disabled(
-        self, int_test_connection_factory
-    ):
-        """Verify auto_cleanup=False prevents atexit registration entirely."""
-        with WiremockClient().start() as wiremock:
-            wiremock.add_mapping("auth/login_success_jwt.json")
-
-            wiremock_url = wiremock.http_url()
-            private_key_path = get_test_private_key_path()
-
-            # Given Snowflake Python client is created with auto_cleanup set to false
-            subprocess_code = textwrap.dedent(f"""\
-                import warnings
-                warnings.filterwarnings("ignore", category=FutureWarning)
-                from snowflake.connector.connection import Connection
+        # Given A separate Python subprocess is spawned
+        subprocess_code = textwrap.dedent(f"""\
+            import sys
+            from snowflake.connector.connection import Connection
+            connections = []
+            for i in range(10):
                 conn = Connection(
                     user="test_user",
                     account="test_account",
@@ -722,33 +640,101 @@ class TestAutoCleanup:
                     server_url="{wiremock_url}",
                     authenticator="SNOWFLAKE_JWT",
                     private_key_file=r"{private_key_path}",
-                    auto_cleanup=False,
+                    auto_cleanup=True,
                     enable_server_session_keep_alive_auto_detection=False,
                 )
-            """)
+                connections.append(conn)
+        """)
 
-            # And Connection is not explicitly closed
-            assert "conn.close()" not in subprocess_code
+        # And 10 Snowflake clients are created with auto_cleanup enabled
+        assert subprocess_code.count("auto_cleanup=True") == 1
 
-            # When Process exits
-            result = subprocess.run(
-                [sys.executable, "-c", subprocess_code],
-                capture_output=True,
-                text=True,
-                timeout=120,
+        # And None of the connections are explicitly closed
+        assert "conn.close()" not in subprocess_code
+
+        # When The subprocess exits
+        result = subprocess.run(
+            [sys.executable, "-c", subprocess_code],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        # Then Auto-cleanup is triggered for all 10 leaked connections
+        logout_requests = wiremock.get_logout_requests()
+        assert len(logout_requests) == 10, (
+            f"Expected 10 logout requests (one per leaked connection), got {len(logout_requests)}"
+        )
+
+        # retry=False → 503 is not retried → total stays at 10 (step above) and the 503
+        # is visible in the journal. retry=True → 503 would trigger a retry → 11+ total.
+        # Both (a) total==10 and (b) one got 503 together prove retry=False was used.
+        # And Each auto-cleanup close is invoked with retry false
+        responses_503 = [r for r in logout_requests if r.get("response", {}).get("status") == 503]
+        assert len(responses_503) == 1, (
+            f"Expected exactly 1 connection to receive 503 (retry=False: not retried). "
+            f"Got {len(responses_503)} 503 responses out of {len(logout_requests)} total. "
+            f"If retry=True, the 503 retry would push total to 11+."
+        )
+
+        # And Deprecation warning is emitted only once per process
+        warning_text = "Auto-cleanup at exit will be disabled"
+        warning_count = result.stderr.count(warning_text)
+        assert warning_count == 1, (
+            f"FutureWarning should be emitted exactly once per process (deduplication), "
+            f"got {warning_count} occurrences.\nstderr:\n{result.stderr}"
+        )
+
+    def test_should_not_register_atexit_handler_when_auto_cleanup_explicitly_disabled(
+        self, int_test_connection_factory, wiremock
+    ):
+        """Verify auto_cleanup=False prevents atexit registration entirely."""
+        wiremock.add_mapping("auth/login_success_jwt.json")
+
+        wiremock_url = wiremock.http_url()
+        private_key_path = get_test_private_key_path()
+
+        # Given Snowflake Python client is created with auto_cleanup set to false
+        subprocess_code = textwrap.dedent(f"""\
+            import warnings
+            warnings.filterwarnings("ignore", category=FutureWarning)
+            from snowflake.connector.connection import Connection
+            conn = Connection(
+                user="test_user",
+                account="test_account",
+                database="test_database",
+                schema="test_schema",
+                warehouse="test_warehouse",
+                role="test_role",
+                server_url="{wiremock_url}",
+                authenticator="SNOWFLAKE_JWT",
+                private_key_file=r"{private_key_path}",
+                auto_cleanup=False,
+                enable_server_session_keep_alive_auto_detection=False,
             )
-            _assert_subprocess_ok(result)
+        """)
 
-            # Then No atexit handler was registered
-            logout_requests = wiremock.get_logout_requests()
+        # And Connection is not explicitly closed
+        assert "conn.close()" not in subprocess_code
 
-            # And No automatic close is performed
-            assert len(logout_requests) == 0, (
-                "auto_cleanup=False must not register an atexit handler: no logout expected on process exit"
-            )
+        # When Process exits
+        result = subprocess.run(
+            [sys.executable, "-c", subprocess_code],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        _assert_subprocess_ok(result)
+
+        # Then No atexit handler was registered
+        logout_requests = wiremock.get_logout_requests()
+
+        # And No automatic close is performed
+        assert len(logout_requests) == 0, (
+            "auto_cleanup=False must not register an atexit handler: no logout expected on process exit"
+        )
 
     def test_should_emit_telemetry_and_warn_when_connection_leaked_at_process_exit(
-        self, int_test_connection_factory
+        self, int_test_connection_factory, wiremock
     ) -> None:
         """Leak detection: WARN + telemetry when connection not closed before exit.
 
@@ -756,32 +742,31 @@ class TestAutoCleanup:
         WARN is currently the FutureWarning emitted by _close_at_process_exit();
         a proper logger.warning() call will be added under SNOW-2912513.
         """
-        with WiremockClient().start() as wiremock:
-            wiremock.add_mapping("auth/login_success_jwt.json")
-            wiremock.add_mapping("session/logout_success.json")
+        wiremock.add_mapping("auth/login_success_jwt.json")
+        wiremock.add_mapping("session/logout_success.json")
 
-            with warnings.catch_warnings(record=True) as captured_warnings:
-                warnings.simplefilter("always")
+        with warnings.catch_warnings(record=True) as captured_warnings:
+            warnings.simplefilter("always")
 
-                # Given Snowflake Python client is logged in
-                conn = int_test_connection_factory(server_url=wiremock.http_url())
+            # Given Snowflake Python client is logged in
+            conn = int_test_connection_factory(server_url=wiremock.http_url())
 
-                # And Connection is not explicitly closed
-                assert not conn.is_closed()
+            # And Connection is not explicitly closed
+            assert not conn.is_closed()
 
-                # When Process exit is detected
-                conn._close_at_process_exit()
+            # When Process exit is detected
+            conn._close_at_process_exit()
 
-            # Current: FutureWarning via warnings.warn(); logger.warning() pending SNOW-2912513.
-            # Then Leak detection emits WARN log
-            leak_warnings = [
-                w
-                for w in captured_warnings
-                if issubclass(w.category, FutureWarning) and "not explicitly closed" in str(w.message)
-            ]
-            assert len(leak_warnings) == 1, f"Expected 1 leak detection FutureWarning, got {len(leak_warnings)}"
+        # Current: FutureWarning via warnings.warn(); logger.warning() pending SNOW-2912513.
+        # Then Leak detection emits WARN log
+        leak_warnings = [
+            w
+            for w in captured_warnings
+            if issubclass(w.category, FutureWarning) and "not explicitly closed" in str(w.message)
+        ]
+        assert len(leak_warnings) == 1, f"Expected 1 leak detection FutureWarning, got {len(leak_warnings)}"
 
-            # And Telemetry event is sent with leak information
-            pass  # TODO(SNOW-2912513): telemetry not yet implemented
-            # And Connection details are included for debugging
-            pass  # TODO(SNOW-2912513): connection details are part of telemetry above
+        # And Telemetry event is sent with leak information
+        pass  # TODO(SNOW-2912513): telemetry not yet implemented
+        # And Connection details are included for debugging
+        pass  # TODO(SNOW-2912513): connection details are part of telemetry above

--- a/python/tests/e2e/session/test_logout.py
+++ b/python/tests/e2e/session/test_logout.py
@@ -10,8 +10,6 @@ import threading
 
 import pytest
 
-from tests.wiremock_client import WiremockClient
-
 
 class TestLogoutTokenCleanup:
     """Token cleanup tests from shared/session/logout.feature.
@@ -27,36 +25,34 @@ class TestLogoutTokenCleanup:
     )
     @pytest.mark.skip_reference(reason="conn.rest is None on reference connector (different token access pattern)")
     def test_should_cleanup_all_tokens_on_close_regardless_of_whether_logout_was_sent(
-        self, int_test_connection_factory, server_session_keep_alive
+        self, int_test_connection_factory, server_session_keep_alive, wiremock
     ):
-        with WiremockClient().start() as wiremock:
-            wiremock.add_mapping("auth/login_success_jwt.json")
-            wiremock.add_mapping("session/logout_success.json")
+        wiremock.add_mapping("auth/login_success_jwt.json")
+        wiremock.add_mapping("session/logout_success.json")
 
-            # Given Snowflake client is logged in
-            kwargs = {"server_url": wiremock.http_url()}
+        # Given Snowflake client is logged in
+        kwargs = {"server_url": wiremock.http_url()}
 
-            # And server_session_keep_alive is set to <server_session_keep_alive>
-            if server_session_keep_alive is not None:
-                kwargs["server_session_keep_alive"] = server_session_keep_alive
-            conn = int_test_connection_factory(**kwargs)
-            assert conn.rest.token, "session_token must be non-null before close"
-            assert conn.rest.master_token, "master_token must be non-null before close"
+        # And server_session_keep_alive is set to <server_session_keep_alive>
+        if server_session_keep_alive is not None:
+            kwargs["server_session_keep_alive"] = server_session_keep_alive
+        conn = int_test_connection_factory(**kwargs)
+        assert conn.rest.token, "session_token must be non-null before close"
+        assert conn.rest.master_token, "master_token must be non-null before close"
 
-            # When Connection is closed
-            conn.close()
+        # When Connection is closed
+        conn.close()
 
-            # Then Session token in Connection.tokens is null
-            assert not conn.rest.token, (  # Core returns "" not None — falsy check
-                f"session_token must be null after close (keep_alive={server_session_keep_alive}), "
-                f"got {conn.rest.token!r}"
-            )
+        # Then Session token in Connection.tokens is null
+        assert not conn.rest.token, (  # Core returns "" not None — falsy check
+            f"session_token must be null after close (keep_alive={server_session_keep_alive}), got {conn.rest.token!r}"
+        )
 
-            # And Master token in Connection.tokens is null
-            assert not conn.rest.master_token, (
-                f"master_token must be null after close (keep_alive={server_session_keep_alive}), "
-                f"got {conn.rest.master_token!r}"
-            )
+        # And Master token in Connection.tokens is null
+        assert not conn.rest.master_token, (
+            f"master_token must be null after close (keep_alive={server_session_keep_alive}), "
+            f"got {conn.rest.master_token!r}"
+        )
 
 
 class TestLogoutSessionInvalidation:
@@ -95,68 +91,66 @@ class TestLogoutEdgeCases:
     by inspecting actual HTTP requests sent via Wiremock.
     """
 
-    def test_should_be_idempotent_when_close_called_multiple_times(self, int_test_connection_factory):
+    def test_should_be_idempotent_when_close_called_multiple_times(self, int_test_connection_factory, wiremock):
         """Verify that calling close() multiple times only sends one logout request."""
-        with WiremockClient().start() as wiremock:
-            # Setup Wiremock mappings
-            wiremock.add_mapping("auth/login_success_jwt.json")
-            wiremock.add_mapping("session/logout_success.json")
+        # Setup Wiremock mappings
+        wiremock.add_mapping("auth/login_success_jwt.json")
+        wiremock.add_mapping("session/logout_success.json")
 
-            # Given Snowflake client is logged in
-            conn = int_test_connection_factory(server_url=wiremock.http_url())
+        # Given Snowflake client is logged in
+        conn = int_test_connection_factory(server_url=wiremock.http_url())
 
-            # When Connection is closed
-            conn.close()
-            # And Connection is closed again
-            conn.close()
-            # And Connection is closed a third time
-            conn.close()
+        # When Connection is closed
+        conn.close()
+        # And Connection is closed again
+        conn.close()
+        # And Connection is closed a third time
+        conn.close()
 
-            # Then Only one logout request is sent
-            logout_requests = wiremock.get_logout_requests()
+        # Then Only one logout request is sent
+        logout_requests = wiremock.get_logout_requests()
 
-            assert len(logout_requests) == 1, (
-                f"Should send exactly 1 logout request despite 3 close() calls, got {len(logout_requests)}"
-            )
+        assert len(logout_requests) == 1, (
+            f"Should send exactly 1 logout request despite 3 close() calls, got {len(logout_requests)}"
+        )
 
-            # And No errors are thrown
-            assert conn.is_closed()
+        # And No errors are thrown
+        assert conn.is_closed()
 
     @pytest.mark.skip_reference(reason="Old connector has no close idempotency — 5 threads send 5 logouts")
-    def test_should_handle_concurrent_close_calls_safely(self, int_test_connection_factory):
+    def test_should_handle_concurrent_close_calls_safely(self, int_test_connection_factory, wiremock):
         """Verify that concurrent close() calls are thread-safe and send only one logout request."""
-        with WiremockClient().start() as wiremock:
-            # Setup Wiremock mappings
-            wiremock.add_mapping("auth/login_success_jwt.json")
-            wiremock.add_mapping("session/logout_success.json")
+        # Setup Wiremock mappings
+        wiremock.add_mapping("auth/login_success_jwt.json")
+        wiremock.add_mapping("session/logout_success.json")
 
-            # Given Snowflake client is logged in
-            conn = int_test_connection_factory(server_url=wiremock.http_url())
+        # Given Snowflake client is logged in
+        conn = int_test_connection_factory(server_url=wiremock.http_url())
 
-            # When Connection is closed from multiple threads concurrently
-            exceptions = []
-            barrier = threading.Barrier(5)
+        # When Connection is closed from multiple threads concurrently
+        exceptions = []
+        barrier = threading.Barrier(5)
 
-            def close_connection():
-                try:
-                    barrier.wait()
-                    conn.close()
-                except Exception as e:
-                    exceptions.append(e)
+        def close_connection():
+            try:
+                barrier.wait()
+                conn.close()
+            except Exception as e:
+                exceptions.append(e)
 
-            threads = [threading.Thread(target=close_connection) for _ in range(5)]
-            for t in threads:
-                t.start()
-            for t in threads:
-                t.join()
+        threads = [threading.Thread(target=close_connection) for _ in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
 
-            # Then Only one logout request is sent
-            logout_requests = wiremock.get_logout_requests()
+        # Then Only one logout request is sent
+        logout_requests = wiremock.get_logout_requests()
 
-            assert len(logout_requests) == 1, (
-                f"Should send exactly 1 logout request despite concurrent close() calls, got {len(logout_requests)}"
-            )
+        assert len(logout_requests) == 1, (
+            f"Should send exactly 1 logout request despite concurrent close() calls, got {len(logout_requests)}"
+        )
 
-            # And All close calls return successfully
-            assert len(exceptions) == 0, f"Expected no exceptions, got: {exceptions}"
-            assert conn.is_closed()
+        # And All close calls return successfully
+        assert len(exceptions) == 0, f"Expected no exceptions, got: {exceptions}"
+        assert conn.is_closed()

--- a/python/tests/integ/put_get/test_put_get_source_compression.py
+++ b/python/tests/integ/put_get/test_put_get_source_compression.py
@@ -2,36 +2,34 @@ import pytest
 
 from tests.compatibility import NEW_DRIVER_ONLY, OLD_DRIVER_ONLY
 from tests.utils import repo_root
-from tests.wiremock_client import WiremockClient
 
 
-def test_should_return_error_for_unsupported_compression_type(int_test_connection_factory):
+def test_should_return_error_for_unsupported_compression_type(int_test_connection_factory, wiremock):
     # Given Snowflake client is logged in
-    with WiremockClient().start() as wiremock:
-        wiremock.add_mapping("auth/login_success_jwt.json")
-        wiremock.add_mapping("put_get/put_unsupported_compression_type.json")
-        connection = int_test_connection_factory(server_url=wiremock.http_url())
-        cursor = connection.cursor()
-        try:
-            assert cursor is not None
+    wiremock.add_mapping("auth/login_success_jwt.json")
+    wiremock.add_mapping("put_get/put_unsupported_compression_type.json")
+    connection = int_test_connection_factory(server_url=wiremock.http_url())
+    cursor = connection.cursor()
+    try:
+        assert cursor is not None
 
-            # And File compressed with unsupported format
-            test_file_path = (
-                repo_root() / "tests" / "test_data" / "generated_test_data" / "compression" / "test_data.csv.xz"
-            )
+        # And File compressed with unsupported format
+        test_file_path = (
+            repo_root() / "tests" / "test_data" / "generated_test_data" / "compression" / "test_data.csv.xz"
+        )
 
-            # When File is uploaded with SOURCE_COMPRESSION set to AUTO_DETECT
-            put_command = f"PUT 'file://{test_file_path}' @TEST_STAGE SOURCE_COMPRESSION=AUTO_DETECT"
+        # When File is uploaded with SOURCE_COMPRESSION set to AUTO_DETECT
+        put_command = f"PUT 'file://{test_file_path}' @TEST_STAGE SOURCE_COMPRESSION=AUTO_DETECT"
 
-            # Then Unsupported compression error is thrown
-            with pytest.raises(Exception) as exc_info:
-                cursor.execute(put_command)
+        # Then Unsupported compression error is thrown
+        with pytest.raises(Exception) as exc_info:
+            cursor.execute(put_command)
 
-            if NEW_DRIVER_ONLY("BD#4"):
-                assert "Unsupported compression type" in str(exc_info.value)
+        if NEW_DRIVER_ONLY("BD#4"):
+            assert "Unsupported compression type" in str(exc_info.value)
 
-            if OLD_DRIVER_ONLY("BD#4"):
-                assert "253007" in str(exc_info.value)
-                assert "Feature is not supported" in str(exc_info.value)
-        finally:
-            cursor.close()
+        if OLD_DRIVER_ONLY("BD#4"):
+            assert "253007" in str(exc_info.value)
+            assert "Feature is not supported" in str(exc_info.value)
+    finally:
+        cursor.close()

--- a/python/tests/integ/session/test_logout.py
+++ b/python/tests/integ/session/test_logout.py
@@ -9,138 +9,129 @@ from unittest.mock import patch
 
 import pytest
 
-from tests.wiremock_client import WiremockClient
-
 
 class TestLogoutWithWiremock:
     """Integration tests for logout using Wiremock to verify HTTP requests."""
 
-    def test_should_send_logout_request_with_correct_method_and_endpoint(self, int_test_connection_factory):
+    def test_should_send_logout_request_with_correct_method_and_endpoint(self, int_test_connection_factory, wiremock):
         """Verify logout sends POST to /session?delete=true."""
-        with WiremockClient().start() as wiremock:
-            # Setup: auth + logout mappings
-            wiremock.add_mapping("auth/login_success_jwt.json")
-            wiremock.add_mapping("session/logout_success.json")
+        # Setup: auth + logout mappings
+        wiremock.add_mapping("auth/login_success_jwt.json")
+        wiremock.add_mapping("session/logout_success.json")
 
-            # Given: Connected client
-            connection = int_test_connection_factory(server_url=wiremock.http_url())
+        # Given: Connected client
+        connection = int_test_connection_factory(server_url=wiremock.http_url())
 
-            # When: Connection is closed
-            connection.close()
+        # When: Connection is closed
+        connection.close()
 
-            # Then: Verify logout request was sent
-            logout_requests = wiremock.get_logout_requests()
+        # Then: Verify logout request was sent
+        logout_requests = wiremock.get_logout_requests()
 
-            assert len(logout_requests) >= 1, "Expected at least one logout request"
+        assert len(logout_requests) >= 1, "Expected at least one logout request"
 
-            logout_req = logout_requests[0]["request"]
-            assert logout_req["method"] == "POST", "Logout should use POST method"
-            assert "delete=true" in logout_req["url"], "Should have delete=true param"
+        logout_req = logout_requests[0]["request"]
+        assert logout_req["method"] == "POST", "Logout should use POST method"
+        assert "delete=true" in logout_req["url"], "Should have delete=true param"
 
-    def test_should_send_logout_with_authorization_header(self, int_test_connection_factory):
+    def test_should_send_logout_with_authorization_header(self, int_test_connection_factory, wiremock):
         """Verify logout request includes Authorization header with session token."""
-        with WiremockClient().start() as wiremock:
-            wiremock.add_mapping("auth/login_success_jwt.json")
-            wiremock.add_mapping("session/logout_success.json")
+        wiremock.add_mapping("auth/login_success_jwt.json")
+        wiremock.add_mapping("session/logout_success.json")
 
-            connection = int_test_connection_factory(server_url=wiremock.http_url())
-            connection.close()
+        connection = int_test_connection_factory(server_url=wiremock.http_url())
+        connection.close()
 
-            # Verify request headers
-            logout_requests = wiremock.get_logout_requests()
+        # Verify request headers
+        logout_requests = wiremock.get_logout_requests()
 
-            assert len(logout_requests) >= 1, "Expected logout request"
+        assert len(logout_requests) >= 1, "Expected logout request"
 
-            headers = logout_requests[0]["request"].get("headers", {})
-            auth_header = headers.get("Authorization") or headers.get("authorization")
-            assert auth_header is not None, "Should have Authorization header"
-            assert auth_header.startswith("Snowflake Token="), "Should use Snowflake Token auth"
+        headers = logout_requests[0]["request"].get("headers", {})
+        auth_header = headers.get("Authorization") or headers.get("authorization")
+        assert auth_header is not None, "Should have Authorization header"
+        assert auth_header.startswith("Snowflake Token="), "Should use Snowflake Token auth"
 
-    def test_should_send_logout_with_correct_content_type(self, int_test_connection_factory):
+    def test_should_send_logout_with_correct_content_type(self, int_test_connection_factory, wiremock):
         """Verify logout request has Content-Type: application/json."""
-        with WiremockClient().start() as wiremock:
-            wiremock.add_mapping("auth/login_success_jwt.json")
-            wiremock.add_mapping("session/logout_success.json")
+        wiremock.add_mapping("auth/login_success_jwt.json")
+        wiremock.add_mapping("session/logout_success.json")
 
-            connection = int_test_connection_factory(server_url=wiremock.http_url())
-            connection.close()
+        connection = int_test_connection_factory(server_url=wiremock.http_url())
+        connection.close()
 
-            # Verify Content-Type header
-            logout_requests = wiremock.get_logout_requests()
+        # Verify Content-Type header
+        logout_requests = wiremock.get_logout_requests()
 
-            assert len(logout_requests) >= 1, "Expected logout request"
+        assert len(logout_requests) >= 1, "Expected logout request"
 
-            headers = logout_requests[0]["request"].get("headers", {})
-            content_type = headers.get("Content-Type") or headers.get("content-type")
-            assert content_type is not None, "Should have Content-Type header"
-            assert "application/json" in content_type, "Content-Type should be JSON"
+        headers = logout_requests[0]["request"].get("headers", {})
+        content_type = headers.get("Content-Type") or headers.get("content-type")
+        assert content_type is not None, "Should have Content-Type header"
+        assert "application/json" in content_type, "Content-Type should be JSON"
 
-    def test_should_not_send_logout_when_server_session_keep_alive_is_true(self, int_test_connection_factory):
+    def test_should_not_send_logout_when_server_session_keep_alive_is_true(self, int_test_connection_factory, wiremock):
         """Verify no logout request when server_session_keep_alive=True."""
-        with WiremockClient().start() as wiremock:
-            wiremock.add_mapping("auth/login_success_jwt.json")
-            # Note: logout mapping not added - request should not be made
+        wiremock.add_mapping("auth/login_success_jwt.json")
+        # Note: logout mapping not added - request should not be made
 
-            connection = int_test_connection_factory(server_url=wiremock.http_url(), server_session_keep_alive=True)
-            connection.close()
+        connection = int_test_connection_factory(server_url=wiremock.http_url(), server_session_keep_alive=True)
+        connection.close()
 
-            # Verify NO logout request was sent
-            logout_requests = wiremock.get_logout_requests()
+        # Verify NO logout request was sent
+        logout_requests = wiremock.get_logout_requests()
 
-            assert len(logout_requests) == 0, (
-                f"Should NOT send logout when keep_alive=True, but got {len(logout_requests)} requests"
-            )
+        assert len(logout_requests) == 0, (
+            f"Should NOT send logout when keep_alive=True, but got {len(logout_requests)} requests"
+        )
 
-    def test_should_send_logout_when_server_session_keep_alive_is_false(self, int_test_connection_factory):
+    def test_should_send_logout_when_server_session_keep_alive_is_false(self, int_test_connection_factory, wiremock):
         """Verify logout IS sent when server_session_keep_alive=False."""
-        with WiremockClient().start() as wiremock:
-            wiremock.add_mapping("auth/login_success_jwt.json")
-            wiremock.add_mapping("session/logout_success.json")
+        wiremock.add_mapping("auth/login_success_jwt.json")
+        wiremock.add_mapping("session/logout_success.json")
 
-            connection = int_test_connection_factory(server_url=wiremock.http_url(), server_session_keep_alive=False)
-            connection.close()
+        connection = int_test_connection_factory(server_url=wiremock.http_url(), server_session_keep_alive=False)
+        connection.close()
 
-            # Verify logout request WAS sent
-            logout_requests = wiremock.get_logout_requests()
+        # Verify logout request WAS sent
+        logout_requests = wiremock.get_logout_requests()
 
-            assert len(logout_requests) >= 1, "Should send logout when keep_alive=False"
+        assert len(logout_requests) >= 1, "Should send logout when keep_alive=False"
 
     @pytest.mark.skip_reference  # Old connector (v4.3.0) doesn't retry logout on 503
-    def test_should_retry_logout_on_503_error(self, int_test_connection_factory):
+    def test_should_retry_logout_on_503_error(self, int_test_connection_factory, wiremock):
         """Verify logout retries on 503 Service Unavailable."""
-        with WiremockClient().start() as wiremock:
-            wiremock.add_mapping("auth/login_success_jwt.json")
-            wiremock.add_mapping("session/logout_503_then_success.json")
+        wiremock.add_mapping("auth/login_success_jwt.json")
+        wiremock.add_mapping("session/logout_503_then_success.json")
 
-            connection = int_test_connection_factory(server_url=wiremock.http_url())
-            connection.close()
+        connection = int_test_connection_factory(server_url=wiremock.http_url())
+        connection.close()
 
-            # Verify multiple logout attempts (retry)
-            logout_requests = wiremock.get_logout_requests()
+        # Verify multiple logout attempts (retry)
+        logout_requests = wiremock.get_logout_requests()
 
-            assert len(logout_requests) >= 2, f"Should retry on 503, got {len(logout_requests)} attempts"
+        assert len(logout_requests) >= 2, f"Should retry on 503, got {len(logout_requests)} attempts"
 
 
 class TestLogoutIdempotency:
     """Tests for logout idempotency."""
 
-    def test_should_only_send_one_logout_when_close_called_multiple_times(self, int_test_connection_factory):
+    def test_should_only_send_one_logout_when_close_called_multiple_times(self, int_test_connection_factory, wiremock):
         """Verify only one logout request is sent for multiple close() calls."""
-        with WiremockClient().start() as wiremock:
-            wiremock.add_mapping("auth/login_success_jwt.json")
-            wiremock.add_mapping("session/logout_success.json")
+        wiremock.add_mapping("auth/login_success_jwt.json")
+        wiremock.add_mapping("session/logout_success.json")
 
-            connection = int_test_connection_factory(server_url=wiremock.http_url())
+        connection = int_test_connection_factory(server_url=wiremock.http_url())
 
-            # Call close multiple times
-            connection.close()
-            connection.close()
-            connection.close()
+        # Call close multiple times
+        connection.close()
+        connection.close()
+        connection.close()
 
-            # Verify only ONE logout request
-            logout_requests = wiremock.get_logout_requests()
+        # Verify only ONE logout request
+        logout_requests = wiremock.get_logout_requests()
 
-            assert len(logout_requests) == 1, f"Should send exactly 1 logout, got {len(logout_requests)}"
+        assert len(logout_requests) == 1, f"Should send exactly 1 logout, got {len(logout_requests)}"
 
 
 class TestLogoutConfigPassing:

--- a/python/tests/integ/telemetry/test_client_identity.py
+++ b/python/tests/integ/telemetry/test_client_identity.py
@@ -4,57 +4,55 @@ import platform
 import pytest
 
 from tests.compatibility import is_old_driver
-from tests.wiremock_client import WiremockClient
 
 
 pytestmark = pytest.mark.skipif(is_old_driver(), reason="Universal driver only")
 
 
-def test_login_request_contains_correct_client_identity(int_test_connection_factory):
+def test_login_request_contains_correct_client_identity(int_test_connection_factory, wiremock):
     """Verify the Python wrapper sends correct client identity in the login request.
 
     Uses Wiremock to intercept the POST to /session/v1/login-request and validates
     CLIENT_APP_ID, CLIENT_APP_VERSION, User-Agent, and CLIENT_ENVIRONMENT fields
     match the expected legacy Python connector values.
     """
-    with WiremockClient().start() as wiremock:
-        wiremock.add_mapping("auth/login_success_jwt.json")
+    wiremock.add_mapping("auth/login_success_jwt.json")
 
-        connection = int_test_connection_factory(server_url=wiremock.http_url())
-        connection.close()
+    connection = int_test_connection_factory(server_url=wiremock.http_url())
+    connection.close()
 
-        login_requests = wiremock.get_requests("/session/v1/login-request.*")
-        assert len(login_requests) >= 1, "Expected at least one login request"
+    login_requests = wiremock.get_requests("/session/v1/login-request.*")
+    assert len(login_requests) >= 1, "Expected at least one login request"
 
-        request = login_requests[0]
-        body = json.loads(request["body"])
-        data = body["data"]
+    request = login_requests[0]
+    body = json.loads(request["body"])
+    data = body["data"]
 
-        # CLIENT_APP_ID must match the legacy Python connector value
-        assert data["CLIENT_APP_ID"] == "PythonConnector"
+    # CLIENT_APP_ID must match the legacy Python connector value
+    assert data["CLIENT_APP_ID"] == "PythonConnector"
 
-        # CLIENT_APP_VERSION is stripped to digits-only for server compat;
-        # CLIENT_APP_VERSION_FULL preserves the original (e.g. "5.0.0b1").
-        from snowflake.connector.version import VERSION, __version__
+    # CLIENT_APP_VERSION is stripped to digits-only for server compat;
+    # CLIENT_APP_VERSION_FULL preserves the original (e.g. "5.0.0b1").
+    from snowflake.connector.version import VERSION, __version__
 
-        assert data["CLIENT_APP_VERSION_FULL"] == __version__
-        # Stripped version must match the release components (no "dev", "rc", etc.)
-        stripped = data["CLIENT_APP_VERSION"]
-        assert stripped == ".".join(str(c) for c in VERSION[:-1])
+    assert data["CLIENT_APP_VERSION_FULL"] == __version__
+    # Stripped version must match the release components (no "dev", "rc", etc.)
+    stripped = data["CLIENT_APP_VERSION"]
+    assert stripped == ".".join(str(c) for c in VERSION[:-1])
 
-        # CLIENT_ENVIRONMENT must contain correct OS and runtime fields
-        env = data["CLIENT_ENVIRONMENT"]
-        assert env["APPLICATION"] == "PythonConnector"
-        assert env["OS"], "OS must not be empty"
-        assert env["OS_VERSION"], "OS_VERSION must not be empty"
-        # Values are trimmed by the Rust core before storing
-        assert env["RUNTIME_NAME"] == platform.python_implementation().strip()
-        assert env["RUNTIME_VERSION"] == platform.python_version().strip()
-        assert env["COMPILER"] == platform.python_compiler().strip()
+    # CLIENT_ENVIRONMENT must contain correct OS and runtime fields
+    env = data["CLIENT_ENVIRONMENT"]
+    assert env["APPLICATION"] == "PythonConnector"
+    assert env["OS"], "OS must not be empty"
+    assert env["OS_VERSION"], "OS_VERSION must not be empty"
+    # Values are trimmed by the Rust core before storing
+    assert env["RUNTIME_NAME"] == platform.python_implementation().strip()
+    assert env["RUNTIME_VERSION"] == platform.python_version().strip()
+    assert env["COMPILER"] == platform.python_compiler().strip()
 
-        # User-Agent header must identify the driver
-        headers = {k.lower(): v for k, v in request["headers"].items()}
-        user_agent = headers["user-agent"]
-        assert user_agent.startswith(f"PythonConnector/{__version__}")
-        assert platform.python_implementation() in user_agent
-        assert platform.python_version() in user_agent
+    # User-Agent header must identify the driver
+    headers = {k.lower(): v for k, v in request["headers"].items()}
+    user_agent = headers["user-agent"]
+    assert user_agent.startswith(f"PythonConnector/{__version__}")
+    assert platform.python_implementation() in user_agent
+    assert platform.python_version() in user_agent

--- a/python/tests/integ/telemetry/test_connection_telemetry.py
+++ b/python/tests/integ/telemetry/test_connection_telemetry.py
@@ -9,70 +9,68 @@ from cryptography.hazmat.primitives.serialization import Encoding, NoEncryption,
 
 from tests.compatibility import is_new_driver
 from tests.private_key_helper import get_test_private_key_path
-from tests.wiremock_client import WiremockClient
 
 
-def test_session_init_telemetry_sent_on_connection_open(int_test_connection_factory):
+def test_session_init_telemetry_sent_on_connection_open(int_test_connection_factory, wiremock):
     """Verify that a session_init telemetry event is sent when a connection is opened.
 
     This test uses Wiremock to intercept the POST to /telemetry/send and validates
     the request path, headers, and top-level payload structure. It runs against both
     the universal and old drivers for comparison.
     """
-    with WiremockClient().start() as wiremock:
-        wiremock.add_mapping("auth/login_success_jwt.json")
-        wiremock.add_mapping("telemetry/telemetry_send_success.json")
+    wiremock.add_mapping("auth/login_success_jwt.json")
+    wiremock.add_mapping("telemetry/telemetry_send_success.json")
 
-        connection = int_test_connection_factory(server_url=wiremock.http_url(), **_jwt_private_key_params())
-        connection.close()
+    connection = int_test_connection_factory(server_url=wiremock.http_url(), **_jwt_private_key_params())
+    connection.close()
 
-        # Telemetry is exported synchronously on connection release via
-        # SimpleSpanProcessor. Poll briefly in case of timing variability.
-        telemetry_requests = wiremock.wait_for_requests("/telemetry/send", min_count=1, timeout=5.0)
-        assert len(telemetry_requests) >= 1, "Expected at least one POST to /telemetry/send after connection open"
+    # Telemetry is exported synchronously on connection release via
+    # SimpleSpanProcessor. Poll briefly in case of timing variability.
+    telemetry_requests = wiremock.wait_for_requests("/telemetry/send", min_count=1, timeout=5.0)
+    assert len(telemetry_requests) >= 1, "Expected at least one POST to /telemetry/send after connection open"
 
-        request = telemetry_requests[0]
+    request = telemetry_requests[0]
 
-        # Validate request path and method
-        assert request["method"] == "POST"
-        assert request["url"] == "/telemetry/send"
+    # Validate request path and method
+    assert request["method"] == "POST"
+    assert request["url"] == "/telemetry/send"
 
-        # Validate required headers. HTTP header names are case-insensitive and
-        # clients/libraries may add transport headers, so normalize and check subset.
-        headers = request["headers"]
-        normalized_headers = {name.lower(): value for name, value in headers.items()}
-        required_header_names = {
-            "authorization",
-            "accept",
-            "user-agent",
-            "content-type",
-            "host",
-            "content-length",
-            "content-encoding",
-            "accept-encoding",
-        }
-        missing_headers = required_header_names - set(normalized_headers.keys())
-        assert not missing_headers, f"Missing required headers: {missing_headers}"
-        assert normalized_headers["authorization"].startswith("Snowflake Token=")
-        assert normalized_headers["content-type"] == "application/json"
-        assert normalized_headers["accept"] == "application/json"
-        assert normalized_headers["user-agent"] is not None
+    # Validate required headers. HTTP header names are case-insensitive and
+    # clients/libraries may add transport headers, so normalize and check subset.
+    headers = request["headers"]
+    normalized_headers = {name.lower(): value for name, value in headers.items()}
+    required_header_names = {
+        "authorization",
+        "accept",
+        "user-agent",
+        "content-type",
+        "host",
+        "content-length",
+        "content-encoding",
+        "accept-encoding",
+    }
+    missing_headers = required_header_names - set(normalized_headers.keys())
+    assert not missing_headers, f"Missing required headers: {missing_headers}"
+    assert normalized_headers["authorization"].startswith("Snowflake Token=")
+    assert normalized_headers["content-type"] == "application/json"
+    assert normalized_headers["accept"] == "application/json"
+    assert normalized_headers["user-agent"] is not None
 
-        body = _decode_telemetry_body(request)
-        assert "logs" in body, "Telemetry payload must contain 'logs' array"
-        assert isinstance(body["logs"], list)
-        assert len(body["logs"]) >= 1, "Expected at least one log entry"
+    body = _decode_telemetry_body(request)
+    assert "logs" in body, "Telemetry payload must contain 'logs' array"
+    assert isinstance(body["logs"], list)
+    assert len(body["logs"]) >= 1, "Expected at least one log entry"
 
-        # Each log entry must have 'message' and 'timestamp'
-        for entry in body["logs"]:
-            assert "message" in entry, "Log entry must contain 'message'"
-            assert "timestamp" in entry, "Log entry must contain 'timestamp'"
-            assert isinstance(entry["message"], dict)
-            assert isinstance(entry["timestamp"], str)
+    # Each log entry must have 'message' and 'timestamp'
+    for entry in body["logs"]:
+        assert "message" in entry, "Log entry must contain 'message'"
+        assert "timestamp" in entry, "Log entry must contain 'timestamp'"
+        assert isinstance(entry["message"], dict)
+        assert isinstance(entry["timestamp"], str)
 
 
 @pytest.mark.skip_reference(reason="api_usage telemetry is universal-driver only")
-def test_api_usage_telemetry_sent_on_cursor_creation(int_test_connection_factory):
+def test_api_usage_telemetry_sent_on_cursor_creation(int_test_connection_factory, wiremock):
     """Verify that an api_usage telemetry event is recorded when a cursor is created.
 
     ``Connection.cursor`` is decorated with ``@api_telemetry``, which calls
@@ -82,79 +80,78 @@ def test_api_usage_telemetry_sent_on_cursor_creation(int_test_connection_factory
     ``/telemetry/send`` with ``message.type == 'api_call'`` and
     ``message.api_method == 'Connection.cursor'``.
     """
-    with WiremockClient().start() as wiremock:
-        wiremock.add_mapping("auth/login_success_jwt.json")
-        wiremock.add_mapping("telemetry/telemetry_send_success.json")
+    wiremock.add_mapping("auth/login_success_jwt.json")
+    wiremock.add_mapping("telemetry/telemetry_send_success.json")
 
-        connection = int_test_connection_factory(server_url=wiremock.http_url(), **_jwt_private_key_params())
-        try:
-            cursor = connection.cursor()
-            cursor.close()
-        finally:
-            # Closing the connection flushes pending telemetry spans via
-            # SimpleSpanProcessor, so it must happen before we poll wiremock.
-            connection.close()
+    connection = int_test_connection_factory(server_url=wiremock.http_url(), **_jwt_private_key_params())
+    try:
+        cursor = connection.cursor()
+        cursor.close()
+    finally:
+        # Closing the connection flushes pending telemetry spans via
+        # SimpleSpanProcessor, so it must happen before we poll wiremock.
+        connection.close()
 
-        telemetry_requests = wiremock.wait_for_requests("/telemetry/send", min_count=1, timeout=5.0)
-        assert len(telemetry_requests) >= 1, "Expected at least one POST to /telemetry/send after cursor creation"
+    telemetry_requests = wiremock.wait_for_requests("/telemetry/send", min_count=1, timeout=5.0)
+    assert len(telemetry_requests) >= 1, "Expected at least one POST to /telemetry/send after cursor creation"
 
-        log_entries = _collect_log_entries(telemetry_requests)
+    log_entries = _collect_log_entries(telemetry_requests)
 
-        cursor_entries = [
-            entry
-            for entry in log_entries
-            if entry["message"].get("type") == "api_call" and entry["message"].get("api_method") == "Connection.cursor"
-        ]
-        assert len(cursor_entries) == 1, (
-            "Expected exactly one api_call telemetry log entry with "
-            f"api_method='Connection.cursor'. Got entries: {log_entries}"
+    cursor_entries = [
+        entry
+        for entry in log_entries
+        if entry["message"].get("type") == "api_call" and entry["message"].get("api_method") == "Connection.cursor"
+    ]
+    assert len(cursor_entries) == 1, (
+        "Expected exactly one api_call telemetry log entry with "
+        f"api_method='Connection.cursor'. Got entries: {log_entries}"
+    )
+
+    entry = cursor_entries[0]
+
+    # Log envelope: {"message": {...}, "timestamp": "<epoch_millis>"}
+    assert set(entry.keys()) == {"message", "timestamp"}, f"Unexpected log entry envelope keys: {set(entry.keys())}"
+    assert isinstance(entry["timestamp"], str) and entry["timestamp"].isdigit(), (
+        f"timestamp must be a decimal epoch-millis string, got: {entry['timestamp']!r}"
+    )
+
+    message = entry["message"]
+
+    # Event attributes (from record_api_call) + inherited connection-span
+    # attributes. `snowflake.session.id` comes from the login mapping
+    # (tests/wiremock/mappings/auth/login_success_jwt.json -> sessionId).
+    # The `code.*`, `busy_ns`, `idle_ns`, `thread.id` attributes are
+    # auto-populated by `tracing::info_span!` at
+    # sf_core/src/apis/database_driver_v1/connection.rs where the
+    # "connection" span is created.
+    expected_exact = {
+        "type": "api_call",
+        "api_method": "Connection.cursor",
+        "snowflake.session.id": 12345,
+        "code.filepath": "sf_core/src/apis/database_driver_v1/connection.rs",
+        "code.namespace": "sf_core::apis::database_driver_v1::connection",
+    }
+    for key, expected in expected_exact.items():
+        actual = message.get(key)
+        # Normalize path separators for cross-platform compatibility (Windows uses backslashes)
+        if key == "code.filepath" and isinstance(actual, str):
+            actual = actual.replace("\\", "/")
+        assert actual == expected, (
+            f"api_call message[{key!r}] expected {expected!r}, got {message.get(key)!r}. Full message: {message}"
         )
 
-        entry = cursor_entries[0]
-
-        # Log envelope: {"message": {...}, "timestamp": "<epoch_millis>"}
-        assert set(entry.keys()) == {"message", "timestamp"}, f"Unexpected log entry envelope keys: {set(entry.keys())}"
-        assert isinstance(entry["timestamp"], str) and entry["timestamp"].isdigit(), (
-            f"timestamp must be a decimal epoch-millis string, got: {entry['timestamp']!r}"
+    numeric_attrs = {"code.lineno", "busy_ns", "idle_ns", "thread.id"}
+    for key in numeric_attrs:
+        assert isinstance(message.get(key), int), (
+            f"api_call message[{key!r}] expected int, got {type(message.get(key)).__name__}: {message.get(key)!r}"
         )
 
-        message = entry["message"]
-
-        # Event attributes (from record_api_call) + inherited connection-span
-        # attributes. `snowflake.session.id` comes from the login mapping
-        # (tests/wiremock/mappings/auth/login_success_jwt.json -> sessionId).
-        # The `code.*`, `busy_ns`, `idle_ns`, `thread.id` attributes are
-        # auto-populated by `tracing::info_span!` at
-        # sf_core/src/apis/database_driver_v1/connection.rs where the
-        # "connection" span is created.
-        expected_exact = {
-            "type": "api_call",
-            "api_method": "Connection.cursor",
-            "snowflake.session.id": 12345,
-            "code.filepath": "sf_core/src/apis/database_driver_v1/connection.rs",
-            "code.namespace": "sf_core::apis::database_driver_v1::connection",
-        }
-        for key, expected in expected_exact.items():
-            actual = message.get(key)
-            # Normalize path separators for cross-platform compatibility (Windows uses backslashes)
-            if key == "code.filepath" and isinstance(actual, str):
-                actual = actual.replace("\\", "/")
-            assert actual == expected, (
-                f"api_call message[{key!r}] expected {expected!r}, got {message.get(key)!r}. Full message: {message}"
-            )
-
-        numeric_attrs = {"code.lineno", "busy_ns", "idle_ns", "thread.id"}
-        for key in numeric_attrs:
-            assert isinstance(message.get(key), int), (
-                f"api_call message[{key!r}] expected int, got {type(message.get(key)).__name__}: {message.get(key)!r}"
-            )
-
-        # Guard against the event silently gaining or losing attributes: the
-        # api_call message is the union of the exact and numeric attribute
-        # sets above — nothing more, nothing less.
-        assert set(message.keys()) == set(expected_exact.keys()) | numeric_attrs, (
-            f"Unexpected api_call message keys: {sorted(message.keys())}"
-        )
+    # Guard against the event silently gaining or losing attributes: the
+    # api_call message is the union of the exact and numeric attribute
+    # sets above — nothing more, nothing less.
+    assert set(message.keys()) == set(expected_exact.keys()) | numeric_attrs, (
+        f"Unexpected api_call message keys: {sorted(message.keys())}"
+    )
 
 
 def _jwt_private_key_params() -> dict:

--- a/python/tests/integ/test_connection.py
+++ b/python/tests/integ/test_connection.py
@@ -15,6 +15,14 @@ from snowflake.connector.cursor import DictCursor
 from snowflake.connector.errors import DatabaseError, InterfaceError, ProgrammingError
 
 
+# These tests heavily mutate the connection (close, autocommit, commit, rollback,
+# set_autocommit). Override the module-scoped default with a fresh function-scoped
+# connection per test so state does not leak across tests.
+@pytest.fixture
+def connection(function_connection):
+    yield function_connection
+
+
 class TestConnectionInfo:
     """Integration tests for Connection._get_connection_info."""
 

--- a/python/tests/integ/test_cursor_format_properties.py
+++ b/python/tests/integ/test_cursor_format_properties.py
@@ -8,6 +8,13 @@ as read-only metadata on the cursor.
 import pytest
 
 
+# ALTER SESSION statements in these tests mutate connection state — use a
+# fresh connection per test instead of the module-scoped default.
+@pytest.fixture
+def connection(function_connection):
+    yield function_connection
+
+
 SIMPLE_PROPERTIES = [
     ("timestamp_output_format", "YYYY-MM-DD", "MM/DD/YYYY HH24:MI"),
     ("date_output_format", "YYYY-MM-DD", "DD/MM/YYYY"),

--- a/python/tests/integ/test_session_parameters.py
+++ b/python/tests/integ/test_session_parameters.py
@@ -9,6 +9,13 @@ import pytest
 pytestmark = pytest.mark.skip_reference(reason="Reference driver has no _get_session_parameter method")
 
 
+# ALTER SESSION statements mutate connection state — use a fresh connection per
+# test instead of the module-scoped default.
+@pytest.fixture
+def connection(function_connection):
+    yield function_connection
+
+
 class TestSessionParametersGet:
     """Test getting session parameter values."""
 

--- a/python/tests/wiremock_client.py
+++ b/python/tests/wiremock_client.py
@@ -118,6 +118,16 @@ class WiremockClient:
             if response.status_code not in (200, 201):
                 raise RuntimeError(f"Failed to add mapping: {response.status_code} {response.text}")
 
+    def reset(self) -> None:
+        """Clear all mappings and captured requests via the admin API.
+
+        Equivalent to restarting the JVM but far cheaper — use this between
+        tests sharing a session-scoped Wiremock instance.
+        """
+        response = requests.post(f"{self.http_url()}/__admin/reset", timeout=5)
+        if response.status_code not in (200, 201):
+            raise RuntimeError(f"Failed to reset Wiremock: {response.status_code} {response.text}")
+
     def get_all_requests(self) -> list:
         """Query admin API for all captured requests."""
         response = requests.get(f"{self.http_url()}/__admin/requests")


### PR DESCRIPTION
## Summary

Reduces wall-clock time of the Python `hatch run dev.py3.13:integ` / `:e2e` suites by trimming per-test fixed costs. No production code changes; tests only.

- **Module-scoped `connection` fixture.** Promote the connection fixture from function scope to module scope. Most test modules only query through the connection and never mutate it; sharing the session across a module avoids repeated JWT login/logout round-trips. A new function-scoped `function_connection` fixture is provided for tests that mutate state (`close`, `autocommit`, `commit/rollback`, `set_autocommit`, `ALTER SESSION`). Three modules override `connection` to `function_connection` where needed: `test_connection.py`, `test_session_parameters.py`, `test_cursor_format_properties.py`. `with_paramstyle` continues to parametrize correctly — pytest creates a module-scoped instance per paramstyle.
- **Session-scoped Wiremock JVM.** Add a `wiremock` fixture that lives for the full session and is reset between tests via a new `WiremockClient.reset()` that hits the `/__admin/reset` admin endpoint. Replaces ~28 per-test `WiremockClient().start()` calls across `e2e/session/test_close.py`, `e2e/session/test_logout.py`, `integ/session/test_logout.py`, `integ/telemetry/test_connection_telemetry.py`, `integ/telemetry/test_client_identity.py`, and `integ/put_get/test_put_get_source_compression.py`. Saves ~1–3 s of JVM startup per invocation.
- **Disable `log_cli`.** `log_cli=true` streams INFO to stdout under `-n auto` — causes worker stdout lock contention and bloats CI logs with no upside. Flip to `false`; people who want live logs can opt in with `--log-cli-level=DEBUG`.
- **xdist worker count.** Drop the 8-worker floor in `pytest_xdist_auto_num_workers`; use `os.cpu_count() or 1`. Matches actual CPU count on small machines and avoids interpreter over-subscription.

## Test plan

- [x] `hatch run dev.py3.13:integ` against local reg: 433 passed / 1 failed / 7 skipped in 23.2s. The 1 failure (`TestCursorDescription::test_description_empty_subquery_type_code[TIMESTAMP_NTZ]`) is a pre-existing server-side type-code mismatch unrelated to fixture scoping.
- [x] `hatch run dev.py3.13:e2e` against local reg: 743 passed / 4 failed / 10 skipped / 44 errors in 76.2s. The 44 errors are the optional pandas/numpy deps not installed in the default `dev` env. The 4 failures are pre-existing server behaviors on local reg (TZ mapping, missing sample data, vector overflow) — none traceable to fixture changes.
- [ ] CI matrix (full OS × Python × cloud-provider sweep) to confirm the module-scoped fixture works against remote Snowflake too, and that the Wiremock reset semantics hold on every platform.

Not included (will follow in later PRs): de-parametrizing large-result-set tests per numeric-type synonym, collapsing serial-INSERT binding loops, reducing `SYSTEM$WAIT(30)` to 3s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)