### PR TITLE
NO-CONN: convert attr_error_handling tests to BD# pattern and add BD#51

### DIFF
--- a/odbc_tests/BehaviorDifferences.yaml
+++ b/odbc_tests/BehaviorDifferences.yaml
@@ -577,3 +577,15 @@ behavior_differences:
       The driver reads TIMESTAMP_TZ_OUTPUT_FORMAT once per execute (matching the rest of the per-execute sequential RPC) and formats the rendered string accordingly. With `TZH:TZM` the offset suffix is appended as `+HH:MM`; with `TZHTZM` as `+HHMM`; with `TZH` as `+HH`. The format is re-read on every execute, so `ALTER SESSION SET / UNSET TIMESTAMP_TZ_OUTPUT_FORMAT` mid-connection takes effect on the next statement. Unrecognised TZ-shaped tokens (`TZHM`, `TZM`, etc.) are tolerated -- the driver emits a `tracing::warn!` and falls back to the bare-UTC default rather than rejecting the format string.
     impact: |
       Migration is forward-compatible. Applications relying on the legacy bare-UTC rendering must either (a) leave TIMESTAMP_TZ_OUTPUT_FORMAT unset, (b) set it to a value containing none of `TZH:TZM`, `TZHTZM`, `TZH`, in which case the driver still emits bare UTC, or (c) parse the new offset-suffixed strings on the application side. The new behaviour matches what Snowsight, snowsql, and the Python connector already render for the same column with the same session format, removing a long-standing surprise where ODBC was the only client silently dropping the offset.
+
+  53:
+    name: "SQLGetStmtAttr/SQLGetConnectAttr with negative buffer length returns HY090 instead of HY000"
+    status: unknown
+    type: bug
+    reviewed: false
+    old_driver_behavior: |
+      Returns SQL_ERROR with SQLSTATE HY000 (General error) on Windows when BufferLength is negative for a string attribute.
+    new_driver_behavior: |
+      Returns SQL_ERROR with SQLSTATE HY090 (Invalid string or buffer length) per the ODBC specification.
+    impact: |
+      Applications checking for SQLSTATE HY090 specifically on Windows will now receive it consistently.

--- a/odbc_tests/tests/e2e/query/attr_error_handling.cpp
+++ b/odbc_tests/tests/e2e/query/attr_error_handling.cpp
@@ -10,8 +10,6 @@
 #include "sf_odbc.h"
 
 TEST_CASE("SQLGetStmtAttr with negative buffer length returns HY090.") {
-  SKIP_OLD_DRIVER("SNOW-3235549", "Negative buffer length validation is new driver only");
-
   // Given Snowflake client is logged in
   Connection conn;
   auto stmt = conn.createStatement();
@@ -21,14 +19,12 @@ TEST_CASE("SQLGetStmtAttr with negative buffer length returns HY090.") {
   SQLINTEGER len = 0;
   SQLRETURN ret = SQLGetStmtAttr(stmt.getHandle(), SQL_SF_STMT_ATTR_LAST_QUERY_ID, buf, -1, &len);
 
-  // Then it should return SQL_ERROR with SQLSTATE HY090
+  // Then it should return SQL_ERROR; new driver returns HY090, old driver may return HY000 (BD#53)
   REQUIRE(ret == SQL_ERROR);
-  CHECK(get_sqlstate(stmt) == "HY090");
+  NEW_DRIVER_ONLY("BD#53") { CHECK(get_sqlstate(stmt) == "HY090"); }
 }
 
 TEST_CASE("SQLGetStmtAttr string attribute truncation returns SQL_SUCCESS_WITH_INFO.") {
-  SKIP_OLD_DRIVER("SNOW-3235549", "String truncation warning is new driver only");
-
   // Given Snowflake client is logged in
   Connection conn;
   auto stmt = conn.createStatement();
@@ -53,8 +49,6 @@ TEST_CASE("SQLGetStmtAttr string attribute truncation returns SQL_SUCCESS_WITH_I
 }
 
 TEST_CASE("SQLGetStmtAttr with invalid attribute identifier returns HY092.") {
-  SKIP_OLD_DRIVER("SNOW-3235549", "HY092 for unknown attributes is new driver only");
-
   // Given Snowflake client is logged in
   Connection conn;
   auto stmt = conn.createStatement();
@@ -70,8 +64,6 @@ TEST_CASE("SQLGetStmtAttr with invalid attribute identifier returns HY092.") {
 }
 
 TEST_CASE("SQLGetConnectAttr with negative buffer length returns HY090.") {
-  SKIP_OLD_DRIVER("SNOW-3235549", "Negative buffer length validation is new driver only");
-
   // Given Snowflake client is logged in
   Connection conn;
 
@@ -80,7 +72,7 @@ TEST_CASE("SQLGetConnectAttr with negative buffer length returns HY090.") {
   SQLINTEGER len = 0;
   SQLRETURN ret = SQLGetConnectAttr(conn.handleWrapper().getHandle(), SQL_ATTR_CURRENT_CATALOG, buf, -1, &len);
 
-  // Then it should return SQL_ERROR with SQLSTATE HY090
+  // Then it should return SQL_ERROR; new driver returns HY090, old driver may return HY000 (BD#53)
   REQUIRE(ret == SQL_ERROR);
-  CHECK(get_sqlstate(conn.handleWrapper()) == "HY090");
+  NEW_DRIVER_ONLY("BD#53") { CHECK(get_sqlstate(conn.handleWrapper()) == "HY090"); }
 }


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                              
  - Removes `SKIP_OLD_DRIVER("SNOW-3235549", ...)` from all four tests in `attr_error_handling.cpp` — the old driver was never actually broken for these cases, it just wasn't tested                                                                                                         
  - Documents the one real behavioral difference (BD#51): on Windows, the old driver returns `HY000` instead of `HY090` for negative `BufferLength`                                                                                                                                           
                                                                                                                                                                                                                                                                                              
  ## Investigation findings                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                              
  After running against the old driver in CI we confirmed:                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                              
  | Test | Old driver `ret` | Old driver SQLSTATE | New driver |                                                                                                                                                                                                                              
  |------|-----------------|---------------------|------------|                                                                                                                                                                                                                               
  | `SQLGetStmtAttr` negative buffer | `SQL_ERROR` | `HY000` (Windows) / `HY090` (Linux) | `SQL_ERROR` + `HY090` |                                                                                                                                                                            
  | `SQLGetStmtAttr` truncation | `SQL_SUCCESS_WITH_INFO` | `01004` | `SQL_SUCCESS_WITH_INFO` + `01004` |                                                                                                                                                                                     
  | `SQLGetStmtAttr` unknown attribute | `SQL_ERROR` | `HY092` | `SQL_ERROR` + `HY092` |                                                                                                                                                                                                      
  | `SQLGetConnectAttr` negative buffer | `SQL_ERROR` | `HY000` (Windows) / `HY090` (Linux) | `SQL_ERROR` + `HY090` |                                                                                                                                                                         
                                                                                                                                                                                                                                                                                              
  The original `SKIP_OLD_DRIVER` guards were added unnecessarily — the old driver already behaves correctly on Linux and for 3 of the 4 cases everywhere. The only real difference is the SQLSTATE code for negative buffer length on Windows.                                                
                                                                                                                                                                                                                                                                                              
  ## Changes                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                              
  ### `odbc_tests/tests/e2e/query/attr_error_handling.cpp`                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                              
  - Removed all four `SKIP_OLD_DRIVER("SNOW-3235549", ...)` macros                                                                                                                                                                                                                            
  - Tests 389 (truncation) and 390 (unknown attr) are now fully unconditional — both drivers pass identically                                                                                                                                                                                 
  - Tests 388 and 391 (negative buffer length): `REQUIRE(ret == SQL_ERROR)` is unconditional; `HY090` SQLSTATE check is wrapped in `NEW_DRIVER_ONLY("BD#51")` to accommodate the Windows old driver returning `HY000`                                                                         
                                                                                                                                                                                                                                                                                              
  ### `odbc_tests/BehaviorDifferences.yaml`                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                              
  - Added BD#51: old Windows driver returns `HY000` instead of `HY090` for negative `BufferLength`      