### PR TITLE
SNOW-3529420: ODBC CI: use setup-msvc composite in odbc_tests

### DIFF
--- a/.github/actions/setup-msvc/action.yml
+++ b/.github/actions/setup-msvc/action.yml
@@ -11,6 +11,15 @@ inputs:
       arm64, x86_arm64, amd64_arm64. The action verifies that
       VSCMD_ARG_TGT_ARCH ends up matching the target portion of this value.
     required: true
+  restore-cmake-dir:
+    description: >
+      When 'true', re-prepend the directory referenced by the CMAKE_DIR env var
+      to PATH after vcvarsall.bat runs. vcvarsall.bat prepends VS's bundled
+      cmake 3.x — callers that installed a newer cmake (via pip/Kitware) into
+      $CMAKE_DIR earlier in the job need this to keep their version resolving
+      first. Set to 'false' (the default) when CMAKE_DIR isn't used.
+    required: false
+    default: 'false'
 
 runs:
   using: composite
@@ -73,6 +82,15 @@ runs:
         if ($expectedTgt -eq 'amd64') { $expectedTgt = 'x64' }
         if ($env:VSCMD_ARG_TGT_ARCH -ne $expectedTgt) {
           throw "VSCMD_ARG_TGT_ARCH is '$($env:VSCMD_ARG_TGT_ARCH)', expected '$expectedTgt' for arch '$arch'"
+        }
+
+        # vcvarsall.bat prepends VS's bundled cmake (3.x) to PATH. Callers that installed
+        # a newer cmake into $CMAKE_DIR (e.g. Kitware pip wheel for cmake 4.x) need the
+        # newer copy to keep resolving first. The env propagation loop above writes the
+        # post-vcvarsall PATH to GITHUB_ENV; we now overwrite it with $CMAKE_DIR prepended.
+        if ("${{ inputs.restore-cmake-dir }}" -eq "true" -and $env:CMAKE_DIR) {
+          $env:PATH = "$env:CMAKE_DIR;$env:PATH"
+          "PATH=$env:PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         }
 
         Write-Host "MSVC ready: VS at $installPath, target arch $env:VSCMD_ARG_TGT_ARCH"

--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -367,6 +367,11 @@ jobs:
             cargo_target: i686-pc-windows-msvc
             cargo_extra: "--no-default-features --features vendored-openssl"
             cache_key: odbc-x86
+          - os: windows-11-arm
+            name: Windows ARM64
+            driver_lib: sfodbc.dll
+            cargo_extra: "--features vendored-openssl"
+            cache_key: odbc-arm64
     runs-on: ${{ matrix.os }}
     name: build_odbc_driver (${{ matrix.name }})
     steps:
@@ -584,7 +589,13 @@ jobs:
           New-Item -ItemType Directory -Force -Path "$env:GITHUB_WORKSPACE\.vcpkg-binary-cache" | Out-Null
 
           $triplet = "${{ matrix.vcpkg_triplet }}"
-          Invoke-Checked "vcpkg install" { vcpkg install zlib:$triplet openssl:$triplet }
+          if ("${{ matrix.msvc_arch }}" -eq "arm64") {
+            # ARM64 vcpkg builds require the ARM64 MSVC toolchain environment
+            cmd /c "`"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat`" arm64 && vcpkg install zlib:$triplet openssl:$triplet"
+            if ($LASTEXITCODE -ne 0) { throw "vcpkg install failed with exit code $LASTEXITCODE" }
+          } else {
+            Invoke-Checked "vcpkg install" { vcpkg install zlib:$triplet openssl:$triplet }
+          }
 
       - name: Setup MSVC environment (Windows)
         if: runner.os == 'Windows'
@@ -792,30 +803,48 @@ jobs:
       matrix:
         include:
           - name: Windows x64 Release
+            os: windows-latest
             arch: x64
             config: release
             cargo_target: x86_64-pc-windows-msvc
             cargo_profile: "--release"
             cargo_extra: ""
           - name: Windows x64 Debug
+            os: windows-latest
             arch: x64
             config: debug
             cargo_target: x86_64-pc-windows-msvc
             cargo_profile: ""
             cargo_extra: ""
           - name: Windows x86 Release
+            os: windows-latest
             arch: x86
             config: release
             cargo_target: i686-pc-windows-msvc
             cargo_profile: "--release"
             cargo_extra: "--no-default-features"
           - name: Windows x86 Debug
+            os: windows-latest
             arch: x86
             config: debug
             cargo_target: i686-pc-windows-msvc
             cargo_profile: ""
             cargo_extra: "--no-default-features"
-    runs-on: windows-latest
+          - name: Windows ARM64 Release
+            os: windows-11-arm
+            arch: arm64
+            config: release
+            cargo_target: aarch64-pc-windows-msvc
+            cargo_profile: "--release"
+            cargo_extra: ""
+          - name: Windows ARM64 Debug
+            os: windows-11-arm
+            arch: arm64
+            config: debug
+            cargo_target: aarch64-pc-windows-msvc
+            cargo_profile: ""
+            cargo_extra: ""
+    runs-on: ${{ matrix.os }}
     name: build_msi (${{ matrix.name }})
     steps:
       - name: Checkout repository
@@ -849,8 +878,11 @@ jobs:
           New-Item -ItemType Directory -Force -Path .cargo-target-msi | Out-Null
 
       - name: Install Rust target
-        if: matrix.cargo_target != 'x86_64-pc-windows-msvc'
+        if: matrix.arch == 'x86'
         run: rustup target add ${{ matrix.cargo_target }}
+
+      - name: Install WiX Toolset v7
+        run: dotnet tool install --global wix
 
       - name: Build ODBC driver
         run: cargo build ${{ matrix.cargo_profile }} --package odbc --features vendored-openssl ${{ matrix.cargo_extra }} --target ${{ matrix.cargo_target }}

--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -600,57 +600,10 @@ jobs:
 
       - name: Setup MSVC environment (Windows)
         if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = "Stop"
-          # Locate Visual Studio via vswhere (pre-installed on windows-latest)
-          $installPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
-          if (-not $installPath) { throw "vswhere could not locate a Visual Studio installation" }
-          $vcvars = Join-Path $installPath "VC\Auxiliary\Build\vcvarsall.bat"
-          if (-not (Test-Path $vcvars)) { throw "vcvarsall.bat not found at $vcvars" }
-
-          # Source vcvarsall.bat and capture its output. Capture to a variable first so we can
-          # inspect $LASTEXITCODE before any pipeline resets it: piping `cmd /c ... | ForEach-Object`
-          # would succeed as a pipeline even if vcvarsall.bat failed, leaving later steps running
-          # without cl.exe / link.exe on PATH.
-          $msvcArch = "${{ matrix.msvc_arch || 'amd64' }}"
-          $vcvarsOutput = cmd /c "`"$vcvars`" $msvcArch && set" 2>&1
-          if ($LASTEXITCODE -ne 0) {
-            Write-Host "vcvarsall.bat output:"
-            $vcvarsOutput | ForEach-Object { Write-Host $_ }
-            throw "vcvarsall.bat $msvcArch failed with exit code $LASTEXITCODE"
-          }
-          # Propagate env vars to BOTH:
-          #   - $env:GITHUB_ENV: visible to subsequent steps in the job (the point of this step)
-          #   - the current PowerShell process: so the post-condition check below actually sees
-          #     the updated PATH. Writes to GITHUB_ENV are buffered and only applied at step
-          #     boundary — without updating the current process env, `Get-Command cl.exe` would
-          #     always fail here even on a perfectly good vcvarsall.bat run.
-          $vcvarsOutput | ForEach-Object {
-            if ($_ -match '^([^=]+)=(.*)$') {
-              $name = $Matches[1]
-              $value = $Matches[2]
-              echo "$name=$value" >> $env:GITHUB_ENV
-              [System.Environment]::SetEnvironmentVariable($name, $value, 'Process')
-            }
-          }
-
-          # Post-condition: verify the MSVC toolchain is actually on PATH. vcvarsall.bat can exit 0
-          # while setting a broken environment (e.g., missing components, wrong host arch), so treat
-          # "cl.exe not found" as a hard failure rather than letting the next build step blow up
-          # with a confusing linker error.
-          if (-not (Get-Command cl.exe -ErrorAction SilentlyContinue)) {
-            throw "MSVC environment setup completed but cl.exe is not on PATH"
-          }
-          if (-not (Get-Command link.exe -ErrorAction SilentlyContinue)) {
-            throw "MSVC environment setup completed but link.exe is not on PATH"
-          }
-
-          # vcvarsall.bat prepends VS's cmake 3.x to PATH; re-prepend the runner's 4.x
-          if ($env:CMAKE_DIR) {
-            $env:PATH = "$env:CMAKE_DIR;$env:PATH"
-            echo "PATH=$env:PATH" >> $env:GITHUB_ENV
-          }
+        uses: ./.github/actions/setup-msvc
+        with:
+          arch: ${{ matrix.msvc_arch || 'amd64' }}
+          restore-cmake-dir: 'true'
 
       - name: Decode secrets
         run: ./scripts/decode_secrets.sh ${{ matrix.cloud_provider }}

--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -800,7 +800,7 @@ jobs:
     needs: detect-changes
     if: github.event_name == 'push' || needs.detect-changes.outputs.run_odbc == 'true'
     runs-on: windows-latest
-    name: build_wix (WiX Toolset ${{ env.WIX_REF }} from source)
+    name: build_wix (WiX Toolset from source)
     env:
       DOTNET_NOLOGO: 'true'
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 'true'

--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -827,23 +827,24 @@ jobs:
           path: wix-src
           fetch-depth: 0
 
-      - name: Disable NuGet audit in WiX nuget.config
+      - name: Disable NuGet audit in WiX Directory.Build.props
         if: steps.wix-cache.outputs.cache-hit != 'true'
         shell: pwsh
         run: |
-          $configPath = Join-Path $PWD 'wix-src/nuget.config'
-          if (-not (Test-Path $configPath)) {
-              throw "WiX nuget.config not found at $configPath"
+          $propsPath = Join-Path $PWD 'wix-src/src/Directory.Build.props'
+          if (-not (Test-Path $propsPath)) {
+              throw "WiX Directory.Build.props not found at $propsPath"
           }
-          $content = Get-Content $configPath -Raw
-          if ($content -notmatch '<auditSources>') {
-              $injection = "  <auditSources>`r`n    <clear />`r`n  </auditSources>`r`n</configuration>"
-              $content = $content -replace '</configuration>', $injection
-              Set-Content -Path $configPath -Value $content -Encoding UTF8 -NoNewline
-              Write-Host "Patched nuget.config to disable NuGet audit:"
-              Get-Content $configPath
+          $content = Get-Content $propsPath -Raw
+          $patched = $content `
+              -replace '<NuGetAudit>true</NuGetAudit>',           '<NuGetAudit>false</NuGetAudit>' `
+              -replace '<NuGetAuditMode>all</NuGetAuditMode>',     '<NuGetAuditMode>direct</NuGetAuditMode>' `
+              -replace '<NuGetAuditLevel>low</NuGetAuditLevel>',   '<NuGetAuditLevel>critical</NuGetAuditLevel>'
+          if ($patched -eq $content) {
+              Write-Host "No NuGetAudit settings found to patch in $propsPath; continuing"
           } else {
-              Write-Host "auditSources already present in nuget.config; skipping patch"
+              Set-Content -Path $propsPath -Value $patched -Encoding UTF8 -NoNewline
+              Write-Host "Patched $propsPath to disable NuGet audit"
           }
 
       - name: Build WiX from source

--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -799,7 +799,9 @@ jobs:
   build_wix:
     needs: detect-changes
     if: github.event_name == 'push' || needs.detect-changes.outputs.run_odbc == 'true'
-    runs-on: windows-latest
+    # Pinned to windows-2022 because WiX v7 sources reference the VS 2022 'v143'
+    # platform toolset. windows-latest is transitioning to VS 2026 which removes v143.
+    runs-on: windows-2022
     name: build_wix (WiX Toolset from source)
     env:
       DOTNET_NOLOGO: 'true'

--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -882,7 +882,10 @@ jobs:
         run: rustup target add ${{ matrix.cargo_target }}
 
       - name: Install WiX Toolset v7
-        run: dotnet tool install --global wix
+        run: |
+          dotnet tool install --global wix
+          wix extension add WixToolset.UI.wixext
+          wix extension add WixToolset.Util.wixext
 
       - name: Build ODBC driver
         run: cargo build ${{ matrix.cargo_profile }} --package odbc --features vendored-openssl ${{ matrix.cargo_extra }} --target ${{ matrix.cargo_target }}

--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -1025,6 +1025,8 @@ jobs:
           $env:PATH = "$toolPath;$env:PATH"
           Write-Host "`nwix --version:"
           & wix --version
+          & wix eula accept wix7
+          if ($LASTEXITCODE -ne 0) { throw "wix eula accept wix7 failed with exit code $LASTEXITCODE" }
 
           # --- Pre-stage WiX extensions directly into the global cache so `wix build` resolves
           # them locally without ever calling NuGet. `wix extension add` is intentionally not used

--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -808,6 +808,7 @@ jobs:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 'true'
       DOTNET_CLI_TELEMETRY_OPTOUT: 'true'
       NUGET_XMLDOC_MODE: skip
+      NuGetAudit: 'false'
     steps:
       - name: Restore WiX build cache
         id: wix-cache
@@ -825,6 +826,25 @@ jobs:
           ref: ${{ env.WIX_REF }}
           path: wix-src
           fetch-depth: 0
+
+      - name: Disable NuGet audit in WiX nuget.config
+        if: steps.wix-cache.outputs.cache-hit != 'true'
+        shell: pwsh
+        run: |
+          $configPath = Join-Path $PWD 'wix-src/nuget.config'
+          if (-not (Test-Path $configPath)) {
+              throw "WiX nuget.config not found at $configPath"
+          }
+          $content = Get-Content $configPath -Raw
+          if ($content -notmatch '<auditSources>') {
+              $injection = "  <auditSources>`r`n    <clear />`r`n  </auditSources>`r`n</configuration>"
+              $content = $content -replace '</configuration>', $injection
+              Set-Content -Path $configPath -Value $content -Encoding UTF8 -NoNewline
+              Write-Host "Patched nuget.config to disable NuGet audit:"
+              Get-Content $configPath
+          } else {
+              Write-Host "auditSources already present in nuget.config; skipping patch"
+          }
 
       - name: Build WiX from source
         if: steps.wix-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -21,6 +21,7 @@ env:
   CCACHE_BASEDIR: ${{ github.workspace }}
   CCACHE_MAXSIZE: 1G
   VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/.vcpkg-binary-cache,readwrite"
+  WIX_REF: v7.0.0
 
 jobs:
   detect-changes:
@@ -795,8 +796,77 @@ jobs:
           python scripts/cleanup_env.py \
             --parameter-path "${{ github.workspace }}/parameters.json"
 
-  build_msi:
+  build_wix:
     needs: detect-changes
+    if: github.event_name == 'push' || needs.detect-changes.outputs.run_odbc == 'true'
+    runs-on: windows-latest
+    name: build_wix (WiX Toolset ${{ env.WIX_REF }} from source)
+    env:
+      DOTNET_NOLOGO: 'true'
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 'true'
+      DOTNET_CLI_TELEMETRY_OPTOUT: 'true'
+      NUGET_XMLDOC_MODE: skip
+    steps:
+      - name: Restore WiX build cache
+        id: wix-cache
+        continue-on-error: true
+        uses: actions/cache/restore@v5
+        with:
+          path: wix-artifacts
+          key: wix-v7-${{ env.WIX_REF }}-${{ runner.os }}-v1
+
+      - name: Checkout wixtoolset/wix @ ${{ env.WIX_REF }}
+        if: steps.wix-cache.outputs.cache-hit != 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: wixtoolset/wix
+          ref: ${{ env.WIX_REF }}
+          path: wix-src
+          fetch-depth: 0
+
+      - name: Build WiX from source
+        if: steps.wix-cache.outputs.cache-hit != 'true'
+        shell: cmd
+        working-directory: wix-src
+        run: .\src\build_all.cmd Release
+
+      - name: Stage WiX nupkgs
+        if: steps.wix-cache.outputs.cache-hit != 'true'
+        shell: pwsh
+        run: |
+          $source = Join-Path $PWD "wix-src\build\artifacts"
+          $dest = Join-Path $PWD "wix-artifacts"
+          New-Item -ItemType Directory -Force -Path $dest | Out-Null
+          Get-ChildItem -Path $source -Recurse -Include *.nupkg, *.snupkg | ForEach-Object {
+              Copy-Item -Path $_.FullName -Destination $dest -Force
+          }
+          $count = (Get-ChildItem $dest -Filter *.nupkg).Count
+          if ($count -eq 0) {
+              throw "No nupkgs found in $source after WiX build"
+          }
+          Write-Host "Staged $count nupkgs to $dest"
+          Get-ChildItem $dest -Filter *.nupkg | Select-Object Name | Format-Table -AutoSize
+
+      - name: Save WiX build cache
+        if: always() && steps.wix-cache.outputs.cache-hit != 'true'
+        continue-on-error: true
+        timeout-minutes: 10
+        env:
+          ZSTD_NBTHREADS: '2'
+        uses: actions/cache/save@v5
+        with:
+          path: wix-artifacts
+          key: wix-v7-${{ env.WIX_REF }}-${{ runner.os }}-v1
+
+      - name: Upload WiX artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: wix-toolset-v7
+          path: wix-artifacts/
+          if-no-files-found: error
+
+  build_msi:
+    needs: [detect-changes, build_wix]
     if: github.event_name == 'push' || needs.detect-changes.outputs.run_odbc == 'true'
     strategy:
       fail-fast: false
@@ -881,11 +951,82 @@ jobs:
         if: matrix.arch == 'x86'
         run: rustup target add ${{ matrix.cargo_target }}
 
-      - name: Install WiX Toolset v7
+      - name: Download self-built WiX
+        uses: actions/download-artifact@v4
+        with:
+          name: wix-toolset-v7
+          path: wix-artifacts
+
+      - name: Install WiX from local source
+        shell: pwsh
+        env:
+          DOTNET_NOLOGO: 'true'
+          DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 'true'
+          DOTNET_CLI_TELEMETRY_OPTOUT: 'true'
         run: |
-          dotnet tool install --global wix
-          wix extension add WixToolset.UI.wixext
-          wix extension add WixToolset.Util.wixext
+          $ErrorActionPreference = 'Stop'
+          $wixSource = Join-Path $PWD 'wix-artifacts'
+          if (-not (Test-Path $wixSource)) {
+              throw "Self-built WiX artifact directory not found: $wixSource"
+          }
+          $wixVersion = '${{ env.WIX_REF }}'.TrimStart('v')
+
+          # --- Hard-block nuget.org so a misconfigured step cannot silently pull a published WiX.
+          # `dotnet nuget disable source nuget.org` is idempotent: if the source isn't configured,
+          # it returns non-zero, which we tolerate.
+          & dotnet nuget disable source nuget.org 2>&1 | Write-Host
+
+          # Register the self-built nupkg directory as the only NuGet source for this job.
+          $existing = (& dotnet nuget list source) -join "`n"
+          if ($existing -match 'local-wix') {
+              & dotnet nuget update source local-wix --source $wixSource | Write-Host
+          } else {
+              & dotnet nuget add source $wixSource --name local-wix | Write-Host
+          }
+          if ($LASTEXITCODE -ne 0) { throw "Failed to register local-wix NuGet source" }
+          Write-Host "`nConfigured NuGet sources:"
+          & dotnet nuget list source
+
+          # --- Install the wix CLI from our local source only.
+          $toolPath = Join-Path $PWD '.wix-tool'
+          New-Item -ItemType Directory -Force -Path $toolPath | Out-Null
+          Write-Host "`nInstalling wix $wixVersion from $wixSource..."
+          & dotnet tool install wix `
+              --tool-path $toolPath `
+              --add-source $wixSource `
+              --version $wixVersion `
+              --ignore-failed-sources
+          if ($LASTEXITCODE -ne 0) { throw "dotnet tool install wix failed with exit code $LASTEXITCODE" }
+
+          "$toolPath" | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
+          $env:PATH = "$toolPath;$env:PATH"
+          Write-Host "`nwix --version:"
+          & wix --version
+
+          # --- Pre-stage WiX extensions directly into the global cache so `wix build` resolves
+          # them locally without ever calling NuGet. `wix extension add` is intentionally not used
+          # because it always calls NuGet for resolution (see wixtoolset/issues#6184, #8044).
+          $extensionsRoot = Join-Path $env:USERPROFILE '.wix\extensions'
+          New-Item -ItemType Directory -Force -Path $extensionsRoot | Out-Null
+          Add-Type -AssemblyName System.IO.Compression.FileSystem
+          foreach ($pkgId in @('WixToolset.UI.wixext', 'WixToolset.Util.wixext')) {
+              $nupkg = Get-ChildItem -Path $wixSource -File `
+                  | Where-Object { $_.Extension -eq '.nupkg' -and $_.BaseName -like "$pkgId.*" } `
+                  | Sort-Object Name -Descending `
+                  | Select-Object -First 1
+              if (-not $nupkg) {
+                  throw "Extension nupkg not found for $pkgId in $wixSource"
+              }
+              $extVersion = $nupkg.BaseName.Substring($pkgId.Length + 1)
+              $destDir = Join-Path $extensionsRoot "$pkgId\$extVersion"
+              if (Test-Path $destDir) { Remove-Item -Recurse -Force $destDir }
+              New-Item -ItemType Directory -Force -Path $destDir | Out-Null
+              [System.IO.Compression.ZipFile]::ExtractToDirectory($nupkg.FullName, $destDir)
+              Write-Host "Staged $($nupkg.Name) -> $destDir"
+          }
+
+          Write-Host "`nRegistered WiX extensions:"
+          & wix extension list --global
 
       - name: Build ODBC driver
         run: cargo build ${{ matrix.cargo_profile }} --package odbc --features vendored-openssl ${{ matrix.cargo_extra }} --target ${{ matrix.cargo_target }}

--- a/ci/test_matrix/mappings/odbc.py
+++ b/ci/test_matrix/mappings/odbc.py
@@ -31,5 +31,6 @@ ODBC_PLATFORM: dict[tuple[str, str], dict[str, str]] = {
                          "vcpkg_triplet": "x64-windows"},
     ("windows", "x86"): {"driver_lib": "sfodbc32.dll",    "driver_artifact": "Windows x86",
                          "msvc_arch": "x86", "vcpkg_triplet": "x86-windows"},
-    ("windows", "arm"): {"driver_lib": "sfodbc.dll"},
+    ("windows", "arm"): {"driver_lib": "sfodbc.dll",      "driver_artifact": "Windows ARM64",
+                         "msvc_arch": "arm64", "vcpkg_triplet": "arm64-windows"},
 }

--- a/ci/test_matrix/models/odbc.py
+++ b/ci/test_matrix/models/odbc.py
@@ -19,8 +19,6 @@ def is_valid(c):
         if c["Arch"] == "x64": return False
         if c["Arch"] == "x86": return False
 
-    # Windows ARM64 is built on the windows-11-arm runner; no exclusion needed.
-
     return True
 
 

--- a/ci/test_matrix/models/odbc.py
+++ b/ci/test_matrix/models/odbc.py
@@ -19,9 +19,7 @@ def is_valid(c):
         if c["Arch"] == "x64": return False
         if c["Arch"] == "x86": return False
 
-    if c["OS"] == "windows":
-        # No Windows-ARM64 ODBC build today.
-        if c["Arch"] == "arm": return False
+    # Windows ARM64 is built on the windows-11-arm runner; no exclusion needed.
 
     return True
 

--- a/odbc/installer/win/package.ps1
+++ b/odbc/installer/win/package.ps1
@@ -1,16 +1,16 @@
 <#
 .SYNOPSIS
-    Builds a Snowflake ODBC Driver MSI installer using the WiX Toolset v3.
+    Builds a Snowflake ODBC Driver MSI installer using WiX Toolset v7.
 
 .DESCRIPTION
-    Invokes candle.exe (compiler) and light.exe (linker) from the WiX Toolset
-    to produce an MSI installer for the Snowflake ODBC Driver.
+    Invokes `wix build` from the WiX Toolset v7 CLI to produce an MSI installer
+    for the Snowflake ODBC Driver.
 
 .PARAMETER DriverBinDir
     Directory containing the built sfodbc.dll (e.g. target\release).
 
 .PARAMETER Arch
-    Target architecture: x64 or x86. Selects the matching WiX source file.
+    Target architecture: x64, x86, or arm64. Selects the matching WiX source file.
     Defaults to x64.
 
 .PARAMETER BuildConfig
@@ -18,7 +18,7 @@
     Defaults to release.
 
 .PARAMETER VCRedistDir
-    Directory containing the VC++ redistributable (vc_redist.x64.exe / vc_redist.x86.exe).
+    Directory containing the VC++ redistributable (vc_redist.x64.exe / vc_redist.x86.exe / vc_redist.arm64.exe).
     Auto-detected from the Visual Studio installation if not specified.
 
 .PARAMETER Version
@@ -35,6 +35,9 @@
 
 .EXAMPLE
     .\odbc\installer\win\package.ps1 -DriverBinDir target\i686-pc-windows-msvc\debug -Arch x86 -BuildConfig debug
+
+.EXAMPLE
+    .\odbc\installer\win\package.ps1 -DriverBinDir target\aarch64-pc-windows-msvc\release -Arch arm64
 #>
 
 [CmdletBinding()]
@@ -42,7 +45,7 @@ param(
     [Parameter(Mandatory)]
     [string]$DriverBinDir,
 
-    [ValidateSet("x64", "x86")]
+    [ValidateSet("x64", "x86", "arm64")]
     [string]$Arch = "x64",
 
     [ValidateSet("release", "debug")]
@@ -66,10 +69,8 @@ if (-not (Test-Path $WxsFile)) {
 }
 
 # --- WiX Toolset preflight ---
-foreach ($tool in @("candle.exe", "light.exe")) {
-    if (-not (Get-Command $tool -ErrorAction SilentlyContinue)) {
-        throw "$tool not found on PATH. Install WiX Toolset v3 or add its bin directory to PATH."
-    }
+if (-not (Get-Command "wix" -ErrorAction SilentlyContinue)) {
+    throw "wix CLI not found on PATH. Install WiX Toolset v7: dotnet tool install --global wix"
 }
 
 # --- Version ---
@@ -162,36 +163,22 @@ Write-Host "  VCRedist dir     : $VCRedistDir"
 Write-Host "  Source dir       : $SourceDir"
 Write-Host "  Output dir       : $OutputDir"
 
-$ObjDir = Join-Path $OutputDir "wixobj"
-New-Item -ItemType Directory -Force -Path $ObjDir | Out-Null
-
-$WixObj = Join-Path $ObjDir "snowflake_odbc_${Arch}${configSuffix}.wixobj"
 $MsiFile = Join-Path $OutputDir "snowflake-odbc-ud-${Version}${configSuffix}-${Arch}.msi"
 
-$candleArch = if ($Arch -eq "x64") { "x64" } else { "x86" }
-
-Write-Host "`n--- Compiling WiX source ---"
-& candle.exe `
-    -nologo `
-    -arch $candleArch `
-    -dProductVersion="$WixVersion" `
-    -dFullVersion="$Version" `
-    -dOdbcApiVer="$OdbcApiVer" `
-    -dDriverBinDir="$DriverBinDir" `
-    -dVCRedistDir="$VCRedistDir" `
-    -dSourceDir="$SourceDir" `
-    -out "$WixObj" `
-    "$WxsFile"
-if ($LASTEXITCODE -ne 0) { throw "candle.exe failed with exit code $LASTEXITCODE" }
-
-Write-Host "`n--- Linking MSI ---"
-& light.exe `
-    -nologo `
-    -ext WixUIExtension `
-    -ext WixUtilExtension `
+Write-Host "`n--- Building MSI ---"
+& wix build `
+    "$WxsFile" `
+    -arch $Arch `
+    -ext WixToolset.UI.wixext `
+    -ext WixToolset.Util.wixext `
+    -d ProductVersion="$WixVersion" `
+    -d FullVersion="$Version" `
+    -d OdbcApiVer="$OdbcApiVer" `
+    -d DriverBinDir="$DriverBinDir" `
+    -d VCRedistDir="$VCRedistDir" `
+    -d SourceDir="$SourceDir" `
     -b "$PSScriptRoot" `
-    -out "$MsiFile" `
-    "$WixObj"
-if ($LASTEXITCODE -ne 0) { throw "light.exe failed with exit code $LASTEXITCODE" }
+    -o "$MsiFile"
+if ($LASTEXITCODE -ne 0) { throw "wix build failed with exit code $LASTEXITCODE" }
 
 Write-Host "`n=== Successfully created MSI: $MsiFile ==="

--- a/odbc/installer/win/snowflake_odbc_arm64.wxs
+++ b/odbc/installer/win/snowflake_odbc_arm64.wxs
@@ -3,19 +3,19 @@
      xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui"
      xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util">
 	<Package
-		Name="Snowflake ODBC UD $(var.FullVersion) PrPr (x86)"
+		Name="Snowflake ODBC UD $(var.FullVersion) PrPr (arm64)"
 		Language="1033"
 		Version="$(var.ProductVersion)"
 		Manufacturer="Snowflake Computing"
-		UpgradeCode="C22845FB-6D0B-45A8-B914-CED965D221B1"
+		UpgradeCode="7F1F121C-929A-4F09-BD1A-3B32E090FB46"
 		InstallerVersion="405"
 		Scope="perMachine">
 
 		<SummaryInformation
-			Description="Snowflake ODBC UD $(var.FullVersion) Private Preview (32-bit)"
+			Description="Snowflake ODBC UD $(var.FullVersion) Private Preview (ARM64)"
 			Comments="Installs the Snowflake ODBC Driver (Private Preview) built on Universal Driver." />
 
-		<Media Id="1" Cabinet="odbc32.cab" EmbedCab="yes" />
+		<Media Id="1" Cabinet="odbc_arm64.cab" EmbedCab="yes" />
 		<MajorUpgrade AllowDowngrades="yes" />
 		<Property Id="REBOOT" Value="ReallySuppress" />
 
@@ -44,7 +44,7 @@
 		<Property Id="VCREDIST2015INSTALLED">
 			<RegistrySearch Id="VCREDIST2015SEARCH"
 				Root="HKLM"
-				Key="Software\Microsoft\VisualStudio\14.0\VC\Runtimes\x86"
+				Key="Software\Microsoft\VisualStudio\14.0\VC\Runtimes\arm64"
 				Name="Installed"
 				Type="raw" />
 		</Property>
@@ -59,7 +59,7 @@
 		<SetProperty Id="WIXUI_EXITDIALOGOPTIONALCHECKBOX" After="AppSearch" Value="1">
 			<![CDATA[NOT VCREDIST2015INSTALLED]]>
 		</SetProperty>
-		<SetProperty Id="WixShellExecTarget" Value="[INSTALLDIR]Redistributable\vc_redist.x86.exe" After="CostFinalize" Sequence="ui" />
+		<SetProperty Id="WixShellExecTarget" Value="[INSTALLDIR]Redistributable\vc_redist.arm64.exe" After="CostFinalize" Sequence="ui" />
 		<CustomAction Id="Install_vc_redist" DllEntry="WixShellExec" BinaryRef="Wix4UtilCA_$(sys.BUILDARCH)" />
 		<UI>
 			<Publish Dialog="ExitDialog" Control="Finish" Event="DoAction"
@@ -82,7 +82,7 @@
 			<Directory Id="PersonalFolder">
 				<Directory Id="SnowflakeODBCUDDriverLogs" Name="Snowflake ODBC UD">
 					<Directory Id="LogDir" Name="log">
-						<Component Id="LogDir" Guid="CD48DCFD-56C5-4BAC-AE02-0635C488499E">
+						<Component Id="LogDir" Guid="D44B3812-31D7-4CDF-920B-BD4E1BE4426B">
 						<CreateFolder />
 							<RemoveFolder Id="LogDir" On="uninstall" />
 							<RemoveFolder Id="RemoveODBCDriverLogParent" Directory="SnowflakeODBCUDDriverLogs" On="uninstall" />
@@ -98,9 +98,9 @@
 		<!-- Files: driver DLL                                                 -->
 		<!-- ================================================================ -->
 		<DirectoryRef Id="BinDir">
-			<Component Id="sfodbc32.dll" Guid="E487E93A-284A-43C8-A6E9-AB54599C0C3A">
-				<File Id="sfodbc32.dll" KeyPath="yes"
-					Source="$(var.DriverBinDir)\sfodbc32.dll" />
+			<Component Id="sfodbc.dll" Guid="A7615A19-016B-4518-B3CE-540B7016803D" Permanent="no">
+			<File Id="sfodbc.dll" KeyPath="yes"
+					Source="$(var.DriverBinDir)\sfodbc.dll" />
 			</Component>
 		</DirectoryRef>
 
@@ -108,8 +108,8 @@
 		<!-- Files: public header                                              -->
 		<!-- ================================================================ -->
 		<DirectoryRef Id="IncludeDir">
-			<Component Id="sf_odbc.h" Guid="18554A74-79EC-4401-BCFE-06F3DD7EE19F">
-				<File Id="sf_odbc.h" KeyPath="yes"
+			<Component Id="sf_odbc.h" Guid="B82E93EF-4D19-4C7E-AB4F-644DB1F17AE9" Permanent="no">
+			<File Id="sf_odbc.h" KeyPath="yes"
 					Source="$(var.SourceDir)\odbc\include\sf_odbc.h" />
 			</Component>
 		</DirectoryRef>
@@ -118,9 +118,9 @@
 		<!-- Files: VC++ Redistributable                                       -->
 		<!-- ================================================================ -->
 		<DirectoryRef Id="RedistDir">
-			<Component Id="vc_redist.x86.exe" Guid="A412FAFC-E3C8-4FE9-9DC4-257C303098F2">
-			<File Id="vc_redist.x86.exe" KeyPath="yes"
-					Source="$(var.VCRedistDir)\vc_redist.x86.exe" />
+			<Component Id="vc_redist.arm64.exe" Guid="C2A38FD7-8E41-4094-8B34-B6D7C7705FC6" Permanent="no">
+			<File Id="vc_redist.arm64.exe" KeyPath="yes"
+					Source="$(var.VCRedistDir)\vc_redist.arm64.exe" />
 			</Component>
 		</DirectoryRef>
 
@@ -128,7 +128,7 @@
 		<!-- ODBC driver registration                                          -->
 		<!-- ================================================================ -->
 		<DirectoryRef Id="TARGETDIR">
-			<Component Id="RegistryEntries" Guid="EFCE448E-AA82-4829-BBFD-2EE34F00B487">
+			<Component Id="RegistryEntries" Guid="BC3B84E0-0AE0-47C5-ADC2-7B3D6BE62D7F">
 			<RegistryKey Root="HKLM"
 				Key="SOFTWARE\ODBC\ODBCINST.INI\ODBC Drivers"
 				ForceCreateOnInstall="yes">
@@ -137,10 +137,10 @@
 			<RegistryKey Root="HKLM"
 				Key="SOFTWARE\ODBC\ODBCINST.INI\Snowflake ODBC UD"
 				ForceCreateOnInstall="yes" ForceDeleteOnUninstall="yes">
-				<RegistryValue Type="string" Name="Driver" Value="[INSTALLDIR]Bin\sfodbc32.dll" KeyPath="yes" />
-				<RegistryValue Type="string" Name="Setup" Value="[INSTALLDIR]Bin\sfodbc32.dll" />
+				<RegistryValue Type="string" Name="Driver" Value="[INSTALLDIR]Bin\sfodbc.dll" KeyPath="yes" />
+				<RegistryValue Type="string" Name="Setup" Value="[INSTALLDIR]Bin\sfodbc.dll" />
 				<RegistryValue Type="string" Name="Description" Value="Snowflake ODBC UD" />
-				<RegistryValue Type="string" Name="DriverODBCVer" Value="$(var.OdbcApiVer)" />
+				<RegistryValue Type="string" Name="DriverODBCVer" Value="03.52" />
 				<RegistryValue Type="string" Name="CompanyName" Value="Snowflake Computing" />
 				<RegistryValue Type="string" Name="ConnectFunctions" Value="YYY" />
 				<RegistryValue Type="string" Name="APILevel" Value="1" />
@@ -155,14 +155,14 @@
 		<!-- Feature tree                                                       -->
 		<!-- ================================================================ -->
 		<Feature Id="MainApplication" Title="Snowflake ODBC UD" Level="1">
-			<ComponentRef Id="sfodbc32.dll" />
+			<ComponentRef Id="sfodbc.dll" />
 			<ComponentRef Id="sf_odbc.h" />
 			<ComponentRef Id="RegistryEntries" />
 			<ComponentRef Id="LogDir" />
 		</Feature>
 
 		<Feature Id="VCRedist" Title="Visual C++ Runtime" AllowAdvertise="yes" Display="expand" Level="1">
-			<ComponentRef Id="vc_redist.x86.exe" />
+			<ComponentRef Id="vc_redist.arm64.exe" />
 		</Feature>
 
 	</Package>

--- a/odbc/installer/win/snowflake_odbc_arm64.wxs
+++ b/odbc/installer/win/snowflake_odbc_arm64.wxs
@@ -34,8 +34,8 @@
 		<!-- ================================================================ -->
 		<ui:WixUI Id="WixUI_InstallDir" InstallDirectory="INSTALLDIR" />
 		<UI>
-			<Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="InstallDirDlg" Order="2">1</Publish>
-			<Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="2">1</Publish>
+			<Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="InstallDirDlg" Order="2" Condition="1" />
+			<Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="2" Condition="1" />
 		</UI>
 
 		<!-- ================================================================ -->
@@ -49,50 +49,45 @@
 				Type="raw" />
 		</Property>
 		<SetProperty Id="WIXUI_EXITDIALOGOPTIONALTEXT" After="AppSearch"
-			Value="Visual C++ Redistributable for VS 2015-2022 is required. It will be installed on exit. Uncheck the box if you do not want to install it.">
-			<![CDATA[NOT VCREDIST2015INSTALLED]]>
-		</SetProperty>
+			Value="Visual C++ Redistributable for VS 2015-2022 is required. It will be installed on exit. Uncheck the box if you do not want to install it."
+			Condition="NOT VCREDIST2015INSTALLED" />
 		<SetProperty Id="WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT" After="AppSearch"
-			Value="Install VC++ 2015-2022 Redistributable">
-			<![CDATA[NOT VCREDIST2015INSTALLED]]>
-		</SetProperty>
-		<SetProperty Id="WIXUI_EXITDIALOGOPTIONALCHECKBOX" After="AppSearch" Value="1">
-			<![CDATA[NOT VCREDIST2015INSTALLED]]>
-		</SetProperty>
+			Value="Install VC++ 2015-2022 Redistributable"
+			Condition="NOT VCREDIST2015INSTALLED" />
+		<SetProperty Id="WIXUI_EXITDIALOGOPTIONALCHECKBOX" After="AppSearch" Value="1"
+			Condition="NOT VCREDIST2015INSTALLED" />
 		<SetProperty Id="WixShellExecTarget" Value="[INSTALLDIR]Redistributable\vc_redist.arm64.exe" After="CostFinalize" Sequence="ui" />
 		<CustomAction Id="Install_vc_redist" DllEntry="WixShellExec" BinaryRef="Wix4UtilCA_$(sys.BUILDARCH)" />
 		<UI>
 			<Publish Dialog="ExitDialog" Control="Finish" Event="DoAction"
-				Value="Install_vc_redist"><![CDATA[WIXUI_EXITDIALOGOPTIONALCHECKBOX = "1"]]></Publish>
+				Value="Install_vc_redist" Condition="WIXUI_EXITDIALOGOPTIONALCHECKBOX = 1" />
 			<Publish Dialog="ExitDialog" Control="Finish" Event="EndDialog"
-				Value="Return"><![CDATA[WIXUI_EXITDIALOGOPTIONALCHECKBOX = "0"]]></Publish>
+				Value="Return" Condition="WIXUI_EXITDIALOGOPTIONALCHECKBOX = 0" />
 		</UI>
 
 		<!-- ================================================================ -->
 		<!-- Directory layout                                                  -->
 		<!-- ================================================================ -->
-		<Directory Id="TARGETDIR" Name="SourceDir">
-			<Directory Id="ProgramFiles6432Folder">
-				<Directory Id="INSTALLDIR" Name="SnowflakeODBCUDDriver">
-					<Directory Id="BinDir" Name="Bin" />
-					<Directory Id="IncludeDir" Name="include" />
-					<Directory Id="RedistDir" Name="Redistributable" />
-				</Directory>
+		<StandardDirectory Id="ProgramFiles6432Folder">
+			<Directory Id="INSTALLDIR" Name="SnowflakeODBCUDDriver">
+				<Directory Id="BinDir" Name="Bin" />
+				<Directory Id="IncludeDir" Name="include" />
+				<Directory Id="RedistDir" Name="Redistributable" />
 			</Directory>
-			<Directory Id="PersonalFolder">
-				<Directory Id="SnowflakeODBCUDDriverLogs" Name="Snowflake ODBC UD">
-					<Directory Id="LogDir" Name="log">
-						<Component Id="LogDir" Guid="D44B3812-31D7-4CDF-920B-BD4E1BE4426B">
+		</StandardDirectory>
+		<StandardDirectory Id="PersonalFolder">
+			<Directory Id="SnowflakeODBCUDDriverLogs" Name="Snowflake ODBC UD">
+				<Directory Id="LogDir" Name="log">
+					<Component Id="LogDir" Guid="D44B3812-31D7-4CDF-920B-BD4E1BE4426B">
 						<CreateFolder />
-							<RemoveFolder Id="LogDir" On="uninstall" />
-							<RemoveFolder Id="RemoveODBCDriverLogParent" Directory="SnowflakeODBCUDDriverLogs" On="uninstall" />
+						<RemoveFolder Id="LogDir" On="uninstall" />
+						<RemoveFolder Id="RemoveODBCDriverLogParent" Directory="SnowflakeODBCUDDriverLogs" On="uninstall" />
 						<RegistryValue Root="HKCU" Key="Software\Snowflake\ODBCDriver"
 							Name="LogDirectory" Value="true" Type="string" KeyPath="yes" />
-						</Component>
-					</Directory>
+					</Component>
 				</Directory>
 			</Directory>
-		</Directory>
+		</StandardDirectory>
 
 		<!-- ================================================================ -->
 		<!-- Files: driver DLL                                                 -->
@@ -127,8 +122,7 @@
 		<!-- ================================================================ -->
 		<!-- ODBC driver registration                                          -->
 		<!-- ================================================================ -->
-		<DirectoryRef Id="TARGETDIR">
-			<Component Id="RegistryEntries" Guid="BC3B84E0-0AE0-47C5-ADC2-7B3D6BE62D7F">
+		<Component Id="RegistryEntries" Directory="TARGETDIR" Guid="BC3B84E0-0AE0-47C5-ADC2-7B3D6BE62D7F">
 			<RegistryKey Root="HKLM"
 				Key="SOFTWARE\ODBC\ODBCINST.INI\ODBC Drivers"
 				ForceCreateOnInstall="yes">
@@ -140,7 +134,7 @@
 				<RegistryValue Type="string" Name="Driver" Value="[INSTALLDIR]Bin\sfodbc.dll" KeyPath="yes" />
 				<RegistryValue Type="string" Name="Setup" Value="[INSTALLDIR]Bin\sfodbc.dll" />
 				<RegistryValue Type="string" Name="Description" Value="Snowflake ODBC UD" />
-				<RegistryValue Type="string" Name="DriverODBCVer" Value="03.52" />
+				<RegistryValue Type="string" Name="DriverODBCVer" Value="$(var.OdbcApiVer)" />
 				<RegistryValue Type="string" Name="CompanyName" Value="Snowflake Computing" />
 				<RegistryValue Type="string" Name="ConnectFunctions" Value="YYY" />
 				<RegistryValue Type="string" Name="APILevel" Value="1" />
@@ -148,8 +142,7 @@
 				<RegistryValue Type="string" Name="FileUsage" Value="0" />
 				<RegistryValue Type="string" Name="CPTimeout" Value="60" />
 			</RegistryKey>
-			</Component>
-		</DirectoryRef>
+		</Component>
 
 		<!-- ================================================================ -->
 		<!-- Feature tree                                                       -->

--- a/odbc/installer/win/snowflake_odbc_arm64.wxs
+++ b/odbc/installer/win/snowflake_odbc_arm64.wxs
@@ -57,7 +57,7 @@
 		<SetProperty Id="WIXUI_EXITDIALOGOPTIONALCHECKBOX" After="AppSearch" Value="1"
 			Condition="NOT VCREDIST2015INSTALLED" />
 		<SetProperty Id="WixShellExecTarget" Value="[INSTALLDIR]Redistributable\vc_redist.arm64.exe" After="CostFinalize" Sequence="ui" />
-		<CustomAction Id="Install_vc_redist" DllEntry="WixShellExec" BinaryRef="Wix4UtilCA_$(sys.BUILDARCH)" />
+		<CustomAction Id="Install_vc_redist" DllEntry="WixShellExec" BinaryRef="Wix4UtilCA_$(sys.BUILDARCHSHORT)" />
 		<UI>
 			<Publish Dialog="ExitDialog" Control="Finish" Event="DoAction"
 				Value="Install_vc_redist" Condition="WIXUI_EXITDIALOGOPTIONALCHECKBOX = 1" />

--- a/odbc/installer/win/snowflake_odbc_x64.wxs
+++ b/odbc/installer/win/snowflake_odbc_x64.wxs
@@ -34,8 +34,8 @@
 		<!-- ================================================================ -->
 		<ui:WixUI Id="WixUI_InstallDir" InstallDirectory="INSTALLDIR" />
 		<UI>
-			<Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="InstallDirDlg" Order="2">1</Publish>
-			<Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="2">1</Publish>
+			<Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="InstallDirDlg" Order="2" Condition="1" />
+			<Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="2" Condition="1" />
 		</UI>
 
 		<!-- ================================================================ -->
@@ -49,50 +49,45 @@
 				Type="raw" />
 		</Property>
 		<SetProperty Id="WIXUI_EXITDIALOGOPTIONALTEXT" After="AppSearch"
-			Value="Visual C++ Redistributable for VS 2015-2022 is required. It will be installed on exit. Uncheck the box if you do not want to install it.">
-			<![CDATA[NOT VCREDIST2015INSTALLED]]>
-		</SetProperty>
+			Value="Visual C++ Redistributable for VS 2015-2022 is required. It will be installed on exit. Uncheck the box if you do not want to install it."
+			Condition="NOT VCREDIST2015INSTALLED" />
 		<SetProperty Id="WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT" After="AppSearch"
-			Value="Install VC++ 2015-2022 Redistributable">
-			<![CDATA[NOT VCREDIST2015INSTALLED]]>
-		</SetProperty>
-		<SetProperty Id="WIXUI_EXITDIALOGOPTIONALCHECKBOX" After="AppSearch" Value="1">
-			<![CDATA[NOT VCREDIST2015INSTALLED]]>
-		</SetProperty>
+			Value="Install VC++ 2015-2022 Redistributable"
+			Condition="NOT VCREDIST2015INSTALLED" />
+		<SetProperty Id="WIXUI_EXITDIALOGOPTIONALCHECKBOX" After="AppSearch" Value="1"
+			Condition="NOT VCREDIST2015INSTALLED" />
 		<SetProperty Id="WixShellExecTarget" Value="[INSTALLDIR]Redistributable\vc_redist.x64.exe" After="CostFinalize" Sequence="ui" />
 		<CustomAction Id="Install_vc_redist" DllEntry="WixShellExec" BinaryRef="Wix4UtilCA_$(sys.BUILDARCH)" />
 		<UI>
 			<Publish Dialog="ExitDialog" Control="Finish" Event="DoAction"
-				Value="Install_vc_redist"><![CDATA[WIXUI_EXITDIALOGOPTIONALCHECKBOX = "1"]]></Publish>
+				Value="Install_vc_redist" Condition="WIXUI_EXITDIALOGOPTIONALCHECKBOX = 1" />
 			<Publish Dialog="ExitDialog" Control="Finish" Event="EndDialog"
-				Value="Return"><![CDATA[WIXUI_EXITDIALOGOPTIONALCHECKBOX = "0"]]></Publish>
+				Value="Return" Condition="WIXUI_EXITDIALOGOPTIONALCHECKBOX = 0" />
 		</UI>
 
 		<!-- ================================================================ -->
 		<!-- Directory layout                                                  -->
 		<!-- ================================================================ -->
-		<Directory Id="TARGETDIR" Name="SourceDir">
-			<Directory Id="ProgramFiles6432Folder">
-				<Directory Id="INSTALLDIR" Name="SnowflakeODBCUDDriver">
-					<Directory Id="BinDir" Name="Bin" />
-					<Directory Id="IncludeDir" Name="include" />
-					<Directory Id="RedistDir" Name="Redistributable" />
-				</Directory>
+		<StandardDirectory Id="ProgramFiles6432Folder">
+			<Directory Id="INSTALLDIR" Name="SnowflakeODBCUDDriver">
+				<Directory Id="BinDir" Name="Bin" />
+				<Directory Id="IncludeDir" Name="include" />
+				<Directory Id="RedistDir" Name="Redistributable" />
 			</Directory>
-			<Directory Id="PersonalFolder">
-				<Directory Id="SnowflakeODBCUDDriverLogs" Name="Snowflake ODBC UD">
-					<Directory Id="LogDir" Name="log">
-						<Component Id="LogDir" Guid="81D33977-BED5-49DE-9357-F7A2EA7EB4FD">
+		</StandardDirectory>
+		<StandardDirectory Id="PersonalFolder">
+			<Directory Id="SnowflakeODBCUDDriverLogs" Name="Snowflake ODBC UD">
+				<Directory Id="LogDir" Name="log">
+					<Component Id="LogDir" Guid="81D33977-BED5-49DE-9357-F7A2EA7EB4FD">
 						<CreateFolder />
-							<RemoveFolder Id="LogDir" On="uninstall" />
-							<RemoveFolder Id="RemoveODBCDriverLogParent" Directory="SnowflakeODBCUDDriverLogs" On="uninstall" />
+						<RemoveFolder Id="LogDir" On="uninstall" />
+						<RemoveFolder Id="RemoveODBCDriverLogParent" Directory="SnowflakeODBCUDDriverLogs" On="uninstall" />
 						<RegistryValue Root="HKCU" Key="Software\Snowflake\ODBCDriver"
 							Name="LogDirectory" Value="true" Type="string" KeyPath="yes" />
-						</Component>
-					</Directory>
+					</Component>
 				</Directory>
 			</Directory>
-		</Directory>
+		</StandardDirectory>
 
 		<!-- ================================================================ -->
 		<!-- Files: driver DLL                                                 -->
@@ -127,8 +122,7 @@
 		<!-- ================================================================ -->
 		<!-- ODBC driver registration                                          -->
 		<!-- ================================================================ -->
-		<DirectoryRef Id="TARGETDIR">
-			<Component Id="RegistryEntries" Guid="46CDADA1-59D9-4E4A-9F29-BB1BCD2F3946">
+		<Component Id="RegistryEntries" Directory="TARGETDIR" Guid="46CDADA1-59D9-4E4A-9F29-BB1BCD2F3946">
 			<RegistryKey Root="HKLM"
 				Key="SOFTWARE\ODBC\ODBCINST.INI\ODBC Drivers"
 				ForceCreateOnInstall="yes">
@@ -148,8 +142,7 @@
 				<RegistryValue Type="string" Name="FileUsage" Value="0" />
 				<RegistryValue Type="string" Name="CPTimeout" Value="60" />
 			</RegistryKey>
-			</Component>
-		</DirectoryRef>
+		</Component>
 
 		<!-- ================================================================ -->
 		<!-- Feature tree                                                       -->

--- a/odbc/installer/win/snowflake_odbc_x64.wxs
+++ b/odbc/installer/win/snowflake_odbc_x64.wxs
@@ -1,18 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-	<Product Id="*"
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs"
+     xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui"
+     xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util">
+	<Package
 		Name="Snowflake ODBC UD $(var.FullVersion) PrPr (x64)"
 		Language="1033"
 		Version="$(var.ProductVersion)"
 		Manufacturer="Snowflake Computing"
-		UpgradeCode="053DF3DF-4EB2-44E2-87BE-D3334ABDE4C6">
+		UpgradeCode="053DF3DF-4EB2-44E2-87BE-D3334ABDE4C6"
+		InstallerVersion="405"
+		Scope="perMachine">
 
-		<Package Id="*"
-			InstallerVersion="405"
-			Compressed="yes"
-			InstallScope="perMachine"
-			Manufacturer="Snowflake Computing"
-			Platform="x64"
+		<SummaryInformation
 			Description="Snowflake ODBC UD $(var.FullVersion) Private Preview (64-bit)"
 			Comments="Installs the Snowflake ODBC Driver (Private Preview) built on Universal Driver." />
 
@@ -33,10 +32,8 @@
 		<!-- ================================================================ -->
 		<!-- Install directory UI                                              -->
 		<!-- ================================================================ -->
-		<Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR" />
-		<UIRef Id="WixUI_InstallDir" />
+		<ui:WixUI Id="WixUI_InstallDir" InstallDirectory="INSTALLDIR" />
 		<UI>
-			<UIRef Id="WixUI_InstallDir" />
 			<Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="InstallDirDlg" Order="2">1</Publish>
 			<Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="2">1</Publish>
 		</UI>
@@ -49,22 +46,21 @@
 				Root="HKLM"
 				Key="Software\Microsoft\VisualStudio\14.0\VC\Runtimes\x64"
 				Name="Installed"
-				Type="raw"
-				Win64="yes" />
+				Type="raw" />
 		</Property>
 		<SetProperty Id="WIXUI_EXITDIALOGOPTIONALTEXT" After="AppSearch"
 			Value="Visual C++ Redistributable for VS 2015-2022 is required. It will be installed on exit. Uncheck the box if you do not want to install it.">
-			<![CDATA[(NOT VCREDIST2015INSTALLED)]]>
+			<![CDATA[NOT VCREDIST2015INSTALLED]]>
 		</SetProperty>
 		<SetProperty Id="WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT" After="AppSearch"
 			Value="Install VC++ 2015-2022 Redistributable">
-			<![CDATA[(NOT VCREDIST2015INSTALLED)]]>
+			<![CDATA[NOT VCREDIST2015INSTALLED]]>
 		</SetProperty>
 		<SetProperty Id="WIXUI_EXITDIALOGOPTIONALCHECKBOX" After="AppSearch" Value="1">
-			<![CDATA[(NOT VCREDIST2015INSTALLED)]]>
+			<![CDATA[NOT VCREDIST2015INSTALLED]]>
 		</SetProperty>
 		<SetProperty Id="WixShellExecTarget" Value="[INSTALLDIR]Redistributable\vc_redist.x64.exe" After="CostFinalize" Sequence="ui" />
-		<CustomAction Id="Install_vc_redist" BinaryKey="WixCA" DllEntry="WixShellExec" />
+		<CustomAction Id="Install_vc_redist" DllEntry="WixShellExec" BinaryRef="Wix4UtilCA_$(sys.BUILDARCH)" />
 		<UI>
 			<Publish Dialog="ExitDialog" Control="Finish" Event="DoAction"
 				Value="Install_vc_redist"><![CDATA[WIXUI_EXITDIALOGOPTIONALCHECKBOX = "1"]]></Publish>
@@ -76,7 +72,7 @@
 		<!-- Directory layout                                                  -->
 		<!-- ================================================================ -->
 		<Directory Id="TARGETDIR" Name="SourceDir">
-			<Directory Id="ProgramFiles64Folder">
+			<Directory Id="ProgramFiles6432Folder">
 				<Directory Id="INSTALLDIR" Name="SnowflakeODBCUDDriver">
 					<Directory Id="BinDir" Name="Bin" />
 					<Directory Id="IncludeDir" Name="include" />
@@ -86,7 +82,7 @@
 			<Directory Id="PersonalFolder">
 				<Directory Id="SnowflakeODBCUDDriverLogs" Name="Snowflake ODBC UD">
 					<Directory Id="LogDir" Name="log">
-						<Component Id="LogDir" Guid="81D33977-BED5-49DE-9357-F7A2EA7EB4FD" Win64="yes">
+						<Component Id="LogDir" Guid="81D33977-BED5-49DE-9357-F7A2EA7EB4FD">
 						<CreateFolder />
 							<RemoveFolder Id="LogDir" On="uninstall" />
 							<RemoveFolder Id="RemoveODBCDriverLogParent" Directory="SnowflakeODBCUDDriverLogs" On="uninstall" />
@@ -102,7 +98,7 @@
 		<!-- Files: driver DLL                                                 -->
 		<!-- ================================================================ -->
 		<DirectoryRef Id="BinDir">
-			<Component Id="sfodbc.dll" Guid="25D9DF06-EB55-469C-8074-4356FD8E281D" Win64="yes" Permanent="no">
+			<Component Id="sfodbc.dll" Guid="25D9DF06-EB55-469C-8074-4356FD8E281D" Permanent="no">
 			<File Id="sfodbc.dll" KeyPath="yes"
 					Source="$(var.DriverBinDir)\sfodbc.dll" />
 			</Component>
@@ -112,7 +108,7 @@
 		<!-- Files: public header                                              -->
 		<!-- ================================================================ -->
 		<DirectoryRef Id="IncludeDir">
-			<Component Id="sf_odbc.h" Guid="7E678D91-F506-4CA3-90FA-F7247A2474A4" Win64="yes" Permanent="no">
+			<Component Id="sf_odbc.h" Guid="7E678D91-F506-4CA3-90FA-F7247A2474A4" Permanent="no">
 			<File Id="sf_odbc.h" KeyPath="yes"
 					Source="$(var.SourceDir)\odbc\include\sf_odbc.h" />
 			</Component>
@@ -122,7 +118,7 @@
 		<!-- Files: VC++ Redistributable                                       -->
 		<!-- ================================================================ -->
 		<DirectoryRef Id="RedistDir">
-			<Component Id="vc_redist.x64.exe" Guid="B55F8416-F349-4EA1-ABBB-46F46AA9E3AA" Win64="yes" Permanent="no">
+			<Component Id="vc_redist.x64.exe" Guid="B55F8416-F349-4EA1-ABBB-46F46AA9E3AA" Permanent="no">
 			<File Id="vc_redist.x64.exe" KeyPath="yes"
 					Source="$(var.VCRedistDir)\vc_redist.x64.exe" />
 			</Component>
@@ -132,7 +128,7 @@
 		<!-- ODBC driver registration                                          -->
 		<!-- ================================================================ -->
 		<DirectoryRef Id="TARGETDIR">
-			<Component Id="RegistryEntries" Guid="46CDADA1-59D9-4E4A-9F29-BB1BCD2F3946" Win64="yes">
+			<Component Id="RegistryEntries" Guid="46CDADA1-59D9-4E4A-9F29-BB1BCD2F3946">
 			<RegistryKey Root="HKLM"
 				Key="SOFTWARE\ODBC\ODBCINST.INI\ODBC Drivers"
 				ForceCreateOnInstall="yes">
@@ -169,5 +165,5 @@
 			<ComponentRef Id="vc_redist.x64.exe" />
 		</Feature>
 
-	</Product>
+	</Package>
 </Wix>

--- a/odbc/installer/win/snowflake_odbc_x64.wxs
+++ b/odbc/installer/win/snowflake_odbc_x64.wxs
@@ -57,7 +57,7 @@
 		<SetProperty Id="WIXUI_EXITDIALOGOPTIONALCHECKBOX" After="AppSearch" Value="1"
 			Condition="NOT VCREDIST2015INSTALLED" />
 		<SetProperty Id="WixShellExecTarget" Value="[INSTALLDIR]Redistributable\vc_redist.x64.exe" After="CostFinalize" Sequence="ui" />
-		<CustomAction Id="Install_vc_redist" DllEntry="WixShellExec" BinaryRef="Wix4UtilCA_$(sys.BUILDARCH)" />
+		<CustomAction Id="Install_vc_redist" DllEntry="WixShellExec" BinaryRef="Wix4UtilCA_$(sys.BUILDARCHSHORT)" />
 		<UI>
 			<Publish Dialog="ExitDialog" Control="Finish" Event="DoAction"
 				Value="Install_vc_redist" Condition="WIXUI_EXITDIALOGOPTIONALCHECKBOX = 1" />

--- a/odbc/installer/win/snowflake_odbc_x86.wxs
+++ b/odbc/installer/win/snowflake_odbc_x86.wxs
@@ -57,7 +57,7 @@
 		<SetProperty Id="WIXUI_EXITDIALOGOPTIONALCHECKBOX" After="AppSearch" Value="1"
 			Condition="NOT VCREDIST2015INSTALLED" />
 		<SetProperty Id="WixShellExecTarget" Value="[INSTALLDIR]Redistributable\vc_redist.x86.exe" After="CostFinalize" Sequence="ui" />
-		<CustomAction Id="Install_vc_redist" DllEntry="WixShellExec" BinaryRef="Wix4UtilCA_$(sys.BUILDARCH)" />
+		<CustomAction Id="Install_vc_redist" DllEntry="WixShellExec" BinaryRef="Wix4UtilCA_$(sys.BUILDARCHSHORT)" />
 		<UI>
 			<Publish Dialog="ExitDialog" Control="Finish" Event="DoAction"
 				Value="Install_vc_redist" Condition="WIXUI_EXITDIALOGOPTIONALCHECKBOX = 1" />

--- a/odbc/installer/win/snowflake_odbc_x86.wxs
+++ b/odbc/installer/win/snowflake_odbc_x86.wxs
@@ -34,8 +34,8 @@
 		<!-- ================================================================ -->
 		<ui:WixUI Id="WixUI_InstallDir" InstallDirectory="INSTALLDIR" />
 		<UI>
-			<Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="InstallDirDlg" Order="2">1</Publish>
-			<Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="2">1</Publish>
+			<Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="InstallDirDlg" Order="2" Condition="1" />
+			<Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="2" Condition="1" />
 		</UI>
 
 		<!-- ================================================================ -->
@@ -49,50 +49,45 @@
 				Type="raw" />
 		</Property>
 		<SetProperty Id="WIXUI_EXITDIALOGOPTIONALTEXT" After="AppSearch"
-			Value="Visual C++ Redistributable for VS 2015-2022 is required. It will be installed on exit. Uncheck the box if you do not want to install it.">
-			<![CDATA[NOT VCREDIST2015INSTALLED]]>
-		</SetProperty>
+			Value="Visual C++ Redistributable for VS 2015-2022 is required. It will be installed on exit. Uncheck the box if you do not want to install it."
+			Condition="NOT VCREDIST2015INSTALLED" />
 		<SetProperty Id="WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT" After="AppSearch"
-			Value="Install VC++ 2015-2022 Redistributable">
-			<![CDATA[NOT VCREDIST2015INSTALLED]]>
-		</SetProperty>
-		<SetProperty Id="WIXUI_EXITDIALOGOPTIONALCHECKBOX" After="AppSearch" Value="1">
-			<![CDATA[NOT VCREDIST2015INSTALLED]]>
-		</SetProperty>
+			Value="Install VC++ 2015-2022 Redistributable"
+			Condition="NOT VCREDIST2015INSTALLED" />
+		<SetProperty Id="WIXUI_EXITDIALOGOPTIONALCHECKBOX" After="AppSearch" Value="1"
+			Condition="NOT VCREDIST2015INSTALLED" />
 		<SetProperty Id="WixShellExecTarget" Value="[INSTALLDIR]Redistributable\vc_redist.x86.exe" After="CostFinalize" Sequence="ui" />
 		<CustomAction Id="Install_vc_redist" DllEntry="WixShellExec" BinaryRef="Wix4UtilCA_$(sys.BUILDARCH)" />
 		<UI>
 			<Publish Dialog="ExitDialog" Control="Finish" Event="DoAction"
-				Value="Install_vc_redist"><![CDATA[WIXUI_EXITDIALOGOPTIONALCHECKBOX = "1"]]></Publish>
+				Value="Install_vc_redist" Condition="WIXUI_EXITDIALOGOPTIONALCHECKBOX = 1" />
 			<Publish Dialog="ExitDialog" Control="Finish" Event="EndDialog"
-				Value="Return"><![CDATA[WIXUI_EXITDIALOGOPTIONALCHECKBOX = "0"]]></Publish>
+				Value="Return" Condition="WIXUI_EXITDIALOGOPTIONALCHECKBOX = 0" />
 		</UI>
 
 		<!-- ================================================================ -->
 		<!-- Directory layout                                                  -->
 		<!-- ================================================================ -->
-		<Directory Id="TARGETDIR" Name="SourceDir">
-			<Directory Id="ProgramFiles6432Folder">
-				<Directory Id="INSTALLDIR" Name="SnowflakeODBCUDDriver">
-					<Directory Id="BinDir" Name="Bin" />
-					<Directory Id="IncludeDir" Name="include" />
-					<Directory Id="RedistDir" Name="Redistributable" />
-				</Directory>
+		<StandardDirectory Id="ProgramFiles6432Folder">
+			<Directory Id="INSTALLDIR" Name="SnowflakeODBCUDDriver">
+				<Directory Id="BinDir" Name="Bin" />
+				<Directory Id="IncludeDir" Name="include" />
+				<Directory Id="RedistDir" Name="Redistributable" />
 			</Directory>
-			<Directory Id="PersonalFolder">
-				<Directory Id="SnowflakeODBCUDDriverLogs" Name="Snowflake ODBC UD">
-					<Directory Id="LogDir" Name="log">
-						<Component Id="LogDir" Guid="CD48DCFD-56C5-4BAC-AE02-0635C488499E">
+		</StandardDirectory>
+		<StandardDirectory Id="PersonalFolder">
+			<Directory Id="SnowflakeODBCUDDriverLogs" Name="Snowflake ODBC UD">
+				<Directory Id="LogDir" Name="log">
+					<Component Id="LogDir" Guid="CD48DCFD-56C5-4BAC-AE02-0635C488499E">
 						<CreateFolder />
-							<RemoveFolder Id="LogDir" On="uninstall" />
-							<RemoveFolder Id="RemoveODBCDriverLogParent" Directory="SnowflakeODBCUDDriverLogs" On="uninstall" />
+						<RemoveFolder Id="LogDir" On="uninstall" />
+						<RemoveFolder Id="RemoveODBCDriverLogParent" Directory="SnowflakeODBCUDDriverLogs" On="uninstall" />
 						<RegistryValue Root="HKCU" Key="Software\Snowflake\ODBCDriver"
 							Name="LogDirectory" Value="true" Type="string" KeyPath="yes" />
-						</Component>
-					</Directory>
+					</Component>
 				</Directory>
 			</Directory>
-		</Directory>
+		</StandardDirectory>
 
 		<!-- ================================================================ -->
 		<!-- Files: driver DLL                                                 -->
@@ -127,8 +122,7 @@
 		<!-- ================================================================ -->
 		<!-- ODBC driver registration                                          -->
 		<!-- ================================================================ -->
-		<DirectoryRef Id="TARGETDIR">
-			<Component Id="RegistryEntries" Guid="EFCE448E-AA82-4829-BBFD-2EE34F00B487">
+		<Component Id="RegistryEntries" Directory="TARGETDIR" Guid="EFCE448E-AA82-4829-BBFD-2EE34F00B487">
 			<RegistryKey Root="HKLM"
 				Key="SOFTWARE\ODBC\ODBCINST.INI\ODBC Drivers"
 				ForceCreateOnInstall="yes">
@@ -148,8 +142,7 @@
 				<RegistryValue Type="string" Name="FileUsage" Value="0" />
 				<RegistryValue Type="string" Name="CPTimeout" Value="60" />
 			</RegistryKey>
-			</Component>
-		</DirectoryRef>
+		</Component>
 
 		<!-- ================================================================ -->
 		<!-- Feature tree                                                       -->

--- a/odbc/src/setup_dialog.rs
+++ b/odbc/src/setup_dialog.rs
@@ -10,9 +10,7 @@ use std::ptr;
 use std::sync::atomic::Ordering;
 
 use crate::c_api::DLL_HINSTANCE;
-use crate::setup_common::{
-    self, SQLValidDSNW, from_wide, read_dsn_value, to_wide, write_dsn_values,
-};
+use crate::setup_common::{SQLValidDSNW, from_wide, read_dsn_value, to_wide, write_dsn_values};
 
 // ---------------------------------------------------------------------------
 // Win32 FFI

--- a/tests/performance/drivers/core/app/Cargo.lock
+++ b/tests/performance/drivers/core/app/Cargo.lock
@@ -1150,6 +1150,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1322,6 +1337,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -1748,6 +1772,12 @@ dependencies = [
  "num-traits",
  "zerocopy",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -2911,6 +2941,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "os_info"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3502,6 +3542,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-ini"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3833,6 +3883,7 @@ dependencies = [
  "proto_utils",
  "rand",
  "reqwest",
+ "rust-ini",
  "rustls 0.23.36",
  "rustls-native-certs",
  "rustls-pemfile",
@@ -3851,6 +3902,7 @@ dependencies = [
  "tokio-util",
  "toml",
  "tracing",
+ "tracing-appender",
  "tracing-opentelemetry",
  "tracing-subscriber",
  "url",
@@ -4109,6 +4161,12 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
@@ -4524,6 +4582,19 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.17",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]


### PR DESCRIPTION
Replace the ~50-line inline MSVC vcvarsall block in build_odbc_driver with
the existing .github/actions/setup-msvc composite. Add an optional
restore-cmake-dir input to that composite so the runner's pip-installed
cmake stays ahead of VS's bundled 3.x copy on PATH (previously handled
inline).