### PR TITLE
NO-SNOW: python - introduce CoreDriver facade to centralize protobuf API access

### DIFF
--- a/python/src/snowflake/connector/_internal/api_client/client_api.py
+++ b/python/src/snowflake/connector/_internal/api_client/client_api.py
@@ -18,6 +18,86 @@ from ..protobuf_gen.database_driver_v1_pb2 import (
     AuthenticationError as ProtoAuthenticationError,
 )
 from ..protobuf_gen.database_driver_v1_pb2 import (
+    ColumnMetadata,
+    ConfigGetPathsRequest,
+    ConfigGetPathsResponse,
+    ConfigLoadAllSectionsRequest,
+    ConfigLoadAllSectionsResponse,
+    ConfigSetting,
+    ConnectionAbortQueryRequest,
+    ConnectionAbortQueryResponse,
+    ConnectionCloseRequest,
+    ConnectionCloseResponse,
+    ConnectionGetAllParametersRequest,
+    ConnectionGetAllParametersResponse,
+    ConnectionGetInfoRequest,
+    ConnectionGetInfoResponse,
+    ConnectionGetParameterRequest,
+    ConnectionGetParameterResponse,
+    ConnectionGetQueryResultRequest,
+    ConnectionGetQueryStatusRequest,
+    ConnectionGetQueryStatusResponse,
+    ConnectionGetResultSetRequest,
+    ConnectionHandle,
+    ConnectionHeartbeatRequest,
+    ConnectionHeartbeatResponse,
+    ConnectionInitRequest,
+    ConnectionInitResponse,
+    ConnectionIsClosedRequest,
+    ConnectionIsClosedResponse,
+    ConnectionNewRequest,
+    ConnectionNewResponse,
+    ConnectionReleaseRequest,
+    ConnectionReleaseResponse,
+    ConnectionSendHttpRequest,
+    ConnectionSendHttpResponse,
+    ConnectionSetOptionsRequest,
+    ConnectionSetOptionsResponse,
+    ConnectionSetSessionParametersRequest,
+    ConnectionSetSessionParametersResponse,
+    ConnectionTokenRequest,
+    ConnectionTokenResponse,
+    DatabaseFetchChunkRequest,
+    DatabaseFetchChunkResponse,
+    DatabaseHandle,
+    DatabaseInitRequest,
+    DatabaseInitResponse,
+    DatabaseNewRequest,
+    DatabaseNewResponse,
+    DatabaseReleaseRequest,
+    DatabaseReleaseResponse,
+    ExecuteQueryResponse,
+    QueryBindings,
+    ResultChunk,
+    ResultSetGetChunksRequest,
+    ResultSetGetChunksResponse,
+    ResultSetGetStreamRequest,
+    ResultSetGetStreamResponse,
+    ResultSetHandle,
+    ResultSetReleaseRequest,
+    ResultSetReleaseResponse,
+    ResultSetResponse,
+    StatementExecuteAsyncRequest,
+    StatementExecuteAsyncResponse,
+    StatementExecuteQueryRequest,
+    StatementHandle,
+    StatementNewRequest,
+    StatementNewResponse,
+    StatementPrepareRequest,
+    StatementPrepareResponse,
+    StatementReleaseRequest,
+    StatementReleaseResponse,
+    StatementSetOptionsRequest,
+    StatementSetOptionsResponse,
+    StatementSetSqlQueryRequest,
+    StatementSetSqlQueryResponse,
+    TelemetrySendApiUsageRequest,
+    TelemetrySendResponse,
+    TelemetrySendWrapperErrorRequest,
+    TokenRequestType,
+    WrapperIdentity,
+)
+from ..protobuf_gen.database_driver_v1_pb2 import (
     InvalidParameterValue as ProtoInvalidParameterValue,
 )
 from ..protobuf_gen.database_driver_v1_pb2 import (
@@ -211,14 +291,266 @@ class ProtoTransport:
         raise ProtoTransportException(f"Unknown error code: {code}")
 
 
-_DATABASE_DRIVER_CLIENT: DatabaseDriverClient | None = None
-_DATABASE_DRIVER_CLIENT_LOCK = threading.Lock()
+class CoreDriver:
+    """Process-wide facade over ``DatabaseDriverClient``.
+
+    Lazily initializes the underlying protobuf client on first access
+    (thread-safe, double-checked lock) and exposes domain-level methods that
+    encapsulate all protobuf request construction so that callers never touch
+    ``*Request`` objects directly.
+    """
+
+    def __init__(self) -> None:
+        self._client: DatabaseDriverClient | None = None
+        self._lock = threading.Lock()
+
+    @property
+    def client(self) -> DatabaseDriverClient:
+        if self._client is not None:
+            return self._client
+
+        with self._lock:
+            if self._client is None:
+                self._client = DatabaseDriverClient(ProtoTransport(), error_handler=_proto_to_public_error)
+
+        return self._client
+
+    @client.setter
+    def client(self, client: DatabaseDriverClient | None) -> None:
+        self._client = client
+
+    # =====================================================================
+    # Database lifecycle
+    # =====================================================================
+
+    def database_new(self) -> DatabaseNewResponse:
+        request = DatabaseNewRequest()
+        return self.client.database_new(request)
+
+    def database_init(self, db_handle: DatabaseHandle) -> DatabaseInitResponse:
+        request = DatabaseInitRequest(db_handle=db_handle)
+        return self.client.database_init(request)
+
+    def database_release(self, db_handle: DatabaseHandle) -> DatabaseReleaseResponse:
+        request = DatabaseReleaseRequest(db_handle=db_handle)
+        return self.client.database_release(request)
+
+    # =====================================================================
+    # Connection lifecycle
+    # =====================================================================
+
+    def connection_new(self) -> ConnectionNewResponse:
+        request = ConnectionNewRequest()
+        return self.client.connection_new(request)
+
+    def connection_init(
+        self,
+        conn_handle: ConnectionHandle,
+        db_handle: DatabaseHandle,
+        wrapper_identity: WrapperIdentity,
+    ) -> ConnectionInitResponse:
+        request = ConnectionInitRequest(
+            conn_handle=conn_handle,
+            db_handle=db_handle,
+            wrapper_identity=wrapper_identity,
+        )
+        return self.client.connection_init(request)
+
+    def connection_set_options(
+        self,
+        conn_handle: ConnectionHandle,
+        options: dict[str, ConfigSetting],
+    ) -> ConnectionSetOptionsResponse:
+        request = ConnectionSetOptionsRequest(conn_handle=conn_handle, options=options)
+        return self.client.connection_set_options(request)
+
+    def connection_set_session_parameters(
+        self, conn_handle: ConnectionHandle, parameters: dict[str, str]
+    ) -> ConnectionSetSessionParametersResponse:
+        request = ConnectionSetSessionParametersRequest(conn_handle=conn_handle, parameters=parameters)
+        return self.client.connection_set_session_parameters(request)
+
+    def connection_close(self, conn_handle: ConnectionHandle) -> ConnectionCloseResponse:
+        request = ConnectionCloseRequest(conn_handle=conn_handle)
+        return self.client.connection_close(request)
+
+    def connection_release(self, conn_handle: ConnectionHandle) -> ConnectionReleaseResponse:
+        request = ConnectionReleaseRequest(conn_handle=conn_handle)
+        return self.client.connection_release(request)
+
+    def connection_is_closed(self, conn_handle: ConnectionHandle) -> ConnectionIsClosedResponse:
+        request = ConnectionIsClosedRequest(conn_handle=conn_handle)
+        return self.client.connection_is_closed(request)
+
+    def connection_heartbeat(self, conn_handle: ConnectionHandle) -> ConnectionHeartbeatResponse:
+        request = ConnectionHeartbeatRequest(conn_handle=conn_handle)
+        return self.client.connection_heartbeat(request)
+
+    def connection_get_info(
+        self,
+        conn_handle: ConnectionHandle,
+        include_master_token: bool = False,
+    ) -> ConnectionGetInfoResponse:
+        request = ConnectionGetInfoRequest(conn_handle=conn_handle, include_master_token=include_master_token)
+        return self.client.connection_get_info(request)
+
+    def connection_get_query_status(
+        self, conn_handle: ConnectionHandle, query_id: str
+    ) -> ConnectionGetQueryStatusResponse:
+        request = ConnectionGetQueryStatusRequest(conn_handle=conn_handle, query_id=query_id)
+        return self.client.connection_get_query_status(request)
+
+    # =====================================================================
+    # Connection data
+    # =====================================================================
+
+    def connection_get_result_set(self, conn_handle: ConnectionHandle, query_id: str) -> ResultSetResponse:
+        request = ConnectionGetResultSetRequest(conn_handle=conn_handle, query_id=query_id)
+        return self.client.connection_get_result_set(request)
+
+    def connection_get_query_result(self, conn_handle: ConnectionHandle, query_id: str) -> ExecuteQueryResponse:
+        request = ConnectionGetQueryResultRequest(conn_handle=conn_handle, query_id=query_id)
+        return self.client.connection_get_query_result(request)
+
+    def connection_abort_query(self, conn_handle: ConnectionHandle, query_id: str) -> ConnectionAbortQueryResponse:
+        request = ConnectionAbortQueryRequest(conn_handle=conn_handle, query_id=query_id)
+        return self.client.connection_abort_query(request)
+
+    def connection_send_http(
+        self,
+        conn_handle: ConnectionHandle,
+        method: str,
+        url: str,
+        headers: dict[str, str],
+        body: bytes | None = None,
+    ) -> ConnectionSendHttpResponse:
+        request = ConnectionSendHttpRequest(
+            conn_handle=conn_handle,
+            method=method,
+            url=url,
+            headers=headers,
+            body=body,
+        )
+        return self.client.connection_send_http(request)
+
+    # =====================================================================
+    # Connection tokens/params
+    # =====================================================================
+
+    def connection_request_token(
+        self, conn_handle: ConnectionHandle, request_type: TokenRequestType.ValueType
+    ) -> ConnectionTokenResponse:
+        request = ConnectionTokenRequest(conn_handle=conn_handle, request_type=request_type)
+        return self.client.connection_request_token(request)
+
+    def connection_get_parameter(self, conn_handle: ConnectionHandle, key: str) -> ConnectionGetParameterResponse:
+        request = ConnectionGetParameterRequest(conn_handle=conn_handle, key=key)
+        return self.client.connection_get_parameter(request)
+
+    def connection_get_all_parameters(self, conn_handle: ConnectionHandle) -> ConnectionGetAllParametersResponse:
+        request = ConnectionGetAllParametersRequest(conn_handle=conn_handle)
+        return self.client.connection_get_all_parameters(request)
+
+    # =====================================================================
+    # Statement lifecycle
+    # =====================================================================
+
+    def statement_new(self, conn_handle: ConnectionHandle) -> StatementNewResponse:
+        request = StatementNewRequest(conn_handle=conn_handle)
+        return self.client.statement_new(request)
+
+    def statement_set_query(self, stmt_handle: StatementHandle, query: str) -> StatementSetSqlQueryResponse:
+        request = StatementSetSqlQueryRequest(stmt_handle=stmt_handle, query=query)
+        return self.client.statement_set_sql_query(request)
+
+    def statement_release(self, stmt_handle: StatementHandle) -> StatementReleaseResponse:
+        request = StatementReleaseRequest(stmt_handle=stmt_handle)
+        return self.client.statement_release(request)
+
+    def statement_set_options(
+        self, stmt_handle: StatementHandle, options: dict[str, ConfigSetting]
+    ) -> StatementSetOptionsResponse:
+        request = StatementSetOptionsRequest(stmt_handle=stmt_handle, options=options)
+        return self.client.statement_set_options(request)
+
+    def statement_execute_query(
+        self, stmt_handle: StatementHandle, bindings: QueryBindings | None = None
+    ) -> ExecuteQueryResponse:
+        request = StatementExecuteQueryRequest(stmt_handle=stmt_handle, bindings=bindings)
+        return self.client.statement_execute_query(request)
+
+    def statement_execute_async(
+        self, stmt_handle: StatementHandle, bindings: QueryBindings | None = None
+    ) -> StatementExecuteAsyncResponse:
+        request = StatementExecuteAsyncRequest(stmt_handle=stmt_handle, bindings=bindings)
+        return self.client.statement_execute_async(request)
+
+    def statement_prepare(self, stmt_handle: StatementHandle) -> StatementPrepareResponse:
+        request = StatementPrepareRequest(stmt_handle=stmt_handle)
+        return self.client.statement_prepare(request)
+
+    # =====================================================================
+    # Result set
+    # =====================================================================
+
+    def result_set_release(self, result_set_handle: ResultSetHandle) -> ResultSetReleaseResponse:
+        request = ResultSetReleaseRequest(result_set_handle=result_set_handle)
+        return self.client.result_set_release(request)
+
+    def result_set_get_stream(self, result_set_handle: ResultSetHandle) -> ResultSetGetStreamResponse:
+        request = ResultSetGetStreamRequest(result_set_handle=result_set_handle)
+        return self.client.result_set_get_stream(request)
+
+    def result_set_get_chunks(self, result_set_handle: ResultSetHandle) -> ResultSetGetChunksResponse:
+        request = ResultSetGetChunksRequest(result_set_handle=result_set_handle)
+        return self.client.result_set_get_chunks(request)
+
+    # =====================================================================
+    # Database fetch
+    # =====================================================================
+
+    def database_fetch_chunk(
+        self,
+        db_handle: DatabaseHandle,
+        chunk: ResultChunk,
+        columns: list[ColumnMetadata],
+    ) -> DatabaseFetchChunkResponse:
+        request = DatabaseFetchChunkRequest(db_handle=db_handle, chunk=chunk, columns=columns)
+        return self.client.database_fetch_chunk(request)
+
+    # =====================================================================
+    # Telemetry
+    # =====================================================================
+
+    def telemetry_send_api_usage(self, conn_handle: ConnectionHandle, api_method: str) -> TelemetrySendResponse:
+        request = TelemetrySendApiUsageRequest(conn_handle=conn_handle, api_method=api_method)
+        return self.client.telemetry_send_api_usage(request)
+
+    def telemetry_send_wrapper_error(
+        self, conn_handle: ConnectionHandle, exception_type: str, error_source: str
+    ) -> TelemetrySendResponse:
+        request = TelemetrySendWrapperErrorRequest(
+            conn_handle=conn_handle,
+            exception_type=exception_type,
+            error_source=error_source,
+        )
+        return self.client.telemetry_send_wrapper_error(request)
+
+    # =====================================================================
+    # Config
+    # =====================================================================
+
+    def config_load_all_sections(
+        self,
+        config_file: str,
+        connections_file: str | None = None,
+    ) -> ConfigLoadAllSectionsResponse:
+        request = ConfigLoadAllSectionsRequest(config_file=config_file, connections_file=connections_file)
+        return self.client.config_load_all_sections(request)
+
+    def config_get_paths(self) -> ConfigGetPathsResponse:
+        request = ConfigGetPathsRequest()
+        return self.client.config_get_paths(request)
 
 
-def database_driver_client() -> DatabaseDriverClient:
-    global _DATABASE_DRIVER_CLIENT
-    if _DATABASE_DRIVER_CLIENT is None:
-        with _DATABASE_DRIVER_CLIENT_LOCK:
-            if _DATABASE_DRIVER_CLIENT is None:
-                _DATABASE_DRIVER_CLIENT = DatabaseDriverClient(ProtoTransport(), error_handler=_proto_to_public_error)
-    return _DATABASE_DRIVER_CLIENT
+core_driver = CoreDriver()

--- a/python/src/snowflake/connector/_internal/freezable_proxy.py
+++ b/python/src/snowflake/connector/_internal/freezable_proxy.py
@@ -6,12 +6,7 @@ import threading
 
 from typing import Any
 
-from .protobuf_gen.database_driver_v1_pb2 import (
-    ConnectionGetAllParametersRequest,
-    ConnectionGetInfoRequest,
-    ConnectionGetInfoResponse,
-    ConnectionGetParameterRequest,
-)
+from .api_client.client_api import core_driver
 
 
 class FreezableProxy:
@@ -21,14 +16,13 @@ class FreezableProxy:
     Call freeze() before releasing the underlying handles.
     """
 
-    def __init__(self, db_api: Any, conn_handle: Any) -> None:
-        self._db_api = db_api
+    def __init__(self, conn_handle: Any) -> None:
         self._conn_handle = conn_handle
         self._cache: dict[str, Any] | None = None
         self._freeze_lock = threading.Lock()
 
     def freeze(self) -> None:
-        """Take a snapshot and release references to db_api/conn_handle.
+        """Take a snapshot and release references to conn_handle.
 
         Thread-safe: concurrent close() calls race through here; double-checked
         locking ensures only the first caller fetches and the rest no-op.
@@ -38,7 +32,6 @@ class FreezableProxy:
         with self._freeze_lock:
             if self._cache is None:
                 self._cache = self._fetch_all()
-                self._db_api = None
                 self._conn_handle = None
 
     def _fetch_one(self, key: str) -> Any:
@@ -57,13 +50,11 @@ class SessionParametersProxy(FreezableProxy):
     """Proxy for Snowflake session parameters (case-insensitive keys)."""
 
     def _fetch_one(self, name: str) -> str | None:
-        request = ConnectionGetParameterRequest(conn_handle=self._conn_handle, key=name)
-        response = self._db_api.connection_get_parameter(request)
+        response = core_driver.connection_get_parameter(conn_handle=self._conn_handle, key=name)
         return response.value if response.value else None
 
     def _fetch_all(self) -> dict[str, str]:
-        request = ConnectionGetAllParametersRequest(conn_handle=self._conn_handle)
-        response = self._db_api.connection_get_all_parameters(request)
+        response = core_driver.connection_get_all_parameters(conn_handle=self._conn_handle)
         return {k.upper(): v for k, v in response.parameters.items()}
 
     def __getitem__(self, name: str) -> str | None:
@@ -81,18 +72,15 @@ class ConnectionInfoProxy(FreezableProxy):
     This matches the pre-proxy behavior where each property did its own RPC.
     """
 
-    def _fetch_info(self, include_master_token: bool = False) -> ConnectionGetInfoResponse:
-        request = ConnectionGetInfoRequest(
-            conn_handle=self._conn_handle,
-            include_master_token=include_master_token,
-        )
-        result: ConnectionGetInfoResponse = self._db_api.connection_get_info(request)
-        return result
-
     def _fetch_one(self, field: str) -> Any:
-        info = self._fetch_info()
+        info = core_driver.connection_get_info(
+            conn_handle=self._conn_handle,
+        )
         return getattr(info, field) if info.HasField(field) else None  # type: ignore[arg-type]
 
     def _fetch_all(self) -> dict[str, Any]:
-        info = self._fetch_info(include_master_token=True)
+        info = core_driver.connection_get_info(
+            conn_handle=self._conn_handle,
+            include_master_token=True,
+        )
         return {desc.name: value for desc, value in info.ListFields()}

--- a/python/src/snowflake/connector/_internal/snowflake_restful.py
+++ b/python/src/snowflake/connector/_internal/snowflake_restful.py
@@ -5,12 +5,11 @@ import json
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
+from snowflake.connector._internal.api_client.client_api import core_driver
 from snowflake.connector._internal.protobuf_gen.database_driver_v1_pb2 import (
     TOKEN_REQUEST_TYPE_ISSUE,
     TOKEN_REQUEST_TYPE_RENEW,
     ConnectionGetInfoResponse,
-    ConnectionSendHttpRequest,
-    ConnectionTokenRequest,
 )
 from snowflake.connector.errors import OperationalError
 
@@ -127,16 +126,13 @@ class SnowflakeRestful:
         else:
             encoded_body = None
 
-        request = ConnectionSendHttpRequest(
-            conn_handle=self._connection.conn_handle,
+        response = core_driver.connection_send_http(
+            conn_handle=self._connection.conn_handle,  # type: ignore[arg-type]
             method=method,
             url=url,
             headers=headers or {},
+            body=encoded_body,
         )
-        if encoded_body is not None:
-            request.body = encoded_body
-
-        response = self._connection.db_api.connection_send_http(request)
         return response.status_code, dict(response.headers), response.body
 
     _SUPPORTED_REQUEST_METHODS = {"get", "post"}
@@ -208,11 +204,10 @@ class SnowflakeRestful:
         if proto_type is None:
             raise ValueError(f"Unknown token request type: {request_type!r}. Must be 'ISSUE' or 'RENEW'.")
 
-        request = ConnectionTokenRequest(
-            conn_handle=self._connection.conn_handle,
+        response = core_driver.connection_request_token(
+            conn_handle=self._connection.conn_handle,  # type: ignore[arg-type]
             request_type=proto_type,
         )
-        response = self._connection.db_api.connection_request_token(request)
         data: dict = {"sessionToken": response.session_token}
         if response.HasField("validity_in_seconds"):
             data["validityInSecondsST"] = response.validity_in_seconds

--- a/python/src/snowflake/connector/_internal/statement_utils.py
+++ b/python/src/snowflake/connector/_internal/statement_utils.py
@@ -2,27 +2,21 @@ from __future__ import annotations
 
 from collections.abc import Generator
 from contextlib import contextmanager
-from typing import TYPE_CHECKING
 
+from .api_client.client_api import core_driver
 from .protobuf_gen.database_driver_v1_pb2 import (
+    ConnectionHandle,
     DatabaseFetchChunkResponse,
     PrepareResult,
     ResultSetDescriptor,
     ResultSetGetStreamResponse,
     StatementHandle,
-    StatementNewRequest,
-    StatementReleaseRequest,
-    StatementSetSqlQueryRequest,
 )
 from .sqlstate import SQLSTATE_SUCCESS
 
 
-if TYPE_CHECKING:
-    from ..connection import Connection
-
-
 @contextmanager
-def statement(connection: Connection, query: str) -> Generator[StatementHandle]:
+def statement(conn_handle: ConnectionHandle, query: str) -> Generator[StatementHandle]:
     """Context manager that owns the full lifecycle of a statement handle.
 
     Allocates a new statement on the server, binds the given SQL query to it,
@@ -31,36 +25,19 @@ def statement(connection: Connection, query: str) -> Generator[StatementHandle]:
     is raised.
 
     Args:
-        connection: Active Snowflake connection used to issue gRPC calls.
+        conn_handle: Active Snowflake conn_handle.
         query: SQL text to bind to the newly created statement.
 
     Yields:
         StatementHandle: A handle that can be passed to ``statement_execute``
         or other statement-level APIs.
     """
-    stmt_handle = _new_stmt(connection)
+    stmt_handle = core_driver.statement_new(conn_handle=conn_handle).stmt_handle
     try:
-        _set_query(connection, stmt_handle, query)
+        core_driver.statement_set_query(stmt_handle=stmt_handle, query=query)
         yield stmt_handle
     finally:
-        _release_stmt(connection, stmt_handle)
-
-
-def _new_stmt(connection: Connection) -> StatementHandle:
-    statement_request = StatementNewRequest(conn_handle=connection.conn_handle)
-    stmt = connection.db_api.statement_new(request=statement_request)
-    return stmt.stmt_handle
-
-
-def _set_query(connection: Connection, stmt_handle: StatementHandle, query: str) -> None:
-    sql_query_request = StatementSetSqlQueryRequest(stmt_handle=stmt_handle, query=query)
-    connection.db_api.statement_set_sql_query(sql_query_request)
-
-
-def _release_stmt(connection: Connection, stmt_handle: StatementHandle | None) -> None:
-    if stmt_handle:
-        release_request = StatementReleaseRequest(stmt_handle=stmt_handle)
-        connection.db_api.statement_release(release_request)
+        core_driver.statement_release(stmt_handle=stmt_handle)
 
 
 def get_stream_ptr(result: DatabaseFetchChunkResponse | PrepareResult | ResultSetGetStreamResponse | None) -> int:

--- a/python/src/snowflake/connector/_internal/telemetry.py
+++ b/python/src/snowflake/connector/_internal/telemetry.py
@@ -10,16 +10,12 @@ import logging
 
 from typing import TYPE_CHECKING
 
-from snowflake.connector._internal.protobuf_gen.database_driver_v1_services import (
-    TelemetrySendApiUsageRequest,
-    TelemetrySendWrapperErrorRequest,
-)
+from .api_client.client_api import core_driver
 
 
 if TYPE_CHECKING:
     from snowflake.connector._internal.protobuf_gen.database_driver_v1_services import (
         ConnectionHandle,
-        DatabaseDriverClient,
     )
 
 logger = logging.getLogger(__name__)
@@ -32,18 +28,15 @@ class TelemetryClient:
     sends runtime events — sf_core attaches the stored identity automatically.
     """
 
-    def __init__(self, db_api: DatabaseDriverClient, conn_handle: ConnectionHandle) -> None:
-        self._db_api = db_api
+    def __init__(self, conn_handle: ConnectionHandle) -> None:
         self._conn_handle = conn_handle
 
     def send_api_usage(self, api_method: str) -> None:
         """Record an API method call for telemetry."""
         try:
-            self._db_api.telemetry_send_api_usage(
-                TelemetrySendApiUsageRequest(
-                    conn_handle=self._conn_handle,
-                    api_method=api_method,
-                )
+            core_driver.telemetry_send_api_usage(
+                conn_handle=self._conn_handle,
+                api_method=api_method,
             )
         except Exception:
             logger.debug("Failed to send api_usage telemetry", exc_info=True)
@@ -51,12 +44,10 @@ class TelemetryClient:
     def send_wrapper_error(self, exception_type: str, error_source: str) -> None:
         """Record a wrapper error for telemetry."""
         try:
-            self._db_api.telemetry_send_wrapper_error(
-                TelemetrySendWrapperErrorRequest(
-                    conn_handle=self._conn_handle,
-                    exception_type=exception_type,
-                    error_source=error_source,
-                )
+            core_driver.telemetry_send_wrapper_error(
+                conn_handle=self._conn_handle,
+                exception_type=exception_type,
+                error_source=error_source,
             )
         except Exception:
             logger.debug("Failed to send wrapper_error telemetry", exc_info=True)

--- a/python/src/snowflake/connector/config_manager.py
+++ b/python/src/snowflake/connector/config_manager.py
@@ -18,8 +18,7 @@ from typing import Any, Literal, NamedTuple, TypeVar
 
 import tomlkit
 
-from ._internal.api_client.client_api import database_driver_client
-from ._internal.protobuf_gen.database_driver_v1_pb2 import ConfigGetPathsRequest, ConfigLoadAllSectionsRequest
+from ._internal.api_client.client_api import core_driver
 from ._internal.protobuf_gen.proto_exception import ProtoApplicationException
 from .errors import ConfigManagerError, ConfigSourceError, MissingConfigOptionError
 from .errors import Error as DriverError
@@ -238,16 +237,13 @@ class ConfigManager:
         if self.file_path is None:
             raise ConfigManagerError("ConfigManager is trying to read config file, but it doesn't have one")
 
-        request = ConfigLoadAllSectionsRequest()
-        request.config_file = str(self.file_path)
-
         connections_file = self._get_connections_file_path()
-        if connections_file is not None:
-            request.connections_file = str(connections_file)
 
         try:
-            client = database_driver_client()
-            response = client.config_load_all_sections(request)
+            response = core_driver.config_load_all_sections(
+                config_file=str(self.file_path),
+                connections_file=str(connections_file) if connections_file is not None else None,
+            )
         except (ProtoApplicationException, DriverError) as e:
             msg = _extract_error_msg(e)
             if "permission" in msg.lower() or "Permission denied" in msg:
@@ -329,8 +325,7 @@ class ConfigManager:
 
 def _get_config_paths_from_core() -> tuple[Path, Path]:
     """Retrieve config file paths from sf_core via protobuf."""
-    client = database_driver_client()
-    response = client.config_get_paths(ConfigGetPathsRequest())
+    response = core_driver.config_get_paths()
     return Path(response.config_file), Path(response.connections_file)
 
 

--- a/python/src/snowflake/connector/connection.py
+++ b/python/src/snowflake/connector/connection.py
@@ -18,7 +18,7 @@ from functools import cached_property
 from io import StringIO
 from typing import Any, TypeVar, cast
 
-from ._internal.api_client.client_api import database_driver_client
+from ._internal.api_client.client_api import core_driver
 from ._internal.binding_converters import ParamStyle
 from ._internal.config_utils import create_config_settings_from_dict
 from ._internal.decorators import api_telemetry, backward_compatibility, internal_api, pep249
@@ -37,21 +37,8 @@ from ._internal.protobuf_gen.database_driver_v1_pb2 import (
     WrapperIdentity,
 )
 from ._internal.protobuf_gen.database_driver_v1_services import (
-    ConnectionCloseRequest,
-    ConnectionGetInfoRequest,
     ConnectionGetInfoResponse,
-    ConnectionGetQueryStatusRequest,
     ConnectionGetQueryStatusResponse,
-    ConnectionHeartbeatRequest,
-    ConnectionInitRequest,
-    ConnectionIsClosedRequest,
-    ConnectionNewRequest,
-    ConnectionReleaseRequest,
-    ConnectionSetOptionsRequest,
-    ConnectionSetSessionParametersRequest,
-    DatabaseInitRequest,
-    DatabaseNewRequest,
-    DatabaseReleaseRequest,
 )
 from ._internal.snowflake_restful import SnowflakeRestful
 from ._internal.sqlstate import SQLSTATE_CONNECTION_NOT_EXISTS
@@ -173,10 +160,9 @@ class Connection(ErrorHandlerMixin):
         # Defaults to False to match the old connector's behavior.
         self._interpolate_empty_sequences: bool = False
 
-        self.db_api = database_driver_client()
-        self.db_handle: DatabaseHandle | None = self.db_api.database_new(DatabaseNewRequest()).db_handle
-        self.db_api.database_init(DatabaseInitRequest(db_handle=self.db_handle))
-        self.conn_handle: ConnectionHandle | None = self.db_api.connection_new(ConnectionNewRequest()).conn_handle
+        self.db_handle: DatabaseHandle | None = core_driver.database_new().db_handle
+        core_driver.database_init(db_handle=self.db_handle)
+        self.conn_handle: ConnectionHandle | None = core_driver.connection_new().conn_handle
 
         # The LogoutConfig modifier re-applies the legacy Python wrapper
         # behaviour (default ``enable_server_session_keep_alive_auto_detection=True``
@@ -189,21 +175,14 @@ class Connection(ErrorHandlerMixin):
         )
 
         if options:
-            response = self.db_api.connection_set_options(
-                ConnectionSetOptionsRequest(
-                    conn_handle=self.conn_handle,
-                    options=options,
-                )
-            )
+            response = core_driver.connection_set_options(conn_handle=self.conn_handle, options=options)
             for warning in response.warnings:
                 warnings.warn(warning.message, stacklevel=2)
 
         # Set session parameters if provided (before connection_init)
         session_params = self.config.session_parameters
         if session_params:
-            self.db_api.connection_set_session_parameters(
-                ConnectionSetSessionParametersRequest(conn_handle=self.conn_handle, parameters=session_params)
-            )
+            core_driver.connection_set_session_parameters(conn_handle=self.conn_handle, parameters=session_params)
 
         # Initialise close-lifecycle state before ``_connect()`` so that the
         # ``__del__`` / atexit fail-safes always observe a sane object even
@@ -215,28 +194,25 @@ class Connection(ErrorHandlerMixin):
 
         self._connect()
 
-        self._session_parameters = SessionParametersProxy(self.db_api, self.conn_handle)
-        self._connection_info = ConnectionInfoProxy(self.db_api, self.conn_handle)
+        self._session_parameters = SessionParametersProxy(self.conn_handle)
+        self._connection_info = ConnectionInfoProxy(self.conn_handle)
 
     def _connect(self) -> None:
         """Establish the connection to Snowflake via the Rust core."""
-        self.db_api.connection_init(
-            ConnectionInitRequest(
-                conn_handle=self.conn_handle,
-                db_handle=self.db_handle,
-                wrapper_identity=WrapperIdentity(
-                    driver_name=_APPLICATION_NAME,
-                    driver_version=__version__,
-                    language_runtime=platform.python_implementation(),
-                    language_version=platform.python_version(),
-                    language_compiler=platform.python_compiler(),
-                ),
-            )
+        core_driver.connection_init(
+            conn_handle=self.conn_handle,  # type: ignore[arg-type]
+            db_handle=self.db_handle,  # type: ignore[arg-type]
+            wrapper_identity=WrapperIdentity(
+                driver_name=_APPLICATION_NAME,
+                driver_version=__version__,
+                language_runtime=platform.python_implementation(),
+                language_version=platform.python_version(),
+                language_compiler=platform.python_compiler(),
+            ),
         )
         from ._internal.telemetry import TelemetryClient
 
         self._telemetry_client = TelemetryClient(
-            db_api=self.db_api,
             conn_handle=cast(ConnectionHandle, self.conn_handle),
         )
 
@@ -280,18 +256,13 @@ class Connection(ErrorHandlerMixin):
         try:
             if conn_handle:
                 if not retry:
-                    self.db_api.connection_set_options(
-                        ConnectionSetOptionsRequest(
-                            conn_handle=conn_handle,
-                            options=create_config_settings_from_dict({LogoutOptionKeys.LOGOUT_MAX_ATTEMPTS: 1}),
-                        )
+                    core_driver.connection_set_options(
+                        conn_handle=conn_handle,
+                        options=create_config_settings_from_dict({LogoutOptionKeys.LOGOUT_MAX_ATTEMPTS: 1}),
                     )
 
-                # Logout + mark closed in Core (network I/O, bounded by Core's timeout)
-                self.db_api.connection_close(ConnectionCloseRequest(conn_handle=conn_handle))
+                core_driver.connection_close(conn_handle=conn_handle)
         finally:
-            # Release handles in Core's object store.
-            # Separated from connection_close for future connection pooling.
             if conn_handle:
                 self._release_connection_handle(conn_handle)
             if db_handle:
@@ -325,14 +296,14 @@ class Connection(ErrorHandlerMixin):
     def _release_connection_handle(self, conn_handle: ConnectionHandle) -> None:
         """Release the Rust-side connection handle."""
         try:
-            self.db_api.connection_release(ConnectionReleaseRequest(conn_handle=conn_handle))
+            core_driver.connection_release(conn_handle=conn_handle)
         except Exception:
             logger.warning("Failed to release connection handle", exc_info=True)
 
     def _release_database_handle(self, db_handle: DatabaseHandle) -> None:
         """Release the Rust-side database handle."""
         try:
-            self.db_api.database_release(DatabaseReleaseRequest(db_handle=db_handle))
+            core_driver.database_release(db_handle=db_handle)
         except Exception:
             logger.warning("Failed to release database handle", exc_info=True)
 
@@ -491,10 +462,9 @@ class Connection(ErrorHandlerMixin):
         since a released handle means close() already completed.
         """
         try:
-            response = self.db_api.connection_is_closed(ConnectionIsClosedRequest(conn_handle=self.conn_handle))
+            response = core_driver.connection_is_closed(conn_handle=self.conn_handle)  # type: ignore[arg-type]
             return bool(response.is_closed)
         except Exception:
-            # Handle released or FFI unavailable — connection is closed
             return True
 
     def is_valid(self) -> bool:
@@ -505,9 +475,8 @@ class Connection(ErrorHandlerMixin):
         if self.is_closed():
             return False
         try:
-            request = ConnectionHeartbeatRequest(conn_handle=self.conn_handle)
-            response = self.db_api.connection_heartbeat(request)
-            return response.valid
+            response = core_driver.connection_heartbeat(conn_handle=self.conn_handle)  # type: ignore[arg-type]
+            return bool(response.valid)
         except Exception:
             return False
 
@@ -598,11 +567,9 @@ class Connection(ErrorHandlerMixin):
     @internal_api
     def _get_connection_info(self, include_master_token: bool = False) -> ConnectionGetInfoResponse:
         """Return connection details from Core."""
-        return self.db_api.connection_get_info(
-            ConnectionGetInfoRequest(
-                conn_handle=self.conn_handle,
-                include_master_token=include_master_token,
-            )
+        return core_driver.connection_get_info(
+            conn_handle=self.conn_handle,  # type: ignore[arg-type]
+            include_master_token=include_master_token,
         )
 
     @internal_api
@@ -842,9 +809,7 @@ class Connection(ErrorHandlerMixin):
         """Fetch query status from the server and map the status name to a QueryStatus enum value."""
         if self.is_closed():
             return QueryStatus.DISCONNECTED, ConnectionGetQueryStatusResponse()
-        response = self.db_api.connection_get_query_status(
-            ConnectionGetQueryStatusRequest(conn_handle=self.conn_handle, query_id=sf_qid)
-        )
+        response = core_driver.connection_get_query_status(conn_handle=self.conn_handle, query_id=sf_qid)  # type: ignore[arg-type]
         try:
             status = QueryStatus[response.status_name]
         except KeyError:

--- a/python/src/snowflake/connector/cursor/_base.py
+++ b/python/src/snowflake/connector/cursor/_base.py
@@ -17,6 +17,7 @@ import logging
 from collections.abc import Callable, Iterator, Sequence
 from typing import TYPE_CHECKING, Any, TypeVar, cast, overload
 
+from .._internal.api_client.client_api import core_driver
 from .._internal.arrow_stream_utils import (
     collect_arrow_table,
     create_row_iterator,
@@ -34,19 +35,12 @@ from .._internal.errorhandler import ErrorHandlerMixin
 from .._internal.extras import check_dependency, pandas, pyarrow, requires_dependency
 from .._internal.protobuf_gen.database_driver_v1_pb2 import (
     BinaryDataPtr,
-    ConnectionAbortQueryRequest,
-    ConnectionGetQueryResultRequest,
-    ConnectionGetResultSetRequest,
     ExecuteQueryResponse,
     MultiStatementResult,
     PrepareResult,
     QueryBindings,
     ResultSetResponse,
-    StatementExecuteAsyncRequest,
-    StatementExecuteQueryRequest,
     StatementHandle,
-    StatementPrepareRequest,
-    StatementSetOptionsRequest,
 )
 from .._internal.statement_utils import statement
 from ..errors import Error, ErrorValue, InterfaceError, NotSupportedError, ProgrammingError
@@ -180,7 +174,7 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
         self._rownumber: int = -1
 
         # -- ResultSet guard (set by _execute, cleared on reset) --
-        self._result_set = _ResultSetWrapper(connection.db_api)
+        self._result_set = _ResultSetWrapper()
 
         # -- Multi-statement navigation (set by _handle_multi_statement_response, cleared on reset) --
         self._multi_statement: _MultiStatementQueryResultState | None = None
@@ -511,7 +505,7 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
 
         query, bindings = self._prepare_query(operation, parameters)
 
-        with statement(self.connection, query) as stmt_handle:
+        with statement(self.connection.conn_handle, query) as stmt_handle:  # type: ignore[arg-type]
             if self._statement_parameters:
                 self._apply_statement_parameters(stmt_handle)
 
@@ -540,15 +534,12 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
             if setting is not None:
                 options[key] = setting
 
-        # Send single RPC with all options
-        request = StatementSetOptionsRequest(stmt_handle=stmt_handle, options=options)
-        self._connection.db_api.statement_set_options(request)
+        core_driver.statement_set_options(stmt_handle=stmt_handle, options=options)
 
     def _execute_query(self, stmt_handle: StatementHandle, bindings: QueryBindings | None) -> ExecuteQueryResponse:
         """Execute query and return ExecuteQueryResponse (single or multi)."""
         try:
-            request = StatementExecuteQueryRequest(stmt_handle=stmt_handle, bindings=bindings)
-            return self._connection.db_api.statement_execute_query(request)
+            return core_driver.statement_execute_query(stmt_handle=stmt_handle, bindings=bindings)
         except ProgrammingError as exc:
             self._query_result = _QueryResult.from_programming_error(exc)
             raise
@@ -573,11 +564,10 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
     def _fetch_result_set_by_query_id(self, query_id: str) -> ResultSetResponse:
         """Fetch a ResultSetResponse (handle + descriptor) for a given query ID."""
         try:
-            request = ConnectionGetResultSetRequest(
-                conn_handle=self._connection.conn_handle,
+            return core_driver.connection_get_result_set(
+                conn_handle=self._connection.conn_handle,  # type: ignore[arg-type]
                 query_id=query_id,
             )
-            return self._connection.db_api.connection_get_result_set(request)
         except Exception as exc:
             if isinstance(exc, ProgrammingError):
                 raise
@@ -585,8 +575,7 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
 
     def _prepare(self, stmt_handle: StatementHandle) -> PrepareResult | None:
         try:
-            request = StatementPrepareRequest(stmt_handle=stmt_handle)
-            return self._connection.db_api.statement_prepare(request).result
+            return core_driver.statement_prepare(stmt_handle=stmt_handle).result
         except ProgrammingError as exc:
             self._query_result = _QueryResult.from_programming_error(exc)
             raise
@@ -685,7 +674,7 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
         query, bindings = self._prepare_query(operation, parameters)
 
         prepare_result: PrepareResult | None = None
-        with statement(self.connection, query) as stmt_handle:
+        with statement(self.connection.conn_handle, query) as stmt_handle:  # type: ignore[arg-type]
             prepare_result = self._prepare(stmt_handle)
 
         self._query_result = _QueryResult.from_prepare_result(prepare_result)
@@ -1130,7 +1119,8 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
     @api_telemetry
     @_requires_open
     def query_result(self, qid: str) -> SnowflakeCursorBase:
-        """Fetch the result of a previously executed query by its Snowflake Query ID.
+        """
+        Fetch the result of a previously executed query by its Snowflake Query ID.
 
         Resets the cursor and populates it with the results from the specified
         query, making them available through the standard fetch methods
@@ -1148,11 +1138,10 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
         """
         self.reset()
 
-        request = ConnectionGetQueryResultRequest(
-            conn_handle=self._connection.conn_handle,
+        response = core_driver.connection_get_query_result(
+            conn_handle=self._connection.conn_handle,  # type: ignore[arg-type]
             query_id=qid,
         )
-        response = self._connection.db_api.connection_get_query_result(request)
 
         # Handle single or multi-statement response
         if response.HasField("multi"):
@@ -1243,9 +1232,8 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
         query, bindings = self._prepare_query(command, params)
 
         response = None
-        with statement(self._connection, query) as stmt_handle:
-            request = StatementExecuteAsyncRequest(stmt_handle=stmt_handle, bindings=bindings)
-            response = self._connection.db_api.statement_execute_async(request)
+        with statement(self._connection.conn_handle, query) as stmt_handle:  # type: ignore[arg-type]
+            response = core_driver.statement_execute_async(stmt_handle=stmt_handle, bindings=bindings)
 
         query_id = (response.query_id if response.query_id else None) if response else None
         self._query_result = _QueryResult(sfqid=query_id)
@@ -1256,9 +1244,8 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
     @_requires_open
     def abort_query(self, qid: str) -> bool:
         """Abort a running query."""
-        request = ConnectionAbortQueryRequest(
-            conn_handle=self._connection.conn_handle,
+        response = core_driver.connection_abort_query(
+            conn_handle=self._connection.conn_handle,  # type: ignore[arg-type]
             query_id=qid,
         )
-        response = self._connection.db_api.connection_abort_query(request)
         return response.success

--- a/python/src/snowflake/connector/cursor/_result_set_wrapper.py
+++ b/python/src/snowflake/connector/cursor/_result_set_wrapper.py
@@ -2,22 +2,15 @@ from __future__ import annotations
 
 import logging
 
-from typing import TYPE_CHECKING
-
+from .._internal.api_client.client_api import core_driver
 from .._internal.errorcode import ER_NO_DATA_FOUND
 from .._internal.protobuf_gen.database_driver_v1_pb2 import (
-    ResultSetGetChunksRequest,
     ResultSetGetChunksResponse,
-    ResultSetGetStreamRequest,
     ResultSetHandle,
-    ResultSetReleaseRequest,
 )
 from .._internal.statement_utils import get_stream_ptr
 from ..errors import ProgrammingError
 
-
-if TYPE_CHECKING:
-    from .._internal.protobuf_gen.database_driver_v1_services import DatabaseDriverClient
 
 logger = logging.getLogger(__name__)
 
@@ -36,10 +29,9 @@ class _ResultSetWrapper:
     double-consumption.)
     """
 
-    __slots__ = ("_db_api", "_handle", "_stream_consumed")
+    __slots__ = ("_handle", "_stream_consumed")
 
-    def __init__(self, db_api: DatabaseDriverClient, handle: ResultSetHandle | None = None) -> None:
-        self._db_api = db_api
+    def __init__(self, handle: ResultSetHandle | None = None) -> None:
         self._handle: ResultSetHandle | None = handle
         self._stream_consumed: bool = False
 
@@ -64,8 +56,7 @@ class _ResultSetWrapper:
             return
         self._handle = None
         try:
-            request = ResultSetReleaseRequest(result_set_handle=handle)
-            self._db_api.result_set_release(request)
+            core_driver.result_set_release(result_set_handle=handle)
         except Exception:
             logger.warning("Failed to release ResultSet handle", exc_info=True)
 
@@ -90,8 +81,7 @@ class _ResultSetWrapper:
                 msg="No results available (arrow stream already consumed)",
                 errno=ER_NO_DATA_FOUND,
             )
-        request = ResultSetGetStreamRequest(result_set_handle=self._handle)
-        response = self._db_api.result_set_get_stream(request)
+        response = core_driver.result_set_get_stream(result_set_handle=self._handle)
         self._stream_consumed = True
         return get_stream_ptr(response)
 
@@ -104,5 +94,4 @@ class _ResultSetWrapper:
         """
         if self._handle is None:
             return None
-        request = ResultSetGetChunksRequest(result_set_handle=self._handle)
-        return self._db_api.result_set_get_chunks(request)
+        return core_driver.result_set_get_chunks(result_set_handle=self._handle)

--- a/python/src/snowflake/connector/result_batch.py
+++ b/python/src/snowflake/connector/result_batch.py
@@ -15,6 +15,7 @@ from collections.abc import Iterator
 from enum import Enum, unique
 from typing import TYPE_CHECKING, Any, cast
 
+from ._internal.api_client.client_api import core_driver
 from ._internal.arrow_stream_utils import (
     collect_arrow_table,
     create_row_iterator,
@@ -26,7 +27,6 @@ from ._internal.errorhandler import ErrorHandlerMixin
 from ._internal.extras import pandas, pyarrow, requires_dependency
 from ._internal.protobuf_gen.database_driver_v1_pb2 import (
     ColumnMetadata,
-    DatabaseFetchChunkRequest,
     ResultChunk,
 )
 from ._internal.statement_utils import get_stream_ptr
@@ -160,12 +160,11 @@ class ResultBatch(ErrorHandlerMixin):
         return conn
 
     def _fetch_arrow_stream_ptr(self, connection: Connection) -> int:
-        request = DatabaseFetchChunkRequest(
-            db_handle=connection.db_handle,
+        response = core_driver.database_fetch_chunk(
+            db_handle=connection.db_handle,  # type: ignore[arg-type]
             chunk=self._chunk,
             columns=self._columns,
         )
-        response = connection.db_api.database_fetch_chunk(request)
         return get_stream_ptr(response)
 
     def _take_arrow_stream_ptr(self, connection: Connection) -> int:

--- a/python/tests/compatibility.py
+++ b/python/tests/compatibility.py
@@ -1,7 +1,7 @@
 def _check_if_universal():
     try:
         # Import universal driver specific code
-        from snowflake.connector._internal.api_client.client_api import database_driver_client  # noqa
+        from snowflake.connector._internal.api_client.client_api import core_driver  # noqa
 
         return True
     except ImportError:

--- a/python/tests/helpers/fixtures.py
+++ b/python/tests/helpers/fixtures.py
@@ -9,7 +9,12 @@ import pytest
 
 @pytest.fixture
 def mock_db_api():
-    """MagicMock db_api with stubs for all RPCs Connection.__init__ calls."""
+    """MagicMock db_api patched into core_driver for Connection.__init__ tests.
+
+    Sets ``core_driver.client`` to the mock so that all RPC calls flow
+    through the mock. Restores the previous client on teardown.
+    """
+    from snowflake.connector._internal.api_client.client_api import core_driver
     from snowflake.connector._internal.protobuf_gen.database_driver_v1_pb2 import (
         ConnectionHandle,
         ConnectionIsClosedResponse,
@@ -23,20 +28,25 @@ def mock_db_api():
     db_api.connection_get_parameter.return_value = MagicMock(value="")
     db_api.connection_is_closed.return_value = ConnectionIsClosedResponse(is_closed=False)
     db_api.connection_set_options.return_value = ConnectionSetOptionsResponse(warnings=[])
-    return db_api
+
+    old_client = core_driver._client
+    core_driver.client = db_api
+    yield db_api
+    core_driver.client = old_client
 
 
 @pytest.fixture
-def core_proxy(monkeypatch):
+def core_proxy():
     """Wrap real Core client with MagicMock recording. Universal driver only.
 
     Lazy imports avoid module-level _internal dependency — safe for reference
     connector collection. Tests using this fixture must be marked @skip_reference.
     """
-    from snowflake.connector._internal.api_client.client_api import database_driver_client
+    from snowflake.connector._internal.api_client.client_api import core_driver
     from tests.helpers.core_introspection import CoreIntrospector
 
-    real_client = database_driver_client()
+    real_client = core_driver.client
     spy = MagicMock(wraps=real_client)
-    monkeypatch.setattr("snowflake.connector.connection.database_driver_client", lambda: spy)
-    return CoreIntrospector(spy)
+    core_driver.client = spy
+    yield CoreIntrospector(spy)
+    core_driver.client = real_client

--- a/python/tests/integ/session/conftest.py
+++ b/python/tests/integ/session/conftest.py
@@ -14,10 +14,9 @@ from tests.helpers.core_introspection import CoreIntrospector
 
 
 @pytest.fixture
-def core_mock(monkeypatch: pytest.MonkeyPatch, mock_db_api: MagicMock) -> CoreIntrospector:
-    """Pure mock — no real Core. Auto-patches database_driver_client.
+def core_mock(mock_db_api: MagicMock) -> CoreIntrospector:
+    """Pure mock — no real Core. mock_db_api fixture patches core_driver.client.
 
     Use for tests that only need to verify what Python passes to Core.
     """
-    monkeypatch.setattr("snowflake.connector.connection.database_driver_client", lambda: mock_db_api)
     return CoreIntrospector(mock_db_api)

--- a/python/tests/unit/test_api_usage_telemetry.py
+++ b/python/tests/unit/test_api_usage_telemetry.py
@@ -30,24 +30,28 @@ def _make_execute_response(query_id: str = "fake-qid") -> ExecuteQueryResponse:
 
 @pytest.fixture
 def mock_db_api():
-    """Create a mock DatabaseDriverClient with minimal stubs for Connection.__init__."""
+    """Create a mock DatabaseDriverClient patched into core_driver."""
+    from snowflake.connector._internal.api_client.client_api import core_driver
+
     db_api = MagicMock()
     db_api.database_new.return_value = MagicMock(db_handle=DatabaseHandle(id=1))
     db_api.connection_new.return_value = MagicMock(conn_handle=ConnectionHandle(id=42))
     db_api.connection_get_parameter.return_value = MagicMock(value="")
 
-    # connection_is_closed reports "closed" once the conn_handle has been
-    # released (Connection.close() swaps the handle to None, which ends up as
-    # id=0 after protobuf default initialization). Mirrors real Core behavior
-    # and lets tests call close() then assert is_closed() == True.
     def _connection_is_closed(request):
         return ConnectionIsClosedResponse(is_closed=request.conn_handle.id == 0)
 
     db_api.connection_is_closed.side_effect = _connection_is_closed
-    # Provide a real StatementHandle so protobuf field validation passes
     db_api.statement_new.return_value.stmt_handle = StatementHandle(id=1)
     db_api.statement_execute_query.return_value = _make_execute_response()
-    return db_api
+    db_api.connection_get_result_set.return_value = MagicMock(
+        result_descriptor=ResultSetDescriptor(query_id="fake-qid"),
+    )
+
+    old_client = core_driver._client
+    core_driver.client = db_api
+    yield db_api
+    core_driver.client = old_client
 
 
 @pytest.fixture
@@ -55,11 +59,7 @@ def connection(mock_db_api):
     """Create a Connection with a mocked db_api."""
     from snowflake.connector.connection import Connection
 
-    # Return stream_ptr=0 so release_arrow_stream (called in __del__) is a no-op.
-    with (
-        patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api),
-        patch("snowflake.connector.cursor._query_result.get_stream_ptr", return_value=0),
-    ):
+    with patch("snowflake.connector.cursor._query_result.get_stream_ptr", return_value=0):
         conn = Connection(user="test_user", account="test_account")
         yield conn
 

--- a/python/tests/unit/test_connection.py
+++ b/python/tests/unit/test_connection.py
@@ -29,11 +29,10 @@ pytestmark = pytest.mark.skipif(not IS_UNIVERSAL_DRIVER, reason="Requires univer
 
 @pytest.fixture
 def connection(mock_db_api):
-    """Create a Connection with a mocked db_api, bypassing the real sf_core."""
+    """Create a Connection with core_driver patched via mock_db_api fixture."""
     from snowflake.connector.connection import Connection
 
-    with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
-        conn = Connection(user="test_user", account="test_account")
+    conn = Connection(user="test_user", account="test_account")
     return conn
 
 
@@ -87,9 +86,8 @@ class TestSetAutocommitValidation:
         """Connection(autocommit=1) should raise ProgrammingError."""
         from snowflake.connector.connection import Connection
 
-        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
-            with pytest.raises(ProgrammingError, match="Invalid autocommit parameter"):
-                Connection(user="test_user", account="test_account", autocommit=1)
+        with pytest.raises(ProgrammingError, match="Invalid autocommit parameter"):
+            Connection(user="test_user", account="test_account", autocommit=1)
 
 
 class TestParamstyleSetter:
@@ -194,10 +192,10 @@ class TestGetAutocommit:
         """get_autocommit should return False when session parameter is empty/unset."""
         assert connection.get_autocommit() is False
 
-    def test_get_autocommit_reads_from_sf_core(self, connection):
+    def test_get_autocommit_reads_from_sf_core(self, connection, mock_db_api):
         """get_autocommit should read from sf_core via _get_session_parameter."""
         assert connection.get_autocommit() is False
-        connection.db_api.connection_get_parameter.return_value = MagicMock(value="true")
+        mock_db_api.connection_get_parameter.return_value = MagicMock(value="true")
         assert connection.get_autocommit() is True
 
 
@@ -208,8 +206,7 @@ class TestAutocommitKwargUnit:
         """Connection(autocommit=True) should pass AUTOCOMMIT=true as a session parameter."""
         from snowflake.connector.connection import Connection
 
-        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
-            Connection(user="test_user", account="test_account", autocommit=True)
+        Connection(user="test_user", account="test_account", autocommit=True)
 
         call_args = mock_db_api.connection_set_session_parameters.call_args
         params = call_args[0][0].parameters
@@ -219,8 +216,7 @@ class TestAutocommitKwargUnit:
         """Connection(autocommit=False) should pass AUTOCOMMIT=false as a session parameter."""
         from snowflake.connector.connection import Connection
 
-        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
-            Connection(user="test_user", account="test_account", autocommit=False)
+        Connection(user="test_user", account="test_account", autocommit=False)
 
         call_args = mock_db_api.connection_set_session_parameters.call_args
         params = call_args[0][0].parameters
@@ -230,8 +226,7 @@ class TestAutocommitKwargUnit:
         """Connection without autocommit kwarg should not inject AUTOCOMMIT, preserving server default."""
         from snowflake.connector.connection import Connection
 
-        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
-            Connection(user="test_user", account="test_account")
+        Connection(user="test_user", account="test_account")
 
         call_args = mock_db_api.connection_set_session_parameters.call_args
         if call_args is not None:
@@ -247,8 +242,7 @@ class TestConnectionSetOptions:
         """String kwargs should be sent as ConfigSetting(string_value=...)."""
         from snowflake.connector.connection import Connection
 
-        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
-            Connection(user="alice", account="acme")
+        Connection(user="alice", account="acme")
 
         request = mock_db_api.connection_set_options.call_args_list[0][0][0]
         assert request.options["user"] == ConfigSetting(string_value="alice")
@@ -258,8 +252,7 @@ class TestConnectionSetOptions:
         """Integer kwargs should be sent as ConfigSetting(int_value=...)."""
         from snowflake.connector.connection import Connection
 
-        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
-            Connection(user="u", account="a", port=8080)
+        Connection(user="u", account="a", port=8080)
 
         request = mock_db_api.connection_set_options.call_args_list[0][0][0]
         assert request.options["port"] == ConfigSetting(int_value=8080)
@@ -268,8 +261,7 @@ class TestConnectionSetOptions:
         """Bool kwargs should use bool_value, not int_value (bool is a subclass of int in Python)."""
         from snowflake.connector.connection import Connection
 
-        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
-            Connection(user="u", account="a", insecure_mode=True)
+        Connection(user="u", account="a", insecure_mode=True)
 
         request = mock_db_api.connection_set_options.call_args_list[0][0][0]
         setting = request.options["insecure_mode"]
@@ -280,8 +272,7 @@ class TestConnectionSetOptions:
         """Float kwargs should be sent as ConfigSetting(double_value=...)."""
         from snowflake.connector.connection import Connection
 
-        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
-            Connection(user="u", account="a", timeout=30.5)
+        Connection(user="u", account="a", timeout=30.5)
 
         request = mock_db_api.connection_set_options.call_args_list[0][0][0]
         assert request.options["timeout"] == ConfigSetting(double_value=30.5)
@@ -291,8 +282,7 @@ class TestConnectionSetOptions:
         from snowflake.connector.connection import Connection
 
         token = b"\x01\x02\x03"
-        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
-            Connection(user="u", account="a", token=token)
+        Connection(user="u", account="a", token=token)
 
         request = mock_db_api.connection_set_options.call_args_list[0][0][0]
         assert request.options["token"] == ConfigSetting(bytes_value=token)
@@ -301,8 +291,7 @@ class TestConnectionSetOptions:
         """All typed options should be submitted in one connection_set_options call."""
         from snowflake.connector.connection import Connection
 
-        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
-            Connection(user="u", account="a", port=443, insecure_mode=False, timeout=1.5)
+        Connection(user="u", account="a", port=443, insecure_mode=False, timeout=1.5)
 
         # Single batched call: generic kwargs + logout config combined
         assert mock_db_api.connection_set_options.call_count == 1
@@ -325,10 +314,9 @@ class TestConnectionSetOptions:
             ]
         )
 
-        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
-            with warnings.catch_warnings(record=True) as caught:
-                warnings.simplefilter("always")
-                Connection(user="u", account="a")
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            Connection(user="u", account="a")
 
         # Filter out FutureWarning from _extract_auto_detection_param
         validation_warnings = [w for w in caught if w.category is not FutureWarning]
@@ -340,8 +328,7 @@ class TestConnectionSetOptions:
         """When there are no user-supplied kwargs, client_app_id + logout defaults are sent."""
         from snowflake.connector.connection import Connection
 
-        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
-            Connection(session_parameters={"AUTOCOMMIT": "true"})
+        Connection(session_parameters={"AUTOCOMMIT": "true"})
 
         # Single batched call: client_app_id + logout config defaults
         assert mock_db_api.connection_set_options.call_count == 1
@@ -360,8 +347,7 @@ class TestDriverIdentity:
         from snowflake.connector.connection import Connection
         from snowflake.connector.version import __version__
 
-        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
-            Connection(user="u", account="a")
+        Connection(user="u", account="a")
 
         init_request = mock_db_api.connection_init.call_args[0][0]
         identity = init_request.wrapper_identity
@@ -424,8 +410,7 @@ class TestClose:
         """__del__ should close + release handles when close() was never called."""
         from snowflake.connector.connection import Connection
 
-        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
-            conn = Connection(user="test_user", account="test_account")
+        conn = Connection(user="test_user", account="test_account")
 
         conn.__del__()
 
@@ -454,9 +439,9 @@ class TestClose:
 class TestContextManagerUnit:
     """Unit tests for __exit__ behavior."""
 
-    def test_exit_skips_commit_when_autocommit_on(self, connection):
+    def test_exit_skips_commit_when_autocommit_on(self, connection, mock_db_api):
         """When autocommit is on, __exit__ should not execute COMMIT or ROLLBACK."""
-        connection.db_api.connection_get_parameter.return_value = MagicMock(value="true")
+        mock_db_api.connection_get_parameter.return_value = MagicMock(value="true")
         connection.commit = MagicMock()
         connection.rollback = MagicMock()
 
@@ -465,7 +450,7 @@ class TestContextManagerUnit:
         connection.commit.assert_not_called()
         connection.rollback.assert_not_called()
 
-    def test_exit_always_closes(self, connection):
+    def test_exit_always_closes(self, connection, mock_db_api):
         """close() should be called even if commit raises an exception."""
 
         def failing_commit():
@@ -477,7 +462,7 @@ class TestContextManagerUnit:
             connection.__exit__(None, None, None)
 
         # Verify Core's connection_close RPC was invoked (close() was called in finally block)
-        connection.db_api.connection_close.assert_called_once()
+        mock_db_api.connection_close.assert_called_once()
 
     def test_exit_rollback_failure_does_not_mask_original_exception(self, connection):
         """If rollback fails during exception handling, the original exception should propagate."""
@@ -722,16 +707,14 @@ class TestApplicationProperty:
     def test_application_custom_value(self, mock_db_api):
         from snowflake.connector.connection import Connection
 
-        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
-            conn = Connection(user="u", account="a", application="MyApp")
+        conn = Connection(user="u", account="a", application="MyApp")
         assert conn.application == "MyApp"
 
     def test_application_maps_to_client_app_id_option(self, mock_db_api):
         """The application value should be forwarded to sf_core as client_app_id."""
         from snowflake.connector.connection import Connection
 
-        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
-            Connection(user="u", account="a", application="CustomApp")
+        Connection(user="u", account="a", application="CustomApp")
 
         request = mock_db_api.connection_set_options.call_args_list[0][0][0]
         assert request.options["client_app_id"] == ConfigSetting(string_value="CustomApp")
@@ -740,45 +723,39 @@ class TestApplicationProperty:
     def test_application_none_defaults_to_client_name(self, mock_db_api):
         from snowflake.connector.connection import Connection
 
-        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
-            conn = Connection(user="u", account="a", application=None)
+        conn = Connection(user="u", account="a", application=None)
         assert conn.application == "PythonConnector"
 
     def test_application_empty_string_defaults_to_client_name(self, mock_db_api):
         from snowflake.connector.connection import Connection
 
-        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
-            conn = Connection(user="u", account="a", application="")
+        conn = Connection(user="u", account="a", application="")
         assert conn.application == "PythonConnector"
 
     def test_application_accepts_dotted_name(self, mock_db_api):
         """Snow CLI passes dotted names like 'SNOWCLI.STAGE.COPY'."""
         from snowflake.connector.connection import Connection
 
-        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
-            conn = Connection(user="u", account="a", application="SNOWCLI.STAGE.COPY")
+        conn = Connection(user="u", account="a", application="SNOWCLI.STAGE.COPY")
         assert conn.application == "SNOWCLI.STAGE.COPY"
 
     def test_application_rejects_non_string(self, mock_db_api):
         from snowflake.connector.connection import Connection
 
-        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
-            with pytest.raises(ProgrammingError, match="Invalid application parameter"):
-                Connection(user="u", account="a", application=123)
+        with pytest.raises(ProgrammingError, match="Invalid application parameter"):
+            Connection(user="u", account="a", application=123)
 
     def test_application_rejects_name_starting_with_non_word_char(self, mock_db_api):
         from snowflake.connector.connection import Connection
 
-        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
-            with pytest.raises(ProgrammingError, match="Invalid application name"):
-                Connection(user="u", account="a", application="!invalid")
+        with pytest.raises(ProgrammingError, match="Invalid application name"):
+            Connection(user="u", account="a", application="!invalid")
 
     def test_application_stored_in_config(self, mock_db_api):
         """application should be stored in config, not leaked into kwargs."""
         from snowflake.connector.connection import Connection
 
-        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
-            conn = Connection(user="u", account="a", application="MyApp")
+        conn = Connection(user="u", account="a", application="MyApp")
         assert conn.config.application == "MyApp"
 
 
@@ -791,8 +768,7 @@ class TestLogMaxQueryLength:
     def test_custom_value_at_connect_time(self, mock_db_api):
         from snowflake.connector.connection import Connection
 
-        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
-            conn = Connection(user="u", account="a", log_max_query_length=200)
+        conn = Connection(user="u", account="a", log_max_query_length=200)
         assert conn.log_max_query_length == 200
 
     def test_format_short_query_unchanged(self, connection):
@@ -823,8 +799,7 @@ class TestLogMaxQueryLength:
     def test_format_collapses_then_truncates(self, mock_db_api):
         from snowflake.connector.connection import Connection
 
-        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
-            conn = Connection(user="u", account="a", log_max_query_length=20)
+        conn = Connection(user="u", account="a", log_max_query_length=20)
 
         query = "SELECT\n    very_long_column_name\nFROM\n    my_table"
         result = conn._format_query_for_log(query)
@@ -834,8 +809,7 @@ class TestLogMaxQueryLength:
     def test_custom_zero_truncates_everything(self, mock_db_api):
         from snowflake.connector.connection import Connection
 
-        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
-            conn = Connection(user="u", account="a", log_max_query_length=0)
+        conn = Connection(user="u", account="a", log_max_query_length=0)
 
         assert conn._format_query_for_log("SELECT 1") == "..."
 
@@ -843,8 +817,7 @@ class TestLogMaxQueryLength:
         """log_max_query_length is used by both Python (log formatting) and Core (log truncation)."""
         from snowflake.connector.connection import Connection
 
-        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
-            Connection(user="u", account="a", log_max_query_length=200)
+        Connection(user="u", account="a", log_max_query_length=200)
 
         request = mock_db_api.connection_set_options.call_args_list[0][0][0]
         assert request.options["log_max_query_length"] == ConfigSetting(int_value=200)
@@ -917,22 +890,19 @@ class TestConnectionArrowProperties:
     def test_arrow_number_to_decimal_true_from_kwargs(self, mock_db_api):
         from snowflake.connector.connection import Connection
 
-        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
-            conn = Connection(user="u", account="a", arrow_number_to_decimal=True)
+        conn = Connection(user="u", account="a", arrow_number_to_decimal=True)
         assert conn.arrow_number_to_decimal is True
 
     def test_arrow_number_to_decimal_false_from_kwargs(self, mock_db_api):
         from snowflake.connector.connection import Connection
 
-        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
-            conn = Connection(user="u", account="a", arrow_number_to_decimal=False)
+        conn = Connection(user="u", account="a", arrow_number_to_decimal=False)
         assert conn.arrow_number_to_decimal is False
 
     def test_arrow_number_to_decimal_not_leaked_to_rust_core(self, mock_db_api):
         from snowflake.connector.connection import Connection
 
-        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
-            Connection(user="u", account="a", arrow_number_to_decimal=True)
+        Connection(user="u", account="a", arrow_number_to_decimal=True)
 
         request = mock_db_api.connection_set_options.call_args_list[0][0][0]
         assert "arrow_number_to_decimal" not in request.options

--- a/python/tests/unit/test_connection_numpy.py
+++ b/python/tests/unit/test_connection_numpy.py
@@ -18,8 +18,7 @@ pytestmark = pytest.mark.skipif(not IS_UNIVERSAL_DRIVER, reason="Requires univer
 def make_connection(mock_db_api, **kwargs):
     from snowflake.connector.connection import Connection
 
-    with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
-        return Connection(user="test_user", account="test_account", **kwargs)
+    return Connection(user="test_user", account="test_account", **kwargs)
 
 
 class TestConnectionNumpyParameter:

--- a/python/tests/unit/test_cursor.py
+++ b/python/tests/unit/test_cursor.py
@@ -7,6 +7,7 @@ from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
+from snowflake.connector._internal.api_client.client_api import core_driver
 from snowflake.connector._internal.binding_converters import ParamStyle
 from snowflake.connector._internal.errorcode import ER_NO_PYARROW
 from snowflake.connector._internal.extras import (
@@ -35,6 +36,16 @@ def _no_native_stream_ops():
         patch("snowflake.connector.cursor._query_result.release_arrow_stream"),
     ):
         yield
+
+
+@pytest.fixture
+def mock_core_client():
+    """Provide a MagicMock patched into core_driver.client for cursor tests."""
+    mock = MagicMock()
+    old = core_driver._client
+    core_driver.client = mock
+    yield mock
+    core_driver.client = old
 
 
 class MockRowIterator:
@@ -499,14 +510,14 @@ class TestHandleLifecycle:
     """
 
     @pytest.fixture
-    def mock_connection(self):
-        """Create a mock connection with db_api stubs for execute flow."""
+    def mock_connection(self, mock_core_client):
+        """Create a mock connection with core_driver stubs for execute flow."""
         conn = MagicMock()
         conn.conn_handle = ConnectionHandle(id=1)
         conn.is_closed.return_value = False
         rs_counter = 0
 
-        conn.db_api.statement_new.return_value.stmt_handle = StatementHandle(id=1)
+        mock_core_client.statement_new.return_value.stmt_handle = StatementHandle(id=1)
 
         def make_execute_response(*_args, **_kwargs):
             nonlocal rs_counter
@@ -520,7 +531,7 @@ class TestHandleLifecycle:
             response.single.result_descriptor.sql_state = "00000"
             return response
 
-        conn.db_api.statement_execute_query.side_effect = make_execute_response
+        mock_core_client.statement_execute_query.side_effect = make_execute_response
 
         return conn
 
@@ -529,70 +540,70 @@ class TestHandleLifecycle:
         """Create a cursor with the mocked connection."""
         return SnowflakeCursor(mock_connection)
 
-    def test_statement_handle_released_after_execute(self, cursor, mock_connection):
+    def test_statement_handle_released_after_execute(self, cursor, mock_core_client):
         """Statement handle is released within execute (context manager)."""
         cursor.execute("SELECT 1")
 
-        mock_connection.db_api.statement_release.assert_called_once()
+        mock_core_client.statement_release.assert_called_once()
 
-    def test_result_set_handle_survives_execute(self, cursor, mock_connection):
+    def test_result_set_handle_survives_execute(self, cursor, mock_core_client):
         """After execute(), the ResultSet handle is still held (not released)."""
         cursor.execute("SELECT 1")
 
-        mock_connection.db_api.result_set_release.assert_not_called()
+        mock_core_client.result_set_release.assert_not_called()
 
-    def test_reset_releases_result_set_handle(self, cursor, mock_connection):
+    def test_reset_releases_result_set_handle(self, cursor, mock_core_client):
         """reset() releases the ResultSet handle held by the cursor."""
         cursor.execute("SELECT 1")
         cursor.reset()
 
-        mock_connection.db_api.result_set_release.assert_called_once()
-        released_id = mock_connection.db_api.result_set_release.call_args.args[0].result_set_handle.id
+        mock_core_client.result_set_release.assert_called_once()
+        released_id = mock_core_client.result_set_release.call_args.args[0].result_set_handle.id
         assert released_id == 1
 
-    def test_close_releases_result_set_handle(self, cursor, mock_connection):
+    def test_close_releases_result_set_handle(self, cursor, mock_core_client):
         """close() releases the ResultSet handle held by the cursor."""
         cursor.execute("SELECT 1")
         cursor.close()
 
-        mock_connection.db_api.result_set_release.assert_called_once()
+        mock_core_client.result_set_release.assert_called_once()
 
-    def test_sequential_executes_release_previous_result_set_handles(self, cursor, mock_connection):
+    def test_sequential_executes_release_previous_result_set_handles(self, cursor, mock_core_client):
         """Each execute() releases the ResultSet handle from the previous execution."""
         n = 5
         for i in range(n):
             cursor.execute(f"SELECT {i}")
 
-        release = mock_connection.db_api.result_set_release
+        release = mock_core_client.result_set_release
         # First n-1 handles released by replace() at the start of each subsequent _apply_result_set;
         # the last handle is still alive.
         assert release.call_count == n - 1
         released_ids = [call.args[0].result_set_handle.id for call in release.call_args_list]
         assert released_ids == list(range(1, n))
 
-    def test_close_without_execute_does_not_release(self, cursor, mock_connection):
+    def test_close_without_execute_does_not_release(self, cursor, mock_core_client):
         """Closing a cursor that never executed should not call release."""
         cursor.close()
 
-        mock_connection.db_api.result_set_release.assert_not_called()
+        mock_core_client.result_set_release.assert_not_called()
 
 
 class TestSqlstate:
     """Unit tests for Cursor.sqlstate property."""
 
     @pytest.fixture
-    def mock_connection(self):
+    def mock_connection(self, mock_core_client):
         conn = MagicMock()
         conn.conn_handle = ConnectionHandle(id=1)
         conn.is_closed.return_value = False
-        conn.db_api.statement_new.return_value.stmt_handle = StatementHandle(id=1)
+        mock_core_client.statement_new.return_value.stmt_handle = StatementHandle(id=1)
         return conn
 
     @pytest.fixture
     def cursor(self, mock_connection):
         return SnowflakeCursor(mock_connection)
 
-    def _stub_execute_result(self, mock_connection, **overrides):
+    def _stub_execute_result(self, mock_core_client, **overrides):
         """Set up the mock to return an execute result with the given overrides."""
         # Mock ResultSetDescriptor
         descriptor = MagicMock()
@@ -620,7 +631,7 @@ class TestSqlstate:
         execute_response.single.result_descriptor = descriptor
         execute_response.single.result_set_handle = ResultSetHandle(id=1)
         execute_response.HasField = MagicMock(side_effect=lambda f: f == "single")
-        mock_connection.db_api.statement_execute_query.return_value = execute_response
+        mock_core_client.statement_execute_query.return_value = execute_response
 
         return descriptor
 
@@ -628,79 +639,79 @@ class TestSqlstate:
         """sqlstate is None on a fresh cursor."""
         assert cursor.sqlstate is None
 
-    def test_sqlstate_none_after_successful_execute(self, cursor, mock_connection):
+    def test_sqlstate_none_after_successful_execute(self, cursor, mock_core_client):
         """sqlstate is None when server returns '00000' (successful completion)."""
-        self._stub_execute_result(mock_connection, sql_state="00000")
+        self._stub_execute_result(mock_core_client, sql_state="00000")
 
         cursor.execute("SELECT 1")
 
         assert cursor.sqlstate is None
 
-    def test_sqlstate_populated_with_error_code(self, cursor, mock_connection):
+    def test_sqlstate_populated_with_error_code(self, cursor, mock_core_client):
         """sqlstate reflects non-success sql_state from execute result."""
-        self._stub_execute_result(mock_connection, sql_state="42601")
+        self._stub_execute_result(mock_core_client, sql_state="42601")
 
         cursor.execute("SELECT 1")
 
         assert cursor.sqlstate == "42601"
 
-    def test_sqlstate_none_when_field_absent(self, cursor, mock_connection):
+    def test_sqlstate_none_when_field_absent(self, cursor, mock_core_client):
         """sqlstate is None when the server does not return sql_state."""
-        self._stub_execute_result(mock_connection, sql_state="")
+        self._stub_execute_result(mock_core_client, sql_state="")
 
         cursor.execute("SELECT 1")
 
         assert cursor.sqlstate is None
 
-    def test_sqlstate_updates_on_subsequent_execute(self, cursor, mock_connection):
+    def test_sqlstate_updates_on_subsequent_execute(self, cursor, mock_core_client):
         """sqlstate is refreshed on every execute call."""
         # First execute with error
-        self._stub_execute_result(mock_connection, sql_state="42601")
+        self._stub_execute_result(mock_core_client, sql_state="42601")
 
         cursor.execute("SELECT 1")
         assert cursor.sqlstate == "42601"
 
         # Second execute with success
-        self._stub_execute_result(mock_connection, sql_state="00000")
+        self._stub_execute_result(mock_core_client, sql_state="00000")
         cursor.execute("SELECT 2")
         assert cursor.sqlstate is None
 
-    def test_sqlstate_set_from_error_on_failed_execute(self, cursor, mock_connection):
+    def test_sqlstate_set_from_error_on_failed_execute(self, cursor, mock_core_client):
         """sqlstate is captured from PEP 249 Error when execute raises."""
-        mock_connection.db_api.statement_execute_query.side_effect = ProgrammingError("error", sqlstate="42601")
+        mock_core_client.statement_execute_query.side_effect = ProgrammingError("error", sqlstate="42601")
 
         with pytest.raises(ProgrammingError):
             cursor.execute("INVALID SQL")
 
         assert cursor.sqlstate == "42601"
 
-    def test_sqlstate_set_to_none_when_error_has_no_sqlstate(self, cursor, mock_connection):
+    def test_sqlstate_set_to_none_when_error_has_no_sqlstate(self, cursor, mock_core_client):
         """sqlstate is set to None when error carries no sqlstate."""
-        mock_connection.db_api.statement_execute_query.side_effect = ProgrammingError("error", sqlstate=None)
+        mock_core_client.statement_execute_query.side_effect = ProgrammingError("error", sqlstate=None)
 
         with pytest.raises(ProgrammingError):
             cursor.execute("INVALID SQL")
 
         assert cursor.sqlstate is None
 
-    def test_sqlstate_transitions_across_success_and_failure(self, cursor, mock_connection):
+    def test_sqlstate_transitions_across_success_and_failure(self, cursor, mock_core_client):
         """sqlstate updates correctly through None -> error -> None."""
         success_result = MagicMock()
         success_result.columns = []
         success_result.sql_state = "00000"
 
-        mock_connection.db_api.statement_execute_query.return_value.result = success_result
-        mock_connection.db_api.statement_execute_query.side_effect = None
+        mock_core_client.statement_execute_query.return_value.result = success_result
+        mock_core_client.statement_execute_query.side_effect = None
         cursor.execute("SELECT 1")
         assert cursor.sqlstate is None
 
-        mock_connection.db_api.statement_execute_query.side_effect = ProgrammingError("error", sqlstate="42601")
+        mock_core_client.statement_execute_query.side_effect = ProgrammingError("error", sqlstate="42601")
         with pytest.raises(ProgrammingError):
             cursor.execute("INVALID SQL")
         assert cursor.sqlstate == "42601"
 
-        mock_connection.db_api.statement_execute_query.side_effect = None
-        mock_connection.db_api.statement_execute_query.return_value.result = success_result
+        mock_core_client.statement_execute_query.side_effect = None
+        mock_core_client.statement_execute_query.return_value.result = success_result
         cursor.execute("SELECT 2")
         assert cursor.sqlstate is None
 
@@ -709,29 +720,29 @@ class TestSfqidOnFailedQuery:
     """Unit tests for cursor.sfqid propagation when execute raises."""
 
     @pytest.fixture
-    def mock_connection(self):
+    def mock_connection(self, mock_core_client):
         conn = MagicMock()
         conn.conn_handle = ConnectionHandle(id=1)
         conn.is_closed.return_value = False
-        conn.db_api.statement_new.return_value.stmt_handle = StatementHandle(id=1)
+        mock_core_client.statement_new.return_value.stmt_handle = StatementHandle(id=1)
         return conn
 
     @pytest.fixture
     def cursor(self, mock_connection):
         return SnowflakeCursor(mock_connection)
 
-    def test_sfqid_set_from_error_on_failed_execute(self, cursor, mock_connection):
+    def test_sfqid_set_from_error_on_failed_execute(self, cursor, mock_core_client):
         """sfqid is captured from ProgrammingError when execute raises."""
-        mock_connection.db_api.statement_execute_query.side_effect = ProgrammingError("error", sfqid="01abc-def-12345")
+        mock_core_client.statement_execute_query.side_effect = ProgrammingError("error", sfqid="01abc-def-12345")
 
         with pytest.raises(ProgrammingError):
             cursor.execute("INVALID SQL")
 
         assert cursor.sfqid == "01abc-def-12345"
 
-    def test_sfqid_none_when_error_has_no_sfqid(self, cursor, mock_connection):
+    def test_sfqid_none_when_error_has_no_sfqid(self, cursor, mock_core_client):
         """sfqid is None when error carries no sfqid."""
-        mock_connection.db_api.statement_execute_query.side_effect = ProgrammingError("error")
+        mock_core_client.statement_execute_query.side_effect = ProgrammingError("error")
 
         with pytest.raises(ProgrammingError):
             cursor.execute("INVALID SQL")
@@ -1486,22 +1497,12 @@ class TestFetchModeValidation:
             cursor.fetchone()
             cursor.fetchone()
 
-    def test_execute_resets_fetch_mode(self, cursor, mock_connection):
-        mock_connection.is_closed.return_value = False
-        result = MagicMock()
-        result.columns = []
-        result.HasField.return_value = False
-        result.sql_state = ""
-        mock_connection.db_api.statement_execute_query.return_value.result = result
+    def test_execute_resets_fetch_mode(self, cursor, mock_connection, mock_core_client):
+        mock_connection.conn_handle = ConnectionHandle(id=1)
+        mock_core_client.statement_new.return_value.stmt_handle = StatementHandle(id=1)
 
         cursor._fetch_mode = FetchMode.ARROW
-        with (
-            patch("snowflake.connector._internal.statement_utils.StatementNewRequest"),
-            patch("snowflake.connector._internal.statement_utils.StatementSetSqlQueryRequest"),
-            patch("snowflake.connector.cursor._base.StatementExecuteQueryRequest"),
-            patch("snowflake.connector._internal.statement_utils.StatementReleaseRequest"),
-        ):
-            cursor.execute("SELECT 1")
+        cursor.execute("SELECT 1")
 
         assert cursor._fetch_mode is None
 
@@ -1690,16 +1691,16 @@ class TestResetIntegration:
     """Integration tests for reset() with other cursor methods."""
 
     @pytest.fixture
-    def mock_connection(self):
+    def mock_connection(self, mock_core_client):
         conn = MagicMock()
         conn.conn_handle = ConnectionHandle(id=1)
         conn.is_closed.return_value = False
-        conn.db_api.statement_new.return_value.stmt_handle = StatementHandle(id=1)
+        mock_core_client.statement_new.return_value.stmt_handle = StatementHandle(id=1)
         execute_result = MagicMock()
         execute_result.columns = []
         execute_result.HasField = MagicMock(return_value=False)
         execute_result.sql_state = "00000"
-        conn.db_api.statement_execute_query.return_value.result = execute_result
+        mock_core_client.statement_execute_query.return_value.result = execute_result
         return conn
 
     @pytest.fixture
@@ -1800,33 +1801,33 @@ class TestDescribe:
     """Unit tests for Cursor.describe method."""
 
     @pytest.fixture
-    def mock_connection(self):
+    def mock_connection(self, mock_core_client):
         conn = MagicMock()
         conn.conn_handle = ConnectionHandle(id=1)
         conn.is_closed.return_value = False
-        conn.db_api.statement_new.return_value.stmt_handle = StatementHandle(id=1)
+        mock_core_client.statement_new.return_value.stmt_handle = StatementHandle(id=1)
         return conn
 
     @pytest.fixture
     def cursor(self, mock_connection):
         return SnowflakeCursor(mock_connection)
 
-    def _setup_prepare(self, mock_connection, columns=None, query_id="", query="", sql_state=None):
+    def _setup_prepare(self, mock_core_client, columns=None, query_id="", query="", sql_state=None):
         result = MagicMock()
         result.columns = columns or []
         result.stream.value = (42).to_bytes(8, byteorder="little", signed=False)
         result.query_id = query_id
         result.query = query
         result.sql_state = sql_state
-        mock_connection.db_api.statement_prepare.return_value.result = result
+        mock_core_client.statement_prepare.return_value.result = result
         return result
 
-    def test_describe_returns_column_metadata(self, cursor, mock_connection):
+    def test_describe_returns_column_metadata(self, cursor, mock_core_client):
         """describe() returns ResultMetadata and updates cursor.description."""
         col = MagicMock(type="FIXED", nullable=True, precision=10, scale=0)
         col.name = "COL1"
         col.HasField = lambda f: f in ("precision", "scale")
-        self._setup_prepare(mock_connection, columns=[col])
+        self._setup_prepare(mock_core_client, columns=[col])
 
         result = cursor.describe("SELECT 1 AS COL1")
 
@@ -1835,19 +1836,19 @@ class TestDescribe:
         assert result[0].name == "COL1"
         assert cursor.description == result
 
-    def test_describe_returns_none_for_no_columns(self, cursor, mock_connection):
+    def test_describe_returns_none_for_no_columns(self, cursor, mock_core_client):
         """describe() returns None when the statement produces no result set."""
-        self._setup_prepare(mock_connection, columns=[])
+        self._setup_prepare(mock_core_client, columns=[])
 
         assert cursor.describe("INSERT INTO t VALUES (1)") is None
 
-    def test_describe_side_effects_with_columns(self, cursor, mock_connection):
+    def test_describe_side_effects_with_columns(self, cursor, mock_core_client):
         """describe() sets sfqid, query, sqlstate, rowcount when result has columns."""
         col = MagicMock(type="FIXED", nullable=True, precision=10, scale=0)
         col.name = "COL1"
         col.HasField = lambda f: f in ("precision", "scale")
         self._setup_prepare(
-            mock_connection,
+            mock_core_client,
             columns=[col],
             query_id="01abc-def",
             query="SELECT 1",
@@ -1865,13 +1866,13 @@ class TestDescribe:
         assert cursor.rowcount == 0
         assert cursor._fetch_mode is None
 
-    def test_describe_forwards_non_success_sqlstate(self, cursor, mock_connection):
+    def test_describe_forwards_non_success_sqlstate(self, cursor, mock_core_client):
         """describe() forwards sqlstate when it differs from '00000'."""
         col = MagicMock(type="FIXED", nullable=True, precision=10, scale=0)
         col.name = "COL1"
         col.HasField = lambda f: f in ("precision", "scale")
         self._setup_prepare(
-            mock_connection,
+            mock_core_client,
             columns=[col],
             sql_state="02000",
         )
@@ -1880,11 +1881,11 @@ class TestDescribe:
 
         assert cursor.sqlstate == "02000"
 
-    def test_describe_side_effects_without_columns(self, cursor, mock_connection):
+    def test_describe_side_effects_without_columns(self, cursor, mock_core_client):
         """describe() resets state; sfqid/query/sqlstate are set from result even without columns."""
         cursor._query_result.rowcount = 42
         cursor._fetch_mode = FetchMode.ARROW
-        self._setup_prepare(mock_connection)
+        self._setup_prepare(mock_core_client)
 
         cursor.describe("SELECT 1")
 
@@ -1892,15 +1893,15 @@ class TestDescribe:
         assert cursor.rowcount is None
         assert cursor._fetch_mode is None
 
-    def test_describe_releases_handle_and_stream(self, cursor, mock_connection):
+    def test_describe_releases_handle_and_stream(self, cursor, mock_core_client):
         """describe() allocates/releases statement handle and releases the arrow stream."""
-        self._setup_prepare(mock_connection)
+        self._setup_prepare(mock_core_client)
 
         with patch("snowflake.connector.cursor._query_result.release_arrow_stream") as mock_release:
             cursor.describe("SELECT 1")
 
-        mock_connection.db_api.statement_new.assert_called_once()
-        mock_connection.db_api.statement_release.assert_called_once()
+        mock_core_client.statement_new.assert_called_once()
+        mock_core_client.statement_release.assert_called_once()
         mock_release.assert_called()
 
     def test_describe_raises_when_closed(self, cursor, mock_connection):
@@ -1914,9 +1915,9 @@ class TestDescribe:
         with pytest.raises(InterfaceError):
             fresh.describe("SELECT 1")
 
-    def test_describe_propagates_prepare_error(self, cursor, mock_connection):
+    def test_describe_propagates_prepare_error(self, cursor, mock_core_client):
         """describe() propagates ProgrammingError and captures sqlstate."""
-        mock_connection.db_api.statement_prepare.side_effect = ProgrammingError("syntax error", sqlstate="42601")
+        mock_core_client.statement_prepare.side_effect = ProgrammingError("syntax error", sqlstate="42601")
 
         with pytest.raises(ProgrammingError):
             cursor.describe("INVALID SQL")
@@ -1928,7 +1929,7 @@ class TestQueryResult:
     """Unit tests for Cursor.query_result method."""
 
     @pytest.fixture
-    def mock_connection(self):
+    def mock_connection(self, mock_core_client):
         conn = MagicMock()
         conn.conn_handle = ConnectionHandle(id=1)
         conn.is_closed.return_value = False
@@ -1938,7 +1939,7 @@ class TestQueryResult:
     def cursor(self, mock_connection):
         return SnowflakeCursor(mock_connection)
 
-    def _stub_result(self, mock_connection, **overrides):
+    def _stub_result(self, mock_core_client, **overrides):
         """Set up the mock RPC to return a result with the given overrides."""
         # Mock ResultSetDescriptor
         descriptor = MagicMock()
@@ -1972,11 +1973,11 @@ class TestQueryResult:
         query_result_response = MagicMock()
         query_result_response.single = result_set_response
         query_result_response.HasField = MagicMock(side_effect=lambda f: f == "single")
-        mock_connection.db_api.connection_get_query_result.return_value = query_result_response
+        mock_core_client.connection_get_query_result.return_value = query_result_response
 
         return descriptor
 
-    def test_query_result_populates_cursor_state(self, cursor, mock_connection):
+    def test_query_result_populates_cursor_state(self, cursor, mock_core_client):
         """query_result returns self, sends correct RPC args, and populates all cursor fields."""
         col = MagicMock()
         col.name = "ID"
@@ -1984,7 +1985,7 @@ class TestQueryResult:
         col.nullable = True
 
         self._stub_result(
-            mock_connection,
+            mock_core_client,
             columns=[col],
             rows_affected=42,
             has_rows_affected=True,
@@ -2000,17 +2001,17 @@ class TestQueryResult:
         assert cursor.rowcount == 42
         assert cursor.sqlstate == "02000"
 
-        request = mock_connection.db_api.connection_get_query_result.call_args.args[0]
+        request = mock_core_client.connection_get_query_result.call_args.args[0]
         assert request.conn_handle == ConnectionHandle(id=1)
         assert request.query_id == "01234567-abcd-ef01-0000-000000000001"
 
-    def test_query_result_resets_prior_state(self, cursor, mock_connection):
+    def test_query_result_resets_prior_state(self, cursor, mock_core_client):
         """query_result clears iterator and fetch mode from a previous execute."""
         cursor._query_result = _QueryResult(rowcount=99)
         cursor._iterator = iter([(1,)])
         cursor._fetch_mode = FetchMode.ROW
 
-        self._stub_result(mock_connection)
+        self._stub_result(mock_core_client)
         cursor.query_result("qid")
 
         assert cursor._fetch_mode is None
@@ -2027,9 +2028,9 @@ class TestQueryResult:
         with pytest.raises(InterfaceError):
             fresh.query_result("qid")
 
-    def test_query_result_propagates_rpc_error(self, cursor, mock_connection):
+    def test_query_result_propagates_rpc_error(self, cursor, mock_core_client):
         """query_result propagates ProgrammingError from the RPC layer."""
-        mock_connection.db_api.connection_get_query_result.side_effect = ProgrammingError("Query has expired")
+        mock_core_client.connection_get_query_result.side_effect = ProgrammingError("Query has expired")
         with pytest.raises(ProgrammingError, match="Query has expired"):
             cursor.query_result("expired-qid")
 
@@ -2091,7 +2092,7 @@ class TestGetResultsFromSfqid:
     """Unit tests for Cursor.get_results_from_sfqid."""
 
     @pytest.fixture
-    def mock_connection(self):
+    def mock_connection(self, mock_core_client):
         conn = MagicMock()
         conn.conn_handle = ConnectionHandle(id=1)
         conn.is_closed.return_value = False
@@ -2101,7 +2102,7 @@ class TestGetResultsFromSfqid:
         result.columns = []
         result.HasField = MagicMock(return_value=False)
         result.sql_state = ""
-        conn.db_api.connection_get_query_result.return_value.result = result
+        mock_core_client.connection_get_query_result.return_value.result = result
         return conn
 
     @pytest.fixture
@@ -2146,26 +2147,20 @@ class TestGetResultsFromSfqid:
         with pytest.raises(ProgrammingError, match="Query failed"):
             cursor.get_results_from_sfqid("bad-qid")
 
-    def test_execute_clears_pending_hook(self, cursor, mock_connection):
+    def test_execute_clears_pending_hook(self, cursor, mock_core_client):
         """A new execute() cancels a pending prefetch hook."""
         cursor.get_results_from_sfqid("test-qid")
         assert cursor._prefetch_hook is not None
 
         handle_resp = MagicMock()
         handle_resp.stmt_handle = StatementHandle(id=1)
-        mock_connection.db_api.statement_new.return_value = handle_resp
+        mock_core_client.statement_new.return_value = handle_resp
         result = MagicMock()
         result.columns = []
         result.HasField = MagicMock(return_value=False)
         result.sql_state = ""
-        mock_connection.db_api.statement_execute_query.return_value.result = result
-        with (
-            patch("snowflake.connector._internal.statement_utils.StatementNewRequest"),
-            patch("snowflake.connector._internal.statement_utils.StatementSetSqlQueryRequest"),
-            patch("snowflake.connector.cursor._base.StatementExecuteQueryRequest"),
-            patch("snowflake.connector._internal.statement_utils.StatementReleaseRequest"),
-        ):
-            cursor.execute("SELECT 1")
+        mock_core_client.statement_execute_query.return_value.result = result
+        cursor.execute("SELECT 1")
 
         assert cursor._prefetch_hook is None
 
@@ -2174,7 +2169,7 @@ class TestAbortQuery:
     """Unit tests for Cursor.abort_query method."""
 
     @pytest.fixture
-    def mock_connection(self):
+    def mock_connection(self, mock_core_client):
         conn = MagicMock()
         conn.conn_handle = ConnectionHandle(id=1)
         conn.is_closed.return_value = False
@@ -2184,28 +2179,28 @@ class TestAbortQuery:
     def cursor(self, mock_connection):
         return SnowflakeCursor(mock_connection)
 
-    def test_abort_query_returns_true_on_success(self, cursor, mock_connection):
+    def test_abort_query_returns_true_on_success(self, cursor, mock_core_client):
         """abort_query sends correct RPC args and returns True on success."""
-        mock_connection.db_api.connection_abort_query.return_value.success = True
+        mock_core_client.connection_abort_query.return_value.success = True
 
         result = cursor.abort_query("01234567-abcd-ef01-0000-000000000001")
 
         assert result is True
-        request = mock_connection.db_api.connection_abort_query.call_args.args[0]
+        request = mock_core_client.connection_abort_query.call_args.args[0]
         assert request.conn_handle == ConnectionHandle(id=1)
         assert request.query_id == "01234567-abcd-ef01-0000-000000000001"
 
-    def test_abort_query_returns_false_on_failure(self, cursor, mock_connection):
+    def test_abort_query_returns_false_on_failure(self, cursor, mock_core_client):
         """abort_query returns False when the server reports failure."""
-        mock_connection.db_api.connection_abort_query.return_value.success = False
+        mock_core_client.connection_abort_query.return_value.success = False
 
         result = cursor.abort_query("some-qid")
 
         assert result is False
 
-    def test_abort_query_does_not_mutate_cursor_state(self, cursor, mock_connection):
+    def test_abort_query_does_not_mutate_cursor_state(self, cursor, mock_core_client):
         """abort_query does not modify description, rowcount, or execute_result."""
-        mock_connection.db_api.connection_abort_query.return_value.success = True
+        mock_core_client.connection_abort_query.return_value.success = True
 
         cursor.abort_query("some-qid")
 
@@ -2223,9 +2218,9 @@ class TestAbortQuery:
         with pytest.raises(InterfaceError):
             fresh.abort_query("qid")
 
-    def test_abort_query_propagates_rpc_error(self, cursor, mock_connection):
+    def test_abort_query_propagates_rpc_error(self, cursor, mock_core_client):
         """abort_query propagates ProgrammingError from the RPC layer."""
-        mock_connection.db_api.connection_abort_query.side_effect = ProgrammingError("Request failed")
+        mock_core_client.connection_abort_query.side_effect = ProgrammingError("Request failed")
         with pytest.raises(ProgrammingError, match="Request failed"):
             cursor.abort_query("bad-qid")
 
@@ -2251,7 +2246,7 @@ class TestExecuteAsync:
     """Unit tests for Cursor.execute_async method."""
 
     @pytest.fixture
-    def mock_connection(self):
+    def mock_connection(self, mock_core_client):
         conn = MagicMock()
         conn.conn_handle = ConnectionHandle(id=1)
         conn.is_closed.return_value = False
@@ -2259,11 +2254,11 @@ class TestExecuteAsync:
 
         handle_resp = MagicMock()
         handle_resp.stmt_handle = StatementHandle(id=42)
-        conn.db_api.statement_new.return_value = handle_resp
+        mock_core_client.statement_new.return_value = handle_resp
 
         async_resp = MagicMock()
         async_resp.query_id = "01abc-fake-query-id"
-        conn.db_api.statement_execute_async.return_value = async_resp
+        mock_core_client.statement_execute_async.return_value = async_resp
 
         return conn
 
@@ -2285,29 +2280,29 @@ class TestExecuteAsync:
 
         assert cursor.sfqid == "01abc-fake-query-id"
 
-    def test_calls_statement_execute_async_rpc(self, cursor, mock_connection):
+    def test_calls_statement_execute_async_rpc(self, cursor, mock_core_client):
         """execute_async creates a statement and invokes the async RPC."""
         cursor.execute_async("SELECT 42")
 
-        mock_connection.db_api.statement_new.assert_called_once()
-        mock_connection.db_api.statement_set_sql_query.assert_called_once()
-        mock_connection.db_api.statement_execute_async.assert_called_once()
-        mock_connection.db_api.statement_release.assert_called_once()
+        mock_core_client.statement_new.assert_called_once()
+        mock_core_client.statement_set_sql_query.assert_called_once()
+        mock_core_client.statement_execute_async.assert_called_once()
+        mock_core_client.statement_release.assert_called_once()
 
-    def test_resets_cursor_state(self, cursor, mock_connection):
+    def test_resets_cursor_state(self, cursor):
         """execute_async resets cursor state before submission."""
         cursor._fetch_mode = FetchMode.ROW
         cursor.execute_async("SELECT 1")
 
         assert cursor._fetch_mode is None
 
-    def test_with_parameters_passes_bindings(self, cursor, mock_connection):
+    def test_with_parameters_passes_bindings(self, cursor, mock_core_client):
         """execute_async forwards parameter bindings to the RPC request."""
-        mock_connection.paramstyle = ParamStyle.QMARK
+        cursor._connection.paramstyle = ParamStyle.QMARK
 
         cursor.execute_async("SELECT ?", [42])
 
-        request = mock_connection.db_api.statement_execute_async.call_args.args[0]
+        request = mock_core_client.statement_execute_async.call_args.args[0]
         assert request.bindings is not None
 
     def test_raises_on_closed_cursor(self, cursor):
@@ -2317,16 +2312,16 @@ class TestExecuteAsync:
         with pytest.raises(InterfaceError):
             cursor.execute_async("SELECT 1")
 
-    def test_propagates_rpc_error(self, cursor, mock_connection):
+    def test_propagates_rpc_error(self, cursor, mock_core_client):
         """execute_async propagates errors from the RPC layer."""
-        mock_connection.db_api.statement_execute_async.side_effect = ProgrammingError("Async submission failed")
+        mock_core_client.statement_execute_async.side_effect = ProgrammingError("Async submission failed")
 
         with pytest.raises(ProgrammingError, match="Async submission failed"):
             cursor.execute_async("SELECT 1")
 
-    def test_handles_empty_query_id(self, cursor, mock_connection):
+    def test_handles_empty_query_id(self, cursor, mock_core_client):
         """execute_async returns None queryId when server returns empty string."""
-        mock_connection.db_api.statement_execute_async.return_value.query_id = ""
+        mock_core_client.statement_execute_async.return_value.query_id = ""
 
         result = cursor.execute_async("SELECT 1")
 

--- a/python/tests/unit/test_internal_telemetry.py
+++ b/python/tests/unit/test_internal_telemetry.py
@@ -2,7 +2,7 @@
 
 import platform
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -22,17 +22,22 @@ class TestConnectionInitIdentity:
 
     @pytest.fixture
     def full_mock_db_api(self):
+        from snowflake.connector._internal.api_client.client_api import core_driver
+
         db_api = MagicMock()
         db_api.database_new.return_value = MagicMock(db_handle=DatabaseHandle(id=1))
         db_api.connection_new.return_value = MagicMock(conn_handle=ConnectionHandle(id=42))
         db_api.connection_get_parameter.return_value = MagicMock(value="")
-        return db_api
+
+        old_client = core_driver._client
+        core_driver.client = db_api
+        yield db_api
+        core_driver.client = old_client
 
     def test_connection_init_includes_identity_fields(self, full_mock_db_api):
         from snowflake.connector.connection import Connection
 
-        with patch("snowflake.connector.connection.database_driver_client", return_value=full_mock_db_api):
-            Connection(user="test_user", account="test_account")
+        Connection(user="test_user", account="test_account")
 
         full_mock_db_api.connection_init.assert_called_once()
         req = full_mock_db_api.connection_init.call_args[0][0]


### PR DESCRIPTION
## Summary

- Introduce `CoreDriver` singleton facade in `client_api.py` that centralizes all `DatabaseDriverClient` protobuf API access behind typed, domain-level methods
- Migrate all 9 source files ([connection.py](http://connection.py), cursor/_base.py, [telemetry.py](http://telemetry.py), freezable_proxy.py, snowflake_restful.py, statement_utils.py, result_batch.py, config_manager.py) to use `core_driver` instead of `self.db_api` / `database_driver_client()`
- Remove `Connection.db_api` field and the `database_driver_client()` singleton function
- Update all test mocking patterns to inject via `core_driver.client` setter

## Context

The previous architecture required every caller to construct raw protobuf `*Request` objects and call `DatabaseDriverClient` methods directly (or indirectly via `connection.db_api`). This led to duplicated request-construction logic, tight coupling to protobuf internals, and made it impossible to type-check handle parameters.

`CoreDriver` encapsulates all request construction in one place, exposes a clean typed API (concrete handle/response types instead of `Any`), and provides a single injection point for test mocks via a property setter.