### PR TITLE
SNOW-3512876 limit macos scope on merge queue

### DIFF
--- a/ci/test_matrix/README.md
+++ b/ci/test_matrix/README.md
@@ -50,7 +50,10 @@ Each emitted row carries a `trigger_level`. Levels are cumulative.
 across every pair of parameters. With *n* parameters of size *k*, full
 coverage is *kⁿ* combinations; pairwise is roughly *k²* — orders of
 magnitude smaller, while still catching any bug that depends on a
-two-parameter interaction.
+two-parameter interaction. A model can further restrict the pairwise pool
+via the optional `MERGE_VALID` block-list (see *Restrict a combo to
+nightly only* below) — useful when a lane is too expensive for the merge
+queue but should still run at nightly.
 
 Concretely, for `odbc.py` the parameter space is OS×Arch×Cloud. After
 applying the constraints (e.g. macOS only on arm, ubuntu only on x64), 12
@@ -110,6 +113,43 @@ the final statement of `is_valid`. This blocks the two accidental drift
 patterns: allow-list creep (`return c["X"] in (...)`) and early
 `return True` short-circuits.
 
+### Restrict a combo to nightly only (`MERGE_VALID`)
+
+Append a predicate to `MERGE_VALID` in `models/<driver>.py` to keep a combo
+out of the merge-queue pairwise pool while still exercising it at nightly.
+Same block-list shape and `True = keep` semantics as `is_valid`, but the
+predicate runs **only inside the pairwise pass**:
+
+* Combos rejected by `MERGE_VALID` do **not** appear at `pr` or `merge`.
+* Combos rejected by `MERGE_VALID` **do** still appear at `nightly` (the
+  full constraint-valid cartesian product is unchanged).
+* Cells listed in `PR_CELLS` always run at `pr` (and therefore at `merge`
+  cumulatively), regardless of `MERGE_VALID`.
+* Mapping coverage is unchanged: `validate_mappings` runs over the full
+  set, so a `MERGE_VALID`-blocked combo whose `(OS, Arch)` is missing from
+  the mapping tables still raises loud.
+
+```python
+def merge_valid(c):
+    if c["OS"] == "macos":
+        # Limited macOS runner availability — defer to nightly.
+        if c["Arch"] == "arm": return False
+        if c["Arch"] == "x64":
+            if c["Cloud"] != "aws":      return False
+            if c["PyVersion"] != "3.13": return False
+            if c["HatchEnv"] != "test":  return False
+    return True
+
+
+MERGE_VALID = [merge_valid]
+```
+
+Use this when a lane's runner cost or scarcity (e.g. `macos-15-intel`)
+makes it unsuitable for every-MQ-run execution but you still want nightly
+to catch interaction bugs. To trim merge-queue load, prefer pinning a
+single representative combo to keep pairwise meaningful — blocking an
+entire OS lane drops all `(OS, X)` pair coverage at merge.
+
 ### Reordering `PARAMS`
 
 `PARAMS` order affects which specific cells land in the merge-level
@@ -150,7 +190,8 @@ merge-level JSON count is pinned by `JsonVariantRegressionTests`.
 ### Add a new driver
 
 1. Create `models/<new>.py` exposing `PARAMS`, `CONSTRAINTS`, `PR_CELLS`, and
-   `JSON_CELLS` (see `models/__init__.py` for the schema).
+   `JSON_CELLS` (and optionally `MERGE_VALID`); see `models/__init__.py` for
+   the schema.
 2. Create `mappings/<new>.py` with `<NEW>_PLATFORM` (or whatever the driver
    needs); re-export it from `mappings/__init__.py`.
 3. In `generate_matrix.py`, add a `_build_<new>_row` builder and route to it

--- a/ci/test_matrix/generate_matrix.py
+++ b/ci/test_matrix/generate_matrix.py
@@ -135,12 +135,21 @@ _TRIGGER_LEVELS_FOR_JSON = ("pr", "merge", "nightly")
 
 def load_model(
     path: Path,
-) -> tuple[dict[str, list[str]], list, list[dict[str, str]], dict[str, list[dict[str, str]]]]:
+) -> tuple[
+    dict[str, list[str]],
+    list,
+    list,
+    list[dict[str, str]],
+    dict[str, list[dict[str, str]]],
+]:
     """
     Load a model module and validate its shape.
 
-    Returns (params, constraints, pr_cells, json_cells). Constraints are
-    callables `(combo) -> bool` returning True when the combo is valid.
+    Returns (params, constraints, merge_valid, pr_cells, json_cells).
+    Constraints and merge_valid are lists of callables `(combo) -> bool`
+    returning True when the combo is valid. CONSTRAINTS gates *all* trigger
+    levels (full cartesian product); MERGE_VALID additionally gates the
+    pairwise pass — a combo blocked by MERGE_VALID still appears at nightly.
     Raises ValueError on any malformed input.
     """
     spec = importlib.util.spec_from_file_location(f"_model_{path.stem}", path)
@@ -151,6 +160,7 @@ def load_model(
 
     raw_params = getattr(module, "PARAMS", None)
     raw_constraints = getattr(module, "CONSTRAINTS", [])
+    raw_merge_valid = getattr(module, "MERGE_VALID", [])
     raw_pr = getattr(module, "PR_CELLS", [])
     raw_json = getattr(module, "JSON_CELLS", {})
 
@@ -170,6 +180,15 @@ def load_model(
             )
     constraints = list(raw_constraints)
 
+    if not isinstance(raw_merge_valid, list):
+        raise ValueError(f"{path}: MERGE_VALID must be a list of callables")
+    for i, c in enumerate(raw_merge_valid):
+        if not callable(c):
+            raise ValueError(
+                f"{path}: MERGE_VALID[{i}] must be callable; got {type(c).__name__}"
+            )
+    merge_valid = list(raw_merge_valid)
+
     pr_cells = [_normalize_cell(c, params, path, "PR_CELLS") for c in raw_pr]
 
     json_cells: dict[str, list[dict[str, str]]] = {lvl: [] for lvl in _TRIGGER_LEVELS_FOR_JSON}
@@ -186,7 +205,7 @@ def load_model(
                 _normalize_cell(c, params, path, f"JSON_CELLS[{level!r}]")
             )
 
-    return params, constraints, pr_cells, json_cells
+    return params, constraints, merge_valid, pr_cells, json_cells
 
 
 def _normalize_cell(
@@ -392,7 +411,7 @@ def generate(model_path: Path, driver: str) -> list[dict]:
 
     Returns the list of GitHub Actions matrix rows.
     """
-    params, constraints, pr_cells, json_cells = load_model(model_path)
+    params, constraints, merge_valid, pr_cells, json_cells = load_model(model_path)
     param_names = list(params.keys())
     param_values = list(params.values())
 
@@ -416,9 +435,16 @@ def generate(model_path: Path, driver: str) -> list[dict]:
     # because the wheel doesn't exist, leaving the (windows, arm) value pair
     # technically "covered" in the abstract pairwise sense but with zero
     # actual matrix rows at merge level.
+    #
+    # MERGE_VALID adds an extra block-list that only applies to the pairwise
+    # pass: combos rejected here still flow through to nightly, but never
+    # land in pr/merge. Use it to keep expensive lanes (e.g. limited macOS
+    # runners) out of the merge queue without losing nightly coverage.
     def _routing_valid(combo_tuple: tuple) -> bool:
         combo = dict(zip(param_names, combo_tuple))
         if not apply_constraints(combo, constraints):
+            return False
+        if not apply_constraints(combo, merge_valid):
             return False
         # `trigger` doesn't influence the build/skip decision, so any
         # placeholder value works. Pass "merge" for clarity.

--- a/ci/test_matrix/models/__init__.py
+++ b/ci/test_matrix/models/__init__.py
@@ -46,6 +46,26 @@ PR_CELLS: list[dict[str, str]]
     Explicit cells that always run on every PR. Each cell must list a value
     for every declared parameter (loader rejects missing or extra keys).
 
+MERGE_VALID: list[Callable[[dict[str, str]], bool]]   (optional, default [])
+    Pairwise-only block-list. Same shape and semantics as CONSTRAINTS
+    (return True = keep, return False = forbid). Predicates here gate
+    *only* the merge-level pairwise cover — combos rejected by MERGE_VALID
+    still appear at nightly via the unfiltered cartesian product, and PR
+    cells listed in PR_CELLS still run regardless. Use for lanes whose
+    runner cost or availability makes them unsuitable for every-MQ-run
+    execution but where nightly should still catch interaction bugs:
+
+        def merge_valid(c):
+            # Limited macOS runner availability — keep Intel mac off the MQ.
+            if c["OS"] == "macos" and c["Arch"] == "x64": return False
+            return True
+
+        MERGE_VALID = [merge_valid]
+
+    Mapping coverage is unaffected: validate_mappings runs over the full
+    constraint-valid combo set, so a MERGE_VALID-blocked combo still needs
+    its (OS, Arch) row in the mappings tables.
+
 JSON_CELLS: dict[str, list[dict[str, str]]]
     Maps trigger level ("pr" / "merge" / "nightly") to cells that get
     duplicated with result_format="json" at that level. Same per-cell

--- a/ci/test_matrix/models/odbc.py
+++ b/ci/test_matrix/models/odbc.py
@@ -24,6 +24,23 @@ def is_valid(c):
 
 CONSTRAINTS = [is_valid]
 
+
+def merge_valid(c):
+    """Pairwise-only block-list: combos returning False run at nightly only.
+
+    macOS runner availability is scarce. Hold MQ macOS load to a single
+    job (the explicit PR_CELL macos-arm-gcp, which still runs at merge
+    cumulatively) by blocking macOS from the pairwise pool entirely.
+    Other (macos, Cloud) cells run at nightly via the unfiltered cartesian
+    product.
+    """
+    if c["OS"] == "macos": return False
+
+    return True
+
+
+MERGE_VALID = [merge_valid]
+
 PR_CELLS = [
     {"OS": "ubuntu",  "Arch": "x64", "Cloud": "aws"},
     {"OS": "macos",   "Arch": "arm", "Cloud": "gcp"},

--- a/ci/test_matrix/models/python.py
+++ b/ci/test_matrix/models/python.py
@@ -23,6 +23,33 @@ def is_valid(c):
 
 CONSTRAINTS = [is_valid]
 
+
+def merge_valid(c):
+    """Pairwise-only block-list: combos returning False run at nightly only.
+
+    macOS runner availability is the binding constraint on merge-queue
+    throughput. Hold MQ macOS load to one Intel + one ARM job:
+
+      * macos-arm:  block from pairwise entirely. The single ARM job at
+        merge comes from the explicit macOS entry in PR_CELLS below — it
+        runs at trigger_level=pr and is promoted to merge by the
+        cumulative trigger filter.
+      * macos-x64 (macos-15-intel): pin to a single representative combo
+        (aws + py3.13 + test). Every other Intel mac combo runs at
+        nightly via the unfiltered cartesian product.
+    """
+    if c["OS"] == "macos":
+        if c["Arch"] == "arm":                  return False
+        if c["Arch"] == "x64":
+            if c["Cloud"] != "aws":             return False
+            if c["PyVersion"] != "3.13":        return False
+            if c["HatchEnv"] != "test":         return False
+
+    return True
+
+
+MERGE_VALID = [merge_valid]
+
 PR_CELLS = [
     {"OS": "ubuntu",  "Arch": "x64", "Cloud": "aws",   "PyVersion": "3.10", "HatchEnv": "test"},
     {"OS": "macos",   "Arch": "arm", "Cloud": "gcp",   "PyVersion": "3.12", "HatchEnv": "test-pandas"},

--- a/ci/test_matrix/test_generate_matrix.py
+++ b/ci/test_matrix/test_generate_matrix.py
@@ -68,7 +68,7 @@ class LoadModelTests(unittest.TestCase):
             "JSON_CELLS = {'pr': [], 'merge': [], 'nightly': []}\n"
         )
         try:
-            params, constraints, pr_cells, json_cells = gm.load_model(path)
+            params, constraints, _merge_valid, pr_cells, json_cells = gm.load_model(path)
             self.assertEqual(params, {"OS": ["ubuntu", "macos"], "Arch": ["x64", "arm"]})
             self.assertEqual(len(constraints), 1)
             self.assertTrue(callable(constraints[0]))
@@ -92,7 +92,7 @@ class LoadModelTests(unittest.TestCase):
             "}\n"
         )
         try:
-            _params, _c, _pr, json_cells = gm.load_model(path)
+            _params, _c, _mv, _pr, json_cells = gm.load_model(path)
             self.assertEqual(json_cells["pr"], [{"OS": "ubuntu", "Arch": "x64"}])
             self.assertEqual(json_cells["merge"], [{"OS": "macos", "Arch": "arm"}])
             self.assertEqual(json_cells["nightly"], [])
@@ -215,7 +215,7 @@ class LoadModelTests(unittest.TestCase):
             "JSON_CELLS = {'pr': [], 'merge': [], 'nightly': []}\n"
         )
         try:
-            _, constraints, _, _ = gm.load_model(path)
+            _, constraints, _mv, _, _ = gm.load_model(path)
             self.assertEqual(len(constraints), 1)
             # Forbidden by an explicit return False.
             self.assertFalse(constraints[0]({"OS": "macos", "Arch": "x64"}))
@@ -224,6 +224,254 @@ class LoadModelTests(unittest.TestCase):
             self.assertTrue(constraints[0]({"OS": "ubuntu", "Arch": "x64"}))
         finally:
             path.unlink(missing_ok=True)
+
+
+    def test_merge_valid_defaults_to_empty(self) -> None:
+        """A model without MERGE_VALID should load with merge_valid=[]."""
+        path = _write_model(
+            "PARAMS = {'OS': ['ubuntu', 'macos'], 'Arch': ['x64', 'arm']}\n"
+            "CONSTRAINTS = []\n"
+            "PR_CELLS = []\n"
+            "JSON_CELLS = {'pr': [], 'merge': [], 'nightly': []}\n"
+        )
+        try:
+            _params, _constraints, merge_valid, _pr, _json = gm.load_model(path)
+            self.assertEqual(merge_valid, [])
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_merge_valid_loads_callable(self) -> None:
+        """MERGE_VALID predicates should round-trip through load_model unchanged."""
+        path = _write_model(
+            "PARAMS = {'OS': ['ubuntu', 'macos'], 'Arch': ['x64', 'arm']}\n"
+            "CONSTRAINTS = []\n"
+            "def merge_valid(c):\n"
+            "    if c['OS'] == 'macos' and c['Arch'] == 'x64': return False\n"
+            "    return True\n"
+            "MERGE_VALID = [merge_valid]\n"
+            "PR_CELLS = []\n"
+            "JSON_CELLS = {'pr': [], 'merge': [], 'nightly': []}\n"
+        )
+        try:
+            _params, _c, merge_valid, _pr, _json = gm.load_model(path)
+            self.assertEqual(len(merge_valid), 1)
+            self.assertTrue(callable(merge_valid[0]))
+            self.assertFalse(merge_valid[0]({"OS": "macos", "Arch": "x64"}))
+            self.assertTrue(merge_valid[0]({"OS": "macos", "Arch": "arm"}))
+            self.assertTrue(merge_valid[0]({"OS": "ubuntu", "Arch": "x64"}))
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_merge_valid_must_be_callable(self) -> None:
+        path = _write_model(
+            "PARAMS = {'OS': ['ubuntu']}\n"
+            "CONSTRAINTS = []\n"
+            "MERGE_VALID = ['not callable']\n"
+            "PR_CELLS = []\n"
+            "JSON_CELLS = {'pr': [], 'merge': [], 'nightly': []}\n"
+        )
+        try:
+            with self.assertRaises(ValueError) as ctx:
+                gm.load_model(path)
+            self.assertIn("MERGE_VALID", str(ctx.exception))
+            self.assertIn("callable", str(ctx.exception))
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_merge_valid_must_be_a_list(self) -> None:
+        path = _write_model(
+            "PARAMS = {'OS': ['ubuntu']}\n"
+            "CONSTRAINTS = []\n"
+            "MERGE_VALID = 'not a list'\n"
+            "PR_CELLS = []\n"
+            "JSON_CELLS = {'pr': [], 'merge': [], 'nightly': []}\n"
+        )
+        try:
+            with self.assertRaises(ValueError) as ctx:
+                gm.load_model(path)
+            self.assertIn("MERGE_VALID", str(ctx.exception))
+        finally:
+            path.unlink(missing_ok=True)
+
+
+class MergeValidSemanticsTests(unittest.TestCase):
+    """
+    End-to-end semantics for MERGE_VALID.
+
+    Combos rejected by MERGE_VALID:
+      * MUST NOT appear at trigger_level=pr or merge.
+      * MUST still appear at nightly (full cartesian product preserved).
+    Combos listed in PR_CELLS take precedence — they always run on PR
+    even if MERGE_VALID would block them from the pairwise pool.
+    Mapping coverage is unaffected: a missing mapping for a MERGE_VALID-
+    blocked but otherwise-valid combo still raises in validate_mappings.
+    """
+
+    def _write_python_model(self, merge_valid_block: str = "") -> Path:
+        return _write_model(
+            "PARAMS = {\n"
+            "    'OS':        ['ubuntu', 'macos', 'windows'],\n"
+            "    'Arch':      ['x64', 'arm'],\n"
+            "    'Cloud':     ['aws', 'gcp', 'azure'],\n"
+            "    'PyVersion': ['3.10', '3.11', '3.12', '3.13', '3.14'],\n"
+            "    'HatchEnv':  ['test', 'test-pandas'],\n"
+            "}\n"
+            "def is_valid(c):\n"
+            "    if c['OS'] == 'windows' and c['Arch'] == 'arm':\n"
+            "        if c['PyVersion'] == '3.10':      return False\n"
+            "        if c['HatchEnv'] == 'test-pandas': return False\n"
+            "    return True\n"
+            "CONSTRAINTS = [is_valid]\n"
+            f"{merge_valid_block}"
+            "PR_CELLS = [\n"
+            "    {'OS': 'ubuntu',  'Arch': 'x64', 'Cloud': 'aws',\n"
+            "     'PyVersion': '3.10', 'HatchEnv': 'test'},\n"
+            "    {'OS': 'macos',   'Arch': 'arm', 'Cloud': 'gcp',\n"
+            "     'PyVersion': '3.12', 'HatchEnv': 'test-pandas'},\n"
+            "    {'OS': 'windows', 'Arch': 'x64', 'Cloud': 'azure',\n"
+            "     'PyVersion': '3.14', 'HatchEnv': 'test'},\n"
+            "]\n"
+            "JSON_CELLS = {'pr': [], 'merge': [], 'nightly': []}\n"
+        )
+
+    def test_macos_x64_only_at_nightly(self) -> None:
+        """Block macos-x64 from merge; nightly must still see it."""
+        block = (
+            "def merge_valid(c):\n"
+            "    if c['OS'] == 'macos' and c['Arch'] == 'x64': return False\n"
+            "    return True\n"
+            "MERGE_VALID = [merge_valid]\n"
+        )
+        path = self._write_python_model(block)
+        try:
+            rows = gm.generate(path, "python")
+            mac_x64 = [r for r in rows if r["os"] == "macos-15-intel"]
+            self.assertTrue(mac_x64, "macos-x64 must still appear at nightly")
+            for r in mac_x64:
+                self.assertEqual(
+                    r["trigger_level"], "nightly",
+                    f"macos-x64 row {r['name']} should be nightly-only "
+                    f"under MERGE_VALID, got trigger_level={r['trigger_level']}",
+                )
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_pr_cells_unaffected_by_merge_valid(self) -> None:
+        """PR_CELLS bypass MERGE_VALID — they always run at PR scope."""
+        # Block ALL macos via MERGE_VALID; the PR_CELLS macos row should
+        # still appear at trigger_level=pr.
+        block = (
+            "def merge_valid(c):\n"
+            "    if c['OS'] == 'macos': return False\n"
+            "    return True\n"
+            "MERGE_VALID = [merge_valid]\n"
+        )
+        path = self._write_python_model(block)
+        try:
+            rows = gm.generate(path, "python")
+            mac_pr = [
+                r for r in rows
+                if "macos" in r["os"] and r["trigger_level"] == "pr"
+            ]
+            self.assertEqual(
+                len(mac_pr), 1,
+                f"expected the explicit macOS PR cell to survive MERGE_VALID; "
+                f"got {[r['name'] for r in mac_pr]}",
+            )
+            self.assertEqual(mac_pr[0]["py"], "3.12")
+            self.assertEqual(mac_pr[0]["cloud_provider"], "gcp")
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_merge_valid_does_not_block_nightly_combos(self) -> None:
+        """Combos blocked from merge must appear in the full nightly product."""
+        block = (
+            "def merge_valid(c):\n"
+            "    if c['OS'] == 'macos' and c['Arch'] == 'x64': return False\n"
+            "    return True\n"
+            "MERGE_VALID = [merge_valid]\n"
+        )
+        path = self._write_python_model(block)
+        try:
+            rows = gm.generate(path, "python")
+            # macOS-x64 has wheels for 3.11, 3.12, 3.13, 3.14 plus py3.10 sdist.
+            # Without MERGE_VALID nightly emits exactly those rows; with
+            # MERGE_VALID they should still appear, just at trigger_level=nightly.
+            mac_x64_pys = {r["py"] for r in rows if r["os"] == "macos-15-intel"}
+            self.assertEqual(
+                mac_x64_pys, {"3.10", "3.11", "3.12", "3.13", "3.14"},
+                f"nightly must cover every PyVersion on macos-x64; got {mac_x64_pys}",
+            )
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_empty_merge_valid_is_no_op(self) -> None:
+        """Adding MERGE_VALID = [] to a model must not change the matrix."""
+        without = self._write_python_model("")
+        with_empty = self._write_python_model("MERGE_VALID = []\n")
+        try:
+            rows_a = gm.generate(without, "python")
+            rows_b = gm.generate(with_empty, "python")
+            self.assertEqual(rows_a, rows_b)
+        finally:
+            without.unlink(missing_ok=True)
+            with_empty.unlink(missing_ok=True)
+
+    def test_merge_valid_predicates_anded(self) -> None:
+        """Multiple MERGE_VALID predicates: all must pass for a combo to be in pairwise."""
+        block = (
+            "def block_x64(c):\n"
+            "    if c['OS'] == 'macos' and c['Arch'] == 'x64': return False\n"
+            "    return True\n"
+            "def block_arm_aws(c):\n"
+            "    if c['OS'] == 'macos' and c['Arch'] == 'arm' and c['Cloud'] == 'aws':\n"
+            "        return False\n"
+            "    return True\n"
+            "MERGE_VALID = [block_x64, block_arm_aws]\n"
+        )
+        path = self._write_python_model(block)
+        try:
+            rows = gm.generate(path, "python")
+            # No macos-x64 should reach merge level (blocked by 1st predicate).
+            mac_x64_at_merge = [
+                r for r in rows
+                if r["os"] == "macos-15-intel" and r["trigger_level"] in ("pr", "merge")
+            ]
+            self.assertEqual(mac_x64_at_merge, [])
+            # No macos-arm + aws should reach merge level (blocked by 2nd predicate),
+            # but PR_CELLS uses macos-arm + gcp so the PR cell is unaffected.
+            mac_arm_aws_at_merge = [
+                r for r in rows
+                if r["os"] == "macos-latest" and r["cloud_provider"] == "aws"
+                and r["trigger_level"] in ("pr", "merge")
+            ]
+            self.assertEqual(mac_arm_aws_at_merge, [])
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_merge_valid_does_not_affect_mapping_validation(self) -> None:
+        """validate_mappings runs over the full constraint-valid set, not the
+        MERGE_VALID-restricted set, so a missing mapping for a MERGE_VALID-
+        blocked combo still raises."""
+        # Pop a mapping for an (OS, Arch) that MERGE_VALID will block, and
+        # confirm generate() still raises because validate_mappings sees the
+        # combo via the unfiltered cartesian product.
+        original = gm.PYTHON_PLATFORM.pop(("macos", "x64"), None)
+        block = (
+            "def merge_valid(c):\n"
+            "    if c['OS'] == 'macos' and c['Arch'] == 'x64': return False\n"
+            "    return True\n"
+            "MERGE_VALID = [merge_valid]\n"
+        )
+        path = self._write_python_model(block)
+        try:
+            with self.assertRaises(RuntimeError) as ctx:
+                gm.generate(path, "python")
+            self.assertIn("PYTHON_PLATFORM", str(ctx.exception))
+        finally:
+            path.unlink(missing_ok=True)
+            if original is not None:
+                gm.PYTHON_PLATFORM[("macos", "x64")] = original
 
 
 class BlockListShapeTests(unittest.TestCase):
@@ -519,6 +767,36 @@ class PythonMatrixTests(unittest.TestCase):
             missing = required - r.keys()
             self.assertFalse(missing, f"row {r} missing keys {missing}")
 
+    def test_no_duplicate_macos_rows_at_mq(self) -> None:
+        # Regression test for the python.py MERGE_VALID/PR_CELLS sync invariant.
+        # The merge_valid() predicate pins macos-arm to one combo and macos-x64
+        # to another. The macOS entry in PR_CELLS MUST match the macos-arm pin
+        # exactly; if they diverge, the PR cell ships at trigger_level=pr while
+        # pairwise ships a *different* macos-arm row at trigger_level=merge,
+        # giving two macOS-arm jobs at the merge queue (defeating the point of
+        # MERGE_VALID). This test fails loudly when the sync drifts.
+        mq_macos = [
+            r for r in self.gha
+            if r["os"] == "macos-latest" and r["trigger_level"] in ("pr", "merge")
+        ]
+        self.assertEqual(
+            len(mq_macos), 1,
+            f"expected exactly one macos-arm row at merge-queue scope; "
+            f"got {[r['name'] for r in mq_macos]}. "
+            f"This usually means the PR_CELLS macOS entry has drifted "
+            f"away from the macos-arm pin in merge_valid(): both reach "
+            f"the merge level and macOS runs twice per MQ build.",
+        )
+        mq_intel = [
+            r for r in self.gha
+            if r["os"] == "macos-15-intel" and r["trigger_level"] in ("pr", "merge")
+        ]
+        self.assertEqual(
+            len(mq_intel), 1,
+            f"expected exactly one macos-x64 row at merge-queue scope; "
+            f"got {[r['name'] for r in mq_intel]}",
+        )
+
 
 class CoreMatrixTests(unittest.TestCase):
     @classmethod
@@ -603,7 +881,7 @@ class ValidationTests(unittest.TestCase):
             with redirect_stderr(buf):
                 # We only want loader/constraint behavior; sidestep validate_mappings
                 # by calling internals.
-                params, constraints, pr_cells, _json_cells = gm.load_model(path)
+                params, constraints, _mv, pr_cells, _json_cells = gm.load_model(path)
                 all_combos = [
                     c for c in (
                         dict(zip(params.keys(), v))


### PR DESCRIPTION
Summary

  • Add an optional MERGE_VALID block-list to the test-matrix model schema — predicates that gate only the merge-level pairwise pool. Combos blocked by MERGE_VALID skip merge but still run at nightly. PR_CELLS entries always run regardless.
  • Apply it in models/python.py and models/odbc.py to cap macOS at the merge queue to one Intel + one ARM job per driver. Nightly mac coverage is unchanged (full constraint-valid cartesian product).

  Context

  Merge-queue throughput is bottlenecked by limited macOS runner availability.