### PR TITLE
SNOW-3406388: refresh AWS STS creds on S3 ExpiredToken

### DIFF
--- a/sf_core/src/apis/database_driver_v1/connection.rs
+++ b/sf_core/src/apis/database_driver_v1/connection.rs
@@ -2423,11 +2423,14 @@ mod tests {
         use wiremock::matchers::{method, path};
         use wiremock::{Mock, MockServer, ResponseTemplate};
 
+        // Non-session codes stay on the "explicit failure → false" path.
+        // 390112 is intercepted by the RefreshContext and covered by the
+        // heartbeat_refreshes_session_on_390112 test below.
         let server = MockServer::start().await;
         Mock::given(method("POST"))
             .and(path("/session/heartbeat"))
             .respond_with(ResponseTemplate::new(200).set_body_json(
-                serde_json::json!({"success": false, "message": "Session gone", "code": "390112"}),
+                serde_json::json!({"success": false, "message": "Heartbeat failed", "code": "390100"}),
             ))
             .mount(&server)
             .await;
@@ -2437,6 +2440,76 @@ mod tests {
 
         let valid = ds.connection_heartbeat(handle).await.unwrap();
         assert!(!valid, "heartbeat should return false on failure response");
+
+        ds.connection_release(handle).unwrap();
+    }
+
+    #[tokio::test]
+    async fn heartbeat_refreshes_session_on_390112() {
+        // First heartbeat returns 200 + 390112 (session expired in the body),
+        // RefreshContext calls /session/token-request to get a new session
+        // token, the retry hits a second heartbeat mock that succeeds.
+        use wiremock::matchers::{body_json, header, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+
+        // First heartbeat: session expired via body code.
+        Mock::given(method("POST"))
+            .and(path("/session/heartbeat"))
+            .and(header(
+                "Authorization",
+                "Snowflake Token=\"test-session-token\"",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "success": false,
+                "message": "Session token expired",
+                "code": "390112",
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        // Token refresh: returns new session token.
+        Mock::given(method("POST"))
+            .and(path("/session/token-request"))
+            .and(body_json(serde_json::json!({
+                "oldSessionToken": "test-session-token",
+                "requestType": "RENEW",
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "success": true,
+                "data": {
+                    "sessionToken": "refreshed-session-token",
+                    "masterToken": "test-master-token",
+                    "sessionId": 1,
+                    "validityInSecondsST": 3600,
+                    "validityInSecondsMT": 14400,
+                },
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        // Retry heartbeat with the refreshed token: succeeds.
+        Mock::given(method("POST"))
+            .and(path("/session/heartbeat"))
+            .and(header(
+                "Authorization",
+                "Snowflake Token=\"refreshed-session-token\"",
+            ))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"success": true})),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let ds = DatabaseDriverV1::new();
+        let handle = setup_connection_for_heartbeat_tests(&ds, &server.uri()).await;
+
+        let valid = ds.connection_heartbeat(handle).await.unwrap();
+        assert!(valid, "heartbeat should succeed after session refresh");
 
         ds.connection_release(handle).unwrap();
     }

--- a/sf_core/src/apis/database_driver_v1/query.rs
+++ b/sf_core/src/apis/database_driver_v1/query.rs
@@ -1,4 +1,6 @@
 use super::ColumnMetadata;
+use super::connection::RefreshContext;
+use super::error::ApiError;
 use super::global_state::{PutGetResultsetFlavor, WrapperPresets};
 use crate::arrow_utils::ArrowUtilsError;
 use crate::arrow_utils::{boxed_arrow_reader, create_schema};
@@ -6,17 +8,26 @@ use crate::chunks::{
     ChunkError, PrefetchConfig, arrow_prefetch_reader, empty_reader, json_prefetch_reader,
     schema_only_reader, single_chunk_reader,
 };
+use crate::config::rest_parameters::QueryParameters;
+use crate::config::retry::RetryPolicy;
 use crate::file_manager;
-use crate::file_manager::{DownloadResult, UploadResult, download_files, upload_files};
+use crate::file_manager::{
+    CloudCredentials, CredentialRefreshError, CredentialRefresher, DownloadResult,
+    RefreshFailedSnafu, UploadResult, download_files, upload_files,
+};
 use crate::query_types::RowType;
 use crate::rest;
 use arrow::array::{Array, Int64Array, RecordBatchReader, StringArray};
 use arrow::datatypes::DataType;
 use arrow::error::ArrowError;
+use futures::FutureExt;
+use futures::future::BoxFuture;
 use reqwest::Client;
 use rest::snowflake::query_response::{self, QueryResponseError};
-use snafu::{IntoError, Location, ResultExt, Snafu};
+use rest::snowflake::{QueryExecutionMode, QueryInput, snowflake_query_with_client};
+use snafu::{IntoError, Location, OptionExt, ResultExt, Snafu};
 use std::sync::Arc;
+use tokio::sync::Mutex;
 
 const PUT_GET_ROWSET_TEXT_LENGTH: u64 = 10000;
 const PUT_GET_ROWSET_FIXED_LENGTH: u64 = 64;
@@ -45,9 +56,12 @@ pub async fn process_query_response(
     http_client: &Client,
     prefetch_config: &PrefetchConfig,
     wrapper_presets: &WrapperPresets,
+    credential_refresher: Option<Arc<dyn CredentialRefresher>>,
 ) -> Result<QueryResult, QueryResponseProcessingError> {
     match data.command {
-        Some(ref command) => perform_put_get(command.clone(), data, wrapper_presets).await,
+        Some(ref command) => {
+            perform_put_get(command.clone(), data, wrapper_presets, credential_refresher).await
+        }
         None => {
             let reader = read_batches(data.to_rowset_data(), http_client.clone(), prefetch_config)
                 .await
@@ -61,12 +75,14 @@ async fn perform_put_get(
     command: String,
     data: &query_response::Data,
     wrapper_presets: &WrapperPresets,
+    refresher: Option<Arc<dyn CredentialRefresher>>,
 ) -> Result<QueryResult, QueryResponseProcessingError> {
     match command.as_str() {
         "UPLOAD" => {
-            let file_upload_data = data
+            let mut file_upload_data = data
                 .to_file_upload_data()
                 .context(FileTransferPreparationSnafu)?;
+            file_upload_data.credential_refresher = refresher;
             let upload_results = upload_files(&file_upload_data)
                 .await
                 .context(FileUploadSnafu)?;
@@ -75,13 +91,14 @@ async fn perform_put_get(
             Ok(QueryResult { reader })
         }
         "DOWNLOAD" => {
-            let file_download_data = data.to_file_download_data().map_err(|e| {
+            let mut file_download_data = data.to_file_download_data().map_err(|e| {
                 if e.to_string().contains("source locations") {
                     RemoteFileNotFoundSnafu.build()
                 } else {
                     FileTransferPreparationSnafu.into_error(e)
                 }
             })?;
+            file_download_data.credential_refresher = refresher;
             let download_results = download_files(file_download_data)
                 .await
                 .context(FileDownloadSnafu)?;
@@ -94,6 +111,159 @@ async fn perform_put_get(
         }
         .fail(),
     }
+}
+
+/// Re-executes the original PUT/GET SQL command to obtain fresh stage
+/// credentials when S3 reports `ExpiredToken`. Re-execution is serialized
+/// against other queries on the same connection by the `Mutex` inside
+/// `RefreshContext`.
+pub(super) struct PutGetCredentialRefresher {
+    conn: Arc<Mutex<super::connection::Connection>>,
+    command: String,
+    query_parameters: QueryParameters,
+    http_client: Client,
+    retry_policy: RetryPolicy,
+}
+
+impl PutGetCredentialRefresher {
+    pub(super) fn new(
+        conn: Arc<Mutex<super::connection::Connection>>,
+        command: String,
+        query_parameters: QueryParameters,
+        http_client: Client,
+        retry_policy: RetryPolicy,
+    ) -> Self {
+        Self {
+            conn,
+            command,
+            query_parameters,
+            http_client,
+            retry_policy,
+        }
+    }
+
+    async fn execute_refresh(&self) -> Result<CloudCredentials, PutGetRefreshError> {
+        let mut ctx = RefreshContext::from_arc(&self.conn)
+            .await
+            .context(RefreshContextSnafu)?;
+
+        let query_input = QueryInput {
+            sql: self.command.clone(),
+            bindings: None,
+            describe_only: None,
+            query_parameters: None,
+        };
+
+        // `execute_with_refresh` is the crate's canonical "retry once on
+        // SessionExpired" helper. Post-#1137, body-level 390112 and HTTP 401
+        // both surface as `SessionExpired`, so one retry covers both paths.
+        let response = ctx
+            .execute_with_refresh(|token| {
+                let http_client = self.http_client.clone();
+                let query_parameters = self.query_parameters.clone();
+                let query_input = query_input.clone();
+                let retry_policy = self.retry_policy.clone();
+                async move {
+                    snowflake_query_with_client(
+                        &http_client,
+                        query_parameters,
+                        token.reveal(),
+                        query_input,
+                        &retry_policy,
+                        QueryExecutionMode::Blocking,
+                    )
+                    .await
+                }
+            })
+            .await
+            .context(SessionRefreshSnafu)?;
+
+        // `success=false` with a non-390112 code (SQL compile error, permission
+        // error, suspended warehouse) still reaches us as Ok(..) — only 390112
+        // is intercepted upstream. Preserve the server message but bound its
+        // length so a misconfigured server can't smuggle arbitrary content
+        // into our logs.
+        if !response.success {
+            return ServerRefusedSnafu {
+                message: truncate_server_message(response.message.as_deref()),
+            }
+            .fail();
+        }
+
+        let stage_info: file_manager::StageInfo = response
+            .data
+            .stage_info_ref()
+            .context(MissingStageInfoSnafu)?
+            .try_into()
+            .context(StageInfoParseSnafu)?;
+        Ok(stage_info.creds)
+    }
+}
+
+/// Bounds server-supplied strings before they land in a displayable error.
+/// Guards against a misbehaving Snowflake endpoint dumping arbitrary content
+/// (presigned URLs, header fragments) into local log aggregation. Matches
+/// the char-boundary-safe truncation in `rest::snowflake::read_response_json`.
+fn truncate_server_message(msg: Option<&str>) -> String {
+    const MAX_LEN: usize = 256;
+    match msg {
+        Some(s) if s.len() <= MAX_LEN => s.to_string(),
+        Some(s) => {
+            let mut end = MAX_LEN;
+            while !s.is_char_boundary(end) {
+                end -= 1;
+            }
+            format!("{}…(truncated)", &s[..end])
+        }
+        None => "success=false".to_string(),
+    }
+}
+
+impl CredentialRefresher for PutGetCredentialRefresher {
+    fn refresh(&self) -> BoxFuture<'_, Result<CloudCredentials, CredentialRefreshError>> {
+        async move {
+            self.execute_refresh()
+                .await
+                .map_err(|e| RefreshFailedSnafu.into_error(Box::new(e)))
+        }
+        .boxed()
+    }
+}
+
+/// Inner error surface of `PutGetCredentialRefresher::execute_refresh`. Lifted
+/// into `CredentialRefreshError` by the trait impl so the `error_trace::ErrorTrace`
+/// chain reaches the original cause.
+#[derive(Debug, Snafu, error_trace::ErrorTrace)]
+pub(super) enum PutGetRefreshError {
+    #[snafu(display("Failed to open refresh context"))]
+    RefreshContext {
+        source: ApiError,
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Re-execution of PUT/GET command failed"))]
+    SessionRefresh {
+        source: ApiError,
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("PUT/GET re-execution returned success=false: {message}"))]
+    ServerRefused {
+        message: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Refreshed PUT/GET response missing stageInfo"))]
+    MissingStageInfo {
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Failed to parse refreshed stageInfo"))]
+    StageInfoParse {
+        source: QueryResponseError,
+        #[snafu(implicit)]
+        location: Location,
+    },
 }
 
 async fn read_batches<'a>(

--- a/sf_core/src/apis/database_driver_v1/statement.rs
+++ b/sf_core/src/apis/database_driver_v1/statement.rs
@@ -460,11 +460,27 @@ impl DatabaseDriverV1 {
         let prebuilt_stream = if super::multistatement::is_multistatement(&response.data) {
             None
         } else {
+            // For PUT/GET the storage client may need to re-fetch credentials
+            // if the cloud provider reports an expired STS token mid-transfer.
+            // The refresher re-runs the PUT/GET SQL to get fresh stageInfo.
+            let credential_refresher: Option<Arc<dyn crate::file_manager::CredentialRefresher>> =
+                if response.data.command.is_some() {
+                    Some(Arc::new(super::query::PutGetCredentialRefresher::new(
+                        conn_arc.clone(),
+                        query.clone(),
+                        query_parameters.clone(),
+                        http_client.clone(),
+                        retry_policy.clone(),
+                    )))
+                } else {
+                    None
+                };
             let query_result = process_query_response(
                 &response.data,
                 &http_client,
                 &prefetch_config,
                 &self.wrapper_presets,
+                credential_refresher,
             )
             .await
             .context(QueryResponseProcessingSnafu)?;
@@ -901,8 +917,10 @@ async fn fetch_and_resolve_result_set(
     let prefetch_config = resolve_prefetch_config(conn_ptr).await;
 
     let descriptor = response_to_descriptor(&data, wrapper_presets);
+    // Result fetch by query_id goes through the server's cached rowset, not
+    // a cloud stage, so no credential refresh path is needed here.
     let query_result =
-        process_query_response(&data, &http_client, &prefetch_config, wrapper_presets)
+        process_query_response(&data, &http_client, &prefetch_config, wrapper_presets, None)
             .await
             .context(QueryResponseProcessingSnafu)?;
     let stream = Box::new(FFI_ArrowArrayStream::new(query_result.reader));

--- a/sf_core/src/file_manager/mod.rs
+++ b/sf_core/src/file_manager/mod.rs
@@ -22,6 +22,7 @@ use snafu::{Location, OptionExt, ResultExt, Snafu};
 use std::fs::File;
 use std::io::{Read, Write};
 use std::path::Path;
+use std::sync::Arc;
 
 pub async fn upload_files(data: &UploadData) -> Result<Vec<UploadResult>, FileManagerError> {
     let file_locations =
@@ -49,14 +50,18 @@ pub async fn upload_files(data: &UploadData) -> Result<Vec<UploadResult>, FileMa
             overwrite: data.overwrite,
         };
 
-        let result = upload_single_file(single_upload_data).await?;
+        let result =
+            upload_single_file(single_upload_data, data.credential_refresher.clone()).await?;
         results.push(result);
     }
 
     Ok(results)
 }
 
-pub async fn upload_single_file(data: SingleUploadData) -> Result<UploadResult, FileManagerError> {
+pub async fn upload_single_file(
+    data: SingleUploadData,
+    credential_refresher: Option<Arc<dyn CredentialRefresher>>,
+) -> Result<UploadResult, FileManagerError> {
     let mut input_file = File::open(&data.file_path).context(IoSnafu)?;
 
     let mut file_buffer = Vec::new();
@@ -70,6 +75,7 @@ pub async fn upload_single_file(data: SingleUploadData) -> Result<UploadResult, 
             &data.stage_info,
             file_metadata.target.as_str(),
             data.overwrite,
+            credential_refresher,
         )
         .await
         .context(S3UploadSnafu)?,
@@ -202,7 +208,8 @@ pub async fn download_files(
             encryption_material,
         };
 
-        let result = download_single_file(single_download_data).await?;
+        let result =
+            download_single_file(single_download_data, data.credential_refresher.clone()).await?;
         results.push(result);
     }
 
@@ -211,11 +218,16 @@ pub async fn download_files(
 
 pub async fn download_single_file(
     data: SingleDownloadData,
+    credential_refresher: Option<Arc<dyn CredentialRefresher>>,
 ) -> Result<DownloadResult, FileManagerError> {
     let (raw_data, digest, file_metadata) = match data.stage_info.location_type {
-        LocationType::S3 => download_from_s3(&data.stage_info, data.src_location.as_str())
-            .await
-            .context(S3DownloadSnafu)?,
+        LocationType::S3 => download_from_s3(
+            &data.stage_info,
+            data.src_location.as_str(),
+            credential_refresher,
+        )
+        .await
+        .context(S3DownloadSnafu)?,
         LocationType::Gcs => download_from_gcs(&data.stage_info, data.src_location.as_str())
             .await
             .context(GcsDownloadSnafu)?,

--- a/sf_core/src/file_manager/s3_transfer.rs
+++ b/sf_core/src/file_manager/s3_transfer.rs
@@ -1,8 +1,10 @@
 use super::types::{
-    EncryptedFileMetadata, MaterialDescription, PreparedUpload, StageInfo, UploadStatus,
+    CloudCredentials, CredentialRefreshError, CredentialRefresher, EncryptedFileMetadata,
+    MaterialDescription, PreparedUpload, StageInfo, UploadStatus,
 };
 use crate::config::retry::{BackoffConfig, Jitter, RetryPolicy};
 use snafu::{Location, ResultExt, Snafu};
+use std::sync::Arc;
 use std::time::Duration;
 
 // AWS SDK imports
@@ -10,12 +12,27 @@ use aws_config::{BehaviorVersion, Region};
 use aws_credential_types::Credentials;
 use aws_sdk_s3::config::retry::RetryConfig as AwsRetryConfig;
 use aws_sdk_s3::config::timeout::TimeoutConfig as AwsTimeoutConfig;
-use aws_sdk_s3::error::SdkError;
+use aws_sdk_s3::error::{ProvideErrorMetadata, SdkError};
 use aws_sdk_s3::{Client as S3Client, primitives::ByteStream};
 
 const SNOWFLAKE_UPLOAD_PROVIDER: &str = "snowflake-upload";
 const SNOWFLAKE_DOWNLOAD_PROVIDER: &str = "snowflake-download";
 const CONTENT_TYPE_OCTET_STREAM: &str = "application/octet-stream";
+
+/// AWS error code returned when an STS session token has expired. Stable
+/// across S3 and STS and surfaced via `ProvideErrorMetadata::code()` for
+/// responses with bodies. HEAD responses carry no body (the SDK drops them),
+/// so S3 mirrors this code into the `x-amz-error-code` response header; we
+/// inspect that header explicitly for HEAD.
+const EXPIRED_TOKEN_CODE: &str = "ExpiredToken";
+
+const X_AMZ_ERROR_CODE_HEADER: &str = "x-amz-error-code";
+
+/// Maximum number of credential-refresh rounds per transfer. One refresh is
+/// typically sufficient (STS credentials are long-lived); a second catches
+/// the edge case where a refresh races with another expiry. Additional
+/// attempts would loop on a broken refresher.
+const MAX_CREDENTIAL_REFRESH_ATTEMPTS: u32 = 2;
 
 /// Per-attempt HTTP timeout applied to every S3 SDK operation.
 ///
@@ -27,30 +44,114 @@ const REQUEST_TIMEOUT_SECS: u64 = 300;
 // TODO: streaming instead of loading the whole file into memory
 
 /// Uploads a file to S3, skipping if it already exists and `overwrite` is false.
+///
+/// If `credential_refresher` is `Some` and the S3 API returns `ExpiredToken`,
+/// fresh credentials are fetched and the operation is retried with a rebuilt
+/// S3 client (bounded by `MAX_CREDENTIAL_REFRESH_ATTEMPTS`).
 pub async fn upload_to_s3_or_skip(
     prepared: PreparedUpload,
     stage_info: &StageInfo,
     filename: &str,
     overwrite: bool,
+    credential_refresher: Option<Arc<dyn CredentialRefresher>>,
 ) -> Result<UploadStatus, UploadFileError> {
-    // Check if the file already exists in S3
-    let s3_client = create_s3_client(stage_info, SNOWFLAKE_UPLOAD_PROVIDER).await?;
     let s3_key = format!("{}{filename}", stage_info.key_prefix);
+    // Creds used by the S3 client for this iteration. Starts as `stage_info.creds`
+    // (via `None` → `create_s3_client` falls back to stage_info) and is replaced
+    // by refreshed creds after an ExpiredToken.
+    let mut active_creds: Option<CloudCredentials> = None;
+    let mut refreshes_done: u32 = 0;
+    loop {
+        let s3_client =
+            create_s3_client(stage_info, SNOWFLAKE_UPLOAD_PROVIDER, active_creds.as_ref()).await?;
+        match try_upload_once(&prepared, &s3_client, stage_info, &s3_key, overwrite).await {
+            Ok(status) => return Ok(status),
+            Err(e) => match try_refresh_after_expired_token(
+                is_expired_token_upload_error(&e),
+                credential_refresher.as_deref(),
+                refreshes_done,
+                |source| UploadFileError::CredentialRefresh {
+                    source,
+                    location: Location::default(),
+                },
+            )
+            .await?
+            {
+                Some(fresh) => {
+                    active_creds = Some(fresh);
+                    refreshes_done += 1;
+                }
+                None => return Err(e),
+            },
+        }
+    }
+}
 
-    if !overwrite && check_if_file_exists(&s3_client, stage_info, &s3_key).await? {
+/// Performs one S3 upload attempt: existence check (if `!overwrite`) followed
+/// by PUT. Isolated so the caller's refresh loop sees a single `Result` per
+/// attempt rather than two phases.
+async fn try_upload_once(
+    prepared: &PreparedUpload,
+    s3_client: &S3Client,
+    stage_info: &StageInfo,
+    s3_key: &str,
+    overwrite: bool,
+) -> Result<UploadStatus, UploadFileError> {
+    if !overwrite && check_if_file_exists(s3_client, stage_info, s3_key).await? {
         tracing::info!("File already exists in S3: {}", s3_key);
         return Ok(UploadStatus::Skipped);
     }
-
-    // Proceed with upload if the file does not exist or overwrite is true
-    upload_to_s3(prepared, &s3_client, stage_info, &s3_key).await?;
+    // Clone per attempt — STS refresh is rare (~hourly), not a hot path.
+    upload_to_s3(prepared.clone(), s3_client, stage_info, s3_key).await?;
     Ok(UploadStatus::Uploaded)
 }
 
+/// Returns `Some(fresh_creds)` when the caller should retry with fresh
+/// credentials; `Ok(None)` when the caller should propagate the original
+/// error unchanged (not an expired-token error, no refresher configured, or
+/// the refresh budget is exhausted).
+///
+/// `on_refresh_error` lifts a `CredentialRefreshError` into the caller's
+/// storage-client error type — each caller picks the right variant (e.g.
+/// `UploadFileError::CredentialRefresh` vs `DownloadFileError::CredentialRefresh`).
+async fn try_refresh_after_expired_token<E>(
+    is_expired_token: bool,
+    refresher: Option<&dyn CredentialRefresher>,
+    refreshes_done: u32,
+    on_refresh_error: impl FnOnce(CredentialRefreshError) -> E,
+) -> Result<Option<CloudCredentials>, E> {
+    if !is_expired_token {
+        return Ok(None);
+    }
+    let Some(refresher) = refresher else {
+        tracing::debug!("S3 ExpiredToken but no credential refresher configured");
+        return Ok(None);
+    };
+    if refreshes_done >= MAX_CREDENTIAL_REFRESH_ATTEMPTS {
+        tracing::warn!(
+            refreshes_done,
+            "S3 ExpiredToken persists after {refreshes_done} refresh(es); giving up"
+        );
+        return Ok(None);
+    }
+    tracing::debug!(
+        refreshes_done,
+        "Refreshing S3 credentials after ExpiredToken"
+    );
+    refresher
+        .refresh()
+        .await
+        .map(Some)
+        .map_err(on_refresh_error)
+}
+
 /// Returns true if the file exists in S3, false if it does not.
-/// When the check cannot be performed due to 403 Forbidden (limited
-/// temporary credentials that allow PUT but not HEAD), returns false
-/// so the caller proceeds with upload.
+///
+/// When the check cannot be performed due to 403 Forbidden (limited temporary
+/// credentials that allow PUT but not HEAD), returns false so the caller
+/// proceeds with upload. An expired STS token is surfaced via the
+/// `x-amz-error-code` header (HEAD responses carry no body, so the SDK cannot
+/// populate the normal `ProvideErrorMetadata::code()` path).
 async fn check_if_file_exists(
     s3_client: &S3Client,
     stage_info: &StageInfo,
@@ -70,6 +171,17 @@ async fn check_if_file_exists(
                 "Access denied when checking if file exists in S3 ({s3_key}), proceeding with upload"
             );
             Ok(false)
+        }
+        Err(SdkError::ServiceError(ref err))
+            if err
+                .raw()
+                .headers()
+                .get(X_AMZ_ERROR_CODE_HEADER)
+                .is_some_and(|code| code == EXPIRED_TOKEN_CODE) =>
+        {
+            Err(UploadFileError::HeadExpiredToken {
+                location: Location::default(),
+            })
         }
         Err(e) => Err(aws_sdk_s3::Error::from(e)).context(upload_file_error::S3HeadSnafu),
     }
@@ -113,17 +225,57 @@ async fn upload_to_s3(
 
 /// Downloads a file from S3 and returns the data with optional encryption metadata.
 /// For SSE stages the metadata headers will be absent and `None` is returned.
+///
+/// If `credential_refresher` is `Some` and the S3 API returns an `ExpiredToken`,
+/// fresh credentials are fetched and the operation is retried with a rebuilt
+/// S3 client (bounded by `MAX_CREDENTIAL_REFRESH_ATTEMPTS`).
 pub async fn download_from_s3(
     stage_info: &StageInfo,
     filename: &str,
+    credential_refresher: Option<Arc<dyn CredentialRefresher>>,
 ) -> Result<(Vec<u8>, Option<String>, Option<EncryptedFileMetadata>), DownloadFileError> {
-    let s3_client = create_s3_client(stage_info, SNOWFLAKE_DOWNLOAD_PROVIDER).await?;
     let s3_key = format!("{}{filename}", stage_info.key_prefix);
+    let mut active_creds: Option<CloudCredentials> = None;
+    let mut refreshes_done: u32 = 0;
+    loop {
+        let s3_client = create_s3_client(
+            stage_info,
+            SNOWFLAKE_DOWNLOAD_PROVIDER,
+            active_creds.as_ref(),
+        )
+        .await?;
+        match try_download_once(&s3_client, stage_info, &s3_key).await {
+            Ok(parsed) => return Ok(parsed),
+            Err(e) => match try_refresh_after_expired_token(
+                is_expired_token_download_error(&e),
+                credential_refresher.as_deref(),
+                refreshes_done,
+                |source| DownloadFileError::CredentialRefresh {
+                    source,
+                    location: Location::default(),
+                },
+            )
+            .await?
+            {
+                Some(fresh) => {
+                    active_creds = Some(fresh);
+                    refreshes_done += 1;
+                }
+                None => return Err(e),
+            },
+        }
+    }
+}
 
+async fn try_download_once(
+    s3_client: &S3Client,
+    stage_info: &StageInfo,
+    s3_key: &str,
+) -> Result<(Vec<u8>, Option<String>, Option<EncryptedFileMetadata>), DownloadFileError> {
     let response = s3_client
         .get_object()
         .bucket(stage_info.bucket.clone())
-        .key(&s3_key)
+        .key(s3_key)
         .send()
         .await
         .map_err(aws_sdk_s3::Error::from)
@@ -179,9 +331,10 @@ pub async fn download_from_s3(
 /// errors, 5xx server errors, and throttling (429, SlowDown). 403 is left to
 /// the SDK's defaults: unlike GCS/Azure (where 403 commonly means "token not
 /// yet propagated" / "SAS clock skew"), S3 returns 403 for genuine AccessDenied
-/// and retrying is rarely productive — `create_s3_client` is called per
-/// operation, so an expired STS token surfaces as a non-retryable 403 and the
-/// caller can re-fetch credentials via a new PUT/GET parse.
+/// and retrying is rarely productive. STS token expiry is surfaced by S3 as a
+/// 400 with error code `ExpiredToken`; that case is caught by the
+/// credential-refresh loop (`upload_to_s3_or_skip`, `download_from_s3`) rather
+/// than by the SDK's retry strategy.
 pub(crate) fn s3_retry_policy() -> RetryPolicy {
     RetryPolicy {
         max_attempts: 6,
@@ -229,12 +382,14 @@ fn to_aws_timeout_config(policy: &RetryPolicy) -> AwsTimeoutConfig {
 async fn create_s3_client(
     stage_info: &StageInfo,
     provider_name: &'static str,
+    creds_override: Option<&CloudCredentials>,
 ) -> Result<S3Client, S3CredentialError> {
+    let effective_creds = creds_override.unwrap_or(&stage_info.creds);
     let super::types::CloudCredentials::S3 {
         ref aws_key_id,
         ref aws_secret_key,
         ref aws_token,
-    } = stage_info.creds
+    } = *effective_creds
     else {
         return Err(S3CredentialError);
     };
@@ -269,6 +424,27 @@ async fn create_s3_client(
     }
 
     Ok(S3Client::from_conf(s3_config.build()))
+}
+
+/// Returns true if this `UploadFileError` wraps an S3 error with code
+/// `ExpiredToken`. The SDK parses the XML error body and exposes the code via
+/// `ProvideErrorMetadata`. HEAD requests surface the code via a typed variant
+/// because their responses have no body to parse.
+fn is_expired_token_upload_error(err: &UploadFileError) -> bool {
+    match err {
+        UploadFileError::S3Upload { source, .. } | UploadFileError::S3Head { source, .. } => {
+            source.code() == Some(EXPIRED_TOKEN_CODE)
+        }
+        UploadFileError::HeadExpiredToken { .. } => true,
+        _ => false,
+    }
+}
+
+fn is_expired_token_download_error(err: &DownloadFileError) -> bool {
+    match err {
+        DownloadFileError::S3Download { source, .. } => source.code() == Some(EXPIRED_TOKEN_CODE),
+        _ => false,
+    }
 }
 
 /// Error returned when `create_s3_client` is called with non-S3 credentials.
@@ -319,6 +495,17 @@ pub enum UploadFileError {
         #[snafu(implicit)]
         location: Location,
     },
+    #[snafu(display("S3 HEAD returned ExpiredToken"))]
+    HeadExpiredToken {
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Failed to refresh S3 credentials during upload"))]
+    CredentialRefresh {
+        source: CredentialRefreshError,
+        #[snafu(implicit)]
+        location: Location,
+    },
 }
 
 #[derive(Snafu, Debug, error_trace::ErrorTrace)]
@@ -351,6 +538,12 @@ pub enum DownloadFileError {
     },
     #[snafu(display("Missing S3 credentials"))]
     MissingS3Credentials {
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Failed to refresh S3 credentials during download"))]
+    CredentialRefresh {
+        source: CredentialRefreshError,
         #[snafu(implicit)]
         location: Location,
     },
@@ -411,5 +604,425 @@ mod tests {
         let cfg = to_aws_timeout_config(&policy);
         assert_eq!(cfg.operation_timeout(), Some(policy.max_elapsed));
         assert_eq!(cfg.operation_attempt_timeout(), policy.per_request_timeout);
+    }
+
+    // --- Credential refresh tests ---
+    //
+    // Drive the refresh path end-to-end against a `wiremock` MockServer that
+    // impersonates S3. For PUT/GET the SDK parses the XML error body; for HEAD
+    // the SDK reads the `x-amz-error-code` response header (HEAD has no body).
+
+    use super::super::types::{CloudCredentials, CredentialRefresher, PreparedUpload, StageInfo};
+    use crate::file_manager::LocationType;
+    use crate::sensitive::SensitiveString;
+    use std::sync::Mutex as StdMutex;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, Request, Respond, ResponseTemplate};
+
+    const EXPIRED_TOKEN_XML: &str = concat!(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+        "<Error><Code>ExpiredToken</Code>",
+        "<Message>The provided token has expired.</Message>",
+        "<RequestId>req-0</RequestId><HostId>host-0</HostId></Error>"
+    );
+
+    fn make_s3_creds(key: &str, secret: &str, token: &str) -> CloudCredentials {
+        CloudCredentials::S3 {
+            aws_key_id: key.to_string(),
+            aws_secret_key: SensitiveString::from(secret),
+            aws_token: SensitiveString::from(token),
+        }
+    }
+
+    fn make_stage_info(endpoint: &str, creds: CloudCredentials) -> StageInfo {
+        StageInfo {
+            location_type: LocationType::S3,
+            bucket: "test-bucket".to_string(),
+            key_prefix: "prefix/".to_string(),
+            region: "us-east-1".to_string(),
+            creds,
+            end_point: Some(endpoint.to_string()),
+            presigned_url: None,
+            use_virtual_url: false,
+            use_regional_url: false,
+            storage_account: None,
+        }
+    }
+
+    /// Responds with `ExpiredToken` for the first N calls, then delegates to `on_success`.
+    struct ExpireThenSucceed {
+        expires_remaining: AtomicUsize,
+        on_success_status: u16,
+        on_success_body: Vec<u8>,
+        on_success_headers: Vec<(String, String)>,
+    }
+
+    impl ExpireThenSucceed {
+        fn new(
+            expire_count: usize,
+            status: u16,
+            body: Vec<u8>,
+            headers: Vec<(String, String)>,
+        ) -> Self {
+            Self {
+                expires_remaining: AtomicUsize::new(expire_count),
+                on_success_status: status,
+                on_success_body: body,
+                on_success_headers: headers,
+            }
+        }
+    }
+
+    impl Respond for ExpireThenSucceed {
+        fn respond(&self, req: &Request) -> ResponseTemplate {
+            // fetch_sub returns the previous value; > 0 means we still owe an expiry.
+            let prev = self.expires_remaining.fetch_sub(1, Ordering::SeqCst);
+            if prev == 0 {
+                // Saturate back to 0 so repeated success calls don't underflow.
+                self.expires_remaining.store(0, Ordering::SeqCst);
+                let mut tmpl = ResponseTemplate::new(self.on_success_status)
+                    .set_body_bytes(self.on_success_body.clone());
+                for (k, v) in &self.on_success_headers {
+                    tmpl = tmpl.insert_header(k.as_str(), v.as_str());
+                }
+                tmpl
+            } else if prev > 0 {
+                // HEAD has no response body per HTTP spec, and the AWS SDK
+                // explicitly drops HEAD bodies (see `parse_http_error_metadata`
+                // in aws-sdk-s3). Real S3 therefore mirrors the XML error code
+                // into the `x-amz-error-code` header for HEAD. Match that here.
+                let base = ResponseTemplate::new(400)
+                    .insert_header(X_AMZ_ERROR_CODE_HEADER, EXPIRED_TOKEN_CODE);
+                if req.method.as_str().eq_ignore_ascii_case("HEAD") {
+                    base
+                } else {
+                    base.set_body_string(EXPIRED_TOKEN_XML)
+                        .insert_header("Content-Type", "application/xml")
+                }
+            } else {
+                // Shouldn't happen — fetch_sub saturated at 0 via the branch above.
+                ResponseTemplate::new(500)
+            }
+        }
+    }
+
+    /// Refresher that records how many times it was called and returns fresh
+    /// creds each time. Stand-in for the production PUT/GET re-execution.
+    struct CountingRefresher {
+        calls: Arc<AtomicUsize>,
+        creds: StdMutex<Option<CloudCredentials>>,
+    }
+
+    impl CountingRefresher {
+        fn new(creds: CloudCredentials) -> (Arc<Self>, Arc<AtomicUsize>) {
+            let calls = Arc::new(AtomicUsize::new(0));
+            let this = Arc::new(Self {
+                calls: calls.clone(),
+                creds: StdMutex::new(Some(creds)),
+            });
+            (this, calls)
+        }
+    }
+
+    impl CredentialRefresher for CountingRefresher {
+        fn refresh(
+            &self,
+        ) -> futures::future::BoxFuture<'_, Result<CloudCredentials, CredentialRefreshError>>
+        {
+            use futures::FutureExt;
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            let creds = self
+                .creds
+                .lock()
+                .unwrap()
+                .clone()
+                .expect("test refresher should always have creds ready");
+            async move { Ok(creds) }.boxed()
+        }
+    }
+
+    #[tokio::test]
+    async fn upload_retries_and_refreshes_creds_on_expired_token() {
+        let server = MockServer::start().await;
+
+        // First HEAD (exists check) → 404 (not found) so upload proceeds.
+        // First PUT → ExpiredToken. Second PUT → success.
+        // Using a single catch-all responder simplifies matching; wiremock replays
+        // mounted mocks in registration order and consumes `expires_remaining`
+        // across all calls.
+        Mock::given(method("HEAD"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+        Mock::given(method("PUT"))
+            .respond_with(ExpireThenSucceed::new(
+                1,
+                200,
+                b"".to_vec(),
+                vec![("ETag".into(), "\"abc\"".into())],
+            ))
+            .mount(&server)
+            .await;
+
+        let stage_info = make_stage_info(
+            &server.uri(),
+            make_s3_creds("STALE_KEY", "STALE_SECRET", "STALE_TOKEN"),
+        );
+        let (refresher, calls) =
+            CountingRefresher::new(make_s3_creds("FRESH_KEY", "FRESH_SECRET", "FRESH_TOKEN"));
+
+        let prepared = PreparedUpload {
+            data: b"hello world".to_vec(),
+            digest: "deadbeef".to_string(),
+            encryption_metadata: None,
+        };
+
+        let status = upload_to_s3_or_skip(
+            prepared,
+            &stage_info,
+            "file.txt",
+            /*overwrite=*/ true,
+            Some(refresher),
+        )
+        .await
+        .expect("upload should succeed after credential refresh");
+
+        assert_eq!(status, UploadStatus::Uploaded);
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "exactly one credential refresh should happen"
+        );
+    }
+
+    #[tokio::test]
+    async fn upload_without_refresher_fails_fast_on_expired_token() {
+        let server = MockServer::start().await;
+        Mock::given(method("HEAD"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+        Mock::given(method("PUT"))
+            .respond_with(
+                ResponseTemplate::new(400)
+                    .set_body_string(EXPIRED_TOKEN_XML)
+                    .insert_header("Content-Type", "application/xml"),
+            )
+            .mount(&server)
+            .await;
+
+        let stage_info = make_stage_info(
+            &server.uri(),
+            make_s3_creds("STALE_KEY", "STALE_SECRET", "STALE_TOKEN"),
+        );
+        let prepared = PreparedUpload {
+            data: b"hello".to_vec(),
+            digest: "d".to_string(),
+            encryption_metadata: None,
+        };
+
+        let err = upload_to_s3_or_skip(
+            prepared,
+            &stage_info,
+            "file.txt",
+            /*overwrite=*/ true,
+            None,
+        )
+        .await
+        .expect_err("upload must fail when there is no refresher");
+
+        // Surfaced as the original S3 upload error, not as ExpiredTokenRefreshExhausted:
+        // without a refresher we propagate immediately on the first error.
+        assert!(
+            matches!(err, UploadFileError::S3Upload { .. }),
+            "expected S3Upload error, got {err:?}"
+        );
+        assert!(
+            is_expired_token_upload_error(&err),
+            "error should be classified as ExpiredToken"
+        );
+    }
+
+    #[tokio::test]
+    async fn upload_gives_up_after_max_refresh_attempts() {
+        let server = MockServer::start().await;
+        Mock::given(method("HEAD"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+        // Always return ExpiredToken — refresher keeps producing fresh creds,
+        // but S3 still rejects them. We expect a bounded number of refreshes.
+        Mock::given(method("PUT"))
+            .respond_with(
+                ResponseTemplate::new(400)
+                    .set_body_string(EXPIRED_TOKEN_XML)
+                    .insert_header("Content-Type", "application/xml"),
+            )
+            .mount(&server)
+            .await;
+
+        let stage_info = make_stage_info(
+            &server.uri(),
+            make_s3_creds("STALE_KEY", "STALE_SECRET", "STALE_TOKEN"),
+        );
+        let (refresher, calls) =
+            CountingRefresher::new(make_s3_creds("F_KEY", "F_SECRET", "F_TOKEN"));
+
+        let prepared = PreparedUpload {
+            data: b"x".to_vec(),
+            digest: "d".to_string(),
+            encryption_metadata: None,
+        };
+
+        let err = upload_to_s3_or_skip(
+            prepared,
+            &stage_info,
+            "file.txt",
+            /*overwrite=*/ true,
+            Some(refresher),
+        )
+        .await
+        .expect_err("upload must fail when ExpiredToken persists");
+
+        assert_eq!(
+            calls.load(Ordering::SeqCst) as u32,
+            MAX_CREDENTIAL_REFRESH_ATTEMPTS,
+            "should refresh exactly MAX_CREDENTIAL_REFRESH_ATTEMPTS times",
+        );
+        // After the bound is hit, the final ExpiredToken propagates as-is.
+        assert!(
+            matches!(err, UploadFileError::S3Upload { .. }),
+            "expected S3Upload error after giving up, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn head_check_refreshes_creds_on_expired_token() {
+        // Mirrors the legacy `test_get_header_expiry_error` (test_s3_util.py:130):
+        // when the HEAD-based file-exists probe hits ExpiredToken, the refresh
+        // loop must invoke the refresher and retry on the second attempt. Here
+        // the second HEAD returns 404 (file not found) so upload proceeds and
+        // the PUT succeeds with the fresh creds.
+        let server = MockServer::start().await;
+
+        Mock::given(method("HEAD"))
+            .respond_with(ExpireThenSucceed::new(
+                /*expire_count=*/ 1,
+                /*status=*/ 404,
+                b"".to_vec(),
+                vec![],
+            ))
+            .mount(&server)
+            .await;
+        Mock::given(method("PUT"))
+            .respond_with(ResponseTemplate::new(200).insert_header("ETag", "\"abc\""))
+            .mount(&server)
+            .await;
+
+        let stage_info = make_stage_info(
+            &server.uri(),
+            make_s3_creds("STALE_KEY", "STALE_SECRET", "STALE_TOKEN"),
+        );
+        let (refresher, calls) =
+            CountingRefresher::new(make_s3_creds("FRESH_KEY", "FRESH_SECRET", "FRESH_TOKEN"));
+
+        let prepared = PreparedUpload {
+            data: b"hello world".to_vec(),
+            digest: "deadbeef".to_string(),
+            encryption_metadata: None,
+        };
+
+        // overwrite=false so the HEAD exists-check actually runs.
+        let status = upload_to_s3_or_skip(
+            prepared,
+            &stage_info,
+            "file.txt",
+            /*overwrite=*/ false,
+            Some(refresher),
+        )
+        .await
+        .expect("upload should succeed after HEAD-triggered credential refresh");
+
+        assert_eq!(status, UploadStatus::Uploaded);
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "refresher should be invoked exactly once from the HEAD branch"
+        );
+    }
+
+    #[tokio::test]
+    async fn download_retries_and_refreshes_creds_on_expired_token() {
+        let server = MockServer::start().await;
+
+        // GET → ExpiredToken on first call, then 200 with an empty body.
+        Mock::given(method("GET"))
+            .respond_with(ExpireThenSucceed::new(1, 200, b"payload".to_vec(), vec![]))
+            .mount(&server)
+            .await;
+
+        let stage_info = make_stage_info(
+            &server.uri(),
+            make_s3_creds("STALE_KEY", "STALE_SECRET", "STALE_TOKEN"),
+        );
+        let (refresher, calls) =
+            CountingRefresher::new(make_s3_creds("FRESH_KEY", "FRESH_SECRET", "FRESH_TOKEN"));
+
+        let (data, _digest, meta) = download_from_s3(&stage_info, "file.txt", Some(refresher))
+            .await
+            .expect("download should succeed after credential refresh");
+
+        assert_eq!(data, b"payload");
+        assert!(meta.is_none());
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "exactly one credential refresh should happen"
+        );
+    }
+
+    #[tokio::test]
+    async fn upload_with_non_expired_token_error_does_not_trigger_refresh() {
+        let server = MockServer::start().await;
+        Mock::given(method("HEAD"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+        // Return a 400 with some *other* error code — we must not treat this
+        // as ExpiredToken and must not invoke the refresher.
+        let other_err = "<?xml version=\"1.0\"?><Error><Code>InvalidRequest</Code><Message>bad</Message></Error>";
+        Mock::given(method("PUT"))
+            .respond_with(
+                ResponseTemplate::new(400)
+                    .set_body_string(other_err)
+                    .insert_header("Content-Type", "application/xml"),
+            )
+            .mount(&server)
+            .await;
+
+        let stage_info = make_stage_info(
+            &server.uri(),
+            make_s3_creds("STALE_KEY", "STALE_SECRET", "STALE_TOKEN"),
+        );
+        let (refresher, calls) =
+            CountingRefresher::new(make_s3_creds("F_KEY", "F_SECRET", "F_TOKEN"));
+
+        let prepared = PreparedUpload {
+            data: b"x".to_vec(),
+            digest: "d".to_string(),
+            encryption_metadata: None,
+        };
+        let err = upload_to_s3_or_skip(prepared, &stage_info, "file.txt", true, Some(refresher))
+            .await
+            .expect_err("non-ExpiredToken error should propagate");
+
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            0,
+            "refresher must not be invoked for non-ExpiredToken errors"
+        );
+        assert!(matches!(err, UploadFileError::S3Upload { .. }));
+        assert!(!is_expired_token_upload_error(&err));
     }
 }

--- a/sf_core/src/file_manager/types.rs
+++ b/sf_core/src/file_manager/types.rs
@@ -1,7 +1,10 @@
 use crate::compression_types::CompressionType;
 use crate::sensitive::SensitiveString;
+use futures::future::BoxFuture;
 use serde::{Deserialize, Serialize};
+use snafu::{Location, Snafu};
 use std::fmt;
+use std::sync::Arc;
 
 /// Result of an upload-or-skip operation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -19,8 +22,12 @@ impl fmt::Display for UploadStatus {
     }
 }
 
-// Dedicated file transfer types
-#[derive(Debug)]
+// Dedicated file transfer types.
+//
+// `UploadData`/`DownloadData` carry an optional `Arc<dyn CredentialRefresher>`,
+// which has no `Debug` impl; we follow the codebase pattern (see
+// `DriverProviders` in `apis/database_driver_v1/global_state.rs`) and omit
+// `Debug` on these structs rather than hand-writing a redacting impl.
 pub struct UploadData {
     pub src_location_pattern: String,
     pub stage_info: StageInfo,
@@ -28,6 +35,9 @@ pub struct UploadData {
     pub auto_compress: bool,
     pub source_compression: SourceCompressionParam,
     pub overwrite: bool,
+    /// Re-fetches storage credentials when the cloud provider reports an
+    /// expired token. `None` makes expired tokens terminal.
+    pub credential_refresher: Option<Arc<dyn CredentialRefresher>>,
 }
 
 pub struct SingleUploadData {
@@ -40,15 +50,14 @@ pub struct SingleUploadData {
     pub overwrite: bool,
 }
 
-#[derive(Debug)]
 pub struct DownloadData {
     pub src_locations: Vec<String>,
     pub local_location: String,
     pub stage_info: StageInfo,
     pub encryption_materials: Vec<Option<EncryptionMaterial>>,
+    pub credential_refresher: Option<Arc<dyn CredentialRefresher>>,
 }
 
-#[derive(Debug)]
 pub struct SingleDownloadData {
     pub src_location: String,
     pub local_location: String,
@@ -127,6 +136,31 @@ pub struct StageInfo {
     pub storage_account: Option<String>,
 }
 
+/// Error returned by a `CredentialRefresher` when re-fetching storage
+/// credentials fails. The underlying error chain is preserved so
+/// `error_trace::ErrorTrace` can render it.
+#[derive(Debug, Snafu, error_trace::ErrorTrace)]
+#[snafu(visibility(pub))]
+pub enum CredentialRefreshError {
+    #[snafu(display("Failed to refresh storage credentials"))]
+    RefreshFailed {
+        source: Box<dyn std::error::Error + Send + Sync>,
+        #[snafu(implicit)]
+        location: Location,
+    },
+}
+
+/// Re-fetches cloud storage credentials when the cloud provider reports an
+/// expired token mid-transfer. Implementations typically re-execute the
+/// originating PUT/GET SQL command and parse fresh `stageInfo.creds`.
+///
+/// The trait is dyn-compat (`Arc<dyn CredentialRefresher>`), so `refresh`
+/// returns a `BoxFuture` — matching `CallerIdentityProvider` in
+/// `telemetry::platform_detection::aws`.
+pub trait CredentialRefresher: Send + Sync + 'static {
+    fn refresh(&self) -> BoxFuture<'_, Result<CloudCredentials, CredentialRefreshError>>;
+}
+
 /// Cloud storage credentials.
 #[derive(Debug, Clone)]
 pub enum CloudCredentials {
@@ -156,7 +190,10 @@ pub struct EncryptionMaterial {
 /// Prepared file data ready for cloud upload.
 /// For client-side encryption: contains encrypted data + encryption metadata.
 /// For server-side encryption (SSE): contains raw data with no encryption metadata.
-#[derive(Debug)]
+///
+/// `Clone` is used by the S3 credential-refresh retry loop, which re-submits
+/// the payload under fresh credentials on `ExpiredToken`.
+#[derive(Debug, Clone)]
 pub struct PreparedUpload {
     pub data: Vec<u8>,
     /// SHA-256 digest of the data (always present for integrity verification).
@@ -166,7 +203,7 @@ pub struct PreparedUpload {
 }
 
 /// Client-side encryption metadata that gets bundled with the uploaded data.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct EncryptedFileMetadata {
     pub encrypted_key: String, // Base64 encoded
     pub iv: String,            // Base64 encoded
@@ -174,7 +211,7 @@ pub struct EncryptedFileMetadata {
 }
 
 // Material description structure for JSON serialization
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MaterialDescription {
     #[serde(rename = "queryId")]
     pub query_id: String,

--- a/sf_core/src/rest/snowflake/heartbeat.rs
+++ b/sf_core/src/rest/snowflake/heartbeat.rs
@@ -169,14 +169,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn heartbeat_failure_response() {
+    async fn heartbeat_session_expired_on_390112_body() {
+        // HTTP 200 with a body-level 390112 must route to SessionExpired so
+        // RefreshContext can refresh and retry, matching the HTTP 401 case.
         let server = MockServer::start().await;
 
         Mock::given(method("POST"))
             .and(path("/session/heartbeat"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "success": false,
-                "message": "Session gone",
+                "message": "Session token expired",
                 "code": "390112"
             })))
             .mount(&server)
@@ -193,9 +195,51 @@ mod tests {
         .await;
 
         assert!(result.is_err());
+        let err = result.unwrap_err();
         assert!(
-            matches!(result.unwrap_err(), RestError::Heartbeat { .. }),
-            "Expected Heartbeat variant"
+            matches!(
+                &err,
+                RestError::InvalidSnowflakeResponse {
+                    source: crate::rest::snowflake::SnowflakeResponseError::SessionExpired { .. },
+                    ..
+                }
+            ),
+            "Expected SessionExpired, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn heartbeat_failure_on_other_code() {
+        // Non-390112 server-side failures pass through to RestError::Heartbeat.
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/session/heartbeat"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "success": false,
+                "message": "Some heartbeat failure",
+                "code": "390100"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = reqwest::Client::new();
+        let server_url = Url::parse(&server.uri()).unwrap();
+        let result = send_heartbeat(
+            &client,
+            &server_url,
+            &test_client_info(),
+            "test_session_token",
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert!(
+            matches!(
+                result.unwrap_err(),
+                RestError::Heartbeat { code: 390100, .. }
+            ),
+            "Expected Heartbeat variant with code 390100"
         );
     }
 }

--- a/sf_core/src/rest/snowflake/mod.rs
+++ b/sf_core/src/rest/snowflake/mod.rs
@@ -1525,9 +1525,23 @@ where
     let response_text = response_text.context(ResponseTextSnafu)?;
 
     tracing::debug!(response_len = response_text.len(), "Received HTTP response");
-    let response_data: T = serde_json::from_str(&response_text).context(ResponseFormatSnafu)?;
+    let value: serde_json::Value =
+        serde_json::from_str(&response_text).context(ResponseFormatSnafu)?;
 
-    Ok(response_data)
+    // 2xx with `success:false, code:"390112"` means the session token expired.
+    // Surface the same SessionExpired signal as the HTTP 401 branch so
+    // RefreshContext can refresh and retry.
+    if value.get("success") == Some(&serde_json::Value::Bool(false))
+        && value
+            .get("code")
+            .and_then(|c| c.as_str())
+            .and_then(|c| c.parse::<i32>().ok())
+            == Some(SESSION_TOKEN_EXPIRED)
+    {
+        return SessionExpiredSnafu.fail();
+    }
+
+    serde_json::from_value(value).context(ResponseFormatSnafu)
 }
 
 #[track_caller]
@@ -2527,6 +2541,77 @@ mod tests {
                 "requestId must be stable across HTTP-level retries: {:?}",
                 request_ids
             );
+        }
+    }
+
+    mod read_response_json_envelope {
+        use super::super::{SESSION_TOKEN_EXPIRED, SnowflakeResponseError, read_response_json};
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        #[derive(Debug, serde::Deserialize)]
+        struct EnvelopeFixture {
+            success: bool,
+            code: Option<String>,
+            message: Option<String>,
+        }
+
+        async fn fetch(body: serde_json::Value) -> Result<EnvelopeFixture, SnowflakeResponseError> {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/x"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(body))
+                .mount(&server)
+                .await;
+            let client = reqwest::Client::new();
+            let response = client
+                .post(format!("{}/x", server.uri()))
+                .send()
+                .await
+                .expect("test: mock request must send");
+            read_response_json::<EnvelopeFixture>(response).await
+        }
+
+        #[tokio::test]
+        async fn body_390112_returns_session_expired() {
+            let result = fetch(serde_json::json!({
+                "success": false,
+                "message": "Session token expired",
+                "code": "390112",
+            }))
+            .await;
+
+            let err = result.expect_err("390112 body must yield SessionExpired");
+            assert!(
+                matches!(err, SnowflakeResponseError::SessionExpired { .. }),
+                "expected SessionExpired, got {err:?}"
+            );
+            // Sanity: the shared constant matches the body code under test.
+            assert_eq!(SESSION_TOKEN_EXPIRED, 390112);
+        }
+
+        #[tokio::test]
+        async fn body_other_failure_code_passes_through() {
+            // Non-390112 failures must NOT be intercepted; the caller is
+            // responsible for mapping them to endpoint-specific errors.
+            let result = fetch(serde_json::json!({
+                "success": false,
+                "message": "Some other failure",
+                "code": "1003",
+            }))
+            .await;
+
+            let parsed = result.expect("non-390112 body must deserialize normally");
+            assert!(!parsed.success);
+            assert_eq!(parsed.code.as_deref(), Some("1003"));
+            assert_eq!(parsed.message.as_deref(), Some("Some other failure"));
+        }
+
+        #[tokio::test]
+        async fn body_success_true_passes_through() {
+            let result = fetch(serde_json::json!({ "success": true })).await;
+            let parsed = result.expect("success body must deserialize");
+            assert!(parsed.success);
         }
     }
 }

--- a/sf_core/src/rest/snowflake/query_response.rs
+++ b/sf_core/src/rest/snowflake/query_response.rs
@@ -385,6 +385,7 @@ impl Data {
             auto_compress,
             source_compression,
             overwrite,
+            credential_refresher: None,
         })
     }
 
@@ -446,7 +447,15 @@ impl Data {
             local_location,
             stage_info,
             encryption_materials,
+            credential_refresher: None,
         })
+    }
+
+    /// Borrow the raw `stageInfo` from this response, if present. Used by the
+    /// credential-refresh path to convert a re-executed PUT/GET response's
+    /// fresh stage credentials without re-building the full `UploadData`.
+    pub fn stage_info_ref(&self) -> Option<&StageInfo> {
+        self.stage_info.as_ref()
     }
 
     pub fn to_rowset_data<'a>(&'a self) -> RowsetData<'a> {
@@ -1195,9 +1204,10 @@ mod tests {
             ],"#,
         );
         let data: Data = serde_json::from_str(&json).unwrap();
-        let result = data.to_file_upload_data();
-        assert!(result.is_err());
-        let err_msg = result.unwrap_err().to_string();
+        let err_msg = match data.to_file_upload_data() {
+            Err(e) => e.to_string(),
+            Ok(_) => panic!("expected to_file_upload_data to fail"),
+        };
         assert!(
             err_msg.contains("Expected exactly one encryption material"),
             "Error should mention the constraint: {err_msg}"

--- a/sf_core/src/rest/snowflake/telemetry.rs
+++ b/sf_core/src/rest/snowflake/telemetry.rs
@@ -215,4 +215,44 @@ mod tests {
 
         assert!(result.is_err());
     }
+
+    #[tokio::test]
+    async fn send_telemetry_session_expired_on_390112_body() {
+        // HTTP 200 with a body-level 390112 must route to SessionExpired so
+        // RefreshContext can refresh and retry.
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/telemetry/send"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "success": false,
+                "message": "Session token expired",
+                "code": "390112"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = reqwest::Client::new();
+        let query_params = test_query_parameters(&server.uri());
+        let result = send_telemetry(
+            &client,
+            &query_params,
+            "test_session_token",
+            &json!({"logs": []}),
+        )
+        .await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            matches!(
+                &err,
+                RestError::InvalidSnowflakeResponse {
+                    source: crate::rest::snowflake::SnowflakeResponseError::SessionExpired { .. },
+                    ..
+                }
+            ),
+            "Expected SessionExpired, got: {err:?}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Adds an STS-token refresh path for S3 PUT/GET file transfers. When S3 returns `ExpiredToken` mid-transfer, the storage client re-fetches fresh stage credentials via a new `CredentialRefresher` trait and rebuilds the SDK client before retrying (bounded by `MAX_CREDENTIAL_REFRESH_ATTEMPTS = 2`). Mirrors `StorageCredential.update()` in the Python connector (`file_transfer_agent.py`, `storage_client.py`, `s3_storage_client.py`).
- HEAD failures carry no response body, so the SDK cannot populate the normal error code. S3 mirrors the code into the `x-amz-error-code` response header — we detect `ExpiredToken` there via a new `UploadFileError::HeadExpiredToken` variant.
- Production refresher (`PutGetCredentialRefresher`) re-executes the original PUT/GET SQL under `RefreshContext` and parses fresh `stageInfo.creds` from the response.

## Test plan

- [x] Added 6 wiremock-backed unit tests in `sf_core/src/file_manager/s3_transfer.rs::tests` covering upload-retry, download-retry, HEAD-refresh, no-refresher fail-fast, max-attempts give-up, and non-expired-token no-refresh.
- [x] Full `sf_core` unit test suite passes (721 tests).
- [x] `cargo clippy --workspace --lib` clean.
- [ ] E2E put/get against a real account to confirm no regression on the happy path.

## Notes

Spawned 4 review agents (security, consistency, readability, minimalism) before opening this PR and applied all MAJOR/MEDIUM findings. Two security MEDIUMs were deferred as out-of-scope for this PR:

1. **Refresh amplification across N files**: `stage_info` is cloned per file in `upload_files`/`download_files`, so a file batch after a refresh still starts from the original stale creds; a misbehaving server can induce `2 * N` PUT/GET re-executions. Fix would require caching the last-known-good creds on the refresher. Low-risk against a well-behaved Snowflake control plane.
2. **Ciphertext not zeroized**: `PreparedUpload.data: Vec<u8>` is cloned per attempt and isn't `Zeroize`. Pre-existing across all upload paths (GCS/Azure too), not introduced by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)