### PR TITLE
SNOW-3512876 align python builds with tests

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -46,24 +46,32 @@ jobs:
     needs: scope-label-gate
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.read.outputs.matrix }}
+      matrix: ${{ steps.matrix.outputs.matrix }}
+      build-targets: ${{ steps.targets.outputs.targets }}
     steps:
       - uses: actions/checkout@v4
-      - id: read
+      - id: matrix
         env:
           LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
         run: |
           python ci/test_matrix/generate_matrix.py \
             --driver python --event "$GITHUB_EVENT_NAME" --labels "$LABELS" --emit-active \
             >> "$GITHUB_OUTPUT"
+      - id: targets
+        env:
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: |
+          python ci/test_matrix/generate_matrix.py \
+            --driver python --event "$GITHUB_EVENT_NAME" --labels "$LABELS" --emit-build-targets \
+            >> "$GITHUB_OUTPUT"
 
   # ── Build all wheels via shared reusable workflow ────────────────────
   build_wheels:
-    needs: detect-changes
+    needs: [detect-changes, load-python-matrix]
     if: github.event_name == 'push' || needs.detect-changes.outputs.run_python == 'true'
     uses: ./.github/workflows/_build-python-wheels.yml
     with:
-      targets: '{"linux_x86": ["3.13"], "linux_aarch": ["3.11","3.14"], "macos_arm": ["3.12","3.14"], "macos_x86": ["3.11","3.12","3.13","3.14"], "windows_x86": ["3.11","3.12","3.14"], "windows_arm": ["3.11","3.12"]}'
+      targets: ${{ needs.load-python-matrix.outputs.build-targets }}
 
   # Packaging tests - verify sdist can be built and installed from source
   packaging_tests:
@@ -487,19 +495,18 @@ jobs:
       matrix:
         # Reference tests must NOT run on Azure: snowflake-connector-python
         # against an Azure deployment is flaky here and destabilises every
-        # PR. Pick PR_CELLS rows whose Cloud is aws/gcp. Both rows below
+        # PR. Pick PR_CELLS rows whose Cloud is aws/gcp. Each row below
         # must also exactly match an entry in ci/test_matrix/models/python.py
         # PR_CELLS (same os/py/cloud_provider/hatch_env) so the artifact
         # downloads in python_compare_results line up with python_tests.
+        # macOS reference comparison was removed when the macOS PR cell
+        # was deferred to merge-queue scope (limited macOS runner
+        # availability). Pandas reference coverage runs only on Ubuntu now.
         include:
           - hatch_env: reference
             os: ubuntu-latest
             py: "3.13"
             cloud_provider: aws
-          - hatch_env: reference-pandas
-            os: macos-latest
-            py: "3.10"
-            cloud_provider: gcp
     runs-on: ${{ matrix.os }}
     name: python_tests_reference (${{ matrix.hatch_env }})
     continue-on-error: true  # Reference tests expected to fail due to behavioral differences
@@ -670,18 +677,16 @@ jobs:
         # Each row must mirror a python_tests_reference row's
         # (os, py, cloud_provider) so artifact downloads pair up; keep this
         # block in sync with the matrix above. Cloud is constrained to
-        # aws/gcp — Azure is excluded for reference stability.
+        # aws/gcp — Azure is excluded for reference stability. The macOS
+        # comparison row was removed when the macOS PR cell was deferred
+        # to merge-queue scope; pandas reference coverage now runs only
+        # on Ubuntu.
         include:
           - hatch_env: test
             ref_hatch_env: reference
             os: ubuntu-latest
             py: "3.13"
             cloud_provider: aws
-          - hatch_env: test-pandas
-            ref_hatch_env: reference-pandas
-            os: macos-latest
-            py: "3.10"
-            cloud_provider: gcp
     runs-on: ubuntu-latest
     name: python_compare_results (${{ matrix.hatch_env }})
     env:

--- a/ci/test_matrix/README.md
+++ b/ci/test_matrix/README.md
@@ -234,15 +234,26 @@ python ci/test_matrix/generate_matrix.py [--driver odbc|python|core | --all]
 python ci/test_matrix/generate_matrix.py --driver <D> --event <NAME> --emit-active
 ```
 
-| Flag             | Description                                                                |
-|------------------|----------------------------------------------------------------------------|
-| `--driver <D>`   | Generate `<D>-gha.json` for one driver.                                    |
-| `--all`          | Regenerate every driver in one shot.                                       |
-| `--event <NAME>` | GHA event name for `--emit-active`.                                        |
-| `--emit-active`  | Print `matrix=<json>` for rows active at the level implied by `--event`.   |
+| Flag                    | Description                                                                |
+|-------------------------|----------------------------------------------------------------------------|
+| `--driver <D>`          | Generate `<D>-gha.json` for one driver.                                    |
+| `--all`                 | Regenerate every driver in one shot.                                       |
+| `--event <NAME>`        | GHA event name for `--emit-active` / `--emit-build-targets`.               |
+| `--emit-active`         | Print `matrix=<json>` for rows active at the level implied by `--event`.   |
+| `--emit-build-targets`  | Print `targets=<json>` for wheel-build targets active at the level implied by `--event`. Python only. |
 
-`--driver` and `--all` are mutually exclusive; `--emit-active` requires both
-`--driver` and `--event`.
+`--driver` and `--all` are mutually exclusive. `--emit-active` and
+`--emit-build-targets` each require both `--driver` and `--event`, and
+are mutually exclusive with each other.
+
+The `--emit-build-targets` mode walks the active test matrix, finds rows
+with a `wheel_artifact`, and emits the JSON shape consumed by
+`_build-python-wheels.yml`'s `targets:` input
+(`{"linux_x86": ["3.13"], "macos_arm": ["3.12"], …}`). Sdist-only py
+versions (`SDIST_PY`) are skipped because their rows carry no
+`wheel_artifact`. The translation `(OS, Arch) → cibw_key` lives in
+`PYTHON_PLATFORM`'s `cibw_key` field; `validate_mappings` enforces every
+row declares it.
 
 ## Row schema
 

--- a/ci/test_matrix/generate_matrix.py
+++ b/ci/test_matrix/generate_matrix.py
@@ -272,7 +272,16 @@ def validate_mappings(driver: str, all_combos: list[dict[str, str]]) -> None:
             raise RuntimeError(
                 f"({pair[0]}, {pair[1]}) is allowed by the Python model but missing "
                 f"from PYTHON_PLATFORM in mappings/python.py — add a row there with "
-                f"'wheel_artifact' + 'wheels', or constrain the model."
+                f"'cibw_key' + 'wheel_artifact' + 'wheels', or constrain the model."
+            )
+        if driver == "python" and "cibw_key" not in PYTHON_PLATFORM[pair]:
+            raise RuntimeError(
+                f"({pair[0]}, {pair[1]}) is in PYTHON_PLATFORM but missing 'cibw_key'. "
+                f"This field is required for --emit-build-targets to translate "
+                f"(OS, Arch) to the platform key consumed by "
+                f"_build-python-wheels.yml. Set it to one of "
+                f"linux_x86, linux_aarch, macos_x86, macos_arm, windows_x86, "
+                f"or windows_arm — see that workflow's inline PLATFORMS dict."
             )
         if driver == "core" and pair not in CORE_PLATFORM:
             raise RuntimeError(
@@ -622,6 +631,62 @@ def emit_active(driver: str, event: str | None, labels: list[str] | None = None)
     print(f"matrix={json.dumps(active)}")
 
 
+def build_targets(driver: str, event: str | None, labels: list[str] | None = None) -> dict[str, list[str]]:
+    """
+    Return the wheel-build targets for `driver` at the trigger level implied
+    by `event`, in the JSON shape consumed by _build-python-wheels.yml's
+    `targets:` input. Currently only supported for the python driver.
+
+    Output shape:
+        {
+            "linux_x86":  ["3.13"],
+            "macos_arm":  ["3.12"],
+            ...
+        }
+
+    A platform key appears only if at least one active test row references
+    a wheel from it; py versions within a platform are deduplicated and
+    sorted. Sdist-only py versions (SDIST_PY) are naturally excluded
+    because their rows carry no `wheel_artifact`.
+    """
+    if driver != "python":
+        raise ValueError(
+            f"--emit-build-targets is only supported for the python driver; got {driver!r}"
+        )
+    model_path = MODELS_DIR / f"{driver}.py"
+    gha_rows = generate(model_path, driver)
+    level = level_for_event_and_labels(event, labels)
+    active = filter_active(gha_rows, level)
+
+    # Reverse-lookup wheel_artifact -> (os, arch) so we can fetch cibw_key.
+    artifact_to_pair: dict[str, tuple[str, str]] = {
+        meta["wheel_artifact"]: pair for pair, meta in PYTHON_PLATFORM.items()
+    }
+
+    targets: dict[str, set[str]] = {}
+    for row in active:
+        artifact = row.get("wheel_artifact")
+        if not artifact:
+            # py3.10 sdist rows and any other no-wheel rows are skipped: the
+            # build workflow doesn't need to produce a wheel for them.
+            continue
+        pair = artifact_to_pair[artifact]
+        cibw_key = PYTHON_PLATFORM[pair]["cibw_key"]
+        targets.setdefault(cibw_key, set()).add(row["py"])
+
+    return {key: sorted(versions) for key, versions in sorted(targets.items())}
+
+
+def emit_build_targets(driver: str, event: str | None, labels: list[str] | None = None) -> None:
+    """
+    Print `targets=<json>` for the wheel-build targets active at the level
+    implied by `event`, optionally upgraded by scope-up PR labels (see
+    LABEL_TO_LEVEL). Suitable for appending to $GITHUB_OUTPUT inside a
+    workflow step. Currently only supported for the python driver.
+    """
+    print(f"targets={json.dumps(build_targets(driver, event, labels))}")
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Pairwise CI matrix generator")
     group = parser.add_mutually_exclusive_group(required=True)
@@ -645,13 +710,30 @@ def main() -> None:
         help="Print 'matrix=<json>' for the active level (requires --driver and --event). "
              "Used inside CI workflow steps to feed strategy.matrix.include.",
     )
+    parser.add_argument(
+        "--emit-build-targets",
+        action="store_true",
+        help="Print 'targets=<json>' for the wheel-build targets active at the trigger "
+             "level implied by --event (requires --driver and --event). Currently only "
+             "supported for the python driver — feeds _build-python-wheels.yml's "
+             "`targets:` input.",
+    )
     args = parser.parse_args()
 
     if args.emit_active:
         if args.all or not args.driver:
             parser.error("--emit-active requires --driver and is incompatible with --all")
+        if args.emit_build_targets:
+            parser.error("--emit-active and --emit-build-targets are mutually exclusive")
         labels = [l.strip() for l in args.labels.split(",") if l.strip()]
         emit_active(args.driver, args.event, labels)
+        return
+
+    if args.emit_build_targets:
+        if args.all or not args.driver:
+            parser.error("--emit-build-targets requires --driver and is incompatible with --all")
+        labels = [l.strip() for l in args.labels.split(",") if l.strip()]
+        emit_build_targets(args.driver, args.event, labels)
         return
 
     drivers = ["odbc", "python", "core"] if args.all else [args.driver]

--- a/ci/test_matrix/mappings/python.py
+++ b/ci/test_matrix/mappings/python.py
@@ -6,6 +6,14 @@ generator needs. Adding a new platform is one row in PYTHON_PLATFORM; adding
 a new sdist-only Python version is one entry in SDIST_PY.
 
 Per-row keys:
+  cibw_key       (str, required) Platform key consumed by
+                 _build-python-wheels.yml's `targets` input. Must be one of
+                 {linux_x86, linux_aarch, macos_x86, macos_arm,
+                  windows_x86, windows_arm} — the keys defined in that
+                 workflow's inline PLATFORMS dict. Used by
+                 generate_matrix.py --emit-build-targets to produce the
+                 JSON the build workflow expects without a parallel
+                 hardcoded translation table.
   wheel_artifact (str, required) Wheel artifact basename uploaded by the
                  _build-python-wheels.yml reusable workflow.
   wheels         (set[str], required) Python versions for which a wheel is
@@ -17,12 +25,12 @@ SDIST_PY is a set of Python versions that always install from sdist
 """
 
 PYTHON_PLATFORM: dict[tuple[str, str], dict] = {
-    ("ubuntu",  "x64"): {"wheel_artifact": "manylinux_x86_64", "wheels": {"3.13"}},
-    ("ubuntu",  "arm"): {"wheel_artifact": "manylinux_aarch64", "wheels": {"3.11", "3.14"}},
-    ("macos",   "arm"): {"wheel_artifact": "macosx_arm64",     "wheels": {"3.12", "3.14"}},
-    ("macos",   "x64"): {"wheel_artifact": "macosx_x86_64",    "wheels": {"3.11", "3.12", "3.13", "3.14"}},
-    ("windows", "x64"): {"wheel_artifact": "win_amd64",        "wheels": {"3.11", "3.12", "3.14"}},
-    ("windows", "arm"): {"wheel_artifact": "win_arm64",        "wheels": {"3.11", "3.12"}},
+    ("ubuntu",  "x64"): {"cibw_key": "linux_x86",   "wheel_artifact": "manylinux_x86_64", "wheels": {"3.13"}},
+    ("ubuntu",  "arm"): {"cibw_key": "linux_aarch", "wheel_artifact": "manylinux_aarch64", "wheels": {"3.11", "3.14"}},
+    ("macos",   "arm"): {"cibw_key": "macos_arm",   "wheel_artifact": "macosx_arm64",     "wheels": {"3.12", "3.14"}},
+    ("macos",   "x64"): {"cibw_key": "macos_x86",   "wheel_artifact": "macosx_x86_64",    "wheels": {"3.11", "3.12", "3.13", "3.14"}},
+    ("windows", "x64"): {"cibw_key": "windows_x86", "wheel_artifact": "win_amd64",        "wheels": {"3.11", "3.12", "3.14"}},
+    ("windows", "arm"): {"cibw_key": "windows_arm", "wheel_artifact": "win_arm64",        "wheels": {"3.11", "3.12"}},
 }
 
 SDIST_PY: set[str] = {"3.10"}

--- a/ci/test_matrix/models/python.py
+++ b/ci/test_matrix/models/python.py
@@ -28,18 +28,21 @@ def merge_valid(c):
     """Pairwise-only block-list: combos returning False run at nightly only.
 
     macOS runner availability is the binding constraint on merge-queue
-    throughput. Hold MQ macOS load to one Intel + one ARM job:
+    throughput. There is no macOS PR cell — all macOS coverage is deferred
+    to the merge queue. To keep MQ macOS load capped at one Intel + one ARM
+    job, pin each arch to a single representative combo via pairwise:
 
-      * macos-arm:  block from pairwise entirely. The single ARM job at
-        merge comes from the explicit macOS entry in PR_CELLS below — it
-        runs at trigger_level=pr and is promoted to merge by the
-        cumulative trigger filter.
-      * macos-x64 (macos-15-intel): pin to a single representative combo
-        (aws + py3.13 + test). Every other Intel mac combo runs at
-        nightly via the unfiltered cartesian product.
+      * macos-arm:  gcp + py3.10 + test-pandas
+      * macos-x64 (macos-15-intel): aws + py3.13 + test
+
+    Every other macOS combo runs at nightly via the unfiltered cartesian
+    product.
     """
     if c["OS"] == "macos":
-        if c["Arch"] == "arm":                  return False
+        if c["Arch"] == "arm":
+            if c["Cloud"] != "gcp":             return False
+            if c["PyVersion"] != "3.10":        return False
+            if c["HatchEnv"] != "test-pandas":  return False
         if c["Arch"] == "x64":
             if c["Cloud"] != "aws":             return False
             if c["PyVersion"] != "3.13":        return False
@@ -52,7 +55,6 @@ MERGE_VALID = [merge_valid]
 
 PR_CELLS = [
     {"OS": "ubuntu",  "Arch": "x64", "Cloud": "aws",   "PyVersion": "3.13", "HatchEnv": "test"},
-    {"OS": "macos",   "Arch": "arm", "Cloud": "gcp",   "PyVersion": "3.10", "HatchEnv": "test-pandas"},
     {"OS": "windows", "Arch": "x64", "Cloud": "azure", "PyVersion": "3.14", "HatchEnv": "test"},
 ]
 

--- a/ci/test_matrix/test_generate_matrix.py
+++ b/ci/test_matrix/test_generate_matrix.py
@@ -975,6 +975,212 @@ class JsonVariantRegressionTests(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# Build targets — wheel-build alignment
+# ---------------------------------------------------------------------------
+
+# Helper: reverse-lookup cibw_key -> (OS, Arch) for build-target tests.
+PYTHON_PLATFORM_BY_CIBW = {p["cibw_key"]: pair for pair, p in gm.PYTHON_PLATFORM.items()}
+
+
+class BuildTargetsTests(unittest.TestCase):
+    """
+    Coverage for the --emit-build-targets generator mode that drives
+    _build-python-wheels.yml's `targets:` input.
+
+    Locks in three invariants:
+      * Coverage equivalence — every active test row with a wheel_artifact
+        has a corresponding (cibw_key, py) entry in build_targets.
+      * No over-build — every (cibw_key, py) in build_targets traces back
+        to at least one active test row at the same trigger level.
+      * Per-trigger contraction — PR build targets are a subset of merge,
+        which is a subset of nightly. PR builds at most as many wheels as
+        tests need.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.gha = gm.generate(PYTHON_PATH, "python")
+        cls.targets_pr      = gm.build_targets("python", "pull_request")
+        cls.targets_merge   = gm.build_targets("python", "merge_group")
+        cls.targets_nightly = gm.build_targets("python", "schedule")
+
+    def _active_wheel_rows(self, level: str) -> list:
+        return [
+            r for r in gm.filter_active(self.gha, level)
+            if r.get("wheel_artifact")
+        ]
+
+    def _expected_targets(self, level: str) -> dict[str, set[str]]:
+        artifact_to_pair = {p["wheel_artifact"]: pair for pair, p in gm.PYTHON_PLATFORM.items()}
+        out: dict[str, set[str]] = {}
+        for r in self._active_wheel_rows(level):
+            pair = artifact_to_pair[r["wheel_artifact"]]
+            out.setdefault(gm.PYTHON_PLATFORM[pair]["cibw_key"], set()).add(r["py"])
+        return out
+
+    def test_only_python_driver_supported(self) -> None:
+        with self.assertRaises(ValueError) as ctx:
+            gm.build_targets("odbc", "pull_request")
+        self.assertIn("python", str(ctx.exception))
+
+    def test_pr_targets_match_active_wheel_rows(self) -> None:
+        expected = self._expected_targets("pr")
+        actual = {k: set(v) for k, v in self.targets_pr.items()}
+        self.assertEqual(actual, expected)
+
+    def test_merge_targets_match_active_wheel_rows(self) -> None:
+        expected = self._expected_targets("merge")
+        actual = {k: set(v) for k, v in self.targets_merge.items()}
+        self.assertEqual(actual, expected)
+
+    def test_nightly_targets_match_active_wheel_rows(self) -> None:
+        expected = self._expected_targets("nightly")
+        actual = {k: set(v) for k, v in self.targets_nightly.items()}
+        self.assertEqual(actual, expected)
+
+    def test_pr_subset_of_merge_subset_of_nightly(self) -> None:
+        # Per-trigger contraction: PR ⊆ merge ⊆ nightly.
+        for cibw_key, versions in self.targets_pr.items():
+            self.assertIn(
+                cibw_key, self.targets_merge,
+                f"PR builds {cibw_key} but merge does not — every PR cell "
+                f"must also be active at merge level (cumulative trigger filter).",
+            )
+            self.assertTrue(
+                set(versions).issubset(self.targets_merge[cibw_key]),
+                f"PR-level {cibw_key} versions {versions} not a subset of merge {self.targets_merge[cibw_key]}",
+            )
+        for cibw_key, versions in self.targets_merge.items():
+            self.assertIn(
+                cibw_key, self.targets_nightly,
+                f"merge builds {cibw_key} but nightly does not — full cartesian "
+                f"product should always cover merge cells.",
+            )
+            self.assertTrue(
+                set(versions).issubset(self.targets_nightly[cibw_key]),
+                f"merge-level {cibw_key} versions {versions} not a subset of nightly {self.targets_nightly[cibw_key]}",
+            )
+
+    def test_no_overbuild(self) -> None:
+        # Every (cibw_key, py) in build_targets must correspond to >=1 active
+        # test row at the same level. Catches "we build wheels nothing tests".
+        artifact_to_pair = {p["wheel_artifact"]: pair for pair, p in gm.PYTHON_PLATFORM.items()}
+        for level, targets in [
+            ("pr", self.targets_pr),
+            ("merge", self.targets_merge),
+            ("nightly", self.targets_nightly),
+        ]:
+            active = self._active_wheel_rows(level)
+            for cibw_key, versions in targets.items():
+                target_pair = PYTHON_PLATFORM_BY_CIBW[cibw_key]
+                for v in versions:
+                    matches = [
+                        r for r in active
+                        if artifact_to_pair[r["wheel_artifact"]] == target_pair
+                        and r["py"] == v
+                    ]
+                    self.assertTrue(
+                        matches,
+                        f"[{level}] {cibw_key}/py{v} in build_targets but no test row consumes it",
+                    )
+
+    def test_no_underbuild(self) -> None:
+        # Every active test row with a wheel_artifact has a (cibw_key, py)
+        # entry in build_targets. Catches "test row references a wheel that
+        # won't be built", which would 404 actions/download-artifact at runtime.
+        artifact_to_pair = {p["wheel_artifact"]: pair for pair, p in gm.PYTHON_PLATFORM.items()}
+        for level, targets in [
+            ("pr", self.targets_pr),
+            ("merge", self.targets_merge),
+            ("nightly", self.targets_nightly),
+        ]:
+            for r in self._active_wheel_rows(level):
+                pair = artifact_to_pair[r["wheel_artifact"]]
+                cibw_key = gm.PYTHON_PLATFORM[pair]["cibw_key"]
+                self.assertIn(
+                    cibw_key, targets,
+                    f"[{level}] test row {r['name']} needs wheel for {cibw_key} "
+                    f"but build_targets has no entry for that platform",
+                )
+                self.assertIn(
+                    r["py"], targets[cibw_key],
+                    f"[{level}] test row {r['name']} needs py{r['py']} on {cibw_key} "
+                    f"but build_targets[{cibw_key}] = {targets[cibw_key]}",
+                )
+
+    def test_sdist_py_excluded_from_targets(self) -> None:
+        # py3.10 always installs from sdist; rows have no wheel_artifact and
+        # must NOT appear in build_targets at any level.
+        for level, targets in [
+            ("pr", self.targets_pr),
+            ("merge", self.targets_merge),
+            ("nightly", self.targets_nightly),
+        ]:
+            for cibw_key, versions in targets.items():
+                self.assertNotIn(
+                    "3.10", versions,
+                    f"[{level}] py3.10 listed under {cibw_key} in build_targets, "
+                    f"but py3.10 is sdist-only (SDIST_PY) and shouldn't be wheel-built",
+                )
+
+    def test_nightly_targets_match_legacy_hardcoded_json(self) -> None:
+        # Regression guard: at nightly scope the generator output must match
+        # the JSON literal previously hardcoded in test-python.yml. Pins the
+        # migration so a future PR can't silently shrink wheel coverage at
+        # nightly without a corresponding model edit.
+        legacy = {
+            "linux_x86":   {"3.13"},
+            "linux_aarch": {"3.11", "3.14"},
+            "macos_arm":   {"3.12", "3.14"},
+            "macos_x86":   {"3.11", "3.12", "3.13", "3.14"},
+            "windows_x86": {"3.11", "3.12", "3.14"},
+            "windows_arm": {"3.11", "3.12"},
+        }
+        actual = {k: set(v) for k, v in self.targets_nightly.items()}
+        self.assertEqual(
+            actual, legacy,
+            "nightly build_targets diverged from the legacy test-python.yml "
+            "hardcoded targets JSON. If this is intentional (e.g. a PARAMS edit), "
+            "update the `legacy` dict in this test to match.",
+        )
+
+    def test_emit_build_targets_cli_format(self) -> None:
+        # CLI emits exactly one line of the form `targets=<json>`.
+        import contextlib
+        import io
+        import json as _json
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            gm.emit_build_targets("python", "pull_request")
+        line = buf.getvalue().rstrip("\n")
+        self.assertTrue(line.startswith("targets="))
+        payload = _json.loads(line[len("targets="):])
+        self.assertEqual(payload, self.targets_pr)
+
+    def test_python_platform_has_cibw_key(self) -> None:
+        # Every PYTHON_PLATFORM row must declare cibw_key. validate_mappings
+        # enforces this at generate() time; this test pins it independently.
+        for pair, meta in gm.PYTHON_PLATFORM.items():
+            self.assertIn(
+                "cibw_key", meta,
+                f"PYTHON_PLATFORM[{pair}] missing 'cibw_key' — "
+                f"--emit-build-targets cannot translate this platform.",
+            )
+
+    def test_validate_mappings_raises_on_missing_cibw_key(self) -> None:
+        # Drift simulation: pop cibw_key from one row, validate_mappings
+        # must fail loud rather than silently degrade.
+        original = gm.PYTHON_PLATFORM[("ubuntu", "x64")].copy()
+        gm.PYTHON_PLATFORM[("ubuntu", "x64")].pop("cibw_key")
+        try:
+            with self.assertRaises(RuntimeError) as ctx:
+                gm.generate(PYTHON_PATH, "python")
+            self.assertIn("cibw_key", str(ctx.exception))
+        finally:
+            gm.PYTHON_PLATFORM[("ubuntu", "x64")] = original
+
+
+# ---------------------------------------------------------------------------
 # Trigger-level filtering
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Summary

  • Drive _build-python-wheels.yml's targets: from the test matrix instead of a hardcoded JSON literal — wheels are now built only for the py versions / platforms the active trigger level actually tests.
  • Adds cibw_key to PYTHON_PLATFORM rows (single source of truth for the build-workflow platform label) and a --emit-build-targets mode to generate_matrix.py.