### PR TITLE
SNOW-3529420: ODBC CI: extract _test-odbc reusable workflow

### DIFF
--- a/.github/workflows/_test-odbc.yml
+++ b/.github/workflows/_test-odbc.yml
@@ -3,19 +3,11 @@ name: ODBC Driver Tests
 # Reusable workflow that builds the UD ODBC driver per-platform and runs
 # the full test matrix (generated from ci/test_matrix/) plus per-cloud
 # parameter cleanup.
-#
-# Called from .github/workflows/test-odbc.yml. The parent gates the entire
-# call with `if:` on the `uses:` line, so the inner jobs no longer carry
-# the `if: ... run_odbc == 'true'` guards their inlined predecessors did.
 
 on:
   workflow_call:
 
 env:
-  # Re-declare workflow-level env that the parent test-odbc.yml provides.
-  # Reusable workflows do NOT inherit env from their caller — without this
-  # the install-deps step's $env:CCACHE_DIR / vcpkg binary-cache path
-  # point at nothing on the runner.
   CARGO_TERM_COLOR: always
   CCACHE_DIR: ${{ github.workspace }}/.ccache
   CCACHE_BASEDIR: ${{ github.workspace }}
@@ -36,7 +28,6 @@ jobs:
             >> "$GITHUB_OUTPUT"
 
   # Build ODBC driver once per platform and share via artifact.
-  # Avoids rebuilding in each of the 9 test matrix cells (3 OSes × 3 cloud providers).
   build_odbc_driver:
     strategy:
       fail-fast: false
@@ -74,7 +65,6 @@ jobs:
 
       - name: Cache Rust dependencies
         id: rust-cache
-        # Cache restore failures never fail the job — fall back to clean build.
         continue-on-error: true
         uses: ./.github/actions/cargo-cache
         with:
@@ -124,7 +114,6 @@ jobs:
         # timeout-minutes is enforced here because it isn't supported on
         # composite action steps. Bounds slim + registry save + target save.
         timeout-minutes: 20
-        # Cache failures (incl. timeout-induced cancellation) never fail the job.
         continue-on-error: true
         uses: ./.github/actions/cargo-cache
         with:

--- a/.github/workflows/_test-odbc.yml
+++ b/.github/workflows/_test-odbc.yml
@@ -1,0 +1,409 @@
+name: ODBC Driver Tests
+
+# Reusable workflow that builds the UD ODBC driver per-platform and runs
+# the full test matrix (generated from ci/test_matrix/) plus per-cloud
+# parameter cleanup.
+#
+# Called from .github/workflows/test-odbc.yml. The parent gates the entire
+# call with `if:` on the `uses:` line, so the inner jobs no longer carry
+# the `if: ... run_odbc == 'true'` guards their inlined predecessors did.
+
+on:
+  workflow_call:
+
+env:
+  # Re-declare workflow-level env that the parent test-odbc.yml provides.
+  # Reusable workflows do NOT inherit env from their caller — without this
+  # the install-deps step's $env:CCACHE_DIR / vcpkg binary-cache path
+  # point at nothing on the runner.
+  CARGO_TERM_COLOR: always
+  CCACHE_DIR: ${{ github.workspace }}/.ccache
+  CCACHE_BASEDIR: ${{ github.workspace }}
+  CCACHE_MAXSIZE: 1G
+  VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/.vcpkg-binary-cache,readwrite"
+
+jobs:
+  load-odbc-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.read.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: read
+        run: |
+          python ci/test_matrix/generate_matrix.py \
+            --driver odbc --event "$GITHUB_EVENT_NAME" --emit-active \
+            >> "$GITHUB_OUTPUT"
+
+  # Build ODBC driver once per platform and share via artifact.
+  # Avoids rebuilding in each of the 9 test matrix cells (3 OSes × 3 cloud providers).
+  build_odbc_driver:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            name: Linux x64
+            driver_lib: libsfodbc.so
+            cache_key: odbc
+          - os: macos-latest
+            name: macOS ARM64
+            driver_lib: libsfodbc.dylib
+            cache_key: odbc
+          - os: windows-latest
+            name: Windows x64
+            driver_lib: sfodbc.dll
+            cargo_extra: "--features vendored-openssl"
+            cache_key: odbc-x64
+          - os: windows-latest
+            name: Windows x86
+            driver_lib: sfodbc32.dll
+            cargo_target: i686-pc-windows-msvc
+            cargo_extra: "--no-default-features --features vendored-openssl"
+            cache_key: odbc-x86
+          - os: windows-11-arm
+            name: Windows ARM64
+            driver_lib: sfodbc.dll
+            cargo_extra: "--features vendored-openssl"
+            cache_key: odbc-arm64
+    runs-on: ${{ matrix.os }}
+    name: build_odbc_driver (${{ matrix.name }})
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Cache Rust dependencies
+        id: rust-cache
+        # Cache restore failures never fail the job — fall back to clean build.
+        continue-on-error: true
+        uses: ./.github/actions/cargo-cache
+        with:
+          mode: restore
+          shared-key: ${{ matrix.cache_key }}
+
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y unixodbc-dev
+
+      - name: Install dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew install unixodbc go
+          echo "ODBC_PREFIX=$(brew --prefix unixodbc)" >> $GITHUB_ENV
+
+      - name: Install Rust target
+        if: matrix.cargo_target
+        run: rustup target add ${{ matrix.cargo_target }}
+
+      - name: Build ODBC driver (Linux)
+        if: runner.os == 'Linux'
+        run: cargo build --package odbc
+        env:
+          RUSTFLAGS: "-C link-arg=-Wl,--undefined-version"
+
+      - name: Build ODBC driver (macOS)
+        if: runner.os == 'macOS'
+        run: cargo build --package odbc
+
+      - name: Build ODBC driver (Windows)
+        if: runner.os == 'Windows'
+        run: cargo build --package odbc ${{ matrix.cargo_extra }} ${{ matrix.cargo_target && format('--target {0}', matrix.cargo_target) || '' }}
+        env:
+          RUSTFLAGS: "-C linker=rust-lld"
+
+      - name: Rename x86 driver DLL
+        if: matrix.cargo_target == 'i686-pc-windows-msvc'
+        shell: pwsh
+        run: |
+          $dir = "target/${{ matrix.cargo_target }}/debug"
+          Move-Item -Force "$dir/sfodbc.dll" "$dir/sfodbc32.dll"
+          if (Test-Path "$dir/sfodbc.pdb") { Move-Item -Force "$dir/sfodbc.pdb" "$dir/sfodbc32.pdb" }
+
+      - name: Save Rust cache
+        if: always()
+        # timeout-minutes is enforced here because it isn't supported on
+        # composite action steps. Bounds slim + registry save + target save.
+        timeout-minutes: 20
+        # Cache failures (incl. timeout-induced cancellation) never fail the job.
+        continue-on-error: true
+        uses: ./.github/actions/cargo-cache
+        with:
+          mode: save
+          shared-key: ${{ matrix.cache_key }}
+          registry-cache-hit: ${{ steps.rust-cache.outputs.registry-cache-hit }}
+          target-cache-hit: ${{ steps.rust-cache.outputs.target-cache-hit }}
+
+      - name: Upload ODBC driver
+        uses: actions/upload-artifact@v4
+        with:
+          name: odbc-driver-${{ matrix.name }}
+          path: ${{ matrix.cargo_target && format('target/{0}/debug', matrix.cargo_target) || 'target/debug' }}/${{ matrix.driver_lib }}
+
+  odbc_tests:
+    needs: [build_odbc_driver, load-odbc-matrix]
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.load-odbc-matrix.outputs.matrix) }}
+    runs-on: ${{ matrix.os }}
+    name: odbc_tests (${{ matrix.name }}, ${{ matrix.cloud_provider }}${{ matrix.result_format && format(', {0}', matrix.result_format) || '' }})
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download pre-built ODBC driver
+        uses: actions/download-artifact@v4
+        with:
+          name: odbc-driver-${{ matrix.driver_artifact }}
+          path: target/debug
+
+      - name: Make driver executable (Unix)
+        if: runner.os != 'Windows'
+        run: chmod +x target/debug/${{ matrix.driver_lib }}
+
+      - name: Restore test dependencies cache
+        id: test-deps-cache
+        uses: ./.github/actions/build-cache
+        with:
+          mode: restore
+          kind: test-deps
+          key-suffix: ${{ matrix.msvc_arch || 'default' }}
+
+      - name: Restore ccache
+        id: ccache
+        uses: ./.github/actions/build-cache
+        with:
+          mode: restore
+          kind: ccache
+          key-suffix: ${{ matrix.msvc_arch || 'default' }}
+
+      - name: Capture vcpkg version (Windows)
+        if: runner.os == 'Windows'
+        uses: ./.github/actions/vcpkg-version
+
+      - name: Restore vcpkg binary cache (Windows)
+        if: runner.os == 'Windows'
+        id: vcpkg-cache
+        uses: ./.github/actions/build-cache
+        with:
+          mode: restore
+          kind: vcpkg
+          key-suffix: ${{ matrix.vcpkg_triplet }}
+
+      - name: Restore Homebrew cache (macOS)
+        if: runner.os == 'macOS'
+        id: brew-cache
+        uses: ./.github/actions/build-cache
+        with:
+          mode: restore
+          kind: brew
+
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          set -euxo pipefail
+          sudo apt-get update
+          sudo apt-get install -y unixodbc-dev build-essential zlib1g-dev ccache ninja-build
+          # odbc_tests/CMakeLists.txt requires CMake >= 4.0; ubuntu-latest ships ~3.30.
+          # Prefer `python3 -m pip` over bare `pip` so we don't depend on PATH resolution
+          # pointing at the expected Python. The pip wheel is an official Kitware artifact
+          # and installs in ~15s (vs ~60s for the .sh installer).
+          python3 -m pip install 'cmake>=4.0.3'
+          cmake --version
+
+      - name: Install dependencies (macOS)
+        if: runner.os == 'macOS'
+        env:
+          # Skip Homebrew's self-update (~30-60s on every invocation) — we don't need bleeding-edge
+          # formulae, just a working unixodbc/ccache/ninja.
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+          HOMEBREW_NO_INSTALL_CLEANUP: "1"
+        run: |
+          set -euxo pipefail
+          # cmake via pip (official Kitware wheel) — faster than brew and keeps Linux/macOS install symmetric.
+          # Use a dedicated venv rather than installing into the default python3: macos-latest's
+          # python3 is Homebrew-managed and marked as an externally-managed environment (PEP 668),
+          # so a bare `pip install` fails. A venv is the PEP-668-compliant way to isolate the install
+          # without system-wide side effects. The venv's bin dir is prepended to PATH via GITHUB_PATH
+          # so `cmake` resolves to the 4.0+ version in subsequent steps.
+          CMAKE_VENV="$RUNNER_TEMP/cmake-venv"
+          python3 -m venv "$CMAKE_VENV"
+          "$CMAKE_VENV/bin/python" -m pip install --upgrade pip >/dev/null
+          "$CMAKE_VENV/bin/pip" install 'cmake>=4.0.3'
+          echo "$CMAKE_VENV/bin" >> $GITHUB_PATH
+          # Verify against the venv's cmake explicitly — GITHUB_PATH isn't applied to this step.
+          "$CMAKE_VENV/bin/cmake" --version
+          # Only packages without pip wheels stay on brew. `ninja` is pre-installed on macos-latest,
+          # but listing it here is cheap (no-op if present) and self-documenting.
+          brew install unixodbc ccache ninja
+          echo "ODBC_PREFIX=$(brew --prefix unixodbc)" >> $GITHUB_ENV
+
+      - name: Install dependencies (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          function Invoke-Checked([string]$commandName, [scriptblock]$command) {
+            & $command
+            if ($LASTEXITCODE -ne 0) { throw "$commandName failed with exit code $LASTEXITCODE" }
+          }
+
+          # install 4.0+ via pip (official Kitware wheel)
+          Invoke-Checked "pip install cmake" { python -m pip install "cmake>=4.0.3" }
+          $cmakePath = (Get-Command cmake.exe).Source | Split-Path
+          echo "CMAKE_DIR=$cmakePath" >> $env:GITHUB_ENV
+          cmake --version
+
+          Invoke-Checked "choco install ccache" { choco install ccache -y --no-progress }
+          New-Item -ItemType Directory -Force -Path $env:CCACHE_DIR | Out-Null
+          New-Item -ItemType Directory -Force -Path "$env:GITHUB_WORKSPACE\.vcpkg-binary-cache" | Out-Null
+
+          $triplet = "${{ matrix.vcpkg_triplet }}"
+          if ("${{ matrix.msvc_arch }}" -eq "arm64") {
+            # ARM64 vcpkg builds require the ARM64 MSVC toolchain environment
+            cmd /c "`"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat`" arm64 && vcpkg install zlib:$triplet openssl:$triplet"
+            if ($LASTEXITCODE -ne 0) { throw "vcpkg install failed with exit code $LASTEXITCODE" }
+          } else {
+            Invoke-Checked "vcpkg install" { vcpkg install zlib:$triplet openssl:$triplet }
+          }
+
+      - name: Setup MSVC environment (Windows)
+        if: runner.os == 'Windows'
+        uses: ./.github/actions/setup-msvc
+        with:
+          arch: ${{ matrix.msvc_arch || 'amd64' }}
+          restore-cmake-dir: 'true'
+
+      - name: Decode secrets
+        run: ./scripts/decode_secrets.sh ${{ matrix.cloud_provider }}
+        env:
+          PARAMETERS_SECRET: ${{ secrets.PARAMETERS_SECRET }}
+        shell: bash
+
+      - name: Build and run ODBC tests (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          ls -l target/debug/
+          export DRIVER_PATH=$(pwd)/target/debug/${{ matrix.driver_lib }}
+          export PARAMETER_PATH=$(pwd)/parameters.json
+          export DRIVER_TYPE=NEW
+          export QUERY_RESULT_FORMAT=${{ matrix.result_format == 'json' && 'JSON' || '' }}
+          REPEAT_ARGS=${{ github.event_name == 'merge_group' && '"--repeat until-pass:2"' || '' }}
+          ./scripts/odbc/run_tests_unix.sh -LE flaky $REPEAT_ARGS
+
+      - name: Run flaky ODBC tests (Unix)
+        if: runner.os != 'Windows'
+        continue-on-error: true
+        run: ctest -L flaky -C Debug --test-dir odbc_tests/cmake-build --output-on-failure
+        env:
+          DRIVER_PATH: ${{ github.workspace }}/target/debug/${{ matrix.driver_lib }}
+          PARAMETER_PATH: ${{ github.workspace }}/parameters.json
+          DRIVER_TYPE: NEW
+          QUERY_RESULT_FORMAT: ${{ matrix.result_format == 'json' && 'JSON' || '' }}
+
+      - name: Build and run ODBC tests (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          dir target\debug\
+          $env:DRIVER_PATH = "$PWD\target\debug\${{ matrix.driver_lib }}"
+          $env:PARAMETER_PATH = "$PWD\parameters.json"
+          $env:DRIVER_TYPE = "NEW"
+          $env:QUERY_RESULT_FORMAT = "${{ matrix.result_format == 'json' && 'JSON' || '' }}"
+          $repeatArgs = if ("${{ github.event_name }}" -eq "merge_group") { @("--repeat", "until-pass:2") } else { @() }
+          .\scripts\odbc\run_tests_windows.ps1 -LE flaky @repeatArgs
+
+      - name: Run flaky ODBC tests (Windows)
+        if: runner.os == 'Windows'
+        continue-on-error: true
+        shell: pwsh
+        run: ctest -L flaky -C Debug --test-dir odbc_tests/cmake-build --output-on-failure
+        env:
+          DRIVER_PATH: ${{ github.workspace }}\target\debug\${{ matrix.driver_lib }}
+          PARAMETER_PATH: ${{ github.workspace }}\parameters.json
+          DRIVER_TYPE: NEW
+          QUERY_RESULT_FORMAT: ${{ matrix.result_format == 'json' && 'JSON' || '' }}
+
+      - name: Cleanup orphaned test schemas
+        if: always() && runner.os == 'Linux'
+        run: |
+          TOOL="odbc_tests/cmake-build/tools/schema_tool"
+          if [[ -x "$TOOL" ]]; then
+            "$TOOL" cleanup --age-days 2
+          else
+            echo "schema_tool not found (build may have failed), skipping cleanup"
+          fi
+        env:
+          PARAMETER_PATH: ${{ github.workspace }}/parameters.json
+          DRIVER_PATH: ${{ github.workspace }}/target/debug/${{ matrix.driver_lib }}
+
+      # Save caches unconditionally (not gated on matrix.cloud_provider == 'aws'): when multiple
+      # matrix cells finish near-simultaneously, GHA returns a benign "Unable to reserve cache"
+      # warning for the late writers. That's acceptable; it's better than losing save-on-failure,
+      # which the combined actions/cache@v5 does NOT support (save-always was removed in v5).
+      - name: Save test dependencies cache
+        if: always()
+        timeout-minutes: 10
+        uses: ./.github/actions/build-cache
+        with:
+          mode: save
+          kind: test-deps
+          key-suffix: ${{ matrix.msvc_arch || 'default' }}
+          cache-hit: ${{ steps.test-deps-cache.outputs.cache-hit }}
+
+      - name: Save ccache
+        if: always()
+        timeout-minutes: 10
+        uses: ./.github/actions/build-cache
+        with:
+          mode: save
+          kind: ccache
+          key-suffix: ${{ matrix.msvc_arch || 'default' }}
+          cache-hit: ${{ steps.ccache.outputs.cache-hit }}
+
+      - name: Save vcpkg binary cache (Windows)
+        if: always() && runner.os == 'Windows'
+        timeout-minutes: 10
+        uses: ./.github/actions/build-cache
+        with:
+          mode: save
+          kind: vcpkg
+          key-suffix: ${{ matrix.vcpkg_triplet }}
+          cache-hit: ${{ steps.vcpkg-cache.outputs.cache-hit }}
+
+      - name: Save Homebrew cache (macOS)
+        if: always() && runner.os == 'macOS'
+        timeout-minutes: 10
+        uses: ./.github/actions/build-cache
+        with:
+          mode: save
+          kind: brew
+          cache-hit: ${{ steps.brew-cache.outputs.cache-hit }}
+
+  cleanup_odbc:
+    needs: odbc_tests
+    # The parent already gates the entire reusable-workflow call on
+    # detect-changes; whenever this workflow runs at all we want cleanup
+    # to follow odbc_tests regardless of pass/fail/cancel.
+    if: always()
+    strategy:
+      fail-fast: false
+      matrix:
+        cloud_provider: [aws, gcp, azure]
+    runs-on: ubuntu-latest
+    name: cleanup_odbc (${{ matrix.cloud_provider }})
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Decode secrets
+        run: ./scripts/decode_secrets.sh ${{ matrix.cloud_provider }}
+        env:
+          PARAMETERS_SECRET: ${{ secrets.PARAMETERS_SECRET }}
+        shell: bash
+
+      - name: Cleanup test PATs
+        continue-on-error: true
+        run: |
+          python -m pip install snowflake-connector-python -q
+          python scripts/cleanup_env.py \
+            --parameter-path "${{ github.workspace }}/parameters.json"

--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -24,18 +24,6 @@ jobs:
   detect-changes:
     uses: ./.github/workflows/detect-changes.yml
 
-  load-odbc-matrix:
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.read.outputs.matrix }}
-    steps:
-      - uses: actions/checkout@v4
-      - id: read
-        run: |
-          python ci/test_matrix/generate_matrix.py \
-            --driver odbc --event "$GITHUB_EVENT_NAME" --emit-active \
-            >> "$GITHUB_OUTPUT"
-
   odbc_unit_tests:
     needs: detect-changes
     if: github.event_name == 'push' || needs.detect-changes.outputs.run_odbc == 'true'
@@ -93,379 +81,17 @@ jobs:
     needs: detect-changes
     if: github.event_name == 'push' || needs.detect-changes.outputs.run_odbc_reference == 'true'
     uses: ./.github/workflows/_test-odbc-reference.yml
-
-  # Build ODBC driver once per platform and share via artifact.
-  # Avoids rebuilding in each of the 9 test matrix cells (3 OSes × 3 cloud providers).
-  build_odbc_driver:
-    needs: detect-changes
-    if: github.event_name == 'push' || needs.detect-changes.outputs.run_odbc == 'true'
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-latest
-            name: Linux x64
-            driver_lib: libsfodbc.so
-            cache_key: odbc
-          - os: macos-latest
-            name: macOS ARM64
-            driver_lib: libsfodbc.dylib
-            cache_key: odbc
-          - os: windows-latest
-            name: Windows x64
-            driver_lib: sfodbc.dll
-            cargo_extra: "--features vendored-openssl"
-            cache_key: odbc-x64
-          - os: windows-latest
-            name: Windows x86
-            driver_lib: sfodbc32.dll
-            cargo_target: i686-pc-windows-msvc
-            cargo_extra: "--no-default-features --features vendored-openssl"
-            cache_key: odbc-x86
-          - os: windows-11-arm
-            name: Windows ARM64
-            driver_lib: sfodbc.dll
-            cargo_extra: "--features vendored-openssl"
-            cache_key: odbc-arm64
-    runs-on: ${{ matrix.os }}
-    name: build_odbc_driver (${{ matrix.name }})
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Cache Rust dependencies
-        id: rust-cache
-        # Cache restore failures never fail the job — fall back to clean build.
-        continue-on-error: true
-        uses: ./.github/actions/cargo-cache
-        with:
-          mode: restore
-          shared-key: ${{ matrix.cache_key }}
-
-      - name: Install dependencies (Linux)
-        if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y unixodbc-dev
-
-      - name: Install dependencies (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          brew install unixodbc go
-          echo "ODBC_PREFIX=$(brew --prefix unixodbc)" >> $GITHUB_ENV
-
-      - name: Install Rust target
-        if: matrix.cargo_target
-        run: rustup target add ${{ matrix.cargo_target }}
-
-      - name: Build ODBC driver (Linux)
-        if: runner.os == 'Linux'
-        run: cargo build --package odbc
-        env:
-          RUSTFLAGS: "-C link-arg=-Wl,--undefined-version"
-
-      - name: Build ODBC driver (macOS)
-        if: runner.os == 'macOS'
-        run: cargo build --package odbc
-
-      - name: Build ODBC driver (Windows)
-        if: runner.os == 'Windows'
-        run: cargo build --package odbc ${{ matrix.cargo_extra }} ${{ matrix.cargo_target && format('--target {0}', matrix.cargo_target) || '' }}
-        env:
-          RUSTFLAGS: "-C linker=rust-lld"
-
-      - name: Rename x86 driver DLL
-        if: matrix.cargo_target == 'i686-pc-windows-msvc'
-        shell: pwsh
-        run: |
-          $dir = "target/${{ matrix.cargo_target }}/debug"
-          Move-Item -Force "$dir/sfodbc.dll" "$dir/sfodbc32.dll"
-          if (Test-Path "$dir/sfodbc.pdb") { Move-Item -Force "$dir/sfodbc.pdb" "$dir/sfodbc32.pdb" }
-
-      - name: Save Rust cache
-        if: always()
-        # timeout-minutes is enforced here because it isn't supported on
-        # composite action steps. Bounds slim + registry save + target save.
-        timeout-minutes: 20
-        # Cache failures (incl. timeout-induced cancellation) never fail the job.
-        continue-on-error: true
-        uses: ./.github/actions/cargo-cache
-        with:
-          mode: save
-          shared-key: ${{ matrix.cache_key }}
-          registry-cache-hit: ${{ steps.rust-cache.outputs.registry-cache-hit }}
-          target-cache-hit: ${{ steps.rust-cache.outputs.target-cache-hit }}
-
-      - name: Upload ODBC driver
-        uses: actions/upload-artifact@v4
-        with:
-          name: odbc-driver-${{ matrix.name }}
-          path: ${{ matrix.cargo_target && format('target/{0}/debug', matrix.cargo_target) || 'target/debug' }}/${{ matrix.driver_lib }}
+    # secrets.PARAMETERS_SECRET is read by decode_secrets inside the
+    # reusable workflow; reusable workflows do NOT auto-inherit secrets
+    # even in the same repo.
+    secrets: inherit
 
   odbc_tests:
-    needs: [detect-changes, build_odbc_driver, load-odbc-matrix]
+    needs: detect-changes
     if: github.event_name == 'push' || needs.detect-changes.outputs.run_odbc == 'true'
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{ fromJSON(needs.load-odbc-matrix.outputs.matrix) }}
-    runs-on: ${{ matrix.os }}
-    name: odbc_tests (${{ matrix.name }}, ${{ matrix.cloud_provider }}${{ matrix.result_format && format(', {0}', matrix.result_format) || '' }})
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Download pre-built ODBC driver
-        uses: actions/download-artifact@v4
-        with:
-          name: odbc-driver-${{ matrix.driver_artifact }}
-          path: target/debug
-
-      - name: Make driver executable (Unix)
-        if: runner.os != 'Windows'
-        run: chmod +x target/debug/${{ matrix.driver_lib }}
-
-      - name: Restore test dependencies cache
-        id: test-deps-cache
-        uses: ./.github/actions/build-cache
-        with:
-          mode: restore
-          kind: test-deps
-          key-suffix: ${{ matrix.msvc_arch || 'default' }}
-
-      - name: Restore ccache
-        id: ccache
-        uses: ./.github/actions/build-cache
-        with:
-          mode: restore
-          kind: ccache
-          key-suffix: ${{ matrix.msvc_arch || 'default' }}
-
-      - name: Capture vcpkg version (Windows)
-        if: runner.os == 'Windows'
-        uses: ./.github/actions/vcpkg-version
-
-      - name: Restore vcpkg binary cache (Windows)
-        if: runner.os == 'Windows'
-        id: vcpkg-cache
-        uses: ./.github/actions/build-cache
-        with:
-          mode: restore
-          kind: vcpkg
-          key-suffix: ${{ matrix.vcpkg_triplet }}
-
-      - name: Restore Homebrew cache (macOS)
-        if: runner.os == 'macOS'
-        id: brew-cache
-        uses: ./.github/actions/build-cache
-        with:
-          mode: restore
-          kind: brew
-
-      - name: Install dependencies (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          set -euxo pipefail
-          sudo apt-get update
-          sudo apt-get install -y unixodbc-dev build-essential zlib1g-dev ccache ninja-build
-          # odbc_tests/CMakeLists.txt requires CMake >= 4.0; ubuntu-latest ships ~3.30.
-          # Prefer `python3 -m pip` over bare `pip` so we don't depend on PATH resolution
-          # pointing at the expected Python. The pip wheel is an official Kitware artifact
-          # and installs in ~15s (vs ~60s for the .sh installer).
-          python3 -m pip install 'cmake>=4.0.3'
-          cmake --version
-
-      - name: Install dependencies (macOS)
-        if: runner.os == 'macOS'
-        env:
-          # Skip Homebrew's self-update (~30-60s on every invocation) — we don't need bleeding-edge
-          # formulae, just a working unixodbc/ccache/ninja.
-          HOMEBREW_NO_AUTO_UPDATE: "1"
-          HOMEBREW_NO_INSTALL_CLEANUP: "1"
-        run: |
-          set -euxo pipefail
-          # cmake via pip (official Kitware wheel) — faster than brew and keeps Linux/macOS install symmetric.
-          # Use a dedicated venv rather than installing into the default python3: macos-latest's
-          # python3 is Homebrew-managed and marked as an externally-managed environment (PEP 668),
-          # so a bare `pip install` fails. A venv is the PEP-668-compliant way to isolate the install
-          # without system-wide side effects. The venv's bin dir is prepended to PATH via GITHUB_PATH
-          # so `cmake` resolves to the 4.0+ version in subsequent steps.
-          CMAKE_VENV="$RUNNER_TEMP/cmake-venv"
-          python3 -m venv "$CMAKE_VENV"
-          "$CMAKE_VENV/bin/python" -m pip install --upgrade pip >/dev/null
-          "$CMAKE_VENV/bin/pip" install 'cmake>=4.0.3'
-          echo "$CMAKE_VENV/bin" >> $GITHUB_PATH
-          # Verify against the venv's cmake explicitly — GITHUB_PATH isn't applied to this step.
-          "$CMAKE_VENV/bin/cmake" --version
-          # Only packages without pip wheels stay on brew. `ninja` is pre-installed on macos-latest,
-          # but listing it here is cheap (no-op if present) and self-documenting.
-          brew install unixodbc ccache ninja
-          echo "ODBC_PREFIX=$(brew --prefix unixodbc)" >> $GITHUB_ENV
-
-      - name: Install dependencies (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = "Stop"
-          function Invoke-Checked([string]$commandName, [scriptblock]$command) {
-            & $command
-            if ($LASTEXITCODE -ne 0) { throw "$commandName failed with exit code $LASTEXITCODE" }
-          }
-
-          # install 4.0+ via pip (official Kitware wheel)
-          Invoke-Checked "pip install cmake" { python -m pip install "cmake>=4.0.3" }
-          $cmakePath = (Get-Command cmake.exe).Source | Split-Path
-          echo "CMAKE_DIR=$cmakePath" >> $env:GITHUB_ENV
-          cmake --version
-
-          Invoke-Checked "choco install ccache" { choco install ccache -y --no-progress }
-          New-Item -ItemType Directory -Force -Path $env:CCACHE_DIR | Out-Null
-          New-Item -ItemType Directory -Force -Path "$env:GITHUB_WORKSPACE\.vcpkg-binary-cache" | Out-Null
-
-          $triplet = "${{ matrix.vcpkg_triplet }}"
-          if ("${{ matrix.msvc_arch }}" -eq "arm64") {
-            # ARM64 vcpkg builds require the ARM64 MSVC toolchain environment
-            cmd /c "`"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat`" arm64 && vcpkg install zlib:$triplet openssl:$triplet"
-            if ($LASTEXITCODE -ne 0) { throw "vcpkg install failed with exit code $LASTEXITCODE" }
-          } else {
-            Invoke-Checked "vcpkg install" { vcpkg install zlib:$triplet openssl:$triplet }
-          }
-
-      - name: Setup MSVC environment (Windows)
-        if: runner.os == 'Windows'
-        uses: ./.github/actions/setup-msvc
-        with:
-          arch: ${{ matrix.msvc_arch || 'amd64' }}
-          restore-cmake-dir: 'true'
-
-      - name: Decode secrets
-        run: ./scripts/decode_secrets.sh ${{ matrix.cloud_provider }}
-        env:
-          PARAMETERS_SECRET: ${{ secrets.PARAMETERS_SECRET }}
-        shell: bash
-
-      - name: Build and run ODBC tests (Unix)
-        if: runner.os != 'Windows'
-        run: |
-          ls -l target/debug/
-          export DRIVER_PATH=$(pwd)/target/debug/${{ matrix.driver_lib }}
-          export PARAMETER_PATH=$(pwd)/parameters.json
-          export DRIVER_TYPE=NEW
-          export QUERY_RESULT_FORMAT=${{ matrix.result_format == 'json' && 'JSON' || '' }}
-          REPEAT_ARGS=${{ github.event_name == 'merge_group' && '"--repeat until-pass:2"' || '' }}
-          ./scripts/odbc/run_tests_unix.sh -LE flaky $REPEAT_ARGS
-
-      - name: Run flaky ODBC tests (Unix)
-        if: runner.os != 'Windows'
-        continue-on-error: true
-        run: ctest -L flaky -C Debug --test-dir odbc_tests/cmake-build --output-on-failure
-        env:
-          DRIVER_PATH: ${{ github.workspace }}/target/debug/${{ matrix.driver_lib }}
-          PARAMETER_PATH: ${{ github.workspace }}/parameters.json
-          DRIVER_TYPE: NEW
-          QUERY_RESULT_FORMAT: ${{ matrix.result_format == 'json' && 'JSON' || '' }}
-
-      - name: Build and run ODBC tests (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          dir target\debug\
-          $env:DRIVER_PATH = "$PWD\target\debug\${{ matrix.driver_lib }}"
-          $env:PARAMETER_PATH = "$PWD\parameters.json"
-          $env:DRIVER_TYPE = "NEW"
-          $env:QUERY_RESULT_FORMAT = "${{ matrix.result_format == 'json' && 'JSON' || '' }}"
-          $repeatArgs = if ("${{ github.event_name }}" -eq "merge_group") { @("--repeat", "until-pass:2") } else { @() }
-          .\scripts\odbc\run_tests_windows.ps1 -LE flaky @repeatArgs
-
-      - name: Run flaky ODBC tests (Windows)
-        if: runner.os == 'Windows'
-        continue-on-error: true
-        shell: pwsh
-        run: ctest -L flaky -C Debug --test-dir odbc_tests/cmake-build --output-on-failure
-        env:
-          DRIVER_PATH: ${{ github.workspace }}\target\debug\${{ matrix.driver_lib }}
-          PARAMETER_PATH: ${{ github.workspace }}\parameters.json
-          DRIVER_TYPE: NEW
-          QUERY_RESULT_FORMAT: ${{ matrix.result_format == 'json' && 'JSON' || '' }}
-
-      - name: Cleanup orphaned test schemas
-        if: always() && runner.os == 'Linux'
-        run: |
-          TOOL="odbc_tests/cmake-build/tools/schema_tool"
-          if [[ -x "$TOOL" ]]; then
-            "$TOOL" cleanup --age-days 2
-          else
-            echo "schema_tool not found (build may have failed), skipping cleanup"
-          fi
-        env:
-          PARAMETER_PATH: ${{ github.workspace }}/parameters.json
-          DRIVER_PATH: ${{ github.workspace }}/target/debug/${{ matrix.driver_lib }}
-
-      # Save caches unconditionally (not gated on matrix.cloud_provider == 'aws'): when multiple
-      # matrix cells finish near-simultaneously, GHA returns a benign "Unable to reserve cache"
-      # warning for the late writers. That's acceptable; it's better than losing save-on-failure,
-      # which the combined actions/cache@v5 does NOT support (save-always was removed in v5).
-      - name: Save test dependencies cache
-        if: always()
-        timeout-minutes: 10
-        uses: ./.github/actions/build-cache
-        with:
-          mode: save
-          kind: test-deps
-          key-suffix: ${{ matrix.msvc_arch || 'default' }}
-          cache-hit: ${{ steps.test-deps-cache.outputs.cache-hit }}
-
-      - name: Save ccache
-        if: always()
-        timeout-minutes: 10
-        uses: ./.github/actions/build-cache
-        with:
-          mode: save
-          kind: ccache
-          key-suffix: ${{ matrix.msvc_arch || 'default' }}
-          cache-hit: ${{ steps.ccache.outputs.cache-hit }}
-
-      - name: Save vcpkg binary cache (Windows)
-        if: always() && runner.os == 'Windows'
-        timeout-minutes: 10
-        uses: ./.github/actions/build-cache
-        with:
-          mode: save
-          kind: vcpkg
-          key-suffix: ${{ matrix.vcpkg_triplet }}
-          cache-hit: ${{ steps.vcpkg-cache.outputs.cache-hit }}
-
-      - name: Save Homebrew cache (macOS)
-        if: always() && runner.os == 'macOS'
-        timeout-minutes: 10
-        uses: ./.github/actions/build-cache
-        with:
-          mode: save
-          kind: brew
-          cache-hit: ${{ steps.brew-cache.outputs.cache-hit }}
-
-  cleanup_odbc:
-    needs: [detect-changes, odbc_tests]
-    if: always() && needs.odbc_tests.result != 'skipped'
-    strategy:
-      fail-fast: false
-      matrix:
-        cloud_provider: [aws, gcp, azure]
-    runs-on: ubuntu-latest
-    name: cleanup_odbc (${{ matrix.cloud_provider }})
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Decode secrets
-        run: ./scripts/decode_secrets.sh ${{ matrix.cloud_provider }}
-        env:
-          PARAMETERS_SECRET: ${{ secrets.PARAMETERS_SECRET }}
-        shell: bash
-
-      - name: Cleanup test PATs
-        continue-on-error: true
-        run: |
-          python -m pip install snowflake-connector-python -q
-          python scripts/cleanup_env.py \
-            --parameter-path "${{ github.workspace }}/parameters.json"
+    uses: ./.github/workflows/_test-odbc.yml
+    # See odbc_tests_reference above for the secrets-inherit rationale.
+    secrets: inherit
 
   build_odbc_packages:
     needs: detect-changes
@@ -478,39 +104,45 @@ jobs:
       wix-ref: v7.0.0
 
   odbc-status:
-    needs: [detect-changes, odbc_unit_tests, odbc_tests_reference, build_odbc_driver, load-odbc-matrix, odbc_tests, cleanup_odbc, build_odbc_packages]
+    needs: [detect-changes, odbc_unit_tests, odbc_tests_reference, odbc_tests, build_odbc_packages]
     if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Check status
         run: |
           echo "=== ODBC CI Status ==="
-          
-          # Check if tests were skipped
+
+          # Check if tests were skipped. needs.odbc_tests is the reusable-
+          # workflow call (_test-odbc.yml) — when detect-changes says no
+          # relevant changes, the call is skipped and so is its aggregate
+          # result, which is the trigger for the "skipped" path here.
           if [[ "${{ needs.odbc_tests.result }}" == "skipped" ]]; then
             echo "✓ ODBC tests were SKIPPED (no relevant changes detected)"
             echo "  - run_odbc: ${{ needs.detect-changes.outputs.run_odbc }}"
             exit 0
           fi
-          
-          # Check if any job failed or was cancelled. build_odbc_packages is a
-          # reusable-workflow call whose result aggregates every job inside
-          # (_build-odbc-packages.yml: build_wix, build_msi, build_rpm, build_dmg)
+
+          # Each `needs.<X>.result` for a reusable-workflow call aggregates
+          # every job inside the called workflow:
+          #   needs.odbc_tests          → _test-odbc.yml
+          #                               (load-odbc-matrix, build_odbc_driver,
+          #                                odbc_tests, cleanup_odbc)
+          #   needs.odbc_tests_reference → _test-odbc-reference.yml
+          #   needs.build_odbc_packages → _build-odbc-packages.yml
+          #                               (build_wix, build_msi, build_rpm, build_dmg)
           # — any internal failure surfaces here.
           if [[ "${{ needs.odbc_unit_tests.result }}" =~ ^(failure|cancelled)$ ]] || \
              [[ "${{ needs.odbc_tests_reference.result }}" =~ ^(failure|cancelled)$ ]] || \
-             [[ "${{ needs.build_odbc_driver.result }}" =~ ^(failure|cancelled)$ ]] || \
              [[ "${{ needs.odbc_tests.result }}" =~ ^(failure|cancelled)$ ]] || \
              [[ "${{ needs.build_odbc_packages.result }}" =~ ^(failure|cancelled)$ ]]; then
             echo "✗ ODBC tests were RUN and FAILED or CANCELLED"
             echo "  - odbc_unit_tests: ${{ needs.odbc_unit_tests.result }}"
             echo "  - odbc_tests_reference: ${{ needs.odbc_tests_reference.result }}"
-            echo "  - build_odbc_driver: ${{ needs.build_odbc_driver.result }}"
             echo "  - odbc_tests: ${{ needs.odbc_tests.result }}"
             echo "  - build_odbc_packages: ${{ needs.build_odbc_packages.result }}"
             exit 1
           fi
-          
+
           # Tests ran and passed
           echo "✓ ODBC tests were RUN and PASSED"
           exit 0


### PR DESCRIPTION
NO-SNOW: ODBC CI: extract _test-odbc reusable workflow

Move the four jobs that own the UD-ODBC build-and-test critical path
(`load-odbc-matrix`, `build_odbc_driver`, `odbc_tests`, `cleanup_odbc`)
out of test-odbc.yml into a new .github/workflows/_test-odbc.yml
reusable workflow. The parent keeps a single call site:

  odbc_tests:
    needs: detect-changes
    if: ... run_odbc == 'true'
    uses: ./.github/workflows/_test-odbc.yml
    secrets: inherit

Notable points:

* secrets: inherit added to both odbc_tests and odbc_tests_reference
  callers because reusable workflows in the same repo still do NOT
  auto-inherit secrets; without it the decode_secrets step would lose
  access to PARAMETERS_SECRET. odbc_tests_reference was added by PR 6 but
  needed this fix \u2014 covered here in lockstep with the broader rollout.

* CCACHE_DIR / CCACHE_BASEDIR / CCACHE_MAXSIZE / VCPKG_BINARY_SOURCES
  re-declared inside the reusable workflow (no env inheritance).

* odbc_unit_tests stays in the parent. It's a quick ubuntu-only Rust
  unit-test job that doesn't share runners, caches, or dependencies
  with the rest, so it doesn't earn a reusable-workflow trip.

* odbc-status needs/echo trimmed: build_odbc_driver, load-odbc-matrix,
  cleanup_odbc now aggregate under needs.odbc_tests.result. Skipped
  detection unchanged \u2014 a skipped reusable-workflow call still produces
  result == 'skipped'.

Net: test-odbc.yml -392 lines (518 \u2192 150). Combined with PRs 1-6, the
parent went from ~1400 LOC of intertwined matrices and inline scripts
to a 150-line orchestration layer that dispatches to three named
reusable workflows plus odbc_unit_tests.

Adjust comment