### PR TITLE
NO-SNOW: split reviewer pool out of CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,30 +1,13 @@
 # Owners of every file in the repo.
 #
-# The team alias @snowflakedb/snow-drivers-warsaw is kept so that
-# GitHub-native CODEOWNERS behaviour (e.g. branch protection rules
-# requiring code-owner approval, organization-wide policies) keeps
-# working against the team as a whole.
+# Only the team alias @snowflakedb/snow-drivers-warsaw is listed here so
+# that GitHub-native code-owner behaviour (branch protection rules
+# requiring code-owner approval, review-request on PR open) targets the
+# team as a whole — a single review request goes to the team, instead
+# of pinging every individual reviewer.
 #
-# The individual @sfc-gh-* logins are listed explicitly so that the PR
-# review bot (see .github/workflows/pr-review-bot.yml) can pick one at
-# random as the reviewer for new PRs. The bot ignores team references
-# on purpose so it does not need the read:org scope.
-#
-# Names for reference (handle -- person):
-#   sfc-gh-daniszewski    -- Dariusz Aniszewski
-#   sfc-gh-turbaszek      -- Tomasz Urbaszek
-#   sfc-gh-rsavenok       -- Ruslan Savenok
-#   sfc-gh-boler          -- Bartosz Oler
-#   sfc-gh-rkowalski      -- Rafal Kowalski
-#   sfc-gh-pbulawa        -- Piotr Bulawa
-#   sfc-gh-dheyman        -- Dawid Heyman
-#   sfc-gh-pfus           -- Piotr Fus
-#   sfc-gh-mhofman        -- Michal Hofman (maintainer)
-#   sfc-gh-pczajka        -- Patryk Czajka
-#   sfc-gh-jszczerbinski  -- Jakub Szczerbinski
-#   sfc-gh-fpawlowski     -- Filip Pawlowski
-#   sfc-gh-ddas           -- Devansh Das
-#   sfc-gh-makowalski     -- Maxymilian Kowalski
-#   sfc-gh-asolarski      -- Antoni Solarski
-#   sfc-gh-mcepiga        -- Michal Cepiga
-*  @snowflakedb/snow-drivers-warsaw @sfc-gh-daniszewski @sfc-gh-turbaszek @sfc-gh-rsavenok @sfc-gh-boler @sfc-gh-rkowalski @sfc-gh-pbulawa @sfc-gh-dheyman @sfc-gh-pfus @sfc-gh-mhofman @sfc-gh-pczajka @sfc-gh-jszczerbinski @sfc-gh-fpawlowski @sfc-gh-ddas @sfc-gh-makowalski @sfc-gh-asolarski @sfc-gh-mcepiga
+# The individual reviewer pool used by the PR review bot (see
+# .github/workflows/pr-review-bot.yml) lives in .github/reviewers. The
+# bot ignores team references on purpose so it does not need the
+# read:org scope.
+*  @snowflakedb/snow-drivers-warsaw

--- a/.github/reviewers
+++ b/.github/reviewers
@@ -1,0 +1,32 @@
+# Reviewer pool for the PR review bot (see .github/workflows/pr-review-bot.yml
+# and scripts/pr_review_bot.py).
+#
+# One `@login` per line. Blank lines and `#` comments are ignored. Team
+# references (`@org/team-slug`) are not supported — list individual
+# members. The bot picks one of these at random when a PR is opened or
+# marked ready-for-review.
+#
+# CODEOWNERS (`.github/CODEOWNERS`) intentionally references only the
+# team `@snowflakedb/snow-drivers-warsaw` so GitHub's native code-owner
+# review-request sends a single team ping instead of pinging everyone.
+# This file is the bot's separate source of truth for the individual
+# members of that team.
+#
+# Keep this list in sync with the team roster.
+
+@sfc-gh-daniszewski
+@sfc-gh-turbaszek
+@sfc-gh-rsavenok
+@sfc-gh-boler
+@sfc-gh-rkowalski
+@sfc-gh-pbulawa
+@sfc-gh-dheyman
+@sfc-gh-pfus
+@sfc-gh-mhofman
+@sfc-gh-pczajka
+@sfc-gh-jszczerbinski
+@sfc-gh-fpawlowski
+@sfc-gh-ddas
+@sfc-gh-makowalski
+@sfc-gh-asolarski
+@sfc-gh-mcepiga

--- a/.github/workflows/pr-review-bot.yml
+++ b/.github/workflows/pr-review-bot.yml
@@ -30,9 +30,12 @@
 #       Channel name (no leading '#') or channel ID. Defaults to
 #       'drivers-review'.
 #
-# Reviewer pool comes from .github/CODEOWNERS — list each reviewer
-# explicitly as @login (team references like @org/team-slug are skipped,
-# so the bot does not need read:org).
+# Reviewer pool comes from .github/reviewers — list each reviewer
+# explicitly as @login, one per line. CODEOWNERS itself only references
+# the team alias so GitHub's native code-owner request fires once
+# against the team (no per-member ping). The bot keeps its own
+# individual pool so it does not need the read:org scope to resolve
+# team membership.
 #
 # Real <@U...> Slack mentions are resolved per-reviewer via
 # users.lookupByEmail using the email from commit.author of each
@@ -78,8 +81,6 @@ jobs:
       (github.event_name == 'pull_request_target' && github.event.pull_request.draft == false)
       || (github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'assign')
     runs-on: ubuntu-latest
-    env:
-      SLACK_PAYLOAD_FILE: ${{ runner.temp }}/slack_payload.json
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -101,6 +102,7 @@ jobs:
           # mention. Optional — falls back to plain @handle text if
           # unset or the lookup fails.
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_PAYLOAD_FILE: ${{ runner.temp }}/slack_payload.json
         run: python scripts/pr_review_bot.py assign
 
       - name: Post assignment notification to Slack
@@ -109,7 +111,7 @@ jobs:
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
-          payload-file-path: ${{ env.SLACK_PAYLOAD_FILE }}
+          payload-file-path: ${{ runner.temp }}/slack_payload.json
 
   remind-reviewers:
     name: Remind pending reviewers
@@ -117,8 +119,6 @@ jobs:
       github.event_name == 'schedule'
       || (github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'remind')
     runs-on: ubuntu-latest
-    env:
-      SLACK_PAYLOAD_FILE: ${{ runner.temp }}/slack_payload.json
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -137,6 +137,7 @@ jobs:
           # Used for users.lookupByEmail to mint <@U...> mentions; see
           # the assign-reviewer job for details.
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_PAYLOAD_FILE: ${{ runner.temp }}/slack_payload.json
         run: python scripts/pr_review_bot.py remind
 
       - name: Post reminder digest to Slack
@@ -145,4 +146,4 @@ jobs:
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
-          payload-file-path: ${{ env.SLACK_PAYLOAD_FILE }}
+          payload-file-path: ${{ runner.temp }}/slack_payload.json

--- a/scripts/pr_review_bot.py
+++ b/scripts/pr_review_bot.py
@@ -12,7 +12,7 @@ Subcommands
 -----------
 ``assign``
     Pick a random reviewer from the candidates listed in
-    ``.github/CODEOWNERS`` (or another path via ``CODEOWNERS_PATH``),
+    ``.github/reviewers`` (or another path via ``REVIEWERS_PATH``),
     excluding the PR author and any user already requested for review.
     Requests review and adds the user as an assignee via the REST
     endpoints ``POST /pulls/:n/requested_reviewers`` and
@@ -25,9 +25,11 @@ Subcommands
     Designed to be run from a ``pull_request_target`` workflow on the
     ``opened`` and ``ready_for_review`` activity types. Drafts are skipped.
 
-    The candidate pool is the union of all individual ``@login`` entries in
-    CODEOWNERS — team references (``@org/team-slug``) are ignored on
-    purpose so the bot does not need ``read:org`` to resolve membership.
+    The candidate pool is the list of individual ``@login`` entries in
+    ``.github/reviewers``. CODEOWNERS itself references only the team
+    alias so GitHub's native code-owner request fires once against the
+    team; the bot keeps its own individual pool here to avoid needing
+    ``read:org`` to resolve team membership.
 
 ``remind``
     Iterate every open non-draft PR in the repository (via ``gh``) and
@@ -80,9 +82,9 @@ Assign-only environment variables
 ``PR_NUMBER``
     Pull request number to operate on.
 
-``CODEOWNERS_PATH`` (optional)
-    Path to the CODEOWNERS file to parse. Defaults to
-    ``.github/CODEOWNERS``.
+``REVIEWERS_PATH`` (optional)
+    Path to the reviewer-pool file to parse. Defaults to
+    ``.github/reviewers``.
 
 Reviewer display names
 ----------------------
@@ -125,7 +127,7 @@ from typing import Any, Iterable
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 log = logging.getLogger("pr-review-bot")
 
-DEFAULT_CODEOWNERS_PATH = Path(".github/CODEOWNERS")
+DEFAULT_REVIEWERS_PATH = Path(".github/reviewers")
 
 # Review states that mean the reviewer has taken action on the PR.
 ACTIONED_STATES = {"APPROVED", "CHANGES_REQUESTED"}
@@ -291,47 +293,40 @@ def github_commit_author(repo: str, login: str) -> tuple[str | None, str | None]
 
 
 # ---------------------------------------------------------------------------
-# CODEOWNERS parsing
+# Reviewer pool parsing
 # ---------------------------------------------------------------------------
 
 
-def parse_codeowners(path: Path = DEFAULT_CODEOWNERS_PATH) -> list[str]:
-    """Return the unique individual ``@login`` owners listed in *path*.
+def parse_reviewers(path: Path = DEFAULT_REVIEWERS_PATH) -> list[str]:
+    """Return the unique individual ``@login`` reviewers listed in *path*.
 
-    Team references (``@org/team-slug``) and email addresses are skipped.
+    One handle per line, ``#`` comments and blank lines are ignored.
+    Team references (``@org/team-slug``) are rejected — this file is the
+    bot's individual-pool source of truth; resolving teams would require
+    ``read:org``.
     """
     if not path.exists():
-        raise FileNotFoundError(f"CODEOWNERS file not found at {path}")
+        raise FileNotFoundError(f"Reviewers file not found at {path}")
 
     individuals: set[str] = set()
-    skipped_teams: set[str] = set()
 
     for raw_line in path.read_text().splitlines():
         line = raw_line.split("#", 1)[0].strip()
         if not line:
             continue
-        tokens = line.split()
-        if len(tokens) < 2:
+        if not line.startswith("@"):
+            log.warning("Ignoring malformed line in %s: %r", path, raw_line)
             continue
-        for token in tokens[1:]:
-            if not token.startswith("@"):
-                continue
-            handle = token[1:]
-            if "/" in handle:
-                skipped_teams.add(token)
-                continue
-            individuals.add(handle)
-
-    if skipped_teams:
-        # The bot intentionally does not resolve team membership (no
-        # read:org needed). Teams are commonly kept alongside individuals
-        # for native CODEOWNERS purposes, so this is INFO, not a warning.
-        log.info(
-            "Skipped team reference(s) in %s: %s (individuals are used "
-            "for random reviewer selection).",
-            path,
-            ", ".join(sorted(skipped_teams)),
-        )
+        handle = line[1:]
+        if "/" in handle:
+            log.warning(
+                "Ignoring team reference %r in %s; list individual "
+                "@logins only.",
+                line,
+                path,
+            )
+            continue
+        individuals.add(handle)
 
     return sorted(individuals)
 
@@ -596,8 +591,8 @@ def cmd_assign(args: argparse.Namespace) -> int:
         log.error("PR_NUMBER is required for assign mode")
         return 2
     pr_number = int(pr_number_env)
-    codeowners_path = Path(
-        os.environ.get("CODEOWNERS_PATH") or DEFAULT_CODEOWNERS_PATH
+    reviewers_path = Path(
+        os.environ.get("REVIEWERS_PATH") or DEFAULT_REVIEWERS_PATH
     )
     channel, payload_file = _slack_runtime()
 
@@ -620,19 +615,19 @@ def cmd_assign(args: argparse.Namespace) -> int:
             f"({', '.join(already_requested)}); skipping auto-assign."
         )
 
-    log.info("Reading reviewer pool from %s ...", codeowners_path)
+    log.info("Reading reviewer pool from %s ...", reviewers_path)
     try:
-        candidates = parse_codeowners(codeowners_path)
+        candidates = parse_reviewers(reviewers_path)
     except FileNotFoundError as e:
         log.error("%s. Aborting assign.", e)
         return 1
 
-    log.info("CODEOWNERS lists %d individual reviewer(s).", len(candidates))
+    log.info("%s lists %d individual reviewer(s).", reviewers_path, len(candidates))
     if not candidates:
         log.warning(
             "No individual @logins found in %s. Add reviewers explicitly to "
             "enable auto-assign.",
-            codeowners_path,
+            reviewers_path,
         )
         set_gh_output("skip", "true")
         return 0


### PR DESCRIPTION
## Summary
- CODEOWNERS now references only `@snowflakedb/snow-drivers-warsaw` so GitHub's native code-owner review request fires once against the team instead of pinging every individual listed in the file. This was contradicting the PR review bot, which is supposed to assign a single random reviewer.
- Move the individual `@sfc-gh-*` pool to a new `.github/reviewers` file — the bot's source of truth for random assignment. Separate from CODEOWNERS so GitHub's auto-request behavior stays on the team alias.
- Update `scripts/pr_review_bot.py` to parse the new file (`parse_reviewers` / `REVIEWERS_PATH` / `DEFAULT_REVIEWERS_PATH`).
- Fix a workflow load error in `pr-review-bot.yml`: `runner.temp` is not available in job-level `env:`, only step-level. Moved `SLACK_PAYLOAD_FILE` onto the step and inlined the path on the Slack action step.

## Test plan
- [ ] Open a fresh non-draft PR and confirm only the team alias gets auto-requested via CODEOWNERS (not every `sfc-gh-*` member).
- [ ] Confirm the bot's `assign` job picks one random member from `.github/reviewers` and posts the Slack notification.
- [ ] Confirm the scheduled `remind` job runs without the earlier `Unrecognized named-value: 'runner'` load error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)