### PR TITLE
ci(python): cache rustup and target/ for Linux build_wheels

### DIFF
--- a/.github/workflows/_build-python-wheels.yml
+++ b/.github/workflows/_build-python-wheels.yml
@@ -247,36 +247,72 @@ jobs:
       # ── sf_core build: Linux (Docker + manylinux for glibc compat) ──
       # Cannot use job-level container: because cibuildwheel needs Docker.
       # Instead, build sf_core via docker run with the manylinux image.
-      - name: Restore Cargo registry cache (Linux)
+      #
+      # Caching strategy: cargo-cache (registry + target/) runs on the HOST,
+      # and its dirs are volume-mounted into the manylinux container so the
+      # in-container `cargo build` reads/writes them directly. The rustup
+      # toolchain (~/.rustup + ~/.cargo/bin) is cached separately — keyed
+      # only on a version marker so Cargo.lock churn doesn't invalidate it.
+      - name: Restore Rust cache (Linux)
         if: runner.os == 'Linux'
+        id: rust-cache-linux
         continue-on-error: true
-        uses: actions/cache@v5
+        uses: ./.github/actions/cargo-cache
+        with:
+          mode: restore
+          shared-key: sf-core-release-${{ matrix.artifact_id }}
+
+      - name: Restore rustup toolchain cache (Linux)
+        if: runner.os == 'Linux'
+        id: rustup-cache-linux
+        continue-on-error: true
+        uses: actions/cache/restore@v5
         with:
           path: |
-            ~/.cargo/registry/index
-            ~/.cargo/registry/cache
-            ~/.cargo/git/db
-          key: ${{ runner.os }}-${{ matrix.target }}-cargo-registry-v2-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-${{ matrix.target }}-cargo-registry-v2-
+            ~/.rustup
+            ~/.cargo/bin
+          key: ${{ runner.os }}-${{ matrix.artifact_id }}-rustup-stable-minimal-v1
+          restore-keys: ${{ runner.os }}-${{ matrix.artifact_id }}-rustup-stable-minimal-
 
       - name: Build sf_core in manylinux container
         if: runner.os == 'Linux'
         run: |
-          mkdir -p "$HOME/.cargo/registry" "$HOME/.cargo/git"
+          mkdir -p "$HOME/.cargo/registry" "$HOME/.cargo/git" \
+                   "$HOME/.cargo/bin" "$HOME/.rustup"
           docker run --rm \
             -v "$HOME/.cargo/registry:/root/.cargo/registry" \
             -v "$HOME/.cargo/git:/root/.cargo/git" \
+            -v "$HOME/.cargo/bin:/root/.cargo/bin" \
+            -v "$HOME/.rustup:/root/.rustup" \
             -v "$GITHUB_WORKSPACE:/workspace" \
             -w /workspace \
             -e CARGO_TERM_COLOR=always \
+            -e RUSTUP_HOME=/root/.rustup \
+            -e CARGO_HOME=/root/.cargo \
             ${{ matrix.container }} \
             bash -c '
-              curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
-              source "$HOME/.cargo/env"
+              set -e
+              export PATH="/root/.cargo/bin:$PATH"
+              if [ ! -x /root/.cargo/bin/cargo ]; then
+                echo "No cached rustup; installing..."
+                curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs \
+                  | sh -s -- -y --default-toolchain stable --profile minimal
+              else
+                echo "Using cached rustup toolchain"
+              fi
               yum install -y perl-IPC-Cmd perl-Time-Piece
               cargo build --release --package sf_core ${{ matrix.cargo_extra_args }}
             '
-          sudo chown -R "$(id -u):$(id -g)" target/ "$HOME/.cargo/registry" "$HOME/.cargo/git"
+
+      # Chown runs in its own always() step so cache save is possible even
+      # when the build failed (and target/ may be partial or missing).
+      - name: Fix ownership of cached dirs (Linux)
+        if: always() && runner.os == 'Linux'
+        run: |
+          sudo chown -R "$(id -u):$(id -g)" \
+            target/ \
+            "$HOME/.cargo/registry" "$HOME/.cargo/git" \
+            "$HOME/.cargo/bin" "$HOME/.rustup" 2>/dev/null || true
 
       # ── sf_core build: macOS / Windows (direct, no container) ──
       - name: Restore Rust cache
@@ -319,6 +355,32 @@ jobs:
           shared-key: sf-core-release
           registry-cache-hit: ${{ steps.rust-cache.outputs.registry-cache-hit }}
           target-cache-hit: ${{ steps.rust-cache.outputs.target-cache-hit }}
+
+      - name: Save Rust cache (Linux)
+        if: always() && runner.os == 'Linux'
+        timeout-minutes: 20
+        continue-on-error: true
+        uses: ./.github/actions/cargo-cache
+        with:
+          mode: save
+          shared-key: sf-core-release-${{ matrix.artifact_id }}
+          registry-cache-hit: ${{ steps.rust-cache-linux.outputs.registry-cache-hit }}
+          target-cache-hit: ${{ steps.rust-cache-linux.outputs.target-cache-hit }}
+
+      # Gated on cache-hit != 'true' to avoid "Unable to reserve cache" races
+      # when the exact key already exists in the cache service.
+      - name: Save rustup toolchain cache (Linux)
+        if: always() && runner.os == 'Linux' && steps.rustup-cache-linux.outputs.cache-hit != 'true'
+        timeout-minutes: 10
+        continue-on-error: true
+        env:
+          ZSTD_NBTHREADS: '2'
+        uses: actions/cache/save@v5
+        with:
+          path: |
+            ~/.rustup
+            ~/.cargo/bin
+          key: ${{ runner.os }}-${{ matrix.artifact_id }}-rustup-stable-minimal-v1
 
       # ── Download protobuf ──
       - name: Download pre-built protobuf code

--- a/.github/workflows/_build-python-wheels.yml
+++ b/.github/workflows/_build-python-wheels.yml
@@ -168,11 +168,18 @@ jobs:
           SNOWFLAKE_DISABLE_COMPILE_ARROW_EXTENSIONS: "true"
           PROTO_CARGO_TARGET_DIR: ${{ github.workspace }}/proto-target
 
+      # Keep protobuf-gen around long enough that "Re-run this job" on a
+      # downstream build_wheels matrix entry can still fetch it. Cibuildwheel
+      # re-runs are common (esp. manylinux_aarch64), and GitHub's per-job re-run
+      # does NOT re-run upstream `needs: generate_proto`, so the artifact must
+      # outlive the workflow run itself. We previously deleted it eagerly in a
+      # cleanup job, which made any single-job re-run impossible.
       - name: Upload protobuf artifacts
         uses: actions/upload-artifact@v4
         with:
           name: protobuf-gen
           path: python/src/snowflake/connector/_internal/protobuf_gen/
+          retention-days: 7
 
   # ── Build source distribution (platform-independent, runs once) ────
   build_sdist:
@@ -560,20 +567,3 @@ jobs:
         with:
           name: ${{ matrix.artifact_name }}
           path: python/dist/*.whl
-
-  # ── Clean up intermediate build artifacts ──────────────────────────
-  cleanup_build_artifacts:
-    needs: [build_wheels, build_wheel]
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      - name: Delete intermediate artifacts
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts \
-            --paginate -q '.artifacts[] | select(.name == "protobuf-gen") | .id' |
-          while read id; do
-            echo "Deleting artifact $id"
-            gh api -X DELETE repos/${{ github.repository }}/actions/artifacts/$id
-          done


### PR DESCRIPTION
## Summary

Linux `build_wheels` reinstalled rustup (~1-2 min) and recompiled sf_core from scratch (~4-6 min) on every run because the manylinux Docker path only mounted the cargo registry — macOS/Windows already cache `target/` via the `cargo-cache` composite action. This PR closes that gap.

**Changes to `.github/workflows/_build-python-wheels.yml`:**
- Restore/save `target/` via existing `cargo-cache` composite action (per-arch `shared-key` so `manylinux_x86_64` and `manylinux_aarch64` don't collide).
- Cache `~/.rustup` + `~/.cargo/bin` in a separate step keyed only on a version marker (decoupled from `Cargo.lock`).
- Mount the rustup dirs into the Docker container; conditional install (`if [ ! -x /root/.cargo/bin/cargo ]`) with `--profile minimal` to shrink the cached toolchain.
- Hoist the post-build `chown` into its own `if: always()` step so cache save still runs after build failures.

Expected warm run: **~10 min → ~4-5 min** on Linux `build_wheels`.

## Rollback

Two independent kill-switches:
- Rustup cache: bump the `-v1` suffix in the new cache keys.
- Registry + target cache: bump `CACHE_VERSION` in `.github/actions/cargo-cache/action.yml`.

## Test plan

- [ ] First run after merge is cold: expect baseline ~10 min, logs show `"No cached rustup; installing..."` and cache miss on both restores.
- [ ] Both `Save Rust cache (Linux)` and `Save rustup toolchain cache (Linux)` execute post-job; no "Unable to reserve cache" warnings.
- [ ] Second run (warm cache): logs show `"Using cached rustup toolchain"` and cache hits on both restores.
- [ ] Warm `build_wheels (manylinux_x86_64)` and `build_wheels (manylinux_aarch64)` jobs complete in ~4-5 min.
- [ ] `cargo build` output shows `Compiling` only for changed crates, not the full dep tree.
- [ ] Wheels still pass `auditwheel show` manylinux_2_28 policy check.
- [ ] Watch for ENOSPC on `ubuntu-24.04-arm` runner; if observed, reduce `max-target-size-mb` via action input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)