### PR TITLE
NO-SNOW: add e2e tests for connection serialization

### DIFF
--- a/nodejs/tests/e2e/connection-serialization.test.ts
+++ b/nodejs/tests/e2e/connection-serialization.test.ts
@@ -1,4 +1,4 @@
-import type { Connection, ConnectionOptions } from 'snowflake-sdk';
+import type { Connection } from 'snowflake-sdk';
 import { describe, it, beforeAll, afterAll, expect } from 'vitest';
 import { createConnection, connectAsync, destroyAsync, getSnowflakeSDK } from './utils';
 import getTestParameter from './utils/getTestParameter';
@@ -42,7 +42,7 @@ describe('Connection Serialization', () => {
       {
         account: getTestParameter('SNOWFLAKE_TEST_ACCOUNT'),
         host: getTestParameter('SNOWFLAKE_TEST_HOST'),
-      } as ConnectionOptions,
+      },
       snowflake.serializeConnection(connection),
     );
 

--- a/nodejs/tests/e2e/connection-serialization.test.ts
+++ b/nodejs/tests/e2e/connection-serialization.test.ts
@@ -1,0 +1,55 @@
+import type { Connection, ConnectionOptions } from 'snowflake-sdk';
+import { describe, it, beforeAll, afterAll, expect } from 'vitest';
+import { createConnection, connectAsync, destroyAsync, getSnowflakeSDK } from './utils';
+import getTestParameter from './utils/getTestParameter';
+
+describe('Connection Serialization', () => {
+  let connection: Connection;
+
+  beforeAll(async () => {
+    connection = createConnection();
+    await connectAsync(connection);
+  });
+
+  afterAll(async () => {
+    await destroyAsync(connection);
+  });
+
+  it('connection.serialize() returns a JSON string with services.sf.tokenInfo', () => {
+    const serialized = connection.serialize();
+    expect(typeof serialized).toBe('string');
+    expect(serialized.length).toBeGreaterThan(0);
+
+    const tokenInfo = JSON.parse(serialized)?.services?.sf?.tokenInfo;
+    expect(tokenInfo).toBeTruthy();
+    expect(typeof tokenInfo.masterToken).toBe('string');
+    expect(typeof tokenInfo.sessionToken).toBe('string');
+    expect(typeof tokenInfo.masterTokenExpirationTime).toBe('number');
+    expect(typeof tokenInfo.sessionTokenExpirationTime).toBe('number');
+  });
+
+  it('snowflake.serializeConnection() returns the same string as connection.serialize()', () => {
+    const snowflake = getSnowflakeSDK();
+    expect(snowflake.serializeConnection(connection)).toBe(connection.serialize());
+  });
+
+  // TODO:
+  // Enable after new driver release with a fix:
+  // https://github.com/snowflakedb/snowflake-connector-nodejs/pull/1406
+  it.skip('snowflake.deserializeConnection() rehydrates into a usable Connection', async () => {
+    const snowflake = getSnowflakeSDK();
+    const connection2 = snowflake.deserializeConnection(
+      {
+        account: getTestParameter('SNOWFLAKE_TEST_ACCOUNT'),
+        host: getTestParameter('SNOWFLAKE_TEST_HOST'),
+      } as ConnectionOptions,
+      snowflake.serializeConnection(connection),
+    );
+
+    try {
+      expect(connection2.isUp()).toBe(true);
+    } finally {
+      await destroyAsync(connection2);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add e2e test `nodejs/tests/e2e/connection-serialization.test.ts` covering the `Connection.serialize()` / `snowflake.serializeConnection()` / `snowflake.deserializeConnection()` round trip in the universal driver's Node.js layer.
- Verifies the serialized payload exposes `services.sf.tokenInfo` with the expected `masterToken`, `sessionToken`, `masterTokenExpirationTime`, and `sessionTokenExpirationTime` fields.
- Verifies `snowflake.serializeConnection(connection)` matches `connection.serialize()`.
- Includes a (currently skipped) case for `snowflake.deserializeConnection()` rehydration that exercises the bugfix from the upstream connector PR.

## Context
This mirrors the test added upstream in [snowflake-connector-nodejs#1406 — "NO-SNOW Improve connection serialization docs"](https://github.com/snowflakedb/snowflake-connector-nodejs/pull/1406) (`test/integration/testSerializeConnection.ts`). The assertions and scenarios here are the **same test implementation** as in that PR, ported into the universal driver's Vitest-based e2e suite so we keep parity with the legacy connector's coverage.

The `deserializeConnection` rehydration case is `it.skip`-ed because it depends on the `ConnectionConfig` fix in the same upstream PR (`consolidateHostAndAccount()` must run when `validateCredentials` is `false`). Once a new `snowflake-sdk` release ships with that fix, the `it.skip` can be flipped to `it`. The TODO in the test points back to the same upstream PR.

## Test plan
- Ran Node.js pre-commit checks (formatting/lint) via `gt modify -c` — passed.
- Functional verification of the test itself relies on a live Snowflake account and is gated on the upstream fix; the two non-skipped cases (`serialize()` shape + `serializeConnection` parity) work against the current driver, while the third case stays skipped until the upstream bugfix is released.
