### PR TITLE
SNOW-3529420: ODBC CI: extract setup-odbc-build-env composite

### DIFF
--- a/.github/actions/setup-odbc-build-env/action.yml
+++ b/.github/actions/setup-odbc-build-env/action.yml
@@ -1,0 +1,38 @@
+name: Set ODBC build environment
+description: >
+  Export the workflow-level env vars that every ODBC build/test job
+  expects in its process environment: CCACHE_DIR/BASEDIR/MAXSIZE so
+  ccache can find and bound its cache, VCPKG_BINARY_SOURCES so vcpkg
+  reuses prebuilt packages across runs, and CARGO_TERM_COLOR so cargo
+  emits coloured output in CI logs. Centralised here instead of being
+  redeclared in an `env:` block at the top of every reusable workflow
+  (workflow-level env doesn't cross reusable-workflow boundaries, so
+  every caller would otherwise have to duplicate the same 5-line
+  block).
+
+  Call as the first step after checkout in each job that runs the
+  ODBC build (i.e. anywhere ccache, vcpkg, or cargo is invoked).
+  Jobs that only orchestrate (matrix generation, parameter cleanup)
+  don't need it.
+
+runs:
+  using: composite
+  steps:
+    # Quoted heredoc ('EOF') stops bash from interpreting anything
+    # inside the body. The ${{ github.workspace }} substitutions are
+    # expanded by GHA at YAML load time, before the shell sees the
+    # script, so they end up as platform-native paths in the lines
+    # written to $GITHUB_ENV — backslashes-and-all on Windows, which
+    # ccache/vcpkg both accept. The redirect target `$GITHUB_ENV` is
+    # outside the heredoc body so bash still expands that part to
+    # locate the env file.
+    - name: Export ODBC build env vars
+      shell: bash
+      run: |
+        cat <<'EOF' >> "$GITHUB_ENV"
+        CARGO_TERM_COLOR=always
+        CCACHE_DIR=${{ github.workspace }}/.ccache
+        CCACHE_BASEDIR=${{ github.workspace }}
+        CCACHE_MAXSIZE=1G
+        VCPKG_BINARY_SOURCES=clear;files,${{ github.workspace }}/.vcpkg-binary-cache,readwrite
+        EOF

--- a/.github/workflows/_test-odbc-reference.yml
+++ b/.github/workflows/_test-odbc-reference.yml
@@ -8,12 +8,6 @@ name: ODBC Reference-Driver Tests
 on:
   workflow_call:
 
-# CCACHE_* / VCPKG_BINARY_SOURCES / CARGO_TERM_COLOR are exported by
-# the setup-odbc-build-env composite below — workflow-level env doesn't
-# cross the workflow_call boundary, so the composite is the single
-# source of truth (shared with _test-odbc.yml and the parent's
-# odbc_unit_tests job).
-
 jobs:
   odbc_tests_reference:
     strategy:

--- a/.github/workflows/_test-odbc-reference.yml
+++ b/.github/workflows/_test-odbc-reference.yml
@@ -8,15 +8,11 @@ name: ODBC Reference-Driver Tests
 on:
   workflow_call:
 
-env:
-  # Re-declare workflow-level env that the parent test-odbc.yml provides.
-  # Reusable workflows do NOT inherit env from their caller — without this
-  # the install-build-prereqs step's $env:CCACHE_DIR / vcpkg binary-cache
-  # path point at nothing on the runner.
-  CCACHE_DIR: ${{ github.workspace }}/.ccache
-  CCACHE_BASEDIR: ${{ github.workspace }}
-  CCACHE_MAXSIZE: 1G
-  VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/.vcpkg-binary-cache,readwrite"
+# CCACHE_* / VCPKG_BINARY_SOURCES / CARGO_TERM_COLOR are exported by
+# the setup-odbc-build-env composite below — workflow-level env doesn't
+# cross the workflow_call boundary, so the composite is the single
+# source of truth (shared with _test-odbc.yml and the parent's
+# odbc_unit_tests job).
 
 jobs:
   odbc_tests_reference:
@@ -35,6 +31,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Setup ODBC build environment
+        uses: ./.github/actions/setup-odbc-build-env
 
       - name: Restore test dependencies cache
         id: test-deps-cache-ref

--- a/.github/workflows/_test-odbc.yml
+++ b/.github/workflows/_test-odbc.yml
@@ -7,12 +7,12 @@ name: ODBC Driver Tests
 on:
   workflow_call:
 
-env:
-  CARGO_TERM_COLOR: always
-  CCACHE_DIR: ${{ github.workspace }}/.ccache
-  CCACHE_BASEDIR: ${{ github.workspace }}
-  CCACHE_MAXSIZE: 1G
-  VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/.vcpkg-binary-cache,readwrite"
+# CCACHE_* / VCPKG_BINARY_SOURCES / CARGO_TERM_COLOR are exported by
+# the setup-odbc-build-env composite — workflow-level env doesn't cross
+# the workflow_call boundary, so the composite is the single source of
+# truth (shared with _test-odbc-reference.yml and the parent's
+# odbc_unit_tests job). load-odbc-matrix and cleanup_odbc don't run any
+# cargo/ccache/vcpkg work, so they skip the composite.
 
 jobs:
   load-odbc-matrix:
@@ -62,6 +62,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Setup ODBC build environment
+        uses: ./.github/actions/setup-odbc-build-env
 
       - name: Cache Rust dependencies
         id: rust-cache
@@ -139,6 +142,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Setup ODBC build environment
+        uses: ./.github/actions/setup-odbc-build-env
 
       - name: Download pre-built ODBC driver
         uses: actions/download-artifact@v4

--- a/.github/workflows/_test-odbc.yml
+++ b/.github/workflows/_test-odbc.yml
@@ -7,13 +7,6 @@ name: ODBC Driver Tests
 on:
   workflow_call:
 
-# CCACHE_* / VCPKG_BINARY_SOURCES / CARGO_TERM_COLOR are exported by
-# the setup-odbc-build-env composite — workflow-level env doesn't cross
-# the workflow_call boundary, so the composite is the single source of
-# truth (shared with _test-odbc-reference.yml and the parent's
-# odbc_unit_tests job). load-odbc-matrix and cleanup_odbc don't run any
-# cargo/ccache/vcpkg work, so they skip the composite.
-
 jobs:
   load-odbc-matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -13,12 +13,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
-env:
-  CARGO_TERM_COLOR: always
-  CCACHE_DIR: ${{ github.workspace }}/.ccache
-  CCACHE_BASEDIR: ${{ github.workspace }}
-  CCACHE_MAXSIZE: 1G
-  VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/.vcpkg-binary-cache,readwrite"
+# Workflow-level env vars (CCACHE_*, VCPKG_BINARY_SOURCES, CARGO_TERM_COLOR)
+# moved into .github/actions/setup-odbc-build-env so the reusable workflows
+# below don't have to redeclare them (workflow-level env doesn't cross the
+# workflow_call boundary). Jobs that need them call the composite as their
+# first step; the lone job that lives in this file (odbc_unit_tests) does
+# the same below.
 
 jobs:
   detect-changes:
@@ -31,6 +31,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Setup ODBC build environment
+        uses: ./.github/actions/setup-odbc-build-env
 
       - name: Cache Rust dependencies
         id: rust-cache

--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -13,13 +13,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
-# Workflow-level env vars (CCACHE_*, VCPKG_BINARY_SOURCES, CARGO_TERM_COLOR)
-# moved into .github/actions/setup-odbc-build-env so the reusable workflows
-# below don't have to redeclare them (workflow-level env doesn't cross the
-# workflow_call boundary). Jobs that need them call the composite as their
-# first step; the lone job that lives in this file (odbc_unit_tests) does
-# the same below.
-
 jobs:
   detect-changes:
     uses: ./.github/workflows/detect-changes.yml


### PR DESCRIPTION
NO-SNOW: ODBC CI: extract setup-odbc-build-env composite

Move the workflow-level env block (CCACHE_DIR/BASEDIR/MAXSIZE,
VCPKG_BINARY_SOURCES, CARGO_TERM_COLOR) into a new
.github/actions/setup-odbc-build-env composite, so we don't have to
redeclare it in every workflow. Workflow-level env doesn't cross
the workflow_call boundary, so before this change the same 5-line
env block was duplicated in test-odbc.yml, _test-odbc.yml, and
_test-odbc-reference.yml.

The composite writes the same values into $GITHUB_ENV via a quoted
heredoc, so subsequent steps see them in process env exactly the way
the old env: block delivered them — including the platform-native
${{ github.workspace }} expansion that ccache/vcpkg need on Windows.

Call sites (added as the first step after checkout in build/test
jobs):
  - test-odbc.yml          odbc_unit_tests
  - _test-odbc.yml         build_odbc_driver, odbc_tests
  - _test-odbc-reference.yml  odbc_tests_reference

Pure orchestration jobs (load-odbc-matrix, cleanup_odbc) don't run
cargo/ccache/vcpkg so they skip the composite.

Adjust comment