### PR TITLE
NO-SNOW: Silently ignore unknown compression type in ODBC

### DIFF
--- a/odbc_tests/BehaviorDifferences.yaml
+++ b/odbc_tests/BehaviorDifferences.yaml
@@ -31,7 +31,7 @@ behavior_differences:
 
   6:
     name: "Unsupported compression type returns error instead of being silently ignored"
-    status: unknown
+    status: fixed
     type: bug
     reviewed: false
 

--- a/odbc_tests/tests/e2e/put_get/put_get_source_compression.cpp
+++ b/odbc_tests/tests/e2e/put_get/put_get_source_compression.cpp
@@ -173,21 +173,33 @@ TEST_CASE("should compress uncompressed file when SOURCE_COMPRESSION set to NONE
   CHECK(get_data<SQL_C_CHAR>(stmt, PUT_ROW_STATUS_IDX) == std::string("UPLOADED"));
 }
 
-TEST_CASE("should return error for unsupported compression type", "[put_get]") {
-  // Given Snowflake client is logged in
+TEST_CASE("should silently upload file with unsupported compression type as uncompressed", "[put_get]") {
   Connection conn;
+  // Given Snowflake client is logged in
   const std::string stage = create_stage(conn, unique_stage_name("ODBCTST_SC_UNSUPPORTED"));
 
   // And File compressed with unsupported format
   auto [filename, file] = test_file("LZMA");
 
   // When File is uploaded with SOURCE_COMPRESSION set to AUTO_DETECT
-  std::string put_sql = "PUT 'file://" + as_file_uri(file) + "' @" + stage + " SOURCE_COMPRESSION=AUTO_DETECT";
+  auto put_stmt =
+      conn.execute_fetch("PUT 'file://" + as_file_uri(file) + "' @" + stage + " SOURCE_COMPRESSION=AUTO_DETECT");
 
-  auto stmt = conn.createStatement();
-  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)put_sql.c_str(), SQL_NTS);
+  // Then Upload succeeds and the file is treated as uncompressed source
+  CHECK(get_data<SQL_C_CHAR>(put_stmt, PUT_ROW_SOURCE_IDX) == expected_put_source(file));
+  CHECK(get_data<SQL_C_CHAR>(put_stmt, PUT_ROW_TARGET_IDX) == filename + ".gz");
+  compare_compression_type(get_data<SQL_C_CHAR>(put_stmt, PUT_ROW_SOURCE_COMPRESSION_IDX), "NONE");
+  compare_compression_type(get_data<SQL_C_CHAR>(put_stmt, PUT_ROW_TARGET_COMPRESSION_IDX), "GZIP");
+  CHECK(get_data<SQL_C_CHAR>(put_stmt, PUT_ROW_STATUS_IDX) == std::string("UPLOADED"));
 
-  // Then Unsupported compression error is thrown
-  OLD_DRIVER_ONLY("BD#6") { REQUIRE(ret == SQL_SUCCESS); }
-  NEW_DRIVER_ONLY("BD#6") { REQUIRE(ret == SQL_ERROR); }
+  // And Downloaded payload decompresses to the original file bytes
+  TempTestDir download_dir("odbc_put_get_unsupported_");
+  conn.execute("GET @" + stage + "/" + filename + " 'file://" + as_file_uri(download_dir.path()) + "/'");
+  const fs::path downloaded_gz = download_dir.path() / (filename + ".gz");
+  REQUIRE(fs::exists(downloaded_gz));
+
+  const std::string decompressed = decompress_gzip_file(downloaded_gz);
+  std::ifstream original_ifs(file, std::ios::binary);
+  const std::string original_bytes((std::istreambuf_iterator(original_ifs)), std::istreambuf_iterator<char>());
+  CHECK(decompressed == original_bytes);
 }

--- a/sf_core/src/file_manager/mod.rs
+++ b/sf_core/src/file_manager/mod.rs
@@ -147,6 +147,7 @@ fn preprocess_file_before_upload(
         data.filename.as_str(),
         file_buffer.as_slice(),
         &data.source_compression,
+        &data.flavor,
     )
     .context(CompressionTypeSnafu)?;
 
@@ -195,9 +196,12 @@ fn get_source_compression(
     filename: &str,
     file_buffer: &[u8],
     source_compression: &SourceCompressionParam,
+    flavor: &PutGetResultsetFlavor,
 ) -> Result<CompressionType, CompressionTypeError> {
     match source_compression {
-        SourceCompressionParam::AutoDetect => try_guess_compression_type(filename, file_buffer),
+        SourceCompressionParam::AutoDetect => {
+            auto_detect_source_compression(filename, file_buffer, flavor)
+        }
         SourceCompressionParam::None => Ok(CompressionType::None),
         SourceCompressionParam::Gzip => Ok(CompressionType::Gzip),
         SourceCompressionParam::Bzip2 => Ok(CompressionType::Bzip2),
@@ -205,6 +209,32 @@ fn get_source_compression(
         SourceCompressionParam::Zstd => Ok(CompressionType::Zstd),
         SourceCompressionParam::Deflate => Ok(CompressionType::Deflate),
         SourceCompressionParam::RawDeflate => Ok(CompressionType::RawDeflate),
+    }
+}
+
+/// Returns the resolved compression type for the `AUTO_DETECT` path,
+/// gated on the active wrapper flavor. Legacy libsnowflakeclient silently
+/// treated unsupported compression formats (e.g. `.xz`, `.lz`, `.parquet`)
+/// as uncompressed and continued the upload — the `Odbc` flavor restores
+/// that behavior. The `Python` flavor (default) surfaces the error,
+/// matching the current UD-Python contract. The recovery is keyed on the
+/// `UnsupportedCompressionType` error variant, so it fires regardless of
+/// whether the detection went through the filename extension or the
+/// magic-bytes (infer crate) path.
+fn auto_detect_source_compression(
+    filename: &str,
+    file_buffer: &[u8],
+    flavor: &PutGetResultsetFlavor,
+) -> Result<CompressionType, CompressionTypeError> {
+    let detected = try_guess_compression_type(filename, file_buffer);
+    match flavor {
+        PutGetResultsetFlavor::Odbc => match detected {
+            Err(CompressionTypeError::UnsupportedCompressionType { .. }) => {
+                Ok(CompressionType::None)
+            }
+            other => other,
+        },
+        _ => detected,
     }
 }
 
@@ -493,6 +523,117 @@ mod tests {
                 download_result_size(n, n, &PutGetResultsetFlavor::Python),
                 n,
                 "Python flavor must report n={n} when cloud == output",
+            );
+        }
+    }
+
+    // BD#6 — when SOURCE_COMPRESSION=AUTO_DETECT detects an unsupported
+    // compression format, legacy libsnowflakeclient silently fell back to
+    // no compression. The `Odbc` flavor restores that behavior; the
+    // `Python` flavor (default) keeps surfacing the error.
+    const UNSUPPORTED_COMPRESSION_FILENAMES: &[&str] = &[
+        "test.xz",
+        "test.lzma",
+        "test.lz",
+        "test.lzo",
+        "test.Z",
+        "test.parquet",
+        "test.orc",
+    ];
+
+    #[test]
+    fn auto_detect_source_compression_odbc_falls_back_to_none_for_unsupported() {
+        for filename in UNSUPPORTED_COMPRESSION_FILENAMES {
+            let result =
+                auto_detect_source_compression(filename, b"", &PutGetResultsetFlavor::Odbc);
+            assert_eq!(
+                result.unwrap(),
+                CompressionType::None,
+                "Odbc flavor must fall back to None for {filename}",
+            );
+        }
+    }
+
+    #[test]
+    fn auto_detect_source_compression_python_surfaces_unsupported_error() {
+        for filename in UNSUPPORTED_COMPRESSION_FILENAMES {
+            let result =
+                auto_detect_source_compression(filename, b"", &PutGetResultsetFlavor::Python);
+            assert!(
+                matches!(
+                    result,
+                    Err(CompressionTypeError::UnsupportedCompressionType { .. })
+                ),
+                "Python flavor must propagate the unsupported error for {filename}, got: {result:?}",
+            );
+        }
+    }
+
+    // Buffer-detection branch (infer crate): an extension-less file whose
+    // magic bytes match an unsupported format must still trigger the
+    // Odbc-flavor fallback. Locks in that the recovery is keyed on the
+    // `UnsupportedCompressionType` error variant, not on the
+    // filename-extension detection path.
+    #[test]
+    fn auto_detect_source_compression_odbc_falls_back_for_buffer_detected_unsupported() {
+        let xz_magic = b"\xFD7zXZ\x00\x00\x01\x69\x22\xDE\x36";
+        let result =
+            auto_detect_source_compression("noext", xz_magic, &PutGetResultsetFlavor::Odbc);
+        assert_eq!(result.unwrap(), CompressionType::None);
+    }
+
+    #[test]
+    fn auto_detect_source_compression_python_surfaces_buffer_detected_unsupported() {
+        let xz_magic = b"\xFD7zXZ\x00\x00\x01\x69\x22\xDE\x36";
+        let result =
+            auto_detect_source_compression("noext", xz_magic, &PutGetResultsetFlavor::Python);
+        assert!(
+            matches!(
+                result,
+                Err(CompressionTypeError::UnsupportedCompressionType { .. })
+            ),
+            "Python flavor must propagate the buffer-detected unsupported error, got: {result:?}",
+        );
+    }
+
+    #[test]
+    fn auto_detect_source_compression_recognizes_gzip_for_both_flavors() {
+        for flavor in [PutGetResultsetFlavor::Python, PutGetResultsetFlavor::Odbc] {
+            let result = auto_detect_source_compression("test.csv.gz", b"", &flavor);
+            assert_eq!(
+                result.unwrap(),
+                CompressionType::Gzip,
+                "{flavor:?} flavor must still recognize supported extensions",
+            );
+        }
+    }
+
+    #[test]
+    fn auto_detect_source_compression_returns_none_for_uncompressed_under_both_flavors() {
+        for flavor in [PutGetResultsetFlavor::Python, PutGetResultsetFlavor::Odbc] {
+            let result = auto_detect_source_compression("test.csv", b"", &flavor);
+            assert_eq!(
+                result.unwrap(),
+                CompressionType::None,
+                "{flavor:?} flavor must report None for plain files",
+            );
+        }
+    }
+
+    #[test]
+    fn get_source_compression_explicit_param_ignores_flavor() {
+        // Explicit SOURCE_COMPRESSION=<known type> never goes through the
+        // auto-detect path, so the flavor branch is a no-op here.
+        for flavor in [PutGetResultsetFlavor::Python, PutGetResultsetFlavor::Odbc] {
+            assert_eq!(
+                get_source_compression("ignored.xz", b"", &SourceCompressionParam::Gzip, &flavor,)
+                    .unwrap(),
+                CompressionType::Gzip,
+            );
+            assert_eq!(
+                get_source_compression("ignored.xz", b"", &SourceCompressionParam::None, &flavor,)
+                    .unwrap(),
+                CompressionType::None,
             );
         }
     }

--- a/tests/definitions/shared/put_get/put_get_source_compression.feature
+++ b/tests/definitions/shared/put_get/put_get_source_compression.feature
@@ -43,10 +43,24 @@ Feature: PUT/GET source compression
     When File is uploaded with SOURCE_COMPRESSION set to NONE and AUTO_COMPRESS set to TRUE
     Then Target compression has GZIP type and all PUT results are correct
 
-  @core_int @python_int  @odbc_e2e
+  @core_int @python_int
   Scenario: should return error for unsupported compression type
     Given Snowflake client is logged in
     And File compressed with unsupported format
     When File is uploaded with SOURCE_COMPRESSION set to AUTO_DETECT
     Then Unsupported compression error is thrown
+
+  # ODBC-only: under the Odbc wrapper preset, sf_core restores the legacy
+  # libsnowflakeclient behavior of silently treating unsupported
+  # compression formats as uncompressed (BehaviorDifferences.yaml BD#6).
+  # The original payload is wrapped verbatim inside an outer gzip (because
+  # AUTO_COMPRESS=TRUE then runs over the "uncompressed" source) and must
+  # roundtrip byte-for-byte through the upload+download cycle.
+  @odbc_e2e
+  Scenario: should silently upload file with unsupported compression type as uncompressed
+    Given Snowflake client is logged in
+    And File compressed with unsupported format
+    When File is uploaded with SOURCE_COMPRESSION set to AUTO_DETECT
+    Then Upload succeeds and the file is treated as uncompressed source
+    And Downloaded payload decompresses to the original file bytes
 


### PR DESCRIPTION
### TL;DR

Restores legacy libsnowflakeclient behavior for the ODBC flavor: files with unsupported compression types are silently treated as uncompressed during `AUTO_DETECT` instead of returning an error (BD#6).

### What changed?

The `get_source_compression` function now accepts the active `PutGetResultsetFlavor`. A new `auto_detect_source_compression` function gates the fallback behavior: when the `Odbc` flavor is active and `AUTO_DETECT` encounters an `UnsupportedCompressionType` error (whether triggered by filename extension or magic-byte detection), it falls back to `CompressionType::None` and continues the upload. The `Python` flavor retains the existing behavior of surfacing the error. The fallback applies uniformly to all unsupported formats (`.xz`, `.lzma`, `.lz`, `.lzo`, `.Z`, `.parquet`, `.orc`, etc.).

The ODBC end-to-end test was updated to reflect the corrected behavior: it now verifies that the upload succeeds, the file is stored as gzip-compressed (since `AUTO_COMPRESS=TRUE` then runs over the "uncompressed" source), and the downloaded payload decompresses byte-for-byte to the original file content. The shared feature file splits the scenario into a `@core_int @python_int` scenario (error is thrown) and a separate `@odbc_e2e` scenario (silent fallback with roundtrip verification). BD#6 in `BehaviorDifferences.yaml` is marked `fixed`.

### How to test?

- Run the ODBC end-to-end test `should silently upload file with unsupported compression type as uncompressed` — it uploads an LZMA-compressed file with `SOURCE_COMPRESSION=AUTO_DETECT`, verifies the PUT result shows `NONE` source compression and `GZIP` target compression, then GETs the file and confirms the decompressed bytes match the original.
- Run the Python/core integration test `should return error for unsupported compression type` to confirm the error-surfacing path is unchanged.
- Run the new unit tests in `sf_core`: `auto_detect_source_compression_odbc_falls_back_to_none_for_unsupported`, `auto_detect_source_compression_python_surfaces_unsupported_error`, and the buffer-detection and explicit-param variants.

### Why make this change?

Legacy `libsnowflakeclient` silently ignored unsupported compression types during `AUTO_DETECT` and proceeded with the upload treating the file as uncompressed. The new driver was returning `SQL_ERROR` instead, breaking existing ODBC workflows that relied on this silent fallback. This change restores parity with the legacy behavior specifically for the ODBC flavor while keeping the stricter error-surfacing behavior intact for the Python connector.