### PR TITLE
ci(odbc): drop restore-keys from Rust target caches to fix flaky x86 linker failures

### DIFF
--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -883,13 +883,13 @@ jobs:
 
       - name: Restore Rust target cache (MSI build)
         # Cache restore failures never fail the job — fall back to clean build.
+        # No restore-keys: a stale target dir (from a different Cargo.lock) causes
+        # rust-lld linker failures on i686 debug due to cross-CGU symbol mismatches.
         continue-on-error: true
         uses: actions/cache/restore@v5
         with:
           path: .cargo-target-msi
           key: ${{ runner.os }}-${{ matrix.arch }}-rust-msi-${{ matrix.config }}-target-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.arch }}-rust-msi-${{ matrix.config }}-target-
 
       - name: Prepare cache directories
         shell: pwsh


### PR DESCRIPTION
## Summary

Removes `restore-keys` from the Rust target directory cache in the `build_msi` job.

## Root cause

The `build_msi (Windows x86 Debug)` job intermittently fails with `rust-lld: error: undefined symbol: _anon.*` errors. This happens when:

1. `Cargo.lock` changes between runs (dependency bump, new crate, etc.)
2. The exact cache key misses, but the prefix-based `restore-keys` restores a stale `.cargo-target-msi` directory from a previous lockfile version
3. Cargo incrementally recompiles `sf_core` (and a few workspace crates) but reuses cached `.rlib` artifacts for dependencies (tokio, tracing, serde_json, etc.)
4. The linker tries to resolve cross-codegen-unit references between freshly compiled object files and stale cached ones, hitting undefined anonymous symbols

This only affects `i686-pc-windows-msvc` debug builds because:
- Debug mode uses many codegen units (more cross-CGU symbol references)
- `rust-lld` is less tolerant of stale metadata than MSVC's `link.exe`
- The x64 debug build happens to work because the symbol layout differs

## Fix

Remove `restore-keys` so that a lockfile change triggers a clean rebuild (~2 min) instead of a corrupt incremental one. The cargo **registry** cache keeps its `restore-keys` since source tarballs are safe to reuse across lockfile versions.

RPM and DMG target caches are left unchanged — they use the platform linker (not `rust-lld`) and only build in release mode.

## Test plan
- [x] `build_msi (Windows x86 Debug)` passes on this PR
- [ ] First cold-cache run after merge builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)