### PR TITLE
SNOW-3098562: Fix Int64 downcast issue

### DIFF
--- a/odbc/src/conversion/converter_tests.rs
+++ b/odbc/src/conversion/converter_tests.rs
@@ -2,7 +2,7 @@
 mod tests {
     use crate::conversion::error::ConversionError;
     use crate::conversion::{Binding, NumericSettings, make_converter};
-    use arrow::array::{ArrayRef, Int64Array};
+    use arrow::array::{ArrayRef, Int32Array, Int64Array};
     use arrow::datatypes::{DataType, Field};
     use std::collections::HashMap;
     use std::sync::Arc;
@@ -13,6 +13,16 @@ mod tests {
             .map(|(k, v)| (k.to_string(), v.to_string()))
             .collect();
         Field::new("col", DataType::Boolean, true).with_metadata(md)
+    }
+
+    fn time_field(scale: u32, data_type: DataType) -> Field {
+        let md: HashMap<String, String> = [
+            ("logicalType".to_string(), "TIME".to_string()),
+            ("scale".to_string(), scale.to_string()),
+        ]
+        .into_iter()
+        .collect();
+        Field::new("col", data_type, true).with_metadata(md)
     }
 
     /// Cached converters now downcast at `convert_arrow_value` time, so a
@@ -39,5 +49,64 @@ mod tests {
             }
             other => panic!("expected ArrowArrayDowncast, got: {other:?}"),
         }
+    }
+
+    /// TIME columns with scale ≤ 4 arrive as Int32-backed arrays; scale ≥ 5
+    /// arrive as Int64. The converter must select its downcast target from
+    /// the Arrow field's data type rather than hardcoding one width.
+    #[test]
+    fn time_int32_field_accepts_int32_array() {
+        let field = time_field(0, DataType::Int32);
+        let ns = NumericSettings::default();
+        let converter = make_converter(&field, &ns).expect("converter for TIME(0) Int32");
+
+        let array: ArrayRef = Arc::new(Int32Array::from(vec![Some(45_296)])); // 12:34:56
+        let mut buffer = vec![0u8; 16];
+        let mut str_len: odbc_sys::Len = 0;
+        let binding = crate::conversion::test_utils::helpers::binding_for_char_buffer(
+            crate::api::CDataType::Char,
+            &mut buffer,
+            &mut str_len,
+        );
+
+        converter
+            .convert_arrow_value(array.as_ref(), 0, &binding, &mut None)
+            .expect("Int32-backed TIME column must convert without downcast errors");
+        assert_eq!(&buffer[..8], b"12:34:56");
+    }
+
+    #[test]
+    fn time_int64_field_accepts_int64_array() {
+        let field = time_field(9, DataType::Int64);
+        let ns = NumericSettings::default();
+        let converter = make_converter(&field, &ns).expect("converter for TIME(9) Int64");
+
+        let array: ArrayRef = Arc::new(Int64Array::from(vec![Some(45_296_123_456_789i64)])); // 12:34:56.123456789
+        let mut buffer = vec![0u8; 32];
+        let mut str_len: odbc_sys::Len = 0;
+        let binding = crate::conversion::test_utils::helpers::binding_for_char_buffer(
+            crate::api::CDataType::Char,
+            &mut buffer,
+            &mut str_len,
+        );
+
+        converter
+            .convert_arrow_value(array.as_ref(), 0, &binding, &mut None)
+            .expect("Int64-backed TIME column must convert");
+        assert_eq!(&buffer[..18], b"12:34:56.123456789");
+    }
+
+    #[test]
+    fn time_unsupported_data_type_fails_converter_construction() {
+        let field = time_field(0, DataType::Float32);
+        let ns = NumericSettings::default();
+        let err = match make_converter(&field, &ns) {
+            Ok(_) => panic!("Float32 must not be accepted as a TIME backing array"),
+            Err(e) => e,
+        };
+        assert!(matches!(
+            err,
+            ConversionError::UnsupportedArrowDataType { .. }
+        ));
     }
 }

--- a/odbc/src/conversion/mod.rs
+++ b/odbc/src/conversion/mod.rs
@@ -516,9 +516,18 @@ pub fn make_converter(
         SnowflakeFieldType::Date(snowflake_type) => {
             make_primitive_data_converter!(Date32Type, snowflake_type, nullable)
         }
-        SnowflakeFieldType::Time(snowflake_type) => {
-            make_primitive_data_converter!(Int64Type, snowflake_type, nullable)
-        }
+        SnowflakeFieldType::Time(snowflake_type) => match field.data_type() {
+            DataType::Int32 => {
+                make_primitive_data_converter!(Int32Type, snowflake_type, nullable)
+            }
+            DataType::Int64 => {
+                make_primitive_data_converter!(Int64Type, snowflake_type, nullable)
+            }
+            dt => UnsupportedArrowDataTypeSnafu {
+                data_type: dt.clone(),
+            }
+            .fail(),
+        },
         SnowflakeFieldType::TimestampNtz(snowflake_type) => {
             make_timestamp_converter!(snowflake_type, field, nullable)
         }

--- a/odbc/src/conversion/time.rs
+++ b/odbc/src/conversion/time.rs
@@ -1,7 +1,7 @@
 use std::io::{Cursor, Write as _};
 
 use arrow::array::{Array, PrimitiveArray};
-use arrow::datatypes::Int64Type;
+use arrow::datatypes::ArrowPrimitiveType;
 use chrono::{Datelike, NaiveDate, NaiveTime, Timelike};
 use odbc_sys as sql;
 use serde_json::Value;
@@ -58,10 +58,13 @@ impl SnowflakeType for SnowflakeTime {
     type Representation<'a> = NaiveTime;
 }
 
-impl ReadArrowType<PrimitiveArray<Int64Type>> for SnowflakeTime {
+impl<T: ArrowPrimitiveType> ReadArrowType<PrimitiveArray<T>> for SnowflakeTime
+where
+    T::Native: Into<i64>,
+{
     fn read_arrow_type<'a>(
         &self,
-        array: &'a PrimitiveArray<Int64Type>,
+        array: &'a PrimitiveArray<T>,
         row_idx: usize,
     ) -> Result<Self::Representation<'a>, ReadArrowError> {
         if array.is_null(row_idx) {
@@ -75,7 +78,7 @@ impl ReadArrowType<PrimitiveArray<Int64Type>> for SnowflakeTime {
             }
             .fail();
         }
-        let raw = array.value(row_idx);
+        let raw: i64 = array.value(row_idx).into();
         if raw < 0 {
             return InvalidArrowValueSnafu {
                 reason: format!("negative TIME value: {raw}"),

--- a/odbc/src/conversion/time_tests.rs
+++ b/odbc/src/conversion/time_tests.rs
@@ -9,7 +9,7 @@ mod tests {
     };
     use crate::conversion::time::SnowflakeTime;
     use arrow::array::PrimitiveArray;
-    use arrow::datatypes::Int64Type;
+    use arrow::datatypes::{Int32Type, Int64Type};
     use chrono::NaiveTime;
     use odbc_sys as sql;
 
@@ -115,6 +115,114 @@ mod tests {
             result,
             Err(ReadArrowError::InvalidArrowValue { .. })
         ));
+    }
+
+    // ========================================================================
+    // ReadArrowType — Int32 backing array. TIME columns with scale ≤ 4
+    // are encoded as Int32 on the wire; the converter must downcast
+    // to PrimitiveArray<Int32Type> in that case rather than Int64Type.
+    // ========================================================================
+
+    #[test]
+    fn read_arrow_int32_scale_0_whole_seconds() {
+        let sn = time(0);
+        let array = PrimitiveArray::<Int32Type>::from(vec![Some(45_296)]); // 12:34:56
+        let value = sn.read_arrow_type(&array, 0).unwrap();
+        assert_eq!(value, NaiveTime::from_hms_opt(12, 34, 56).unwrap());
+    }
+
+    #[test]
+    fn read_arrow_int32_scale_0_max_second_of_day() {
+        let sn = time(0);
+        let array = PrimitiveArray::<Int32Type>::from(vec![Some(86_399)]); // 23:59:59
+        let value = sn.read_arrow_type(&array, 0).unwrap();
+        assert_eq!(value, NaiveTime::from_hms_opt(23, 59, 59).unwrap());
+    }
+
+    #[test]
+    fn read_arrow_int32_scale_3_milliseconds() {
+        let sn = time(3);
+        let array = PrimitiveArray::<Int32Type>::from(vec![Some(45_296_789)]); // 12:34:56.789
+        let value = sn.read_arrow_type(&array, 0).unwrap();
+        assert_eq!(
+            value,
+            NaiveTime::from_hms_milli_opt(12, 34, 56, 789).unwrap()
+        );
+    }
+
+    #[test]
+    fn read_arrow_int32_scale_4_max_value() {
+        // The largest value Snowflake stores in an Int32 TIME column: scale=4
+        // and time = 23:59:59.9999 → 86_399 * 10_000 + 9_999 = 863_999_999,
+        // which still fits in i32::MAX (2_147_483_647).
+        let sn = time(4);
+        let array = PrimitiveArray::<Int32Type>::from(vec![Some(863_999_999)]);
+        let value = sn.read_arrow_type(&array, 0).unwrap();
+        assert_eq!(
+            value,
+            NaiveTime::from_hms_nano_opt(23, 59, 59, 999_900_000).unwrap()
+        );
+    }
+
+    #[test]
+    fn read_arrow_int32_midnight() {
+        let sn = time(4);
+        let array = PrimitiveArray::<Int32Type>::from(vec![Some(0)]);
+        let value = sn.read_arrow_type(&array, 0).unwrap();
+        assert_eq!(value, NaiveTime::from_hms_opt(0, 0, 0).unwrap());
+    }
+
+    #[test]
+    fn read_arrow_int32_null_returns_null_error() {
+        let sn = time(0);
+        let array = PrimitiveArray::<Int32Type>::from(vec![None::<i32>]);
+        let result = sn.read_arrow_type(&array, 0);
+        assert!(matches!(result, Err(ReadArrowError::NullValue { .. })));
+    }
+
+    #[test]
+    fn read_arrow_int32_negative_value_returns_invalid() {
+        let sn = time(0);
+        let array = PrimitiveArray::<Int32Type>::from(vec![Some(-1)]);
+        let result = sn.read_arrow_type(&array, 0);
+        assert!(matches!(
+            result,
+            Err(ReadArrowError::InvalidArrowValue { .. })
+        ));
+    }
+
+    #[test]
+    fn read_arrow_int32_overflow_secs_returns_invalid() {
+        let sn = time(0);
+        // 86400 seconds = 24:00:00, out of valid range 0..86399
+        let array = PrimitiveArray::<Int32Type>::from(vec![Some(86_400)]);
+        let result = sn.read_arrow_type(&array, 0);
+        assert!(matches!(
+            result,
+            Err(ReadArrowError::InvalidArrowValue { .. })
+        ));
+    }
+
+    #[test]
+    fn read_arrow_int32_picks_correct_row() {
+        let sn = time(0);
+        let array = PrimitiveArray::<Int32Type>::from(vec![
+            Some(0),      // 00:00:00
+            None,         // null
+            Some(45_296), // 12:34:56
+        ]);
+        assert_eq!(
+            sn.read_arrow_type(&array, 0).unwrap(),
+            NaiveTime::from_hms_opt(0, 0, 0).unwrap()
+        );
+        assert!(matches!(
+            sn.read_arrow_type(&array, 1),
+            Err(ReadArrowError::NullValue { .. })
+        ));
+        assert_eq!(
+            sn.read_arrow_type(&array, 2).unwrap(),
+            NaiveTime::from_hms_opt(12, 34, 56).unwrap()
+        );
     }
 
     // ========================================================================


### PR DESCRIPTION
## Summary
  - TIME columns with scale ≤ 4 are wire-encoded as Int32, but the ODBC converter hardcoded a downcast to `PrimitiveArray<Int64Type>`, so every row failed with `ArrowArrayDowncast` (DTM3103).
  - `make_converter` now dispatches on `field.data_type()` (Int32 / Int64 → matching primitive converter, anything else → `UnsupportedArrowDataType`).
  - `ReadArrowType` for `SnowflakeTime` is generalized over `T: ArrowPrimitiveType where T::Native: Into<i64>`, mirroring how `SnowflakeNumber` covers Int8/16/32/64.