### PR TITLE
SNOW-3480688: use typed param constant for CLIENT_SESSION_KEEP_ALIVE lookup

### DIFF
--- a/sf_core/src/apis/database_driver_v1/connection.rs
+++ b/sf_core/src/apis/database_driver_v1/connection.rs
@@ -265,7 +265,7 @@ impl DatabaseDriverV1 {
                 };
 
                 let keep_alive = merged_params
-                    .get("CLIENT_SESSION_KEEP_ALIVE")
+                    .get(param_names::CLIENT_SESSION_KEEP_ALIVE.as_str())
                     .map(|v| v.eq_ignore_ascii_case("true"))
                     .unwrap_or(false);
 

--- a/sf_core/src/config/param_registry.rs
+++ b/sf_core/src/config/param_registry.rs
@@ -88,6 +88,7 @@ pub mod param_names {
     pub const LOG_QUERY_TEXT: ParamKey = ParamKey("log_query_text");
     pub const LOG_QUERY_PARAMETERS: ParamKey = ParamKey("log_query_parameters");
     pub const CLIENT_TELEMETRY_ENABLED: ParamKey = ParamKey("CLIENT_TELEMETRY_ENABLED");
+    pub const CLIENT_SESSION_KEEP_ALIVE: ParamKey = ParamKey("CLIENT_SESSION_KEEP_ALIVE");
     // Logout configuration
     pub const SERVER_SESSION_KEEP_ALIVE: ParamKey = ParamKey("server_session_keep_alive");
     pub const ENABLE_SERVER_SESSION_KEEP_ALIVE_AUTO_DETECTION: ParamKey =


### PR DESCRIPTION
## Summary
- Add a `CLIENT_SESSION_KEEP_ALIVE` typed constant to `param_names` (next to `CLIENT_TELEMETRY_ENABLED`) and use it in `connection_init` instead of a bare string literal, matching the pattern already used for `CLIENT_TELEMETRY_ENABLED`.
- Removes a typo footgun: the parameter name is now anchored in a single typed constant rather than a free-floating string.

## Context
Addresses a review comment on the heartbeat-integration-tests stack (#745). The `CLIENT_SESSION_KEEP_ALIVE` lookup originally landed in `connection.rs` via #744 as a bare string literal. The reviewer pointed out that telemetry already uses `param_names::CLIENT_TELEMETRY_ENABLED.as_str()` for the same kind of session-parameter lookup, and asked for the keep-alive lookup to be migrated to the same typed-constant pattern. Filed as a separate stacked PR because the touched code lives in a sibling/parent of the heartbeat PR's own diff.

Note: `connection_config.py` is auto-generated from `PARAM_DEFS` and was regenerated by the `generate-connection-config` pre-commit hook to pick up `log_query_text` / `log_query_parameters` (already in `PARAM_DEFS` on `main`). This regen is unrelated to the typed-constant change but is required by the hook.

## Test plan
- `cargo check -p sf_core --tests` passes.
- Pre-commit hooks (rustfmt, clippy, cargo check, ConnectionConfig generation, etc.) all pass.
- No behavior change: the constant resolves to the same `"CLIENT_SESSION_KEEP_ALIVE"` string the literal previously used, and existing heartbeat integration tests still exercise the keep-alive path.