### PR TITLE
SNOW-2872434: deprecate client_fetch_threads and legacy config aliases

### DIFF
--- a/python/BehaviorDifferences.yaml
+++ b/python/BehaviorDifferences.yaml
@@ -25,7 +25,8 @@ behavior_differences:
     old_driver_behavior: |
       `private_key_file_pwd`
     new_driver_behavior: |
-      `private_key_password`
+      `private_key_password`. The legacy name `private_key_file_pwd` is still accepted
+      and mapped to `private_key_password`, but emits a `DeprecationWarning`.
 
   11:
     name: "CONFIG_PARSER deprecated alias removed"
@@ -86,8 +87,8 @@ behavior_differences:
       `client_request_mfa_token` enables MFA token caching.
     new_driver_behavior: |
       `client_store_temporary_credential` enables MFA token caching. The legacy name
-      `client_request_mfa_token` is also accepted as a backward-compatible alias and is silently
-      mapped to `client_store_temporary_credential`.
+      `client_request_mfa_token` is also accepted as a backward-compatible alias and is mapped
+      to `client_store_temporary_credential`, but emits a `DeprecationWarning`.
 
   17:
     name: "rest.request() validates HTTP method (internal API)"
@@ -203,3 +204,19 @@ behavior_differences:
       not have a `region` property. Callers that previously relied on `region` to derive
       the hostname must supply the fully-qualified `account` identifier (e.g.
       `"myaccount.us-east-1"`) or set `host` explicitly instead.
+
+  25:
+    name: "client_fetch_threads deprecated; client_fetch_use_mp removed"
+    status: allowed
+    type: api_incompatibility
+    reviewed: false
+    old_driver_behavior: |
+      `client_fetch_threads` controls the chunk-fetch pool size (defaulting to
+      `client_prefetch_threads`). `client_fetch_use_mp=True` switches the pool from
+      `ThreadPoolExecutor` to `ProcessPoolExecutor`.
+    new_driver_behavior: |
+      `client_fetch_threads` is accepted as a deprecated alias for `client_prefetch_threads`
+      and emits a `DeprecationWarning`. The legacy `client_fetch_use_mp` parameter (which switched
+      chunk fetching from a thread pool to a process pool) has no equivalent: the universal driver
+      always uses a thread pool. Passing `client_fetch_use_mp` is accepted for source compatibility
+      but has no effect and emits a `DeprecationWarning`.

--- a/python/src/snowflake/connector/_internal/connection_config_mixin.py
+++ b/python/src/snowflake/connector/_internal/connection_config_mixin.py
@@ -14,6 +14,7 @@ touch.
 from __future__ import annotations
 
 import re
+import warnings
 
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field, fields
@@ -112,11 +113,27 @@ class ConnectionConfigMixin:
     )
     """Fields handled only in Python, not forwarded to Rust."""
 
-    _LEGACY_REWRITES: ClassVar[dict[str, str]] = {
-        "private_key_file_pwd": "private_key_password",
+    _LEGACY_REWRITES: ClassVar[dict[str, str]] = {}
+    """Legacy parameter names -> canonical replacements (silent)."""
+
+    _DEPRECATED_REWRITES: ClassVar[dict[str, str]] = {
+        "client_fetch_threads": "client_prefetch_threads",
         "client_request_mfa_token": "client_store_temporary_credential",
+        "private_key_file_pwd": "private_key_password",
     }
-    """Legacy parameter names -> canonical replacements."""
+    """Deprecated parameter names -> canonical replacements.
+
+    Each hit emits a ``DeprecationWarning``.  Unlike ``_LEGACY_REWRITES`` these
+    names are not silently supported forever — they exist so users migrating
+    from ``snowflake-connector-python`` get a pointer to the new name.
+    """
+
+    _UNSUPPORTED_PARAMS: ClassVar[dict[str, str]] = {
+        "client_fetch_use_mp": (
+            "not supported; universal driver uses a thread pool for chunk fetch (see BehaviorDifferences)"
+        ),
+    }
+    """Legacy kwargs that are accepted for source compatibility but have no effect."""
 
     _APPLICATION_NAME: ClassVar[str] = "PythonConnector"
     """Default application name."""
@@ -153,11 +170,39 @@ class ConnectionConfigMixin:
         Resolves case-insensitive aliases, applies legacy parameter name
         rewrites, and collects unknown keys into ``_extra``.
         """
+        # Apply legacy rewrites first (silent — canonical replacements).
         for old_name, new_name in cls._LEGACY_REWRITES.items():
             if old_name in kwargs:
                 value = kwargs.pop(old_name)
                 if new_name not in kwargs:
                     kwargs[new_name] = value
+
+        # Apply deprecated rewrites with a ``DeprecationWarning`` so callers
+        # migrating from snowflake-connector-python see a pointer to the new
+        # name.  ``stacklevel=3`` surfaces the caller of ``Connection(...)`` /
+        # ``ConnectionConfig.from_kwargs(...)`` rather than this file.
+        for old_name, new_name in cls._DEPRECATED_REWRITES.items():
+            if old_name in kwargs:
+                value = kwargs.pop(old_name)
+                warnings.warn(
+                    f"{old_name!r} is deprecated; use {new_name!r} instead.",
+                    DeprecationWarning,
+                    stacklevel=3,
+                )
+                if new_name not in kwargs:
+                    kwargs[new_name] = value
+
+        # Drop unsupported legacy kwargs with a warning so the caller knows
+        # they had no effect instead of silently forwarding them to Rust.
+        for key in list(kwargs):
+            if key.lower() in cls._UNSUPPORTED_PARAMS:
+                reason = cls._UNSUPPORTED_PARAMS[key.lower()]
+                warnings.warn(
+                    f"{key!r} has no effect in the universal driver: {reason}.",
+                    DeprecationWarning,
+                    stacklevel=3,
+                )
+                kwargs.pop(key)
 
         known_fields = cls._all_field_names()
         resolved: dict[str, Any] = {}

--- a/python/tests/unit/test_connection_config.py
+++ b/python/tests/unit/test_connection_config.py
@@ -62,19 +62,41 @@ class TestFromKwargs:
         assert config._extra == {"custom_param": "value"}
 
     def test_legacy_rewrite_private_key_file_pwd(self):
-        config = ConnectionConfig.from_kwargs(private_key_file_pwd="secret")
+        with pytest.warns(DeprecationWarning, match="private_key_file_pwd"):
+            config = ConnectionConfig.from_kwargs(private_key_file_pwd="secret")
         assert config.private_key_password == "secret"
 
     def test_legacy_rewrite_client_request_mfa_token(self):
-        config = ConnectionConfig.from_kwargs(client_request_mfa_token=True)
+        with pytest.warns(DeprecationWarning, match="client_request_mfa_token"):
+            config = ConnectionConfig.from_kwargs(client_request_mfa_token=True)
         assert config.client_store_temporary_credential is True
 
     def test_legacy_rewrite_does_not_override_canonical(self):
-        config = ConnectionConfig.from_kwargs(
-            client_request_mfa_token=True,
-            client_store_temporary_credential=False,
-        )
+        with pytest.warns(DeprecationWarning):
+            config = ConnectionConfig.from_kwargs(
+                client_request_mfa_token=True,
+                client_store_temporary_credential=False,
+            )
         assert config.client_store_temporary_credential is False
+
+    def test_client_fetch_threads_maps_to_prefetch_with_warning(self):
+        with pytest.warns(DeprecationWarning, match="client_fetch_threads"):
+            config = ConnectionConfig.from_kwargs(client_fetch_threads=8)
+        assert config.client_prefetch_threads == 8
+
+    def test_client_fetch_threads_does_not_override_canonical(self):
+        with pytest.warns(DeprecationWarning):
+            config = ConnectionConfig.from_kwargs(
+                client_fetch_threads=8,
+                client_prefetch_threads=2,
+            )
+        assert config.client_prefetch_threads == 2
+
+    def test_client_fetch_use_mp_is_dropped_with_warning(self):
+        with pytest.warns(DeprecationWarning, match="client_fetch_use_mp"):
+            config = ConnectionConfig.from_kwargs(user="u", client_fetch_use_mp=True)
+        assert config.user == "u"
+        assert "client_fetch_use_mp" not in config._extra
 
 
 class TestFromConnectionArgs:


### PR DESCRIPTION
Map `client_fetch_threads` to `client_prefetch_threads` with a `DeprecationWarning` so callers migrating from snowflake-connector-python get a pointer to the new name.  Drop unsupported `client_fetch_use_mp` with a warning — the universal driver always uses a thread pool.

Promote `private_key_file_pwd` and `client_request_mfa_token` from the silent `_LEGACY_REWRITES` map to `_DEPRECATED_REWRITES` so they warn on use.  Update BehaviorDifferences #5 / #16 and add entry #24 to document the behavioral differences vs. the legacy Python connector.