### PR TITLE
Add e2e tests for SQL_SF_STMT_ATTR_LAST_QUERY_ID

### DIFF
--- a/odbc_tests/tests/e2e/CMakeLists.txt
+++ b/odbc_tests/tests/e2e/CMakeLists.txt
@@ -38,6 +38,7 @@ add_odbc_test(e2e_query_sql_row_count query/sql_row_count.cpp)
 add_odbc_test(e2e_query_sql_set_pos query/sql_set_pos.cpp)
 add_odbc_test(e2e_query_sql_bulk_operations query/sql_bulk_operations.cpp)
 add_odbc_test(e2e_query_attr_error_handling query/attr_error_handling.cpp)
+add_odbc_test(e2e_query_last_query_id query/last_query_id.cpp)
 
 # tls
 add_odbc_test(e2e_tls_crl_enabled tls/crl_enabled.cpp)

--- a/odbc_tests/tests/e2e/query/last_query_id.cpp
+++ b/odbc_tests/tests/e2e/query/last_query_id.cpp
@@ -2,7 +2,6 @@
 #include <sqlext.h>
 #include <sqltypes.h>
 
-#include <cstring>
 #include <string>
 
 #include <catch2/catch_test_macros.hpp>
@@ -12,9 +11,9 @@
 #include "sf_odbc.h"
 
 static std::string get_last_query_id(StatementHandleWrapper& stmt) {
-  char buf[64] = {};
+  char buf[40] = {};
   SQLINTEGER len = 0;
-  SQLRETURN ret = SQLGetStmtAttrW(stmt.getHandle(), SQL_SF_STMT_ATTR_LAST_QUERY_ID, buf, sizeof(buf), &len);
+  SQLRETURN ret = SQLGetStmtAttr(stmt.getHandle(), SQL_SF_STMT_ATTR_LAST_QUERY_ID, buf, sizeof(buf), &len);
   REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
   return std::string(buf, len);
 }

--- a/odbc_tests/tests/e2e/query/last_query_id.cpp
+++ b/odbc_tests/tests/e2e/query/last_query_id.cpp
@@ -55,7 +55,7 @@ TEST_CASE("should set last query ID after successful SQLExecDirect", "[query][la
 
   // When SQLExecDirect is called with a valid query
   SQLRETURN ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT 1"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_ODBC(ret, stmt);
 
   // Then the last query ID should be a valid UUID
   auto id = get_last_query_id(stmt);
@@ -69,9 +69,9 @@ TEST_CASE("should set last query ID after successful SQLPrepare + SQLExecute", "
 
   // When SQLPrepare and SQLExecute are called with a valid query
   SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("SELECT 1"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_ODBC(ret, stmt);
   ret = SQLExecute(stmt.getHandle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_ODBC(ret, stmt);
 
   // Then the last query ID should be a valid UUID
   auto id = get_last_query_id(stmt);
@@ -85,14 +85,14 @@ TEST_CASE("should produce different last query IDs for successive queries", "[qu
 
   // When two different queries are executed sequentially
   SQLRETURN ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT 1"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_ODBC(ret, stmt);
   auto id1 = get_last_query_id(stmt);
 
   ret = SQLCloseCursor(stmt.getHandle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_ODBC(ret, stmt);
 
   ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT 2"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_ODBC(ret, stmt);
   auto id2 = get_last_query_id(stmt);
 
   // Then the last query IDs should differ
@@ -114,7 +114,7 @@ TEST_CASE("should set last query ID after failed query with syntax error", "[que
 
   // When SQLExecDirect is called with a syntax error
   SQLRETURN ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT failed query syntax"), SQL_NTS);
-  REQUIRE(ret == SQL_ERROR);
+  REQUIRE_ODBC_ERROR(ret, stmt);
 
   // Then the last query ID should be a valid UUID
   auto id = get_last_query_id(stmt);
@@ -130,7 +130,7 @@ TEST_CASE("should set last query ID after failed query referencing nonexistent t
 
   // When SQLExecDirect is called referencing a nonexistent table
   SQLRETURN ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT col FROM non_existent_table_xyz_12345"), SQL_NTS);
-  REQUIRE(ret == SQL_ERROR);
+  REQUIRE_ODBC_ERROR(ret, stmt);
 
   // Then the last query ID should be a valid UUID
   auto id = get_last_query_id(stmt);
@@ -146,11 +146,11 @@ TEST_CASE("should produce different last query IDs for successive failed queries
 
   // When two different invalid queries are executed sequentially
   SQLRETURN ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT failed query 1"), SQL_NTS);
-  REQUIRE(ret == SQL_ERROR);
+  REQUIRE_ODBC_ERROR(ret, stmt);
   auto id1 = get_last_query_id(stmt);
 
   ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT failed query 2"), SQL_NTS);
-  REQUIRE(ret == SQL_ERROR);
+  REQUIRE_ODBC_ERROR(ret, stmt);
   auto id2 = get_last_query_id(stmt);
 
   // Then the last query IDs should differ
@@ -168,14 +168,14 @@ TEST_CASE("should update last query ID from successful to failed query", "[query
 
   // When a successful query is followed by a failed query
   SQLRETURN ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT 1"), SQL_NTS);
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_ODBC(ret, stmt);
   auto id_success = get_last_query_id(stmt);
 
   ret = SQLCloseCursor(stmt.getHandle());
-  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE_ODBC(ret, stmt);
 
   ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT failed query"), SQL_NTS);
-  REQUIRE(ret == SQL_ERROR);
+  REQUIRE_ODBC_ERROR(ret, stmt);
   auto id_fail = get_last_query_id(stmt);
 
   // Then the last query IDs should differ

--- a/odbc_tests/tests/e2e/query/last_query_id.cpp
+++ b/odbc_tests/tests/e2e/query/last_query_id.cpp
@@ -8,14 +8,16 @@
 
 #include "Connection.hpp"
 #include "compatibility.hpp"
+#include "odbc_cast.hpp"
+#include "odbc_matchers.hpp"
 #include "sf_odbc.h"
 
 static std::string get_last_query_id(StatementHandleWrapper& stmt) {
   char buf[40] = {};
   SQLINTEGER len = 0;
   SQLRETURN ret = SQLGetStmtAttr(stmt.getHandle(), SQL_SF_STMT_ATTR_LAST_QUERY_ID, buf, sizeof(buf), &len);
-  REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
-  return std::string(buf, len);
+  REQUIRE_ODBC(ret, stmt);
+  return std::string(buf);
 }
 
 static bool is_valid_query_id(const std::string& id) {
@@ -34,7 +36,7 @@ static bool is_valid_query_id(const std::string& id) {
 // SUCCESSFUL QUERIES
 // =============================================================================
 
-TEST_CASE("Last query ID is empty before any query is executed.", "[query][last_query_id]") {
+TEST_CASE("should return empty last query ID before any query is executed", "[query][last_query_id]") {
   // Given Snowflake client is logged in
   Connection conn;
   auto stmt = conn.createStatement();
@@ -46,13 +48,13 @@ TEST_CASE("Last query ID is empty before any query is executed.", "[query][last_
   CHECK(id.empty());
 }
 
-TEST_CASE("Last query ID is set after successful SQLExecDirect.", "[query][last_query_id]") {
+TEST_CASE("should set last query ID after successful SQLExecDirect", "[query][last_query_id]") {
   // Given Snowflake client is logged in
   Connection conn;
   auto stmt = conn.createStatement();
 
   // When SQLExecDirect is called with a valid query
-  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT 1", SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT 1"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
 
   // Then the last query ID should be a valid UUID
@@ -60,13 +62,13 @@ TEST_CASE("Last query ID is set after successful SQLExecDirect.", "[query][last_
   CHECK(is_valid_query_id(id));
 }
 
-TEST_CASE("Last query ID is set after successful SQLPrepare + SQLExecute.", "[query][last_query_id]") {
+TEST_CASE("should set last query ID after successful SQLPrepare + SQLExecute", "[query][last_query_id]") {
   // Given Snowflake client is logged in
   Connection conn;
   auto stmt = conn.createStatement();
 
   // When SQLPrepare and SQLExecute are called with a valid query
-  SQLRETURN ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)"SELECT 1", SQL_NTS);
+  SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("SELECT 1"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   ret = SQLExecute(stmt.getHandle());
   REQUIRE(ret == SQL_SUCCESS);
@@ -76,20 +78,20 @@ TEST_CASE("Last query ID is set after successful SQLPrepare + SQLExecute.", "[qu
   CHECK(is_valid_query_id(id));
 }
 
-TEST_CASE("Successive queries produce different last query IDs.", "[query][last_query_id]") {
+TEST_CASE("should produce different last query IDs for successive queries", "[query][last_query_id]") {
   // Given Snowflake client is logged in
   Connection conn;
   auto stmt = conn.createStatement();
 
   // When two different queries are executed sequentially
-  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT 1", SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT 1"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   auto id1 = get_last_query_id(stmt);
 
   ret = SQLCloseCursor(stmt.getHandle());
   REQUIRE(ret == SQL_SUCCESS);
 
-  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT 2", SQL_NTS);
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT 2"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   auto id2 = get_last_query_id(stmt);
 
@@ -103,7 +105,7 @@ TEST_CASE("Successive queries produce different last query IDs.", "[query][last_
 // FAILED QUERIES
 // =============================================================================
 
-TEST_CASE("Last query ID is set after failed query with syntax error.", "[query][last_query_id]") {
+TEST_CASE("should set last query ID after failed query with syntax error", "[query][last_query_id]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Given Snowflake client is logged in
@@ -111,7 +113,7 @@ TEST_CASE("Last query ID is set after failed query with syntax error.", "[query]
   auto stmt = conn.createStatement();
 
   // When SQLExecDirect is called with a syntax error
-  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT failed query syntax", SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT failed query syntax"), SQL_NTS);
   REQUIRE(ret == SQL_ERROR);
 
   // Then the last query ID should be a valid UUID
@@ -119,7 +121,7 @@ TEST_CASE("Last query ID is set after failed query with syntax error.", "[query]
   CHECK(is_valid_query_id(id));
 }
 
-TEST_CASE("Last query ID is set after failed query referencing nonexistent table.", "[query][last_query_id]") {
+TEST_CASE("should set last query ID after failed query referencing nonexistent table", "[query][last_query_id]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Given Snowflake client is logged in
@@ -127,7 +129,7 @@ TEST_CASE("Last query ID is set after failed query referencing nonexistent table
   auto stmt = conn.createStatement();
 
   // When SQLExecDirect is called referencing a nonexistent table
-  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT col FROM non_existent_table_xyz_12345", SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT col FROM non_existent_table_xyz_12345"), SQL_NTS);
   REQUIRE(ret == SQL_ERROR);
 
   // Then the last query ID should be a valid UUID
@@ -135,7 +137,7 @@ TEST_CASE("Last query ID is set after failed query referencing nonexistent table
   CHECK(is_valid_query_id(id));
 }
 
-TEST_CASE("Last query ID changes between successive failed queries.", "[query][last_query_id]") {
+TEST_CASE("should produce different last query IDs for successive failed queries", "[query][last_query_id]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Given Snowflake client is logged in
@@ -143,10 +145,12 @@ TEST_CASE("Last query ID changes between successive failed queries.", "[query][l
   auto stmt = conn.createStatement();
 
   // When two different invalid queries are executed sequentially
-  SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT failed query 1", SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT failed query 1"), SQL_NTS);
+  REQUIRE(ret == SQL_ERROR);
   auto id1 = get_last_query_id(stmt);
 
-  SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT failed query 2", SQL_NTS);
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT failed query 2"), SQL_NTS);
+  REQUIRE(ret == SQL_ERROR);
   auto id2 = get_last_query_id(stmt);
 
   // Then the last query IDs should differ
@@ -155,7 +159,7 @@ TEST_CASE("Last query ID changes between successive failed queries.", "[query][l
   CHECK(id1 != id2);
 }
 
-TEST_CASE("Last query ID updates from successful to failed query.", "[query][last_query_id]") {
+TEST_CASE("should update last query ID from successful to failed query", "[query][last_query_id]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
 
   // Given Snowflake client is logged in
@@ -163,14 +167,14 @@ TEST_CASE("Last query ID updates from successful to failed query.", "[query][las
   auto stmt = conn.createStatement();
 
   // When a successful query is followed by a failed query
-  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT 1", SQL_NTS);
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT 1"), SQL_NTS);
   REQUIRE(ret == SQL_SUCCESS);
   auto id_success = get_last_query_id(stmt);
 
   ret = SQLCloseCursor(stmt.getHandle());
   REQUIRE(ret == SQL_SUCCESS);
 
-  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT failed query", SQL_NTS);
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT failed query"), SQL_NTS);
   REQUIRE(ret == SQL_ERROR);
   auto id_fail = get_last_query_id(stmt);
 

--- a/odbc_tests/tests/e2e/query/last_query_id.cpp
+++ b/odbc_tests/tests/e2e/query/last_query_id.cpp
@@ -1,0 +1,182 @@
+#include <sql.h>
+#include <sqlext.h>
+#include <sqltypes.h>
+
+#include <cstring>
+#include <string>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "Connection.hpp"
+#include "compatibility.hpp"
+#include "sf_odbc.h"
+
+static std::string get_last_query_id(StatementHandleWrapper& stmt) {
+  char buf[64] = {};
+  SQLINTEGER len = 0;
+  SQLRETURN ret = SQLGetStmtAttrW(stmt.getHandle(), SQL_SF_STMT_ATTR_LAST_QUERY_ID, buf, sizeof(buf), &len);
+  REQUIRE((ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO));
+  return std::string(buf, len);
+}
+
+static bool is_valid_query_id(const std::string& id) {
+  if (id.length() != 36) return false;
+  for (size_t i = 0; i < id.length(); ++i) {
+    if (i == 8 || i == 13 || i == 18 || i == 23) {
+      if (id[i] != '-') return false;
+    } else {
+      if (!std::isxdigit(static_cast<unsigned char>(id[i]))) return false;
+    }
+  }
+  return true;
+}
+
+// =============================================================================
+// SUCCESSFUL QUERIES
+// =============================================================================
+
+TEST_CASE("Last query ID is empty before any query is executed.", "[query][last_query_id]") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQLGetStmtAttr is called for SQL_SF_STMT_ATTR_LAST_QUERY_ID
+  auto id = get_last_query_id(stmt);
+
+  // Then the returned query ID should be empty
+  CHECK(id.empty());
+}
+
+TEST_CASE("Last query ID is set after successful SQLExecDirect.", "[query][last_query_id]") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQLExecDirect is called with a valid query
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT 1", SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Then the last query ID should be a valid UUID
+  auto id = get_last_query_id(stmt);
+  CHECK(is_valid_query_id(id));
+}
+
+TEST_CASE("Last query ID is set after successful SQLPrepare + SQLExecute.", "[query][last_query_id]") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQLPrepare and SQLExecute are called with a valid query
+  SQLRETURN ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)"SELECT 1", SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLExecute(stmt.getHandle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Then the last query ID should be a valid UUID
+  auto id = get_last_query_id(stmt);
+  CHECK(is_valid_query_id(id));
+}
+
+TEST_CASE("Successive queries produce different last query IDs.", "[query][last_query_id]") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When two different queries are executed sequentially
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT 1", SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  auto id1 = get_last_query_id(stmt);
+
+  ret = SQLCloseCursor(stmt.getHandle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT 2", SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  auto id2 = get_last_query_id(stmt);
+
+  // Then the last query IDs should differ
+  CHECK(is_valid_query_id(id1));
+  CHECK(is_valid_query_id(id2));
+  CHECK(id1 != id2);
+}
+
+// =============================================================================
+// FAILED QUERIES
+// =============================================================================
+
+TEST_CASE("Last query ID is set after failed query with syntax error.", "[query][last_query_id]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQLExecDirect is called with a syntax error
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT failed query syntax", SQL_NTS);
+  REQUIRE(ret == SQL_ERROR);
+
+  // Then the last query ID should be a valid UUID
+  auto id = get_last_query_id(stmt);
+  CHECK(is_valid_query_id(id));
+}
+
+TEST_CASE("Last query ID is set after failed query referencing nonexistent table.", "[query][last_query_id]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQLExecDirect is called referencing a nonexistent table
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT col FROM non_existent_table_xyz_12345", SQL_NTS);
+  REQUIRE(ret == SQL_ERROR);
+
+  // Then the last query ID should be a valid UUID
+  auto id = get_last_query_id(stmt);
+  CHECK(is_valid_query_id(id));
+}
+
+TEST_CASE("Last query ID changes between successive failed queries.", "[query][last_query_id]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When two different invalid queries are executed sequentially
+  SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT failed query 1", SQL_NTS);
+  auto id1 = get_last_query_id(stmt);
+
+  SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT failed query 2", SQL_NTS);
+  auto id2 = get_last_query_id(stmt);
+
+  // Then the last query IDs should differ
+  CHECK(is_valid_query_id(id1));
+  CHECK(is_valid_query_id(id2));
+  CHECK(id1 != id2);
+}
+
+TEST_CASE("Last query ID updates from successful to failed query.", "[query][last_query_id]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When a successful query is followed by a failed query
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT 1", SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  auto id_success = get_last_query_id(stmt);
+
+  ret = SQLCloseCursor(stmt.getHandle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT failed query", SQL_NTS);
+  REQUIRE(ret == SQL_ERROR);
+  auto id_fail = get_last_query_id(stmt);
+
+  // Then the last query IDs should differ
+  CHECK(is_valid_query_id(id_success));
+  CHECK(is_valid_query_id(id_fail));
+  CHECK(id_success != id_fail);
+}


### PR DESCRIPTION
## Summary
- Adds functional e2e tests for `SQL_SF_STMT_ATTR_LAST_QUERY_ID` covering successful queries (ExecDirect, Prepare+Execute), successive queries producing different IDs, and query ID on failed queries.
- Failed-query tests are gated with `SKIP_NEW_DRIVER_NOT_IMPLEMENTED` pending the error-path fix ([SNOW-2881686](https://snowflakecomputing.atlassian.net/browse/SNOW-2881686)).
- Registers the new test in CMakeLists.

## Test plan
- [ ] Run `e2e_query_last_query_id` against old driver — all 8 tests should pass (4 success-path, 4 failure-path)
- [ ] Run against new driver — 4 success-path tests pass, 4 failure-path tests skip
- [ ] After error-path fix lands, remove `SKIP_NEW_DRIVER_NOT_IMPLEMENTED` guards and verify all 8 pass

🤖 Generated with [Claude Code](https://claude.ai/code)

[SNOW-2881686]: https://snowflakecomputing.atlassian.net/browse/SNOW-2881686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ