### PR TITLE
NO-SNOW: scope workflow change detection per-language

### DIFF
--- a/.github/workflows/detect-changes.yml
+++ b/.github/workflows/detect-changes.yml
@@ -96,6 +96,14 @@ jobs:
         id: filter
         uses: dorny/paths-filter@v3
         with:
+          # Each language filter explicitly includes:
+          #   1. its source directories, and
+          #   2. the GHA workflows + composite actions it actually consumes.
+          # The `shared` filter lists only truly cross-cutting items (the
+          # detect-changes workflow itself, the universally-used cargo-cache
+          # action, the Rust workspace root, shared test infra).  Editing one
+          # language's CI — or an admin-only workflow like labeler.yml —
+          # therefore no longer retriggers every other language's CI.
           filters: |
             core:
               - 'sf_core/**'
@@ -106,10 +114,14 @@ jobs:
               - 'protobuf/**'
               - 'thrift/**'
               - 'tests/definitions/core/**'
+              - '.github/workflows/test-rust-core.yml'
+              - '.github/actions/setup-msvc/**'
+              - '.github/actions/setup-windows-openssl/**'
             jdbc:
               - 'jdbc/**'
               - 'jdbc_bridge/**'
               - 'tests/definitions/jdbc/**'
+              - '.github/workflows/test-jdbc.yml'
             jdbc_e2e_integ:
               - 'jdbc/src/test/java/net/snowflake/client/api/**'
               - 'jdbc/src/test/java/net/snowflake/jdbc/**'
@@ -121,6 +133,10 @@ jobs:
               - 'tests/definitions/odbc/**'
               - 'scripts/odbc/**'
               - 'scripts/old_odbc/**'
+              - '.github/workflows/test-odbc.yml'
+              - '.github/actions/setup-msvc/**'
+              - '.github/actions/setup-windows-openssl/**'
+              - '.github/actions/vcpkg-version/**'
             odbc_e2e_integ:
               - 'odbc_tests/tests/e2e/**'
               - 'odbc_tests/tests/integration/**'
@@ -138,6 +154,10 @@ jobs:
               - 'pep249_dbapi/**'
               - 'tests/definitions/python/**'
               - 'scripts/old_python/**'
+              - '.github/workflows/test-python.yml'
+              - '.github/workflows/_build-python-wheels.yml'
+              - '.github/workflows/build-python-release.yml'
+              - '.github/actions/setup-windows-openssl/**'
             python_e2e_integ:
               - 'python/tests/e2e/**'
               - 'python/tests/integ/**'
@@ -160,7 +180,8 @@ jobs:
               - 'odbc_trace_tool/**'
               - 'tests/!(performance|tests_format_validator|test_coverage_report|definitions)/**'
               - 'tests/definitions/shared/**'
-              - '.github/workflows/**'
+              - '.github/workflows/detect-changes.yml'
+              - '.github/actions/cargo-cache/**'
               - '.buildkite/**'
               - 'scripts/decode_secrets.*'
               - 'scripts/shared/**'


### PR DESCRIPTION
The `shared` filter previously matched `.github/workflows/**`, so editing any workflow file re-triggered every language CI. Split those patterns so each language filter (core / jdbc / odbc / python) now explicitly includes the workflow and composite actions it actually consumes. `shared` shrinks to detect-changes.yml itself plus cargo-cache (used everywhere). Admin-only workflows (labeler, environment-cleanup, pre-commit, validations, accept-performance-changes) no longer fan out to language CIs.

Push to main still bypasses detect-changes via the existing `github.event_name == 'push' || ...` guard on every job, so main is never starved.