### PR TITLE
NO-SNOW: Bump reference py driver version

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -15,7 +15,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  PYTHON_REFERENCE_DRIVER_VERSION: "4.3.0"
+  PYTHON_REFERENCE_DRIVER_VERSION: "4.4.0"
 
 jobs:
   detect-changes:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -339,7 +339,7 @@ template = "test"
 [tool.hatch.envs.reference.scripts]
 test = [
     "uv pip uninstall snowflake-connector-python",
-    "uv pip install snowflake-connector-python=={env:PYTHON_REFERENCE_DRIVER_VERSION:4.3.0}",
+    "uv pip install snowflake-connector-python=={env:PYTHON_REFERENCE_DRIVER_VERSION:4.4.0}",
     "pytest tests/integ tests/e2e --ignore=tests/e2e/pandas {args}",
 ]
 compare = "python ci/reference_tests/compare_reports.py {args}"
@@ -350,6 +350,6 @@ template = "test"
 [tool.hatch.envs.reference-pandas.scripts]
 test = [
     "uv pip uninstall snowflake-connector-python",
-    "uv pip install snowflake-connector-python[pandas]=={env:PYTHON_REFERENCE_DRIVER_VERSION:4.3.0}",
+    "uv pip install snowflake-connector-python[pandas]=={env:PYTHON_REFERENCE_DRIVER_VERSION:4.4.0}",
     "pytest tests/e2e/pandas {args}",
 ]


### PR DESCRIPTION
4.4.0 fixed a bug where Azure GET commands would incorrectly set the file status to UPLOADED instead of preserving the DOWNLOADED status during metadata retrieval.