### PR TITLE
NO-SNOW: ODBC CI: drop Windows debug MSI builds

### DIFF
--- a/.github/workflows/_build-odbc-packages.yml
+++ b/.github/workflows/_build-odbc-packages.yml
@@ -127,13 +127,6 @@ jobs:
             cargo_target: x86_64-pc-windows-msvc
             cargo_profile: "--release"
             cargo_extra: ""
-          - name: Windows x64 Debug
-            os: windows-latest
-            arch: x64
-            config: debug
-            cargo_target: x86_64-pc-windows-msvc
-            cargo_profile: ""
-            cargo_extra: ""
           - name: Windows x86 Release
             os: windows-latest
             arch: x86
@@ -141,26 +134,12 @@ jobs:
             cargo_target: i686-pc-windows-msvc
             cargo_profile: "--release"
             cargo_extra: "--no-default-features"
-          - name: Windows x86 Debug
-            os: windows-latest
-            arch: x86
-            config: debug
-            cargo_target: i686-pc-windows-msvc
-            cargo_profile: ""
-            cargo_extra: "--no-default-features"
           - name: Windows ARM64 Release
             os: windows-11-arm
             arch: arm64
             config: release
             cargo_target: aarch64-pc-windows-msvc
             cargo_profile: "--release"
-            cargo_extra: ""
-          - name: Windows ARM64 Debug
-            os: windows-11-arm
-            arch: arm64
-            config: debug
-            cargo_target: aarch64-pc-windows-msvc
-            cargo_profile: ""
             cargo_extra: ""
     runs-on: ${{ matrix.os }}
     name: build_msi (${{ matrix.name }})


### PR DESCRIPTION
Halves the Windows packaging matrix (6 -> 3 jobs) by removing the three
Debug entries (x64, x86, ARM64). Debug MSI artifacts named
snowflake-odbc-ud-debug-<arch> were never consumed downstream: the ODBC
test workflows build the driver from source in cargo's debug profile
themselves (target/debug/) and don't pull from the MSI artifact, and no
other workflow references the debug-named artifact (verified by grep
across .github/).

The Release matrix retains full architecture coverage (x64/x86/ARM64);
the matrix.config axis is left in place so re-enabling a single Debug
lane stays a 7-line additive change rather than a structural one.

Co-authored-by: Cursor <cursoragent@cursor.com>