### PR TITLE
SNOW-3530279: fix pyformat percent escaping with empty params

### DIFF
--- a/python/src/snowflake/connector/_internal/binding_converters.py
+++ b/python/src/snowflake/connector/_internal/binding_converters.py
@@ -515,7 +515,13 @@ class ClientSideBindingConverter:
             return tuple(cls.process_single_param(param) for param in params)
 
     @classmethod
-    def interpolate_query(cls, query: str, params: Sequence[Any] | Mapping[str, Any] | None) -> str:
+    def interpolate_query(
+        cls,
+        query: str,
+        params: Sequence[Any] | Mapping[str, Any] | None,
+        *,
+        interpolate_empty_sequences: bool = False,
+    ) -> str:
         """Interpolate parameters into query using Python % formatting.
 
         This is the main entry point for client-side binding, mirroring
@@ -524,15 +530,20 @@ class ClientSideBindingConverter:
         Args:
             query: SQL query with %s or %(name)s placeholders
             params: Parameters to interpolate
+            interpolate_empty_sequences: When True, perform ``query % params``
+                even when *params* is empty.  This unescapes ``%%`` → ``%``
+                which is required when SQLAlchemy doubles percent signs during
+                compilation (pyformat paramstyle).  Matches the old connector's
+                ``connection._interpolate_empty_sequences`` flag.
 
         Returns:
             Query string with parameters interpolated
         """
-        if params is None or (not isinstance(params, Mapping) and len(params) == 0):
+        if params is None:
             return query
 
         processed_params = cls.process_params_pyformat(params)
 
-        if processed_params:
+        if interpolate_empty_sequences or len(processed_params) > 0:
             return query % processed_params
         return query

--- a/python/src/snowflake/connector/connection.py
+++ b/python/src/snowflake/connector/connection.py
@@ -166,6 +166,13 @@ class Connection(ErrorHandlerMixin):
         # ``ConnectionConfig`` so it is never forwarded to the Rust core.
         self.auto_cleanup: bool = True if self.config.auto_cleanup is None else bool(self.config.auto_cleanup)
 
+        # Controls whether `query % params` is applied even when params is
+        # empty (e.g. {} or ()).  When True, doubled percents (`%%`) are
+        # unescaped to `%`.  The SQLAlchemy dialect toggles this in pre_exec /
+        # post_exec for compiled statements that use pyformat paramstyle.
+        # Defaults to False to match the old connector's behavior.
+        self._interpolate_empty_sequences: bool = False
+
         self.db_api = database_driver_client()
         self.db_handle: DatabaseHandle | None = self.db_api.database_new(DatabaseNewRequest()).db_handle
         self.db_api.database_init(DatabaseInitRequest(db_handle=self.db_handle))

--- a/python/src/snowflake/connector/cursor/_base.py
+++ b/python/src/snowflake/connector/cursor/_base.py
@@ -452,7 +452,11 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
                     errno=ER_INVALID_VALUE,
                 )
             # Client-side binding: interpolate parameters into SQL string
-            query = ClientSideBindingConverter.interpolate_query(operation, parameters)
+            query = ClientSideBindingConverter.interpolate_query(
+                operation,
+                parameters,
+                interpolate_empty_sequences=self._connection._interpolate_empty_sequences,
+            )
             return query, None
         else:
             # Server-side binding: qmark or numeric

--- a/python/tests/integ/test_cursor.py
+++ b/python/tests/integ/test_cursor.py
@@ -2633,3 +2633,57 @@ class TestCursorAbortQuery:
         except ProgrammingError as e:
             assert "57014" in e.msg
             assert "canceled" in e.msg
+
+
+@with_paramstyle("pyformat")
+class TestInterpolateEmptySequences:
+    """Integration tests for _interpolate_empty_sequences flag.
+
+    The pyformat paramstyle doubles literal '%' to '%%' during compilation.
+    The connector must unescape '%%' back to '%' when the flag is set (as
+    SQLAlchemy does), but preserve '%%' when the flag is off (default).
+    """
+
+    def test_flag_defaults_to_false(self, connection):
+        assert connection._interpolate_empty_sequences is False
+
+    def test_doubled_percents_preserved_by_default(self, connection):
+        """Without the flag, '%%' is NOT unescaped with empty params."""
+        cursor = connection.cursor()
+        with pytest.raises(ProgrammingError):
+            cursor.execute("SELECT 1600 %% 400 AS a", {})
+
+    def test_doubled_percents_unescaped_when_flag_set(self, connection):
+        """With the flag set, '%%' is unescaped and the query succeeds."""
+        connection._interpolate_empty_sequences = True
+        try:
+            cursor = connection.cursor()
+            cursor.execute("SELECT 1600 %% 400 AS a, 1599 %% 400 AS b", {})
+            row = cursor.fetchone()
+            assert row == (0, 399)
+        finally:
+            connection._interpolate_empty_sequences = False
+
+    def test_doubled_percents_unescaped_with_empty_list(self, connection):
+        """With the flag set, '%%' is unescaped even with an empty list."""
+        connection._interpolate_empty_sequences = True
+        try:
+            cursor = connection.cursor()
+            cursor.execute("SELECT 100 %% 7 AS a", [])
+            row = cursor.fetchone()
+            assert row == (2,)
+        finally:
+            connection._interpolate_empty_sequences = False
+
+    def test_normal_params_always_interpolate(self, cursor):
+        """Parameterized queries work regardless of the flag."""
+        cursor.execute("SELECT %s AS a, %s AS b", [42, "hello"])
+        row = cursor.fetchone()
+        assert row == (42, "hello")
+
+    def test_percent_with_params_works(self, connection):
+        """When actual params are present, '%%' is unescaped even without the flag."""
+        cursor = connection.cursor()
+        cursor.execute("SELECT %s AS a, 100 %% 7 AS b", [42])
+        row = cursor.fetchone()
+        assert row == (42, 2)

--- a/python/tests/unit/test_binding_converters.py
+++ b/python/tests/unit/test_binding_converters.py
@@ -1206,6 +1206,42 @@ class TestInterpolateQuery:
         )
         assert result == "SELECT * FROM t WHERE id = 42 AND name = 'Alice' AND active = TRUE"
 
+    def test_empty_dict_preserves_doubled_percents_by_default(self):
+        result = ClientSideBindingConverter.interpolate_query("SELECT 1600 %% 400 AS a", {})
+        assert result == "SELECT 1600 %% 400 AS a"
+
+    def test_empty_list_preserves_doubled_percents_by_default(self):
+        result = ClientSideBindingConverter.interpolate_query("SELECT 1600 %% 400 AS a", [])
+        assert result == "SELECT 1600 %% 400 AS a"
+
+    def test_empty_dict_unescapes_doubled_percents_when_flag_set(self):
+        result = ClientSideBindingConverter.interpolate_query(
+            "SELECT 1600 %% 400 AS a, 1599 %% 400 AS b", {}, interpolate_empty_sequences=True
+        )
+        assert result == "SELECT 1600 % 400 AS a, 1599 % 400 AS b"
+
+    def test_empty_list_unescapes_doubled_percents_when_flag_set(self):
+        result = ClientSideBindingConverter.interpolate_query(
+            "SELECT 1600 %% 400 AS a", [], interpolate_empty_sequences=True
+        )
+        assert result == "SELECT 1600 % 400 AS a"
+
+    def test_empty_dict_no_percents_unchanged(self):
+        query = "SELECT * FROM t"
+        assert ClientSideBindingConverter.interpolate_query(query, {}) == query
+
+    def test_stage_path_unescapes_when_flag_set(self):
+        result = ClientSideBindingConverter.interpolate_query(
+            "PUT file:///tmp/data.txt @%%users", {}, interpolate_empty_sequences=True
+        )
+        assert result == "PUT file:///tmp/data.txt @%users"
+
+    def test_nonempty_params_always_interpolate_regardless_of_flag(self):
+        result = ClientSideBindingConverter.interpolate_query(
+            "SELECT %s, 100 %% 3", [42], interpolate_empty_sequences=False
+        )
+        assert result == "SELECT 42, 100 % 3"
+
 
 class TestJsonBindingConverterNumpy:
     """Test that JsonBindingConverter handles numpy types via _is_numeric."""


### PR DESCRIPTION
## Summary
- Implement `_interpolate_empty_sequences` flag on the Connection class, matching the reference connector's behavior
- When the flag is `False` (default): `%%` is preserved with empty params — no behavior change for direct cursor users
- When the flag is `True` (set by SA dialect in `pre_exec`/`post_exec`): `%%` is unescaped to `%` even with empty params
- This is the mechanism SQLAlchemy uses to unescape doubled percent signs after pyformat compilation

## Context
SQLAlchemy uses `pyformat` paramstyle, which doubles literal `%` to `%%` during query compilation. The SA dialect toggles `connection._interpolate_empty_sequences = True` around execution so the connector unescapes `%%` → `%` via Python's `query % params` formatting. The universal-driver was missing this flag entirely, so `%%` always reached the server verbatim, causing syntax errors in queries with literal percent signs (modulo, `LIKE '%x%'`, stage paths `@%table`).

## Test plan
- **Unit tests**: Verify `interpolate_query` preserves `%%` by default with empty params, unescapes when `interpolate_empty_sequences=True`, and always interpolates when params are non-empty
- **Integration tests** (`TestInterpolateEmptySequences`): Run against both old and new connector:
  - Flag defaults to `False`
  - `%%` causes syntax error with empty params when flag is off (default)
  - `%%` is unescaped and query succeeds when flag is on
  - Works with both empty dict and empty list
  - Normal parameterized queries work regardless of flag
  - `%%` with actual params always unescapes (no flag needed)