### PR TITLE
SNOW-2872349: ODBC logout best-effort strategy and WireMock e2e tests

### DIFF
--- a/odbc/src/api/connection.rs
+++ b/odbc/src/api/connection.rs
@@ -49,11 +49,6 @@ fn normalize_crl_enabled_value(value: &str) -> String {
     }
 }
 
-fn is_truthy(value: &str) -> bool {
-    let v = value.trim();
-    v.eq_ignore_ascii_case("true") || v.eq_ignore_ascii_case("on") || v == "1"
-}
-
 fn normalize_connection_string_options(
     connection_string_map: HashMap<String, String>,
 ) -> HashMap<String, ConfigSetting> {
@@ -89,11 +84,7 @@ fn normalize_connection_string_option(
         "PRIV_KEY_FILE_PWD" | "PRIV_KEY_PWD" => {
             Some(("private_key_password".to_owned(), value.into()))
         }
-        "SSL" => {
-            let protocol = if is_truthy(&value) { "https" } else { "http" };
-            Some(("protocol".to_owned(), protocol.to_owned().into()))
-        }
-        // Forward other keys (e.g. SERVER, UID) for `sf_core` alias resolution; do not
+        // Forward other keys (e.g. SERVER, UID, SSL) for `sf_core` alias resolution; do not
         // pre-canonicalize here to avoid duplicate seed keys.
         _ => Some((upper, value.into())),
     }

--- a/odbc/src/api/connection.rs
+++ b/odbc/src/api/connection.rs
@@ -240,7 +240,7 @@ fn connect_with_params(
 
     // Legacy ODBC silently swallows all logout errors (destructor catch-all).
     options
-        .entry("logout_error_strategy".to_owned())
+        .entry("LOGOUT_ERROR_STRATEGY".to_owned())
         .or_insert_with(|| "best_effort".to_owned().into());
 
     let dbc = conn_from_handle(connection_handle)?;

--- a/odbc/src/api/connection.rs
+++ b/odbc/src/api/connection.rs
@@ -49,6 +49,11 @@ fn normalize_crl_enabled_value(value: &str) -> String {
     }
 }
 
+fn is_truthy(value: &str) -> bool {
+    let v = value.trim();
+    v.eq_ignore_ascii_case("true") || v.eq_ignore_ascii_case("on") || v == "1"
+}
+
 fn normalize_connection_string_options(
     connection_string_map: HashMap<String, String>,
 ) -> HashMap<String, ConfigSetting> {
@@ -83,6 +88,10 @@ fn normalize_connection_string_option(
         "PRIV_KEY_BASE64" => Some(("private_key".to_owned(), value.into())),
         "PRIV_KEY_FILE_PWD" | "PRIV_KEY_PWD" => {
             Some(("private_key_password".to_owned(), value.into()))
+        }
+        "SSL" => {
+            let protocol = if is_truthy(&value) { "https" } else { "http" };
+            Some(("protocol".to_owned(), protocol.to_owned().into()))
         }
         // Forward other keys (e.g. SERVER, UID) for `sf_core` alias resolution; do not
         // pre-canonicalize here to avoid duplicate seed keys.

--- a/odbc/src/api/connection.rs
+++ b/odbc/src/api/connection.rs
@@ -238,6 +238,11 @@ fn connect_with_params(
         options.insert("port".to_owned(), port_int.into());
     }
 
+    // Legacy ODBC silently swallows all logout errors (destructor catch-all).
+    options
+        .entry("logout_error_strategy".to_owned())
+        .or_insert_with(|| "best_effort".to_owned().into());
+
     let dbc = conn_from_handle(connection_handle)?;
     // Read pre-connection data under lock, then release before the async call.
     let (pre_connection_attrs, login_timeout_in_options, login_timeout_in_attrs) = {

--- a/odbc_tests/BehaviorDifferences.yaml
+++ b/odbc_tests/BehaviorDifferences.yaml
@@ -589,3 +589,15 @@ behavior_differences:
       Returns SQL_ERROR with SQLSTATE HY090 (Invalid string or buffer length) per the ODBC specification.
     impact: |
       Applications checking for SQLSTATE HY090 specifically on Windows will now receive it consistently.
+
+  54:
+    name: "Concurrent SQLDisconnect causes segfault without thread-safety guard"
+    status: unknown
+    type: bug
+    reviewed: false
+    old_driver_behavior: |
+      Calling SQLDisconnect concurrently from multiple threads on the same connection handle causes a segfault in the old driver due to lack of synchronisation in the disconnect path.
+    new_driver_behavior: |
+      Concurrent SQLDisconnect calls are serialized; exactly one returns SQL_SUCCESS and the rest return SQL_ERROR with SQLSTATE 08003 (Connection not open).
+    impact: |
+      Multi-threaded applications that disconnect from multiple threads no longer risk a crash.

--- a/odbc_tests/Dockerfile
+++ b/odbc_tests/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:22.04
 
 # Install dependencies
 RUN apt-get update && apt-get install -y unixodbc unixodbc-dev curl odbcinst wget build-essential git gdb \
-    zlib1g-dev libssl-dev jq ccache
+    zlib1g-dev libssl-dev jq ccache default-jre-headless
 
 # Install CMake (detect architecture automatically)
 RUN ARCH=$(dpkg --print-architecture) && \

--- a/odbc_tests/common/CMakeLists.txt
+++ b/odbc_tests/common/CMakeLists.txt
@@ -26,6 +26,12 @@ add_library(common STATIC
     include/EnvOverride.hpp
 )
 
+if (WIN32)
+    target_sources(common PRIVATE src/SubprocessWindows.cpp)
+else()
+    target_sources(common PRIVATE src/SubprocessUnix.cpp)
+endif()
+
 target_include_directories(common PUBLIC ${picojson_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_link_libraries(common PUBLIC Catch2::Catch2WithMain ODBC::ODBC ZLIB::ZLIB OpenSSL::Crypto)
 

--- a/odbc_tests/common/include/Subprocess.hpp
+++ b/odbc_tests/common/include/Subprocess.hpp
@@ -1,0 +1,27 @@
+#ifndef SUBPROCESS_HPP
+#define SUBPROCESS_HPP
+
+#include <memory>
+#include <string>
+#include <vector>
+
+/// RAII wrapper around a background subprocess.
+///
+/// Starts the given program with arguments, suppressing stdout/stderr.
+/// The destructor terminates the process and waits for it to exit.
+class Subprocess {
+ public:
+  Subprocess(const std::string& program, const std::vector<std::string>& args);
+  ~Subprocess();
+
+  Subprocess(const Subprocess&) = delete;
+  Subprocess& operator=(const Subprocess&) = delete;
+  Subprocess(Subprocess&&) noexcept;
+  Subprocess& operator=(Subprocess&&) noexcept;
+
+ private:
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+#endif  // SUBPROCESS_HPP

--- a/odbc_tests/common/include/WiremockClient.hpp
+++ b/odbc_tests/common/include/WiremockClient.hpp
@@ -56,17 +56,28 @@ class WiremockClient {
     if (!std::filesystem::exists(file_path)) {
       throw std::runtime_error("WireMock mapping file not found: " + file_path.string());
     }
-    std::string cmd = "curl -s -X POST " + admin_url("/__admin/mappings") +
-                      " -H \"Content-Type: application/json\""
-                      " --data-binary \"@" +
-                      file_path.string() + "\"" + null_redirect();
-    if (std::system(cmd.c_str()) != 0) {
-      throw std::runtime_error("Failed to add WireMock mapping: " + relative_path);
+
+    std::ifstream ifs(file_path);
+    std::string content((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
+
+    picojson::value json;
+    std::string err = picojson::parse(json, content);
+    if (!err.empty()) {
+      throw std::runtime_error("Failed to parse mapping file " + relative_path + ": " + err);
+    }
+
+    if (json.is<picojson::object>() && json.get<picojson::object>().count("mappings")) {
+      auto& arr = json.get<picojson::object>().at("mappings").get<picojson::array>();
+      for (auto& mapping : arr) {
+        post_mapping(mapping.serialize(), relative_path);
+      }
+    } else {
+      post_mapping(content, relative_path);
     }
   }
 
   void add_catch_all() {
-    auto tmp = std::filesystem::temp_directory_path() / "wm_catch_all.json";
+    auto tmp = std::filesystem::temp_directory_path() / ("wm_catch_all_" + std::to_string(port_) + ".json");
     {
       std::ofstream f(tmp);
       f << R"({
@@ -83,14 +94,17 @@ class WiremockClient {
                       " -H \"Content-Type: application/json\""
                       " --data-binary \"@" +
                       tmp.string() + "\"" + null_redirect();
-    std::system(cmd.c_str());
+    if (std::system(cmd.c_str()) != 0) {
+      std::filesystem::remove(tmp);
+      throw std::runtime_error("Failed to add WireMock catch-all mapping");
+    }
     std::filesystem::remove(tmp);
   }
 
   int get_request_count(const std::string& method, const std::string& url_path) const {
     std::string body = R"({"method":")" + method + R"(","urlPath":")" + url_path + R"("})";
 
-    auto tmp = std::filesystem::temp_directory_path() / "wm_request_count.json";
+    auto tmp = std::filesystem::temp_directory_path() / ("wm_request_count_" + std::to_string(port_) + ".json");
     {
       std::ofstream f(tmp);
       f << body;
@@ -127,6 +141,23 @@ class WiremockClient {
 
   std::string admin_url(const std::string& path) const { return "http://localhost:" + std::to_string(port_) + path; }
 
+  void post_mapping(const std::string& body, const std::string& source_name) {
+    auto tmp = std::filesystem::temp_directory_path() / ("wm_mapping_" + std::to_string(port_) + ".json");
+    {
+      std::ofstream f(tmp);
+      f << body;
+    }
+    std::string cmd = "curl -s -X POST " + admin_url("/__admin/mappings") +
+                      " -H \"Content-Type: application/json\""
+                      " --data-binary \"@" +
+                      tmp.string() + "\"" + null_redirect();
+    int rc = std::system(cmd.c_str());
+    std::filesystem::remove(tmp);
+    if (rc != 0) {
+      throw std::runtime_error("Failed to add WireMock mapping: " + source_name);
+    }
+  }
+
   static std::string null_redirect() {
 #ifdef _WIN32
     return " > NUL 2>&1";
@@ -142,8 +173,6 @@ class WiremockClient {
   static std::filesystem::path wiremock_jar_path() {
     return test_utils::repo_root() / "tests" / "wiremock" / "wiremock_standalone" / "wiremock-standalone-3.13.2.jar";
   }
-
-  static std::filesystem::path wiremock_root_dir() { return test_utils::repo_root() / "tests" / "wiremock"; }
 
   static int find_free_port() {
 #ifdef _WIN32
@@ -242,6 +271,10 @@ class WiremockClient {
       AssignProcessToJobObject(job_handle_, process_handle_);
     }
 #else
+    auto empty_root = std::filesystem::temp_directory_path() / ("wm_root_" + port_str);
+    std::filesystem::create_directories(empty_root / "mappings");
+    std::filesystem::create_directories(empty_root / "__files");
+
     pid_ = fork();
     if (pid_ < 0) {
       throw std::runtime_error("fork() failed for WireMock process");
@@ -255,9 +288,6 @@ class WiremockClient {
         dup2(dev_null, STDERR_FILENO);
         close(dev_null);
       }
-      auto empty_root = std::filesystem::temp_directory_path() / ("wm_root_" + port_str);
-      std::filesystem::create_directories(empty_root / "mappings");
-      std::filesystem::create_directories(empty_root / "__files");
       execlp("java", "java", "-jar", jar.string().c_str(), "--root-dir", empty_root.string().c_str(), "--port",
              port_str.c_str(), "--proxy-pass-through", "false", "--disable-gzip", static_cast<char*>(nullptr));
       _exit(1);
@@ -266,6 +296,8 @@ class WiremockClient {
   }
 
   void stop_process() {
+    std::string port_str = std::to_string(port_);
+    auto empty_root = std::filesystem::temp_directory_path() / ("wm_root_" + port_str);
 #ifdef _WIN32
     if (process_handle_ != INVALID_HANDLE_VALUE) {
       TerminateProcess(process_handle_, 0);
@@ -284,6 +316,7 @@ class WiremockClient {
       pid_ = -1;
     }
 #endif
+    std::filesystem::remove_all(empty_root);
   }
 
   void wait_for_health(int timeout_secs = 15) const {

--- a/odbc_tests/common/include/WiremockClient.hpp
+++ b/odbc_tests/common/include/WiremockClient.hpp
@@ -10,24 +10,8 @@
 #include <string>
 #include <thread>
 
-#ifdef _WIN32
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-#include <winsock2.h>
-#include <ws2tcpip.h>
-#pragma comment(lib, "ws2_32.lib")
-#else
-#include <fcntl.h>
-#include <sys/socket.h>
-#include <sys/types.h>
-#include <sys/wait.h>
-#include <unistd.h>
-
-#include <csignal>
-
-#include <netinet/in.h>
-#endif
-
+#include "Subprocess.hpp"
+#include "platform.hpp"
 #include "utils.hpp"
 
 /// Cross-platform wrapper around the WireMock standalone JAR.
@@ -37,12 +21,15 @@
 class WiremockClient {
  public:
   WiremockClient() {
-    port_ = find_free_port();
+    port_ = platform::find_free_port();
     start_process();
     wait_for_health();
   }
 
-  ~WiremockClient() { stop_process(); }
+  ~WiremockClient() {
+    process_.reset();
+    std::filesystem::remove_all(root_dir_);
+  }
 
   WiremockClient(const WiremockClient&) = delete;
   WiremockClient& operator=(const WiremockClient&) = delete;
@@ -77,7 +64,7 @@ class WiremockClient {
   }
 
   void add_catch_all() {
-    auto tmp = std::filesystem::temp_directory_path() / ("wm_catch_all_" + std::to_string(port_) + ".json");
+    auto tmp = tmp_file("catch_all");
     {
       std::ofstream f(tmp);
       f << R"({
@@ -90,10 +77,7 @@ class WiremockClient {
         "priority": 999
       })";
     }
-    std::string cmd = "curl -s -X POST " + admin_url("/__admin/mappings") +
-                      " -H \"Content-Type: application/json\""
-                      " --data-binary \"@" +
-                      tmp.string() + "\"" + null_redirect();
+    std::string cmd = curl_post("/__admin/mappings", tmp) + platform::null_redirect();
     if (std::system(cmd.c_str()) != 0) {
       std::filesystem::remove(tmp);
       throw std::runtime_error("Failed to add WireMock catch-all mapping");
@@ -104,16 +88,13 @@ class WiremockClient {
   int get_request_count(const std::string& method, const std::string& url_path) const {
     std::string body = R"({"method":")" + method + R"(","urlPath":")" + url_path + R"("})";
 
-    auto tmp = std::filesystem::temp_directory_path() / ("wm_request_count_" + std::to_string(port_) + ".json");
+    auto tmp = tmp_file("request_count");
     {
       std::ofstream f(tmp);
       f << body;
     }
-    std::string cmd = "curl -s -X POST " + admin_url("/__admin/requests/count") +
-                      " -H \"Content-Type: application/json\""
-                      " --data-binary \"@" +
-                      tmp.string() + "\"";
-    std::string response = exec_popen(cmd);
+    std::string cmd = curl_post("/__admin/requests/count", tmp);
+    std::string response = platform::exec_command(cmd);
     std::filesystem::remove(tmp);
 
     picojson::value json;
@@ -131,39 +112,34 @@ class WiremockClient {
 
  private:
   int port_;
-
-#ifdef _WIN32
-  HANDLE process_handle_{INVALID_HANDLE_VALUE};
-  HANDLE job_handle_{INVALID_HANDLE_VALUE};
-#else
-  pid_t pid_{-1};
-#endif
+  std::filesystem::path root_dir_;
+  std::unique_ptr<Subprocess> process_;
 
   std::string admin_url(const std::string& path) const { return "http://localhost:" + std::to_string(port_) + path; }
 
+  std::filesystem::path tmp_file(const std::string& label) const {
+    return std::filesystem::temp_directory_path() / ("wm_" + label + "_" + std::to_string(port_) + ".json");
+  }
+
+  std::string curl_post(const std::string& endpoint, const std::filesystem::path& data_file) const {
+    return "curl -s -X POST " + admin_url(endpoint) +
+           " -H \"Content-Type: application/json\""
+           " --data-binary \"@" +
+           data_file.string() + "\"";
+  }
+
   void post_mapping(const std::string& body, const std::string& source_name) {
-    auto tmp = std::filesystem::temp_directory_path() / ("wm_mapping_" + std::to_string(port_) + ".json");
+    auto tmp = tmp_file("mapping");
     {
       std::ofstream f(tmp);
       f << body;
     }
-    std::string cmd = "curl -s -X POST " + admin_url("/__admin/mappings") +
-                      " -H \"Content-Type: application/json\""
-                      " --data-binary \"@" +
-                      tmp.string() + "\"" + null_redirect();
+    std::string cmd = curl_post("/__admin/mappings", tmp) + platform::null_redirect();
     int rc = std::system(cmd.c_str());
     std::filesystem::remove(tmp);
     if (rc != 0) {
       throw std::runtime_error("Failed to add WireMock mapping: " + source_name);
     }
-  }
-
-  static std::string null_redirect() {
-#ifdef _WIN32
-    return " > NUL 2>&1";
-#else
-    return " > /dev/null 2>&1";
-#endif
   }
 
   static std::filesystem::path wiremock_mappings_dir() {
@@ -174,58 +150,6 @@ class WiremockClient {
     return test_utils::repo_root() / "tests" / "wiremock" / "wiremock_standalone" / "wiremock-standalone-3.13.2.jar";
   }
 
-  static int find_free_port() {
-#ifdef _WIN32
-    WSADATA wsa_data;
-    WSAStartup(MAKEWORD(2, 2), &wsa_data);
-    SOCKET sock = ::socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
-    if (sock == INVALID_SOCKET) throw std::runtime_error("Failed to create socket for port allocation");
-
-    sockaddr_in addr{};
-    addr.sin_family = AF_INET;
-    addr.sin_addr.s_addr = INADDR_ANY;
-    addr.sin_port = 0;
-
-    if (::bind(sock, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) == SOCKET_ERROR) {
-      closesocket(sock);
-      throw std::runtime_error("Failed to bind to port 0");
-    }
-
-    int len = sizeof(addr);
-    if (::getsockname(sock, reinterpret_cast<sockaddr*>(&addr), &len) == SOCKET_ERROR) {
-      closesocket(sock);
-      throw std::runtime_error("Failed to get assigned port");
-    }
-
-    int port = ntohs(addr.sin_port);
-    closesocket(sock);
-    return port;
-#else
-    int sock = ::socket(AF_INET, SOCK_STREAM, 0);
-    if (sock < 0) throw std::runtime_error("Failed to create socket for port allocation");
-
-    sockaddr_in addr{};
-    addr.sin_family = AF_INET;
-    addr.sin_addr.s_addr = INADDR_ANY;
-    addr.sin_port = 0;
-
-    if (::bind(sock, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) {
-      ::close(sock);
-      throw std::runtime_error("Failed to bind to port 0");
-    }
-
-    socklen_t len = sizeof(addr);
-    if (::getsockname(sock, reinterpret_cast<sockaddr*>(&addr), &len) < 0) {
-      ::close(sock);
-      throw std::runtime_error("Failed to get assigned port");
-    }
-
-    int port = ntohs(addr.sin_port);
-    ::close(sock);
-    return port;
-#endif
-  }
-
   void start_process() {
     auto jar = wiremock_jar_path();
     if (!std::filesystem::exists(jar)) {
@@ -233,128 +157,24 @@ class WiremockClient {
     }
 
     std::string port_str = std::to_string(port_);
+    root_dir_ = std::filesystem::temp_directory_path() / ("wm_root_" + port_str);
+    std::filesystem::create_directories(root_dir_ / "mappings");
+    std::filesystem::create_directories(root_dir_ / "__files");
 
-#ifdef _WIN32
-    // Create a Job Object so all child processes are killed when the job is closed.
-    job_handle_ = CreateJobObject(nullptr, nullptr);
-    if (job_handle_ != nullptr) {
-      JOBOBJECT_EXTENDED_LIMIT_INFORMATION job_info{};
-      job_info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
-      SetInformationJobObject(job_handle_, JobObjectExtendedLimitInformation, &job_info, sizeof(job_info));
-    }
-
-    auto empty_root = std::filesystem::temp_directory_path() / ("wm_root_" + port_str);
-    std::filesystem::create_directories(empty_root / "mappings");
-    std::filesystem::create_directories(empty_root / "__files");
-
-    std::string cmd_line = "java -jar \"" + jar.string() + "\" --root-dir \"" + empty_root.string() + "\" --port " +
-                           port_str + " --proxy-pass-through false --disable-gzip";
-
-    STARTUPINFOA si{};
-    si.cb = sizeof(si);
-    si.dwFlags = STARTF_USESTDHANDLES;
-    si.hStdInput = INVALID_HANDLE_VALUE;
-    si.hStdOutput = INVALID_HANDLE_VALUE;
-    si.hStdError = INVALID_HANDLE_VALUE;
-
-    PROCESS_INFORMATION pi{};
-    BOOL ok = CreateProcessA(nullptr, cmd_line.data(), nullptr, nullptr, FALSE,
-                             CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP, nullptr, nullptr, &si, &pi);
-    if (!ok) {
-      throw std::runtime_error("CreateProcess failed for WireMock (error " + std::to_string(GetLastError()) + ")");
-    }
-
-    process_handle_ = pi.hProcess;
-    CloseHandle(pi.hThread);
-
-    if (job_handle_ != nullptr) {
-      AssignProcessToJobObject(job_handle_, process_handle_);
-    }
-#else
-    auto empty_root = std::filesystem::temp_directory_path() / ("wm_root_" + port_str);
-    std::filesystem::create_directories(empty_root / "mappings");
-    std::filesystem::create_directories(empty_root / "__files");
-
-    pid_ = fork();
-    if (pid_ < 0) {
-      throw std::runtime_error("fork() failed for WireMock process");
-    }
-
-    if (pid_ == 0) {
-      setsid();
-      int dev_null = open("/dev/null", O_WRONLY);
-      if (dev_null >= 0) {
-        dup2(dev_null, STDOUT_FILENO);
-        dup2(dev_null, STDERR_FILENO);
-        close(dev_null);
-      }
-      execlp("java", "java", "-jar", jar.string().c_str(), "--root-dir", empty_root.string().c_str(), "--port",
-             port_str.c_str(), "--proxy-pass-through", "false", "--disable-gzip", static_cast<char*>(nullptr));
-      _exit(1);
-    }
-#endif
-  }
-
-  void stop_process() {
-    std::string port_str = std::to_string(port_);
-    auto empty_root = std::filesystem::temp_directory_path() / ("wm_root_" + port_str);
-#ifdef _WIN32
-    if (process_handle_ != INVALID_HANDLE_VALUE) {
-      TerminateProcess(process_handle_, 0);
-      WaitForSingleObject(process_handle_, 5000);
-      CloseHandle(process_handle_);
-      process_handle_ = INVALID_HANDLE_VALUE;
-    }
-    if (job_handle_ != INVALID_HANDLE_VALUE) {
-      CloseHandle(job_handle_);
-      job_handle_ = INVALID_HANDLE_VALUE;
-    }
-#else
-    if (pid_ > 0) {
-      kill(-pid_, SIGTERM);
-      waitpid(pid_, nullptr, 0);
-      pid_ = -1;
-    }
-#endif
-    std::filesystem::remove_all(empty_root);
+    process_ = std::make_unique<Subprocess>(
+        "java", std::vector<std::string>{"-jar", jar.string(), "--root-dir", root_dir_.string(), "--port", port_str,
+                                         "--proxy-pass-through", "false", "--disable-gzip"});
   }
 
   void wait_for_health(int timeout_secs = 15) const {
     for (int i = 0; i < timeout_secs * 5; ++i) {
-      std::string cmd = "curl -s -o " +
-#ifdef _WIN32
-                        std::string("NUL") +
-#else
-                        std::string("/dev/null") +
-#endif
-                        " -w \"%{http_code}\" " + admin_url("/__admin/health");
-      std::string code = exec_popen(cmd);
+      std::string cmd =
+          "curl -s -o " + platform::null_device() + " -w \"%{http_code}\" " + admin_url("/__admin/health");
+      std::string code = platform::exec_command(cmd);
       if (code == "200") return;
       std::this_thread::sleep_for(std::chrono::milliseconds(200));
     }
     throw std::runtime_error("WireMock did not become healthy within " + std::to_string(timeout_secs) + "s");
-  }
-
-  static std::string exec_popen(const std::string& cmd) {
-#ifdef _WIN32
-    FILE* pipe = _popen(cmd.c_str(), "r");
-#else
-    FILE* pipe = popen(cmd.c_str(), "r");
-#endif
-    if (!pipe) throw std::runtime_error("popen failed for: " + cmd);
-    std::ostringstream ss;
-    char buf[256];
-    while (fgets(buf, sizeof(buf), pipe))
-      ss << buf;
-#ifdef _WIN32
-    int status = _pclose(pipe);
-#else
-    int status = pclose(pipe);
-#endif
-    if (status == -1) {
-      throw std::runtime_error("pclose failed for: " + cmd);
-    }
-    return ss.str();
   }
 };
 

--- a/odbc_tests/common/include/WiremockClient.hpp
+++ b/odbc_tests/common/include/WiremockClient.hpp
@@ -65,6 +65,28 @@ class WiremockClient {
     }
   }
 
+  void add_catch_all() {
+    auto tmp = std::filesystem::temp_directory_path() / "wm_catch_all.json";
+    {
+      std::ofstream f(tmp);
+      f << R"({
+        "request": {"method": "ANY", "urlPattern": ".*"},
+        "response": {
+          "status": 200,
+          "headers": {"Content-Type": "application/json"},
+          "jsonBody": {"success": true, "data": {}}
+        },
+        "priority": 999
+      })";
+    }
+    std::string cmd = "curl -s -X POST " + admin_url("/__admin/mappings") +
+                      " -H \"Content-Type: application/json\""
+                      " --data-binary \"@" +
+                      tmp.string() + "\"" + null_redirect();
+    std::system(cmd.c_str());
+    std::filesystem::remove(tmp);
+  }
+
   int get_request_count(const std::string& method, const std::string& url_path) const {
     std::string body = R"({"method":")" + method + R"(","urlPath":")" + url_path + R"("})";
 
@@ -181,7 +203,6 @@ class WiremockClient {
       throw std::runtime_error("WireMock JAR not found at: " + jar.string());
     }
 
-    auto root_dir = wiremock_root_dir();
     std::string port_str = std::to_string(port_);
 
 #ifdef _WIN32
@@ -193,8 +214,12 @@ class WiremockClient {
       SetInformationJobObject(job_handle_, JobObjectExtendedLimitInformation, &job_info, sizeof(job_info));
     }
 
-    std::string cmd_line = "java -jar \"" + jar.string() + "\" --root-dir \"" + root_dir.string() + "\" --port " +
-                           port_str + " --proxy-pass-through false";
+    auto empty_root = std::filesystem::temp_directory_path() / ("wm_root_" + port_str);
+    std::filesystem::create_directories(empty_root / "mappings");
+    std::filesystem::create_directories(empty_root / "__files");
+
+    std::string cmd_line = "java -jar \"" + jar.string() + "\" --root-dir \"" + empty_root.string() + "\" --port " +
+                           port_str + " --proxy-pass-through false --disable-gzip";
 
     STARTUPINFOA si{};
     si.cb = sizeof(si);
@@ -230,8 +255,11 @@ class WiremockClient {
         dup2(dev_null, STDERR_FILENO);
         close(dev_null);
       }
-      execlp("java", "java", "-jar", jar.string().c_str(), "--root-dir", root_dir.string().c_str(), "--port",
-             port_str.c_str(), "--proxy-pass-through", "false", static_cast<char*>(nullptr));
+      auto empty_root = std::filesystem::temp_directory_path() / ("wm_root_" + port_str);
+      std::filesystem::create_directories(empty_root / "mappings");
+      std::filesystem::create_directories(empty_root / "__files");
+      execlp("java", "java", "-jar", jar.string().c_str(), "--root-dir", empty_root.string().c_str(), "--port",
+             port_str.c_str(), "--proxy-pass-through", "false", "--disable-gzip", static_cast<char*>(nullptr));
       _exit(1);
     }
 #endif
@@ -299,15 +327,6 @@ class WiremockClient {
 
 /// Build an ODBC connection string pointing to a running WireMock instance.
 inline std::string get_wiremock_connection_string(const WiremockClient& wm) {
-  auto key_path = test_utils::repo_root() / "tests" / "test_data" / "invalid_rsa_key.p8";
-  std::ifstream key_file(key_path);
-  if (!key_file) {
-    throw std::runtime_error("Test private key not found at: " + key_path.string());
-  }
-  std::ostringstream key_ss;
-  key_ss << key_file.rdbuf();
-  std::string key_pem = key_ss.str();
-
   const char* driver_path_env = std::getenv("DRIVER_PATH");
   if (driver_path_env == nullptr || driver_path_env[0] == '\0') {
     throw std::runtime_error("DRIVER_PATH not set — cannot locate ODBC driver library");
@@ -318,9 +337,9 @@ inline std::string get_wiremock_connection_string(const WiremockClient& wm) {
   ss << "PORT=" << wm.port() << ";";
   ss << "ACCOUNT=testaccount;";
   ss << "UID=testuser;";
-  ss << "PROTOCOL=http;";
-  ss << "AUTHENTICATOR=SNOWFLAKE_JWT;";
-  ss << "PRIV_KEY_BASE64=" << test_utils::base64_encode(key_pem) << ";";
+  ss << "PWD=testpass;";
+  ss << "SSL=off;";
+  ss << "DisableOCSPCheck=true;";
   return ss.str();
 }
 

--- a/odbc_tests/common/include/WiremockClient.hpp
+++ b/odbc_tests/common/include/WiremockClient.hpp
@@ -67,11 +67,18 @@ class WiremockClient {
 
   int get_request_count(const std::string& method, const std::string& url_path) const {
     std::string body = R"({"method":")" + method + R"(","urlPath":")" + url_path + R"("})";
+
+    auto tmp = std::filesystem::temp_directory_path() / "wm_request_count.json";
+    {
+      std::ofstream f(tmp);
+      f << body;
+    }
     std::string cmd = "curl -s -X POST " + admin_url("/__admin/requests/count") +
                       " -H \"Content-Type: application/json\""
-                      " -d \"" +
-                      body + "\"";
+                      " --data-binary \"@" +
+                      tmp.string() + "\"";
     std::string response = exec_popen(cmd);
+    std::filesystem::remove(tmp);
 
     picojson::value json;
     std::string err = picojson::parse(json, response);

--- a/odbc_tests/common/include/WiremockClient.hpp
+++ b/odbc_tests/common/include/WiremockClient.hpp
@@ -1,0 +1,320 @@
+#ifndef WIREMOCK_CLIENT_HPP
+#define WIREMOCK_CLIENT_HPP
+
+#include <picojson.h>
+
+#include <cstdlib>
+#include <fstream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <thread>
+
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#pragma comment(lib, "ws2_32.lib")
+#else
+#include <fcntl.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <csignal>
+
+#include <netinet/in.h>
+#endif
+
+#include "utils.hpp"
+
+/// Cross-platform wrapper around the WireMock standalone JAR.
+///
+/// Starts WireMock as a subprocess, exposes admin API helpers, and
+/// cleans up on destruction.
+class WiremockClient {
+ public:
+  WiremockClient() {
+    port_ = find_free_port();
+    start_process();
+    wait_for_health();
+  }
+
+  ~WiremockClient() { stop_process(); }
+
+  WiremockClient(const WiremockClient&) = delete;
+  WiremockClient& operator=(const WiremockClient&) = delete;
+
+  std::string http_url() const { return "http://localhost:" + std::to_string(port_); }
+
+  int port() const { return port_; }
+
+  void add_mapping_file(const std::string& relative_path) {
+    auto file_path = wiremock_mappings_dir() / relative_path;
+    if (!std::filesystem::exists(file_path)) {
+      throw std::runtime_error("WireMock mapping file not found: " + file_path.string());
+    }
+    std::string cmd = "curl -s -X POST " + admin_url("/__admin/mappings") +
+                      " -H \"Content-Type: application/json\""
+                      " --data-binary \"@" +
+                      file_path.string() + "\"" + null_redirect();
+    if (std::system(cmd.c_str()) != 0) {
+      throw std::runtime_error("Failed to add WireMock mapping: " + relative_path);
+    }
+  }
+
+  int get_request_count(const std::string& method, const std::string& url_path) const {
+    std::string body = R"({"method":")" + method + R"(","urlPath":")" + url_path + R"("})";
+    std::string cmd = "curl -s -X POST " + admin_url("/__admin/requests/count") +
+                      " -H \"Content-Type: application/json\""
+                      " -d \"" +
+                      body + "\"";
+    std::string response = exec_popen(cmd);
+
+    picojson::value json;
+    std::string err = picojson::parse(json, response);
+    if (!err.empty() || !json.is<picojson::object>()) {
+      throw std::runtime_error("WireMock count response parse error: " + err + " | body: " + response);
+    }
+    const auto& obj = json.get<picojson::object>();
+    auto it = obj.find("count");
+    if (it == obj.end() || !it->second.is<double>()) {
+      throw std::runtime_error("WireMock count response missing 'count' field: " + response);
+    }
+    return static_cast<int>(it->second.get<double>());
+  }
+
+ private:
+  int port_;
+
+#ifdef _WIN32
+  HANDLE process_handle_{INVALID_HANDLE_VALUE};
+  HANDLE job_handle_{INVALID_HANDLE_VALUE};
+#else
+  pid_t pid_{-1};
+#endif
+
+  std::string admin_url(const std::string& path) const { return "http://localhost:" + std::to_string(port_) + path; }
+
+  static std::string null_redirect() {
+#ifdef _WIN32
+    return " > NUL 2>&1";
+#else
+    return " > /dev/null 2>&1";
+#endif
+  }
+
+  static std::filesystem::path wiremock_mappings_dir() {
+    return test_utils::repo_root() / "tests" / "wiremock" / "mappings";
+  }
+
+  static std::filesystem::path wiremock_jar_path() {
+    return test_utils::repo_root() / "tests" / "wiremock" / "wiremock_standalone" / "wiremock-standalone-3.13.2.jar";
+  }
+
+  static std::filesystem::path wiremock_root_dir() { return test_utils::repo_root() / "tests" / "wiremock"; }
+
+  static int find_free_port() {
+#ifdef _WIN32
+    WSADATA wsa_data;
+    WSAStartup(MAKEWORD(2, 2), &wsa_data);
+    SOCKET sock = ::socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    if (sock == INVALID_SOCKET) throw std::runtime_error("Failed to create socket for port allocation");
+
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = INADDR_ANY;
+    addr.sin_port = 0;
+
+    if (::bind(sock, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) == SOCKET_ERROR) {
+      closesocket(sock);
+      throw std::runtime_error("Failed to bind to port 0");
+    }
+
+    int len = sizeof(addr);
+    if (::getsockname(sock, reinterpret_cast<sockaddr*>(&addr), &len) == SOCKET_ERROR) {
+      closesocket(sock);
+      throw std::runtime_error("Failed to get assigned port");
+    }
+
+    int port = ntohs(addr.sin_port);
+    closesocket(sock);
+    return port;
+#else
+    int sock = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (sock < 0) throw std::runtime_error("Failed to create socket for port allocation");
+
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = INADDR_ANY;
+    addr.sin_port = 0;
+
+    if (::bind(sock, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) {
+      ::close(sock);
+      throw std::runtime_error("Failed to bind to port 0");
+    }
+
+    socklen_t len = sizeof(addr);
+    if (::getsockname(sock, reinterpret_cast<sockaddr*>(&addr), &len) < 0) {
+      ::close(sock);
+      throw std::runtime_error("Failed to get assigned port");
+    }
+
+    int port = ntohs(addr.sin_port);
+    ::close(sock);
+    return port;
+#endif
+  }
+
+  void start_process() {
+    auto jar = wiremock_jar_path();
+    if (!std::filesystem::exists(jar)) {
+      throw std::runtime_error("WireMock JAR not found at: " + jar.string());
+    }
+
+    auto root_dir = wiremock_root_dir();
+    std::string port_str = std::to_string(port_);
+
+#ifdef _WIN32
+    // Create a Job Object so all child processes are killed when the job is closed.
+    job_handle_ = CreateJobObject(nullptr, nullptr);
+    if (job_handle_ != nullptr) {
+      JOBOBJECT_EXTENDED_LIMIT_INFORMATION job_info{};
+      job_info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+      SetInformationJobObject(job_handle_, JobObjectExtendedLimitInformation, &job_info, sizeof(job_info));
+    }
+
+    std::string cmd_line = "java -jar \"" + jar.string() + "\" --root-dir \"" + root_dir.string() + "\" --port " +
+                           port_str + " --proxy-pass-through false";
+
+    STARTUPINFOA si{};
+    si.cb = sizeof(si);
+    si.dwFlags = STARTF_USESTDHANDLES;
+    si.hStdInput = INVALID_HANDLE_VALUE;
+    si.hStdOutput = INVALID_HANDLE_VALUE;
+    si.hStdError = INVALID_HANDLE_VALUE;
+
+    PROCESS_INFORMATION pi{};
+    BOOL ok = CreateProcessA(nullptr, cmd_line.data(), nullptr, nullptr, FALSE,
+                             CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP, nullptr, nullptr, &si, &pi);
+    if (!ok) {
+      throw std::runtime_error("CreateProcess failed for WireMock (error " + std::to_string(GetLastError()) + ")");
+    }
+
+    process_handle_ = pi.hProcess;
+    CloseHandle(pi.hThread);
+
+    if (job_handle_ != nullptr) {
+      AssignProcessToJobObject(job_handle_, process_handle_);
+    }
+#else
+    pid_ = fork();
+    if (pid_ < 0) {
+      throw std::runtime_error("fork() failed for WireMock process");
+    }
+
+    if (pid_ == 0) {
+      setsid();
+      int dev_null = open("/dev/null", O_WRONLY);
+      if (dev_null >= 0) {
+        dup2(dev_null, STDOUT_FILENO);
+        dup2(dev_null, STDERR_FILENO);
+        close(dev_null);
+      }
+      execlp("java", "java", "-jar", jar.string().c_str(), "--root-dir", root_dir.string().c_str(), "--port",
+             port_str.c_str(), "--proxy-pass-through", "false", static_cast<char*>(nullptr));
+      _exit(1);
+    }
+#endif
+  }
+
+  void stop_process() {
+#ifdef _WIN32
+    if (process_handle_ != INVALID_HANDLE_VALUE) {
+      TerminateProcess(process_handle_, 0);
+      WaitForSingleObject(process_handle_, 5000);
+      CloseHandle(process_handle_);
+      process_handle_ = INVALID_HANDLE_VALUE;
+    }
+    if (job_handle_ != INVALID_HANDLE_VALUE) {
+      CloseHandle(job_handle_);
+      job_handle_ = INVALID_HANDLE_VALUE;
+    }
+#else
+    if (pid_ > 0) {
+      kill(-pid_, SIGTERM);
+      waitpid(pid_, nullptr, 0);
+      pid_ = -1;
+    }
+#endif
+  }
+
+  void wait_for_health(int timeout_secs = 15) const {
+    for (int i = 0; i < timeout_secs * 5; ++i) {
+      std::string cmd = "curl -s -o " +
+#ifdef _WIN32
+                        std::string("NUL") +
+#else
+                        std::string("/dev/null") +
+#endif
+                        " -w \"%{http_code}\" " + admin_url("/__admin/health");
+      std::string code = exec_popen(cmd);
+      if (code == "200") return;
+      std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    }
+    throw std::runtime_error("WireMock did not become healthy within " + std::to_string(timeout_secs) + "s");
+  }
+
+  static std::string exec_popen(const std::string& cmd) {
+#ifdef _WIN32
+    FILE* pipe = _popen(cmd.c_str(), "r");
+#else
+    FILE* pipe = popen(cmd.c_str(), "r");
+#endif
+    if (!pipe) throw std::runtime_error("popen failed for: " + cmd);
+    std::ostringstream ss;
+    char buf[256];
+    while (fgets(buf, sizeof(buf), pipe))
+      ss << buf;
+#ifdef _WIN32
+    int status = _pclose(pipe);
+#else
+    int status = pclose(pipe);
+#endif
+    if (status == -1) {
+      throw std::runtime_error("pclose failed for: " + cmd);
+    }
+    return ss.str();
+  }
+};
+
+/// Build an ODBC connection string pointing to a running WireMock instance.
+inline std::string get_wiremock_connection_string(const WiremockClient& wm) {
+  auto key_path = test_utils::repo_root() / "tests" / "test_data" / "invalid_rsa_key.p8";
+  std::ifstream key_file(key_path);
+  if (!key_file) {
+    throw std::runtime_error("Test private key not found at: " + key_path.string());
+  }
+  std::ostringstream key_ss;
+  key_ss << key_file.rdbuf();
+  std::string key_pem = key_ss.str();
+
+  const char* driver_path_env = std::getenv("DRIVER_PATH");
+  if (driver_path_env == nullptr || driver_path_env[0] == '\0') {
+    throw std::runtime_error("DRIVER_PATH not set — cannot locate ODBC driver library");
+  }
+  std::ostringstream ss;
+  ss << "DRIVER={" << driver_path_env << "};";
+  ss << "SERVER=localhost;";
+  ss << "PORT=" << wm.port() << ";";
+  ss << "ACCOUNT=testaccount;";
+  ss << "UID=testuser;";
+  ss << "PROTOCOL=http;";
+  ss << "AUTHENTICATOR=SNOWFLAKE_JWT;";
+  ss << "PRIV_KEY_BASE64=" << test_utils::base64_encode(key_pem) << ";";
+  return ss.str();
+}
+
+#endif  // WIREMOCK_CLIENT_HPP

--- a/odbc_tests/common/include/platform.hpp
+++ b/odbc_tests/common/include/platform.hpp
@@ -1,0 +1,109 @@
+#ifndef PLATFORM_HPP
+#define PLATFORM_HPP
+
+#include <cstdio>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#pragma comment(lib, "ws2_32.lib")
+#else
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <netinet/in.h>
+#endif
+
+namespace platform {
+
+inline std::string null_device() {
+#ifdef _WIN32
+  return "NUL";
+#else
+  return "/dev/null";
+#endif
+}
+
+inline std::string null_redirect() { return " > " + null_device() + " 2>&1"; }
+
+inline std::string exec_command(const std::string& cmd) {
+#ifdef _WIN32
+  FILE* pipe = _popen(cmd.c_str(), "r");
+#else
+  FILE* pipe = popen(cmd.c_str(), "r");
+#endif
+  if (!pipe) throw std::runtime_error("popen failed for: " + cmd);
+  std::ostringstream ss;
+  char buf[256];
+  while (fgets(buf, sizeof(buf), pipe))
+    ss << buf;
+#ifdef _WIN32
+  int status = _pclose(pipe);
+#else
+  int status = pclose(pipe);
+#endif
+  if (status == -1) {
+    throw std::runtime_error("pclose failed for: " + cmd);
+  }
+  return ss.str();
+}
+
+inline int find_free_port() {
+#ifdef _WIN32
+  WSADATA wsa_data;
+  WSAStartup(MAKEWORD(2, 2), &wsa_data);
+  SOCKET sock = ::socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+  if (sock == INVALID_SOCKET) throw std::runtime_error("Failed to create socket for port allocation");
+
+  sockaddr_in addr{};
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = INADDR_ANY;
+  addr.sin_port = 0;
+
+  if (::bind(sock, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) == SOCKET_ERROR) {
+    closesocket(sock);
+    throw std::runtime_error("Failed to bind to port 0");
+  }
+
+  int len = sizeof(addr);
+  if (::getsockname(sock, reinterpret_cast<sockaddr*>(&addr), &len) == SOCKET_ERROR) {
+    closesocket(sock);
+    throw std::runtime_error("Failed to get assigned port");
+  }
+
+  int port = ntohs(addr.sin_port);
+  closesocket(sock);
+  return port;
+#else
+  int sock = ::socket(AF_INET, SOCK_STREAM, 0);
+  if (sock < 0) throw std::runtime_error("Failed to create socket for port allocation");
+
+  sockaddr_in addr{};
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = INADDR_ANY;
+  addr.sin_port = 0;
+
+  if (::bind(sock, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) {
+    ::close(sock);
+    throw std::runtime_error("Failed to bind to port 0");
+  }
+
+  socklen_t len = sizeof(addr);
+  if (::getsockname(sock, reinterpret_cast<sockaddr*>(&addr), &len) < 0) {
+    ::close(sock);
+    throw std::runtime_error("Failed to get assigned port");
+  }
+
+  int port = ntohs(addr.sin_port);
+  ::close(sock);
+  return port;
+#endif
+}
+
+}  // namespace platform
+
+#endif  // PLATFORM_HPP

--- a/odbc_tests/common/src/SubprocessUnix.cpp
+++ b/odbc_tests/common/src/SubprocessUnix.cpp
@@ -1,0 +1,58 @@
+#include <fcntl.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <csignal>
+#include <stdexcept>
+
+#include "Subprocess.hpp"
+
+struct Subprocess::Impl {
+  pid_t pid{-1};
+
+  void start(const std::string& program, const std::vector<std::string>& args) {
+    pid = fork();
+    if (pid < 0) {
+      throw std::runtime_error("fork() failed for subprocess: " + program);
+    }
+
+    if (pid == 0) {
+      setsid();
+      int dev_null = open("/dev/null", O_WRONLY);
+      if (dev_null >= 0) {
+        dup2(dev_null, STDOUT_FILENO);
+        dup2(dev_null, STDERR_FILENO);
+        close(dev_null);
+      }
+
+      std::vector<const char*> argv;
+      argv.push_back(program.c_str());
+      for (auto& a : args)
+        argv.push_back(a.c_str());
+      argv.push_back(nullptr);
+
+      execvp(program.c_str(), const_cast<char* const*>(argv.data()));
+      _exit(1);
+    }
+  }
+
+  void stop() {
+    if (pid > 0) {
+      kill(-pid, SIGTERM);
+      waitpid(pid, nullptr, 0);
+      pid = -1;
+    }
+  }
+};
+
+Subprocess::Subprocess(const std::string& program, const std::vector<std::string>& args)
+    : impl_(std::make_unique<Impl>()) {
+  impl_->start(program, args);
+}
+
+Subprocess::~Subprocess() {
+  if (impl_) impl_->stop();
+}
+
+Subprocess::Subprocess(Subprocess&&) noexcept = default;
+Subprocess& Subprocess::operator=(Subprocess&&) noexcept = default;

--- a/odbc_tests/common/src/SubprocessWindows.cpp
+++ b/odbc_tests/common/src/SubprocessWindows.cpp
@@ -1,0 +1,73 @@
+#include <windows.h>
+
+#include <sstream>
+#include <stdexcept>
+
+#include "Subprocess.hpp"
+
+struct Subprocess::Impl {
+  HANDLE process_handle{INVALID_HANDLE_VALUE};
+  HANDLE job_handle{INVALID_HANDLE_VALUE};
+
+  void start(const std::string& program, const std::vector<std::string>& args) {
+    job_handle = CreateJobObject(nullptr, nullptr);
+    if (job_handle != nullptr) {
+      JOBOBJECT_EXTENDED_LIMIT_INFORMATION job_info{};
+      job_info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+      SetInformationJobObject(job_handle, JobObjectExtendedLimitInformation, &job_info, sizeof(job_info));
+    }
+
+    std::ostringstream cmd;
+    cmd << "\"" << program << "\"";
+    for (auto& a : args)
+      cmd << " \"" << a << "\"";
+    std::string cmd_line = cmd.str();
+
+    STARTUPINFOA si{};
+    si.cb = sizeof(si);
+    si.dwFlags = STARTF_USESTDHANDLES;
+    si.hStdInput = INVALID_HANDLE_VALUE;
+    si.hStdOutput = INVALID_HANDLE_VALUE;
+    si.hStdError = INVALID_HANDLE_VALUE;
+
+    PROCESS_INFORMATION pi{};
+    BOOL ok = CreateProcessA(nullptr, cmd_line.data(), nullptr, nullptr, FALSE,
+                             CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP, nullptr, nullptr, &si, &pi);
+    if (!ok) {
+      throw std::runtime_error("CreateProcess failed for " + program + " (error " + std::to_string(GetLastError()) +
+                               ")");
+    }
+
+    process_handle = pi.hProcess;
+    CloseHandle(pi.hThread);
+
+    if (job_handle != nullptr) {
+      AssignProcessToJobObject(job_handle, process_handle);
+    }
+  }
+
+  void stop() {
+    if (process_handle != INVALID_HANDLE_VALUE) {
+      TerminateProcess(process_handle, 0);
+      WaitForSingleObject(process_handle, 5000);
+      CloseHandle(process_handle);
+      process_handle = INVALID_HANDLE_VALUE;
+    }
+    if (job_handle != INVALID_HANDLE_VALUE) {
+      CloseHandle(job_handle);
+      job_handle = INVALID_HANDLE_VALUE;
+    }
+  }
+};
+
+Subprocess::Subprocess(const std::string& program, const std::vector<std::string>& args)
+    : impl_(std::make_unique<Impl>()) {
+  impl_->start(program, args);
+}
+
+Subprocess::~Subprocess() {
+  if (impl_) impl_->stop();
+}
+
+Subprocess::Subprocess(Subprocess&&) noexcept = default;
+Subprocess& Subprocess::operator=(Subprocess&&) noexcept = default;

--- a/odbc_tests/tests/e2e/CMakeLists.txt
+++ b/odbc_tests/tests/e2e/CMakeLists.txt
@@ -49,6 +49,7 @@ add_odbc_test(e2e_logging_odbc_logging logging/odbc_logging.cpp)
 # session
 add_odbc_test(e2e_session_session_parameters session/session_parameters.cpp)
 add_odbc_test(e2e_session_connection_params session/connection_params.cpp)
+add_odbc_test(e2e_session_logout session/logout.cpp)
 
 # types
 add_odbc_test(e2e_types_binary types/binary.cpp)

--- a/odbc_tests/tests/e2e/session/logout.cpp
+++ b/odbc_tests/tests/e2e/session/logout.cpp
@@ -1,0 +1,103 @@
+#include <sql.h>
+#include <sqlext.h>
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+#include <vector>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "Connection.hpp"
+#include "HandleWrapper.hpp"
+#include "WiremockClient.hpp"
+#include "compatibility.hpp"
+#include "get_diag_rec.hpp"
+#include "odbc_matchers.hpp"
+
+static ConnectionHandleWrapper connect_to_wiremock(EnvironmentHandleWrapper& env, const WiremockClient& wm) {
+  ConnectionHandleWrapper dbc = env.createConnectionHandle();
+  auto conn_str = get_wiremock_connection_string(wm);
+  SQLRETURN ret = SQLDriverConnect(dbc.getHandle(), nullptr, (SQLCHAR*)conn_str.c_str(), SQL_NTS, nullptr, 0, nullptr,
+                                   SQL_DRIVER_NOPROMPT);
+  REQUIRE_ODBC(ret, dbc);
+  return dbc;
+}
+
+TEST_CASE("should be idempotent when close called multiple times", "[session][logout]") {
+  SKIP_OLD_DRIVER("BD#000", "Old driver does not support WireMock-based logout testing");
+
+  // Given Snowflake client is logged in
+  WiremockClient wm;
+  wm.add_mapping_file("auth/login_success_jwt.json");
+  wm.add_mapping_file("session/logout_success.json");
+
+  auto env = Connection::initEnv();
+  auto dbc = connect_to_wiremock(env, wm);
+
+  // When Connection is closed
+  SQLRETURN first_ret = SQLDisconnect(dbc.getHandle());
+  REQUIRE_ODBC(first_ret, dbc);
+
+  // And Connection is closed again
+  SQLRETURN second_ret = SQLDisconnect(dbc.getHandle());
+  CHECK(second_ret == SQL_ERROR);
+  CHECK(get_sqlstate(dbc) == "08003");
+
+  // And Connection is closed a third time
+  SQLRETURN third_ret = SQLDisconnect(dbc.getHandle());
+  CHECK(third_ret == SQL_ERROR);
+  CHECK(get_sqlstate(dbc) == "08003");
+
+  // Then Only one logout request is sent
+  CHECK(wm.get_request_count("POST", "/session") == 1);
+  // And No errors are thrown
+  CHECK(first_ret == SQL_SUCCESS);
+}
+
+TEST_CASE("should handle concurrent close calls safely", "[session][logout]") {
+  SKIP_OLD_DRIVER("BD#000", "Old driver does not support WireMock-based logout testing");
+
+  // Given Snowflake client is logged in
+  WiremockClient wm;
+  wm.add_mapping_file("auth/login_success_jwt.json");
+  wm.add_mapping_file("session/logout_success.json");
+
+  auto env = Connection::initEnv();
+  auto dbc = connect_to_wiremock(env, wm);
+
+  constexpr int num_threads = 5;
+  std::vector<SQLRETURN> results(num_threads, SQL_ERROR);
+  std::atomic<int> ready_count{0};
+
+  // When Connection is closed from multiple threads concurrently
+  std::vector<std::thread> threads;
+  for (int i = 0; i < num_threads; ++i) {
+    threads.emplace_back([&, i]() {
+      ready_count.fetch_add(1, std::memory_order_release);
+      auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+      while (ready_count.load(std::memory_order_acquire) < num_threads) {
+        if (std::chrono::steady_clock::now() > deadline) break;
+      }
+      results[i] = SQLDisconnect(dbc.getHandle());
+    });
+  }
+  for (auto& t : threads)
+    t.join();
+
+  // Then Only one logout request is sent
+  CHECK(wm.get_request_count("POST", "/session") == 1);
+
+  // And All close calls return successfully
+  int success_count = 0;
+  int expected_error_count = 0;
+  for (auto r : results) {
+    if (r == SQL_SUCCESS) {
+      success_count++;
+    } else if (r == SQL_ERROR) {
+      expected_error_count++;
+    }
+  }
+  CHECK(success_count + expected_error_count == num_threads);
+  CHECK(success_count == 1);
+}

--- a/odbc_tests/tests/e2e/session/logout.cpp
+++ b/odbc_tests/tests/e2e/session/logout.cpp
@@ -25,11 +25,9 @@ static ConnectionHandleWrapper connect_to_wiremock(EnvironmentHandleWrapper& env
 }
 
 TEST_CASE("should be idempotent when close called multiple times", "[session][logout]") {
-  SKIP_OLD_DRIVER("BD#000", "Old driver does not support WireMock-based logout testing");
-
   // Given Snowflake client is logged in
   WiremockClient wm;
-  wm.add_mapping_file("auth/login_success_jwt.json");
+  wm.add_mapping_file("auth/login_success_any.json");
   wm.add_mapping_file("session/logout_success.json");
 
   auto env = Connection::initEnv();
@@ -56,11 +54,11 @@ TEST_CASE("should be idempotent when close called multiple times", "[session][lo
 }
 
 TEST_CASE("should handle concurrent close calls safely", "[session][logout]") {
-  SKIP_OLD_DRIVER("BD#000", "Old driver does not support WireMock-based logout testing");
+  SKIP_OLD_DRIVER("BD#000", "Old driver segfaults on concurrent SQLDisconnect (no thread-safety guard)");
 
   // Given Snowflake client is logged in
   WiremockClient wm;
-  wm.add_mapping_file("auth/login_success_jwt.json");
+  wm.add_mapping_file("auth/login_success_any.json");
   wm.add_mapping_file("session/logout_success.json");
 
   auto env = Connection::initEnv();

--- a/odbc_tests/tests/e2e/session/logout.cpp
+++ b/odbc_tests/tests/e2e/session/logout.cpp
@@ -25,6 +25,9 @@ static ConnectionHandleWrapper connect_to_wiremock(EnvironmentHandleWrapper& env
 }
 
 TEST_CASE("should be idempotent when close called multiple times", "[session][logout]") {
+#ifdef _WIN32
+  SKIP("WireMock tests not yet validated on Windows");
+#endif
   // Given Snowflake client is logged in
   WiremockClient wm;
   wm.add_mapping_file("auth/login_success_any.json");
@@ -54,6 +57,9 @@ TEST_CASE("should be idempotent when close called multiple times", "[session][lo
 }
 
 TEST_CASE("should handle concurrent close calls safely", "[session][logout]") {
+#ifdef _WIN32
+  SKIP("WireMock tests not yet validated on Windows");
+#endif
   SKIP_OLD_DRIVER("BD#000", "Old driver segfaults on concurrent SQLDisconnect (no thread-safety guard)");
 
   // Given Snowflake client is logged in

--- a/odbc_tests/tests/e2e/session/logout.cpp
+++ b/odbc_tests/tests/e2e/session/logout.cpp
@@ -92,16 +92,19 @@ TEST_CASE("should handle concurrent close calls safely", "[session][logout]") {
 
   // And All close calls return successfully
   int success_count = 0;
-  int expected_error_count = 0;
+  int error_count = 0;
   for (auto r : results) {
-    if (r == SQL_SUCCESS) {
+    if (r == SQL_SUCCESS)
       success_count++;
-    } else if (r == SQL_ERROR) {
-      expected_error_count++;
-    }
+    else if (r == SQL_ERROR)
+      error_count++;
   }
-  CHECK(success_count + expected_error_count == num_threads);
   CHECK(success_count == 1);
+  CHECK(error_count == num_threads - 1);
+
+  // Verify a subsequent disconnect still reports 08003
+  SQLRETURN after = SQLDisconnect(dbc.getHandle());
+  CHECK_THAT(OdbcResult(after, dbc), OdbcMatchers::IsError() && OdbcMatchers::HasSqlState("08003"));
 }
 
 TEST_CASE("should succeed even when server returns error during logout", "[session][logout]") {

--- a/odbc_tests/tests/e2e/session/logout.cpp
+++ b/odbc_tests/tests/e2e/session/logout.cpp
@@ -12,13 +12,13 @@
 #include "HandleWrapper.hpp"
 #include "WiremockClient.hpp"
 #include "compatibility.hpp"
-#include "get_diag_rec.hpp"
+#include "odbc_cast.hpp"
 #include "odbc_matchers.hpp"
 
 static ConnectionHandleWrapper connect_to_wiremock(EnvironmentHandleWrapper& env, const WiremockClient& wm) {
   ConnectionHandleWrapper dbc = env.createConnectionHandle();
   auto conn_str = get_wiremock_connection_string(wm);
-  SQLRETURN ret = SQLDriverConnect(dbc.getHandle(), nullptr, (SQLCHAR*)conn_str.c_str(), SQL_NTS, nullptr, 0, nullptr,
+  SQLRETURN ret = SQLDriverConnect(dbc.getHandle(), nullptr, sqlchar(conn_str.c_str()), SQL_NTS, nullptr, 0, nullptr,
                                    SQL_DRIVER_NOPROMPT);
   REQUIRE_ODBC(ret, dbc);
   return dbc;
@@ -38,17 +38,15 @@ TEST_CASE("should be idempotent when close called multiple times", "[session][lo
 
   // When Connection is closed
   SQLRETURN first_ret = SQLDisconnect(dbc.getHandle());
-  REQUIRE_ODBC(first_ret, dbc);
+  CHECK(first_ret == SQL_SUCCESS);
 
   // And Connection is closed again
   SQLRETURN second_ret = SQLDisconnect(dbc.getHandle());
-  CHECK(second_ret == SQL_ERROR);
-  CHECK(get_sqlstate(dbc) == "08003");
+  CHECK_THAT(OdbcResult(second_ret, dbc), OdbcMatchers::IsError() && OdbcMatchers::HasSqlState("08003"));
 
   // And Connection is closed a third time
   SQLRETURN third_ret = SQLDisconnect(dbc.getHandle());
-  CHECK(third_ret == SQL_ERROR);
-  CHECK(get_sqlstate(dbc) == "08003");
+  CHECK_THAT(OdbcResult(third_ret, dbc), OdbcMatchers::IsError() && OdbcMatchers::HasSqlState("08003"));
 
   // Then Only one logout request is sent
   CHECK(wm.get_request_count("POST", "/session") == 1);
@@ -60,7 +58,7 @@ TEST_CASE("should handle concurrent close calls safely", "[session][logout]") {
 #ifdef _WIN32
   SKIP("WireMock tests not yet validated on Windows");
 #endif
-  SKIP_OLD_DRIVER("BD#000", "Old driver segfaults on concurrent SQLDisconnect (no thread-safety guard)");
+  SKIP_OLD_DRIVER("BD#54", "Old driver segfaults on concurrent SQLDisconnect (no thread-safety guard)");
 
   // Given Snowflake client is logged in
   WiremockClient wm;
@@ -104,4 +102,26 @@ TEST_CASE("should handle concurrent close calls safely", "[session][logout]") {
   }
   CHECK(success_count + expected_error_count == num_threads);
   CHECK(success_count == 1);
+}
+
+TEST_CASE("should succeed even when server returns error during logout", "[session][logout]") {
+#ifdef _WIN32
+  SKIP("WireMock tests not yet validated on Windows");
+#endif
+  // Given Snowflake client is logged in
+  WiremockClient wm;
+  wm.add_mapping_file("auth/login_success_any.json");
+  // And Server will return 500 on logout
+  wm.add_mapping_file("session/logout_500_always.json");
+
+  auto env = Connection::initEnv();
+  auto dbc = connect_to_wiremock(env, wm);
+
+  // When Connection is closed
+  SQLRETURN ret = SQLDisconnect(dbc.getHandle());
+
+  // Then Disconnect succeeds
+  CHECK(ret == SQL_SUCCESS);
+  // And Logout was attempted
+  CHECK(wm.get_request_count("POST", "/session") >= 1);
 }

--- a/python/src/snowflake/connector/connection_config.py
+++ b/python/src/snowflake/connector/connection_config.py
@@ -138,14 +138,17 @@ class ConnectionConfig(ConnectionConfigMixin):
     private_key_password: str | None = None
     """Passphrase for encrypted private key"""
 
-    protocol: str | None = "https"
-    """Connection protocol (http or https). Default: 'https'"""
+    protocol: str | None = None
+    """Connection protocol (http or https)"""
 
     server_session_keep_alive: bool | None = None
     """Control server session lifecycle: true=keep alive, false=always logout, null=auto-detect"""
 
     server_url: str | None = None
     """Full server URL (alternative to host/port/protocol)"""
+
+    ssl: bool | None = None
+    """Enable or disable SSL/TLS (sets protocol to https or http). Deprecated: use protocol instead"""
 
     token: str | None = None
     """Programmatic access token. Required when authenticator=PROGRAMMATIC_ACCESS_TOKEN"""

--- a/sf_core/src/apis/database_driver_v1/validation.rs
+++ b/sf_core/src/apis/database_driver_v1/validation.rs
@@ -58,8 +58,8 @@ fn try_coerce_to_value_type(setting: &Setting, expected: ValueType) -> Option<Se
         ValueType::Int => s.parse::<i64>().ok().map(Setting::Int),
         ValueType::Double => s.parse::<f64>().ok().map(Setting::Double),
         ValueType::Bool => match s.to_lowercase().as_str() {
-            "true" => Some(Setting::Bool(true)),
-            "false" => Some(Setting::Bool(false)),
+            "true" | "1" | "on" => Some(Setting::Bool(true)),
+            "false" | "0" | "off" => Some(Setting::Bool(false)),
             _ => None,
         },
         ValueType::String | ValueType::Bytes => None,

--- a/sf_core/src/config/connection_config.rs
+++ b/sf_core/src/config/connection_config.rs
@@ -227,14 +227,26 @@ fn non_empty_string(settings: &ParamStore, key: crate::config::ParamKey) -> Opti
 // Server URL derivation (mirrored from rest_parameters::get_server_url)
 // ---------------------------------------------------------------------------
 
+/// Resolve the effective protocol from settings.
+///
+/// `ssl` takes precedence when present because it has no registry default
+/// and therefore is always an explicit user choice.  `protocol` serves as
+/// the fallback (its registry default is `"https"`).
+fn resolve_protocol(settings: &ParamStore) -> String {
+    if let Some(ssl_on) = settings.get_bool(SSL) {
+        return if ssl_on { "https" } else { "http" }.to_string();
+    }
+    settings
+        .get_string(PROTOCOL)
+        .unwrap_or_else(|| "https".to_string())
+}
+
 fn derive_server_url(settings: &ParamStore) -> Result<String, ConfigError> {
     if let Some(url) = settings.get_string(SERVER_URL) {
         return Ok(url);
     }
 
-    let protocol = settings
-        .get_string(PROTOCOL)
-        .unwrap_or_else(|| "https".to_string());
+    let protocol = resolve_protocol(settings);
     let host = settings.get_string(HOST).context(MissingParameterSnafu {
         parameter: String::from(HOST),
     })?;
@@ -688,6 +700,16 @@ pub fn validate_settings(settings: &ParamStore) -> Vec<ValidationIssue> {
         });
     }
 
+    // --- ConflictingParameters: ssl + protocol ---
+    if settings.get_bool(SSL).is_some() && settings.get_string(PROTOCOL).is_some() {
+        issues.push(ValidationIssue {
+            severity: ValidationSeverity::Error,
+            parameter: SSL.into(),
+            message: "Both 'ssl' and 'protocol' are set. Please provide only one.".into(),
+            code: ValidationCode::ConflictingParameters,
+        });
+    }
+
     // --- InvalidValue: protocol ---
     if let Some(protocol) = settings.get_string(PROTOCOL)
         && protocol != "http"
@@ -854,6 +876,57 @@ mod tests {
         ]);
         let config = ConnectionConfig::build(&settings).unwrap();
         assert_eq!(config.server.server_url, "https://custom.url");
+    }
+
+    #[test]
+    fn build_server_url_from_ssl_true() {
+        let settings = settings_from(&[
+            ("account", Setting::String("acct".into())),
+            ("user", Setting::String("u".into())),
+            ("password", Setting::String("p".into())),
+            ("host", Setting::String("myhost.com".into())),
+            ("ssl", Setting::Bool(true)),
+        ]);
+        let config = ConnectionConfig::build(&settings).unwrap();
+        assert_eq!(config.server.server_url, "https://myhost.com");
+    }
+
+    #[test]
+    fn build_server_url_from_ssl_false() {
+        let settings = settings_from(&[
+            ("account", Setting::String("acct".into())),
+            ("user", Setting::String("u".into())),
+            ("password", Setting::String("p".into())),
+            ("host", Setting::String("myhost.com".into())),
+            ("ssl", Setting::Bool(false)),
+        ]);
+        let config = ConnectionConfig::build(&settings).unwrap();
+        assert_eq!(config.server.server_url, "http://myhost.com");
+    }
+
+    #[test]
+    fn build_server_url_ssl_and_protocol_conflict() {
+        let settings = settings_from(&[
+            ("account", Setting::String("acct".into())),
+            ("user", Setting::String("u".into())),
+            ("password", Setting::String("p".into())),
+            ("host", Setting::String("myhost.com".into())),
+            ("protocol", Setting::String("http".into())),
+            ("ssl", Setting::Bool(true)),
+        ]);
+        let err = ConnectionConfig::build(&settings).unwrap_err();
+        match err {
+            ConfigError::ValidationFailed { ref issues, .. } => {
+                assert!(
+                    issues
+                        .iter()
+                        .any(|i| i.code == ValidationCode::ConflictingParameters
+                            && i.parameter == "ssl"),
+                    "Expected ConflictingParameters for ssl + protocol, got: {issues:?}"
+                );
+            }
+            other => panic!("Expected ValidationFailed, got: {other}"),
+        }
     }
 
     #[test]

--- a/sf_core/src/config/connection_config.rs
+++ b/sf_core/src/config/connection_config.rs
@@ -231,7 +231,7 @@ fn non_empty_string(settings: &ParamStore, key: crate::config::ParamKey) -> Opti
 ///
 /// `ssl` takes precedence when present because it has no registry default
 /// and therefore is always an explicit user choice.  `protocol` serves as
-/// the fallback (its registry default is `"https"`).
+/// the fallback (the fallback `"https"` is hardcoded here).
 fn resolve_protocol(settings: &ParamStore) -> String {
     if let Some(ssl_on) = settings.get_bool(SSL) {
         return if ssl_on { "https" } else { "http" }.to_string();

--- a/sf_core/src/config/param_registry.rs
+++ b/sf_core/src/config/param_registry.rs
@@ -48,6 +48,7 @@ pub mod param_names {
     pub const HOST: ParamKey = ParamKey("host");
     pub const PORT: ParamKey = ParamKey("port");
     pub const PROTOCOL: ParamKey = ParamKey("protocol");
+    pub const SSL: ParamKey = ParamKey("ssl");
     pub const SERVER_URL: ParamKey = ParamKey("server_url");
     pub const PRESERVE_UNDERSCORES_IN_HOSTNAME: ParamKey =
         ParamKey("preserve_underscores_in_hostname");
@@ -227,10 +228,24 @@ static PARAM_DEFS: &[ParamDef] = &[
         value_type: ValueType::String,
         additional_value_type: None,
         required: Required::Never,
-        default: Some(|| Setting::String("https".to_string())),
+        default: None,
         sensitive: false,
         description: "Connection protocol (http or https)",
         deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: true,
+        mutable_after_connect: false,
+    },
+    ParamDef {
+        canonical_name: param_names::SSL.as_str(),
+        aliases: &["SSL"],
+        value_type: ValueType::Bool,
+        additional_value_type: None,
+        required: Required::Never,
+        default: None,
+        sensitive: false,
+        description: "Enable or disable SSL/TLS (sets protocol to https or http)",
+        deprecated_by: Some("protocol"),
         scope: ParamScope::Connection,
         used_at_connect: true,
         mutable_after_connect: false,

--- a/sf_core/src/config/param_store.rs
+++ b/sf_core/src/config/param_store.rs
@@ -74,8 +74,8 @@ impl ParamStore {
         match self.get(key)? {
             Setting::Bool(b) => Some(*b),
             Setting::String(s) => match s.to_lowercase().as_str() {
-                "true" | "1" => Some(true),
-                "false" | "0" => Some(false),
+                "true" | "1" | "on" => Some(true),
+                "false" | "0" | "off" => Some(false),
                 _ => None,
             },
             Setting::Int(i) => Some(*i != 0),

--- a/sf_core/src/config/param_store.rs
+++ b/sf_core/src/config/param_store.rs
@@ -65,11 +65,11 @@ impl ParamStore {
     /// Extract a boolean value for `key`.
     ///
     /// Checks `Setting::Bool` first, then falls back to `Setting::String` with
-    /// `"true"` / `"1"` / `"false"` / `"0"` parsing for backward compatibility
-    /// with TOML-loaded values and ODBC connection-string encodings. Non-zero
-    /// `Setting::Int` values are also accepted. Unrecognised strings return
-    /// `None` so the caller falls through to its default rather than silently
-    /// degrading to `false`.
+    /// `"true"` / `"1"` / `"on"` / `"false"` / `"0"` / `"off"` parsing for
+    /// backward compatibility with TOML-loaded values and ODBC connection-string
+    /// encodings (e.g. `SSL=on`). Non-zero `Setting::Int` values are also
+    /// accepted. Unrecognised strings return `None` so the caller falls through
+    /// to its default rather than silently degrading to `false`.
     pub fn get_bool(&self, key: ParamKey) -> Option<bool> {
         match self.get(key)? {
             Setting::Bool(b) => Some(*b),

--- a/sf_core/src/config/resolver.rs
+++ b/sf_core/src/config/resolver.rs
@@ -413,12 +413,8 @@ account = "file_account"
             panic!("Expected account setting");
         }
 
-        // Registry default for protocol should be present
-        if let Some(Setting::String(protocol)) = resolved.get(param_names::PROTOCOL) {
-            assert_eq!(protocol, "https");
-        } else {
-            panic!("Expected default protocol setting");
-        }
+        // protocol has no registry default (handled by consumption code)
+        assert_eq!(resolved.get(param_names::PROTOCOL), None);
     }
 
     fn get_str(map: &ParamStore, key: crate::config::param_registry::ParamKey) -> Option<String> {
@@ -480,9 +476,7 @@ database = "conn_db"
             get_str(&resolved, param_names::WAREHOUSE),
             Some("config_wh".to_owned())
         );
-        assert_eq!(
-            get_str(&resolved, param_names::PROTOCOL),
-            Some("https".to_owned())
-        );
+        // protocol has no registry default
+        assert_eq!(get_str(&resolved, param_names::PROTOCOL), None);
     }
 }

--- a/tests/definitions/shared/session/logout.feature
+++ b/tests/definitions/shared/session/logout.feature
@@ -71,3 +71,15 @@ Feature: Session Logout
     When Connection is closed from multiple threads concurrently
     Then Only one logout request is sent
     And All close calls return successfully
+
+  # ===========================================================================
+  #                        Best-Effort Error Handling
+  # ===========================================================================
+
+  @odbc_e2e
+  Scenario: should succeed even when server returns error during logout
+    Given Snowflake client is logged in
+    And Server will return 500 on logout
+    When Connection is closed
+    Then Disconnect succeeds
+    And Logout was attempted

--- a/tests/definitions/shared/session/logout.feature
+++ b/tests/definitions/shared/session/logout.feature
@@ -1,4 +1,4 @@
-@core @python
+@core @python @odbc
 Feature: Session Logout
 
   # Core-level HTTP protocol details are in core/session/logout.feature
@@ -24,7 +24,7 @@ Feature: Session Logout
       | True                      |
       | None                      |
 
-  @core_e2e @python_e2e
+  @core_e2e @python_e2e @odbc_e2e
   Scenario: should be idempotent when close called multiple times
     Given Snowflake client is logged in
     When Connection is closed
@@ -65,7 +65,7 @@ Feature: Session Logout
   #                        Concurrency
   # ===========================================================================
 
-  @core_e2e @python_e2e
+  @core_e2e @python_e2e @odbc_e2e
   Scenario: should handle concurrent close calls safely
     Given Snowflake client is logged in
     When Connection is closed from multiple threads concurrently

--- a/tests/wiremock/mappings/auth/login_success_any.json
+++ b/tests/wiremock/mappings/auth/login_success_any.json
@@ -1,0 +1,33 @@
+{
+  "name": "Successful login (any authenticator)",
+  "request": {
+    "urlPathPattern": "/session/v1/login-request.*",
+    "method": "POST"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "success": true,
+      "data": {
+        "token": "mock_session_token",
+        "masterToken": "mock_master_token",
+        "sessionId": 12345,
+        "validityInSeconds": 3600,
+        "masterValidityInSeconds": 14400,
+        "sessionInfo": {
+          "databaseName": "",
+          "schemaName": "",
+          "warehouseName": "",
+          "roleName": ""
+        },
+        "parameters": [
+          {"name": "CLIENT_TELEMETRY_ENABLED", "value": false}
+        ]
+      }
+    }
+  },
+  "priority": 10
+}


### PR DESCRIPTION
## Summary

- Set `logout_error_strategy=best_effort` for ODBC wrapper to match legacy driver behavior (destructor `catch(...)` silently swallows all logout errors)
- Add `SSL` parameter support in sf_core (maps `ssl=on/off` to protocol selection)
- Add WireMock-based ODBC e2e tests verifying disconnect idempotency, thread safety, and best-effort error handling
- Tag shared logout Gherkin scenarios with `@odbc_e2e`
- Extract platform abstraction layer (`Subprocess`, `platform.hpp`) from WiremockClient to eliminate all `#ifdef _WIN32` blocks

## Context

Legacy ODBC calls `disconnect()` from `~Connection()` inside a `catch(...)` block, so logout failures never reach the application. The UD default is `Strict` (surfaces errors). This PR aligns UD ODBC with legacy by setting `best_effort` — errors are logged as WARN but `SQLDisconnect` always returns `SQL_SUCCESS`.

## Changes

- **`odbc/src/api/connection.rs`**: Inject `logout_error_strategy=best_effort` into connection options
- **`sf_core/src/config/`**: Add `SSL` param (bool, maps to protocol), add `on`/`off` to `get_bool`, validate ssl+protocol conflict
- **`odbc_tests/common/include/WiremockClient.hpp`**: Rewritten to use platform layer — zero ifdefs, clean linear logic
- **`odbc_tests/common/include/Subprocess.hpp`** + platform `.cpp` files: RAII process wrapper (pimpl pattern)
- **`odbc_tests/common/include/platform.hpp`**: Portable `find_free_port()`, `exec_command()`, `null_device()`
- **`odbc_tests/tests/e2e/session/logout.cpp`**: Three WireMock tests (idempotent, concurrent, server-error-during-logout)

## Test plan

- [x] WireMock e2e tests pass on Linux CI (idempotency + concurrent disconnect + best-effort 500)
- [x] Windows tests skip gracefully (`SKIP("WireMock tests not yet validated on Windows")`)
- [x] Existing e2e/integ tests still pass (no behavioral change for successful logout)
- [x] sf_core unit tests pass (config, validation)
- [ ] Windows CI build passes with new Subprocess/platform abstraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)