### PR TITLE
NO-SNOW: Clippy fix using multiple_of

### DIFF
--- a/odbc/src/conversion/binary.rs
+++ b/odbc/src/conversion/binary.rs
@@ -66,7 +66,7 @@ fn hex_digit_to_ascii(nibble: u8) -> u8 {
 /// separators), and odd-length / non-hex input must surface as
 /// SQLSTATE 22018.
 fn hex_decode_ascii(input: &str) -> Result<Vec<u8>, JsonBindingError> {
-    if input.len() % 2 != 0 {
+    if !input.len().is_multiple_of(2) {
         return InvalidHexLiteralSnafu {
             reason: format!(
                 "hex literal must contain an even number of digits (got {} chars)",


### PR DESCRIPTION
### TL;DR

Replaced manual modulo check with `is_multiple_of` for even-length validation in hex decoding.

### What changed?

The even-length check in `hex_decode_ascii` was updated to use the `is_multiple_of(2)` method instead of the explicit `% 2 != 0` modulo expression.

### How to test?

Pass odd-length and even-length hex strings to the binary conversion logic and verify that odd-length inputs still return a `SQLSTATE 22018` error, while valid even-length hex strings decode correctly.

### Why make this change?

`is_multiple_of` is more expressive and idiomatic, making the intent of the check immediately clear without requiring the reader to mentally parse the modulo arithmetic.