### PR TITLE
SNOW-3235553 Parameter Array Attributes

### DIFF
--- a/odbc/src/api/connection.rs
+++ b/odbc/src/api/connection.rs
@@ -1256,6 +1256,28 @@ pub fn get_info<E: OdbcEncoding>(
             }
             Ok(())
         }
+        // SQL_PAS_BATCH (1): each SELECT in the array produces a result set;
+        // only the last one is available after the batch completes.
+        InfoType::ParamArraySelects => {
+            if !info_value_ptr.is_null() {
+                unsafe { *(info_value_ptr as *mut u32) = 1 };
+            }
+            if !string_length_ptr.is_null() {
+                unsafe { *string_length_ptr = std::mem::size_of::<u32>() as sql::SmallInt };
+            }
+            Ok(())
+        }
+        // SQL_PARC_BATCH (1): individual row counts are available per set via
+        // SQL_ATTR_PARAMS_PROCESSED_PTR.
+        InfoType::ParamArrayRowCounts => {
+            if !info_value_ptr.is_null() {
+                unsafe { *(info_value_ptr as *mut u32) = 1 };
+            }
+            if !string_length_ptr.is_null() {
+                unsafe { *string_length_ptr = std::mem::size_of::<u32>() as sql::SmallInt };
+            }
+            Ok(())
+        }
     }
 }
 

--- a/odbc/src/api/descriptor.rs
+++ b/odbc/src/api/descriptor.rs
@@ -525,6 +525,12 @@ fn get_apd_field(
             }
             return Ok(());
         }
+        DescField::ArrayStatusPtr => {
+            unsafe {
+                std::ptr::write_unaligned(value_ptr as *mut *mut u16, desc.array_status_ptr);
+            }
+            return Ok(());
+        }
         _ => {}
     }
 
@@ -620,6 +626,10 @@ fn set_apd_field(
             }
             DescField::BindOffsetPtr => {
                 desc.bind_offset_ptr = value_ptr as *mut sql::Len;
+                Ok(())
+            }
+            DescField::ArrayStatusPtr => {
+                desc.array_status_ptr = value_ptr as *mut u16;
                 Ok(())
             }
             _ => {

--- a/odbc/src/api/statement.rs
+++ b/odbc/src/api/statement.rs
@@ -14,7 +14,7 @@ use crate::api::query_type::{QueryType, ResultKind};
 use crate::api::runtime::global;
 use crate::api::{
     ApdRecord, Connection, ConnectionState, DaeContext, ExecutionOrigin, FreeStmtOption, IpdRecord,
-    OdbcResult, ParamDirection, ParamValue, SQL_CONCUR_LOCK, SQL_CONCUR_READ_ONLY,
+    OdbcError, OdbcResult, ParamDirection, ParamValue, SQL_CONCUR_LOCK, SQL_CONCUR_READ_ONLY,
     SQL_CONCUR_VALUES, SQL_INSENSITIVE, SQL_NONSCROLLABLE, SQL_NOSCAN_OFF, SQL_NOSCAN_ON,
     SQL_RD_OFF, SQL_RD_ON, SQL_SCROLLABLE, SQL_SENSITIVE, SQL_UNSPECIFIED, SqlType, StatementInner,
     StatementState, stmt_from_handle,
@@ -63,26 +63,31 @@ pub fn exec_direct<E: OdbcEncoding>(
     statement_handle: sql::Handle,
     statement_text: *const E::Char,
     text_length: sql::Integer,
+    warnings: &mut crate::conversion::warning::Warnings,
 ) -> OdbcResult<()> {
     let query = E::read_string(statement_text, text_length)?;
-    exec_direct_impl(statement_handle, &query)
+    exec_direct_impl(statement_handle, &query, warnings)
 }
 
-fn exec_direct_impl(statement_handle: sql::Handle, statement_text: &str) -> OdbcResult<()> {
+fn exec_direct_impl(
+    statement_handle: sql::Handle,
+    statement_text: &str,
+    warnings: &mut crate::conversion::warning::Warnings,
+) -> OdbcResult<()> {
     let guard = stmt_from_handle(statement_handle)?;
     let dbc = guard.conn()?;
-    let mut conn = dbc.connection.lock();
-    let mut inner = guard.inner.lock();
-    tracing::debug!("exec_direct: statement_handle={:?}", statement_handle);
-
-    // Validate connection before committing to NeedData state.
-    let conn_handle = match &conn.state {
-        ConnectionState::Connected { conn_handle, .. } => *conn_handle,
-        ConnectionState::Disconnected => {
-            tracing::error!("exec_direct: connection is disconnected");
-            return DisconnectedSnafu.fail();
+    let conn_handle = {
+        let conn = dbc.connection.lock();
+        match &conn.state {
+            ConnectionState::Connected { conn_handle, .. } => *conn_handle,
+            ConnectionState::Disconnected => {
+                tracing::error!("exec_direct: connection is disconnected");
+                return DisconnectedSnafu.fail();
+            }
         }
     };
+    let mut inner = guard.inner.lock();
+    tracing::debug!("exec_direct: statement_handle={:?}", statement_handle);
 
     if inner.state.as_ref().is_need_data() {
         return InvalidDuringDaeSnafu.fail();
@@ -114,72 +119,210 @@ fn exec_direct_impl(statement_handle: sql::Handle, statement_text: &str) -> Odbc
         return DaeRequiredSnafu.fail();
     }
 
-    let (bindings, _json_owner) = apply_parameter_bindings(&inner.apd, &inner.ipd, false, None)?;
     let stmt_handle = guard.stmt_handle;
     let query_timeout = inner.query_timeout;
     let effective_query = statement_text.to_string();
     let multi_statement_count = inner.multi_statement_count;
 
-    let token = CancellationToken::new();
-    *guard.active_cancel.lock() = Some(token.clone());
+    let array_size = inner.apd.array_size.max(1);
+    let bind_offset = if inner.apd.bind_offset_ptr.is_null() {
+        0
+    } else {
+        unsafe { *inner.apd.bind_offset_ptr as isize }
+    };
+    let param_status_ptr = inner.ipd.array_status_ptr;
+    let rows_processed_ptr = inner.ipd.rows_processed_ptr;
+    let param_operation_ptr = inner.apd.array_status_ptr;
 
-    let response = global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
-        tokio::select! {
-            biased;
-            _ = token.cancelled() => Err(OperationCanceledSnafu.build()),
-            result = async {
-                if multi_statement_count >= 0 {
-                    let mut options = std::collections::HashMap::new();
-                    options.insert(
-                        "multi_statement_count".to_string(),
-                        ConfigSetting {
-                            value: Some(config_setting::Value::IntValue(
-                                multi_statement_count as i64,
-                            )),
-                        },
-                    );
-                    c.statement_set_options(StatementSetOptionsRequest {
+    if array_size == 1 {
+        // Honour SQL_PARAM_IGNORE for the single set (mirrors array-loop behaviour).
+        if !param_operation_ptr.is_null()
+            && unsafe { param_operation_ptr.read() } == SQL_PARAM_IGNORE
+        {
+            unsafe { write_param_status(param_status_ptr, 0, SQL_PARAM_UNUSED) };
+            if !rows_processed_ptr.is_null() {
+                unsafe { rows_processed_ptr.write(0) };
+            }
+            set_state(
+                &mut inner,
+                StatementState::DmlExecuted {
+                    rows_affected: 0,
+                    schema: arrow::datatypes::Schema::empty().into(),
+                    origin: ExecutionOrigin::Direct,
+                },
+            );
+            inner.rows_returned = 0;
+            return Ok(());
+        }
+
+        let (bindings, _json_owner) =
+            apply_parameter_bindings(&inner.apd, &inner.ipd, false, None, 0, bind_offset)?;
+
+        let token = CancellationToken::new();
+        *guard.active_cancel.lock() = Some(token.clone());
+
+        let response = global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
+            tokio::select! {
+                biased;
+                _ = token.cancelled() => Err(OperationCanceledSnafu.build()),
+                result = async {
+                    if multi_statement_count >= 0 {
+                        let mut options = std::collections::HashMap::new();
+                        options.insert(
+                            "multi_statement_count".to_string(),
+                            ConfigSetting {
+                                value: Some(config_setting::Value::IntValue(
+                                    multi_statement_count as i64,
+                                )),
+                            },
+                        );
+                        c.statement_set_options(StatementSetOptionsRequest {
+                            stmt_handle: Some(stmt_handle),
+                            options,
+                        })
+                        .await?;
+                    }
+
+                    c.statement_set_sql_query(StatementSetSqlQueryRequest {
                         stmt_handle: Some(stmt_handle),
-                        options,
+                        query: effective_query,
                     })
                     .await?;
-                }
 
-                c.statement_set_sql_query(StatementSetSqlQueryRequest {
+                    c.statement_execute_query(StatementExecuteQueryRequest {
+                        stmt_handle: Some(stmt_handle),
+                        bindings,
+                        timeout_seconds: if query_timeout > 0 {
+                            Some(query_timeout.min(u32::MAX as sql::ULen) as u32)
+                        } else {
+                            None
+                        },
+                    })
+                    .await
+                } => result.map_err(Into::into),
+            }
+        });
+
+        *guard.active_cancel.lock() = None;
+
+        tracing::info!("exec_direct: response={:?}", response);
+        let response = match response {
+            Ok(r) => r,
+            Err(e) => {
+                if let Some(qid) = e.query_id() {
+                    inner.last_query_id = Some(qid.to_owned());
+                }
+                // write_param_status is null-safe; if the app set PARAM_STATUS_PTR
+                // it guaranteed an array of at least array_size (1) elements.
+                unsafe { write_param_status(param_status_ptr, 0, SQL_PARAM_ERROR) };
+                if !rows_processed_ptr.is_null() {
+                    unsafe { rows_processed_ptr.write(1) };
+                }
+                return Err(e);
+            }
+        };
+
+        update_numeric_settings(&conn_handle, &mut dbc.connection.lock().numeric_settings)?;
+        let apply_result =
+            apply_execute_response(&mut inner, conn_handle, response, ExecutionOrigin::Direct);
+        // write_param_status is null-safe; if the app set PARAM_STATUS_PTR
+        // it guaranteed an array of at least array_size (1) elements.
+        unsafe { write_param_status(param_status_ptr, 0, SQL_PARAM_SUCCESS) };
+        if !rows_processed_ptr.is_null() {
+            unsafe { rows_processed_ptr.write(1) };
+        }
+        // Re-propagate any error that is NOT NoMoreData (which just means a DML
+        // statement affected 0 rows — a valid outcome, not a failure).
+        match apply_result {
+            Ok(()) | Err(OdbcError::NoMoreData { .. }) => {}
+            Err(e) => return Err(e),
+        }
+    } else {
+        // Parameter array execution: send the query text once, then run one
+        // RPC per set via the shared helper.
+        let token = CancellationToken::new();
+        *guard.active_cancel.lock() = Some(token.clone());
+        let set_query_result = global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
+            tokio::select! {
+                biased;
+                _ = token.cancelled() => Err(OperationCanceledSnafu.build()),
+                result = c.statement_set_sql_query(StatementSetSqlQueryRequest {
                     stmt_handle: Some(stmt_handle),
                     query: effective_query,
-                })
-                .await?;
-
-                c.statement_execute_query(StatementExecuteQueryRequest {
-                    stmt_handle: Some(stmt_handle),
-                    bindings,
-                    timeout_seconds: if query_timeout > 0 {
-                        Some(query_timeout.min(u32::MAX as sql::ULen) as u32)
-                    } else {
-                        None
-                    },
-                })
-                .await
-            } => result.map_err(Into::into),
-        }
-    });
-
-    *guard.active_cancel.lock() = None;
-
-    tracing::info!("exec_direct: response={:?}", response);
-    let response = match response {
-        Ok(r) => r,
-        Err(e) => {
-            if let Some(qid) = e.query_id() {
-                inner.last_query_id = Some(qid.to_owned());
+                }) => result.map_err(Into::into),
             }
-            return Err(e);
-        }
-    };
+        });
+        *guard.active_cancel.lock() = None;
+        set_query_result?;
 
-    update_numeric_settings(&conn_handle, &mut conn.numeric_settings)?;
-    apply_execute_response(&mut inner, conn_handle, response, ExecutionOrigin::Direct)?;
+        let ArrayLoopResult {
+            last_response,
+            any_error,
+            total_rows_affected,
+        } = execute_param_array_loop(
+            &mut inner,
+            &guard.active_cancel,
+            stmt_handle,
+            array_size,
+            bind_offset,
+            param_status_ptr,
+            rows_processed_ptr,
+            param_operation_ptr,
+            false,
+            query_timeout,
+            multi_statement_count,
+        )?;
+
+        if let Some(response) = last_response {
+            update_numeric_settings(&conn_handle, &mut dbc.connection.lock().numeric_settings)?;
+            // NoMoreData from apply_execute_response means the last set was a
+            // DML statement that affected 0 rows — that is a valid outcome and
+            // must not override SQL_SUCCESS/SQL_SUCCESS_WITH_INFO for the batch.
+            match apply_execute_response(&mut inner, conn_handle, response, ExecutionOrigin::Direct)
+            {
+                Ok(()) | Err(OdbcError::NoMoreData { .. }) => {
+                    // Overwrite the single-set rows_affected with the batch total.
+                    inner
+                        .state
+                        .transition_or_err::<(), ()>(|s| {
+                            Ok((
+                                match s {
+                                    StatementState::DmlExecuted { schema, origin, .. } => {
+                                        StatementState::DmlExecuted {
+                                            rows_affected: total_rows_affected,
+                                            schema,
+                                            origin,
+                                        }
+                                    }
+                                    other => other,
+                                },
+                                (),
+                            ))
+                        })
+                        .ok();
+                }
+                Err(e) => return Err(e),
+            }
+            if any_error {
+                warnings.push(crate::conversion::warning::Warning::RowError);
+            }
+        } else if !any_error {
+            // All sets were SQL_PARAM_IGNORE — no RPC was ever sent. Transition
+            // the statement to DmlExecuted so it is not left in Created/Prepared.
+            set_state(
+                &mut inner,
+                StatementState::DmlExecuted {
+                    rows_affected: 0,
+                    schema: arrow::datatypes::Schema::empty().into(),
+                    origin: ExecutionOrigin::Direct,
+                },
+            );
+            if !rows_processed_ptr.is_null() {
+                unsafe { rows_processed_ptr.write(0) };
+            }
+        }
+    }
+
     inner.rows_returned = 0;
     Ok(())
 }
@@ -484,7 +627,10 @@ fn prepare_impl(statement_handle: sql::Handle, query: &str) -> OdbcResult<()> {
 }
 
 /// Execute a prepared statement
-pub fn execute(statement_handle: sql::Handle) -> OdbcResult<()> {
+pub fn execute(
+    statement_handle: sql::Handle,
+    warnings: &mut crate::conversion::warning::Warnings,
+) -> OdbcResult<()> {
     tracing::debug!("execute: statement_handle={:?}", statement_handle);
     let guard = stmt_from_handle(statement_handle)?;
     let mut inner = guard.inner.lock();
@@ -544,70 +690,191 @@ pub fn execute(statement_handle: sql::Handle) -> OdbcResult<()> {
             }
         }
     };
-    let (bindings, _json_owner) = apply_parameter_bindings(
-        &inner.apd,
-        &inner.ipd,
-        is_prepared,
-        inner.prepared_param_count,
-    )?;
 
     let stmt_handle = guard.stmt_handle;
     let query_timeout = inner.query_timeout;
     let multi_statement_count = inner.multi_statement_count;
 
-    let token = CancellationToken::new();
-    let _cancel_guard = ActiveCancelGuard::arm(&guard.active_cancel, token.clone());
-
-    let response = global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
-        tokio::select! {
-            biased;
-            _ = token.cancelled() => Err(OperationCanceledSnafu.build()),
-            result = async {
-                if multi_statement_count >= 0 {
-                    let mut options = std::collections::HashMap::new();
-                    options.insert(
-                        "multi_statement_count".to_string(),
-                        ConfigSetting {
-                            value: Some(config_setting::Value::IntValue(
-                                multi_statement_count as i64,
-                            )),
-                        },
-                    );
-                    c.statement_set_options(StatementSetOptionsRequest {
-                        stmt_handle: Some(stmt_handle),
-                        options,
-                    })
-                    .await?;
-                }
-                c.statement_execute_query(StatementExecuteQueryRequest {
-                    stmt_handle: Some(stmt_handle),
-                    bindings,
-                    timeout_seconds: if query_timeout > 0 {
-                        Some(query_timeout.min(u32::MAX as sql::ULen) as u32)
-                    } else {
-                        None
-                    },
-                })
-                .await
-            } => result.map_err(Into::into),
-        }
-    });
-
-    let response = match response {
-        Ok(r) => r,
-        Err(e) => {
-            if let Some(qid) = e.query_id() {
-                inner.last_query_id = Some(qid.to_owned());
-            }
-            return Err(e);
-        }
+    let array_size = inner.apd.array_size.max(1);
+    let bind_offset = if inner.apd.bind_offset_ptr.is_null() {
+        0
+    } else {
+        unsafe { *inner.apd.bind_offset_ptr as isize }
     };
+    let param_status_ptr = inner.ipd.array_status_ptr;
+    let rows_processed_ptr = inner.ipd.rows_processed_ptr;
+    let param_operation_ptr = inner.apd.array_status_ptr;
 
-    tracing::info!("execute: Successfully executed statement");
-    let mut settings = dbc.connection.lock().numeric_settings;
-    update_numeric_settings(&conn_handle, &mut settings)?;
-    dbc.connection.lock().numeric_settings = settings;
-    apply_execute_response(&mut inner, conn_handle, response, origin)?;
+    if array_size == 1 {
+        // Honour SQL_PARAM_IGNORE for the single set (mirrors array-loop behaviour).
+        if !param_operation_ptr.is_null()
+            && unsafe { param_operation_ptr.read() } == SQL_PARAM_IGNORE
+        {
+            unsafe { write_param_status(param_status_ptr, 0, SQL_PARAM_UNUSED) };
+            if !rows_processed_ptr.is_null() {
+                unsafe { rows_processed_ptr.write(0) };
+            }
+            set_state(
+                &mut inner,
+                StatementState::DmlExecuted {
+                    rows_affected: 0,
+                    schema: arrow::datatypes::Schema::empty().into(),
+                    origin,
+                },
+            );
+            inner.rows_returned = 0;
+            return Ok(());
+        }
+
+        let (bindings, _json_owner) = apply_parameter_bindings(
+            &inner.apd,
+            &inner.ipd,
+            is_prepared,
+            inner.prepared_param_count,
+            0,
+            bind_offset,
+        )?;
+
+        let token = CancellationToken::new();
+        let _cancel_guard = ActiveCancelGuard::arm(&guard.active_cancel, token.clone());
+
+        let response = global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
+            tokio::select! {
+                biased;
+                _ = token.cancelled() => Err(OperationCanceledSnafu.build()),
+                result = async {
+                    if multi_statement_count >= 0 {
+                        let mut options = std::collections::HashMap::new();
+                        options.insert(
+                            "multi_statement_count".to_string(),
+                            ConfigSetting {
+                                value: Some(config_setting::Value::IntValue(
+                                    multi_statement_count as i64,
+                                )),
+                            },
+                        );
+                        c.statement_set_options(StatementSetOptionsRequest {
+                            stmt_handle: Some(stmt_handle),
+                            options,
+                        })
+                        .await?;
+                    }
+                    c.statement_execute_query(StatementExecuteQueryRequest {
+                        stmt_handle: Some(stmt_handle),
+                        bindings,
+                        timeout_seconds: if query_timeout > 0 {
+                            Some(query_timeout.min(u32::MAX as sql::ULen) as u32)
+                        } else {
+                            None
+                        },
+                    })
+                    .await
+                } => result.map_err(Into::into),
+            }
+        });
+
+        let response = match response {
+            Ok(r) => r,
+            Err(e) => {
+                if let Some(qid) = e.query_id() {
+                    inner.last_query_id = Some(qid.to_owned());
+                }
+                // write_param_status is null-safe; if the app set PARAM_STATUS_PTR
+                // it guaranteed an array of at least array_size (1) elements.
+                unsafe { write_param_status(param_status_ptr, 0, SQL_PARAM_ERROR) };
+                if !rows_processed_ptr.is_null() {
+                    unsafe { rows_processed_ptr.write(1) };
+                }
+                return Err(e);
+            }
+        };
+
+        tracing::info!("execute: Successfully executed statement");
+        update_numeric_settings(&conn_handle, &mut dbc.connection.lock().numeric_settings)?;
+        let apply_result = apply_execute_response(&mut inner, conn_handle, response, origin);
+        // write_param_status is null-safe; if the app set PARAM_STATUS_PTR
+        // it guaranteed an array of at least array_size (1) elements.
+        unsafe { write_param_status(param_status_ptr, 0, SQL_PARAM_SUCCESS) };
+        if !rows_processed_ptr.is_null() {
+            unsafe { rows_processed_ptr.write(1) };
+        }
+        // Re-propagate any error that is NOT NoMoreData (which just means a DML
+        // statement affected 0 rows — a valid outcome, not a failure).
+        match apply_result {
+            Ok(()) | Err(OdbcError::NoMoreData { .. }) => {}
+            Err(e) => return Err(e),
+        }
+    } else {
+        let loop_result = execute_param_array_loop(
+            &mut inner,
+            &guard.active_cancel,
+            stmt_handle,
+            array_size,
+            bind_offset,
+            param_status_ptr,
+            rows_processed_ptr,
+            param_operation_ptr,
+            is_prepared,
+            query_timeout,
+            multi_statement_count,
+        );
+        inner.rows_returned = 0;
+        let ArrayLoopResult {
+            last_response,
+            any_error,
+            total_rows_affected,
+        } = loop_result?;
+
+        if let Some(response) = last_response {
+            tracing::info!("execute: Successfully executed statement (array mode)");
+            update_numeric_settings(&conn_handle, &mut dbc.connection.lock().numeric_settings)?;
+            // NoMoreData from apply_execute_response means the last set was a
+            // DML statement that affected 0 rows — that is a valid outcome and
+            // must not override SQL_SUCCESS/SQL_SUCCESS_WITH_INFO for the batch.
+            match apply_execute_response(&mut inner, conn_handle, response, origin) {
+                Ok(()) | Err(OdbcError::NoMoreData { .. }) => {
+                    // Overwrite the single-set rows_affected with the batch total.
+                    inner
+                        .state
+                        .transition_or_err::<(), ()>(|s| {
+                            Ok((
+                                match s {
+                                    StatementState::DmlExecuted { schema, origin, .. } => {
+                                        StatementState::DmlExecuted {
+                                            rows_affected: total_rows_affected,
+                                            schema,
+                                            origin,
+                                        }
+                                    }
+                                    other => other,
+                                },
+                                (),
+                            ))
+                        })
+                        .ok();
+                }
+                Err(e) => return Err(e),
+            }
+            if any_error {
+                warnings.push(crate::conversion::warning::Warning::RowError);
+            }
+        } else if !any_error {
+            // All sets were SQL_PARAM_IGNORE — no RPC was ever sent. Transition
+            // the statement to DmlExecuted so it is not left in Created/Prepared.
+            set_state(
+                &mut inner,
+                StatementState::DmlExecuted {
+                    rows_affected: 0,
+                    schema: arrow::datatypes::Schema::empty().into(),
+                    origin,
+                },
+            );
+            if !rows_processed_ptr.is_null() {
+                unsafe { rows_processed_ptr.write(0) };
+            }
+        }
+    }
+
     inner.rows_returned = 0;
     Ok(())
 }
@@ -757,6 +1024,189 @@ fn release_result_set(rs_handle: ResultSetHandle) {
     }
 }
 
+/// Release any server-side result-set resources held by a response that will
+/// not be consumed (i.e. all but the last response in an array-parameter batch).
+fn discard_response(response: ExecuteQueryResponse) {
+    if let Some(execute_query_response::Result::Single(rs)) = response.result
+        && let Some(handle) = rs.result_set_handle
+    {
+        release_result_set(handle);
+    }
+    // Multi responses carry only query IDs (no live ResultSetHandle), so there
+    // is nothing to release for them.
+}
+
+/// Result of running the parameter-array execution loop.
+struct ArrayLoopResult {
+    /// Last successful response (apply as the statement's active result).
+    last_response: Option<ExecuteQueryResponse>,
+    /// True when at least one set failed.
+    any_error: bool,
+    /// Accumulated rows affected across all successful DML sets.
+    total_rows_affected: i64,
+}
+
+/// Execute the parameter-array loop (PARAMSET_SIZE > 1).
+///
+/// Iterates over `array_size` sets, skipping those marked `SQL_PARAM_IGNORE`,
+/// and calls `statement_execute_query` once per set.  Uses a single batch-wide
+/// `CancellationToken` so that `SQLCancel` reliably aborts the in-flight RPC
+/// regardless of which set is executing.
+///
+/// Intermediate responses (all but the last) are released immediately to avoid
+/// server-side resource leaks.  The `total_rows_affected` field accumulates DML
+/// row counts so `SQLRowCount` reflects the whole batch, not just the last set.
+#[allow(clippy::too_many_arguments)]
+fn execute_param_array_loop(
+    inner: &mut StatementInner,
+    active_cancel: &parking_lot::Mutex<Option<CancellationToken>>,
+    stmt_handle: StatementHandle,
+    array_size: usize,
+    bind_offset: isize,
+    param_status_ptr: *mut u16,
+    rows_processed_ptr: *mut sql::ULen,
+    param_operation_ptr: *const u16,
+    is_prepared: bool,
+    query_timeout: sql::ULen,
+    multi_statement_count: sql::SmallInt,
+) -> OdbcResult<ArrayLoopResult> {
+    let mut sets_processed: usize = 0;
+    let mut last_response: Option<ExecuteQueryResponse> = None;
+    let mut last_error: Option<OdbcError> = None;
+    let mut any_error = false;
+    let mut total_rows_affected: i64 = 0;
+
+    // A single token covers the entire batch so SQLCancel stops the in-flight
+    // RPC no matter which iteration is currently executing.
+    let batch_token = CancellationToken::new();
+    *active_cancel.lock() = Some(batch_token.clone());
+
+    for set_idx in 0..array_size {
+        // Honour SQL_PARAM_IGNORE on APD.array_status_ptr.
+        if !param_operation_ptr.is_null()
+            // SAFETY: null-checked above; app guarantees the array has array_size elements.
+            && unsafe { param_operation_ptr.add(set_idx).read() } == SQL_PARAM_IGNORE
+        {
+            // write_param_status is null-safe; app guarantees PARAM_STATUS_PTR
+            // array has at least array_size elements when non-null.
+            unsafe { write_param_status(param_status_ptr, set_idx, SQL_PARAM_UNUSED) };
+            continue;
+        }
+
+        let bindings_result = apply_parameter_bindings(
+            &inner.apd,
+            &inner.ipd,
+            is_prepared,
+            inner.prepared_param_count,
+            set_idx,
+            bind_offset,
+        );
+        let (bindings, _json_owner) = match bindings_result {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::error!("array loop: set_idx={set_idx} parameter binding failed: {e}");
+                // write_param_status is null-safe; see comment above.
+                unsafe { write_param_status(param_status_ptr, set_idx, SQL_PARAM_ERROR) };
+                add_param_set_error_diag(inner, set_idx, &e);
+                last_error = Some(e);
+                sets_processed += 1;
+                if !rows_processed_ptr.is_null() {
+                    unsafe { rows_processed_ptr.write(sets_processed as sql::ULen) };
+                }
+                any_error = true;
+                continue;
+            }
+        };
+
+        let exec_result = global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
+            // Forward multi_statement_count when set (matches single-set path).
+            if multi_statement_count >= 0 {
+                let mut options = std::collections::HashMap::new();
+                options.insert(
+                    "multi_statement_count".to_string(),
+                    ConfigSetting {
+                        value: Some(config_setting::Value::IntValue(
+                            multi_statement_count as i64,
+                        )),
+                    },
+                );
+                c.statement_set_options(StatementSetOptionsRequest {
+                    stmt_handle: Some(stmt_handle),
+                    options,
+                })
+                .await
+                .map_err(OdbcError::from)?;
+            }
+            tokio::select! {
+                biased;
+                _ = batch_token.cancelled() => Err(OperationCanceledSnafu.build()),
+                result = c.statement_execute_query(StatementExecuteQueryRequest {
+                    stmt_handle: Some(stmt_handle),
+                    bindings,
+                    timeout_seconds: if query_timeout > 0 {
+                        Some(query_timeout.min(u32::MAX as sql::ULen) as u32)
+                    } else {
+                        None
+                    },
+                }) => result.map_err(Into::into),
+            }
+        });
+
+        sets_processed += 1;
+        // Write the running count after each set so a cancellation handler
+        // or diagnostic inspector can observe progress mid-batch.
+        if !rows_processed_ptr.is_null() {
+            unsafe { rows_processed_ptr.write(sets_processed as sql::ULen) };
+        }
+        match exec_result {
+            Ok(resp) => {
+                // Accumulate row counts so SQLRowCount reflects the whole batch.
+                if let Some(execute_query_response::Result::Single(ref rs)) = resp.result
+                    && let Some(ref d) = rs.result_descriptor
+                {
+                    total_rows_affected += d.rows_affected.unwrap_or(0);
+                }
+                // write_param_status is null-safe; see comment above.
+                unsafe { write_param_status(param_status_ptr, set_idx, SQL_PARAM_SUCCESS) };
+                // Release the previous response before replacing it to avoid leaking
+                // server-side result-set resources (e.g. SELECT in array mode).
+                if let Some(prev) = last_response.take() {
+                    discard_response(prev);
+                }
+                last_response = Some(resp);
+            }
+            Err(e) => {
+                tracing::error!("array loop: set_idx={set_idx} execution failed: {e}");
+                if let Some(qid) = e.query_id() {
+                    inner.last_query_id = Some(qid.to_owned());
+                }
+                // write_param_status is null-safe; see comment above.
+                unsafe { write_param_status(param_status_ptr, set_idx, SQL_PARAM_ERROR) };
+                add_param_set_error_diag(inner, set_idx, &e);
+                last_error = Some(e);
+                any_error = true;
+            }
+        }
+    }
+
+    *active_cancel.lock() = None;
+
+    if any_error && last_response.is_none() {
+        return Err(last_error.ok_or_else(|| {
+            crate::api::error::InternalSnafu {
+                message: "array execution: any_error flag set but no error stored".to_string(),
+            }
+            .build()
+        })?);
+    }
+
+    Ok(ArrayLoopResult {
+        last_response,
+        any_error,
+        total_rows_affected,
+    })
+}
+
 fn create_execute_state_from_stream(
     stream: ArrowArrayStreamPtr,
     statement_type_id: Option<i64>,
@@ -782,7 +1232,7 @@ fn create_execute_state_from_stream(
     Ok(state)
 }
 
-/// Build JSON query bindings from ODBC parameter bindings.
+/// Build JSON query bindings from ODBC parameter bindings for a specific set index.
 ///
 /// When `prepared` is true (SQLPrepare+SQLExecute flow), the IPD has server-
 /// provided parameter count and we validate that the APD covers every marker.
@@ -792,11 +1242,16 @@ fn create_execute_state_from_stream(
 /// `prepared_param_count` caps how many parameters are serialized for prepared
 /// statements, preventing phantom bindings beyond the server-reported marker
 /// count from being dereferenced.
+///
+/// `set_idx` is 0-based (pass 0 for the single-set / non-array path).
+/// `bind_offset` is the dereferenced value of `APD.bind_offset_ptr` (pass 0 when null).
 fn apply_parameter_bindings(
     apd: &crate::api::ApdDescriptor,
     ipd: &crate::api::IpdDescriptor,
     prepared: bool,
     prepared_param_count: Option<u16>,
+    set_idx: usize,
+    bind_offset: isize,
 ) -> OdbcResult<(Option<QueryBindings>, Option<String>)> {
     let effective_count: u16 = if prepared {
         prepared_param_count.ok_or_else(|| {
@@ -838,13 +1293,14 @@ fn apply_parameter_bindings(
         }
     }
     tracing::info!(
-        "apply_parameter_bindings: Found {} bound parameters (effective_count={})",
+        "apply_parameter_bindings: Found {} bound parameters (effective_count={}, set_idx={})",
         apd.records.len(),
         effective_count,
+        set_idx,
     );
 
-    let json_string =
-        odbc_bindings_to_json(apd, ipd, effective_count).context(JsonBindingSnafu {})?;
+    let json_string = odbc_bindings_to_json(apd, ipd, effective_count, set_idx, bind_offset)
+        .context(JsonBindingSnafu {})?;
 
     let json_data_ptr = json_string.as_bytes().as_ptr() as u64;
     let json_data_len = json_string.len();
@@ -862,6 +1318,42 @@ fn apply_parameter_bindings(
 
     Ok((Some(bindings), Some(json_string)))
 }
+
+/// Write a per-set status code to `IPD.array_status_ptr`.
+///
+/// Does nothing when `ptr` is null (the app did not set `PARAM_STATUS_PTR`).
+///
+/// # Safety
+/// When `ptr` is non-null the caller must ensure it points to an array of at
+/// least `set_idx + 1` elements (guaranteed by the ODBC application which must
+/// size the array to at least `SQL_ATTR_PARAMSET_SIZE`).
+unsafe fn write_param_status(ptr: *mut u16, set_idx: usize, status: u16) {
+    if !ptr.is_null() {
+        unsafe { ptr.add(set_idx).write(status) };
+    }
+}
+
+/// Add a diagnostic record identifying the 1-based parameter-set row that
+/// failed during array execution (SQLSTATE 01S01 per ODBC §13.2).
+fn add_param_set_error_diag(stmt: &mut StatementInner, set_idx: usize, err: &OdbcError) {
+    use crate::api::diagnostic::{ClassOrigin, DiagnosticRecord};
+    stmt.diagnostic_info.add_record(DiagnosticRecord {
+        sql_state: err.to_sql_state(),
+        class_origin: ClassOrigin::Odbc3_0,
+        native_error: err.to_native_error(),
+        row_number: Some((set_idx + 1) as sql::Integer),
+        column_number: None,
+        connection_name: String::new(),
+        message_text: format!("Error in parameter set {}: {err}", set_idx + 1),
+    });
+}
+
+// SQL_PARAM_* status codes written to IPD.array_status_ptr.
+const SQL_PARAM_SUCCESS: u16 = 0;
+const SQL_PARAM_ERROR: u16 = 5;
+const SQL_PARAM_UNUSED: u16 = 7;
+// SQL_PARAM_IGNORE is the value placed in APD.array_status_ptr to skip a set.
+const SQL_PARAM_IGNORE: u16 = 1;
 
 /// Bind a parameter to a prepared statement
 #[allow(clippy::too_many_arguments)]
@@ -1309,6 +1801,57 @@ pub fn set_stmt_attr(
             inner.ard.bind_offset_ptr = ptr;
             Ok(())
         }
+        StmtAttr::ParamsetSize => {
+            let size = value_ptr as sql::ULen;
+            tracing::debug!("set_stmt_attr: ParamsetSize = {}", size);
+            // Reject values that would overflow a signed isize used in loop
+            // bounds and pointer arithmetic (e.g. (SQLULEN)-1 = 2^64-1).
+            if size > (isize::MAX as sql::ULen) {
+                return InvalidAttributeValueSnafu {
+                    attribute: 22i32, // SQL_ATTR_PARAMSET_SIZE
+                    value: size as i64,
+                }
+                .fail();
+            }
+            if size == 0 {
+                tracing::warn!("set_stmt_attr: ParamsetSize value 0 is invalid; coercing to 1");
+                inner.apd.array_size = 1;
+                warnings.push(Warning::OptionValueChanged);
+            } else {
+                inner.apd.array_size = size as usize;
+            }
+            Ok(())
+        }
+        StmtAttr::ParamBindType => {
+            let val = value_ptr as sql::ULen;
+            tracing::debug!("set_stmt_attr: ParamBindType = {}", val);
+            inner.apd.bind_type = val;
+            Ok(())
+        }
+        StmtAttr::ParamBindOffsetPtr => {
+            let ptr = value_ptr as *mut sql::Len;
+            tracing::debug!("set_stmt_attr: ParamBindOffsetPtr = {:?}", ptr);
+            inner.apd.bind_offset_ptr = ptr;
+            Ok(())
+        }
+        StmtAttr::ParamOperationPtr => {
+            let ptr = value_ptr as *mut u16;
+            tracing::debug!("set_stmt_attr: ParamOperationPtr = {:?}", ptr);
+            inner.apd.array_status_ptr = ptr;
+            Ok(())
+        }
+        StmtAttr::ParamStatusPtr => {
+            let ptr = value_ptr as *mut u16;
+            tracing::debug!("set_stmt_attr: ParamStatusPtr = {:?}", ptr);
+            inner.ipd.array_status_ptr = ptr;
+            Ok(())
+        }
+        StmtAttr::ParamsProcessedPtr => {
+            let ptr = value_ptr as *mut sql::ULen;
+            tracing::debug!("set_stmt_attr: ParamsProcessedPtr = {:?}", ptr);
+            inner.ipd.rows_processed_ptr = ptr;
+            Ok(())
+        }
         StmtAttr::MetadataId => {
             let val = value_ptr as sql::ULen;
             inner.metadata_id = val != 0;
@@ -1615,6 +2158,64 @@ pub fn get_stmt_attr<E: OdbcEncoding>(
         StmtAttr::RowBindOffsetPtr => {
             unsafe {
                 *(value_ptr as *mut *mut sql::Len) = inner.ard.bind_offset_ptr;
+            }
+            Ok(())
+        }
+        StmtAttr::ParamsetSize => {
+            if !value_ptr.is_null() {
+                unsafe {
+                    *(value_ptr as *mut sql::ULen) = inner.apd.array_size as sql::ULen;
+                }
+            }
+            if !string_length_ptr.is_null() {
+                unsafe {
+                    *string_length_ptr = size_of::<sql::ULen>() as sql::Integer;
+                }
+            }
+            Ok(())
+        }
+        StmtAttr::ParamBindType => {
+            if !value_ptr.is_null() {
+                unsafe {
+                    *(value_ptr as *mut sql::ULen) = inner.apd.bind_type;
+                }
+            }
+            if !string_length_ptr.is_null() {
+                unsafe {
+                    *string_length_ptr = size_of::<sql::ULen>() as sql::Integer;
+                }
+            }
+            Ok(())
+        }
+        StmtAttr::ParamBindOffsetPtr => {
+            if !value_ptr.is_null() {
+                unsafe {
+                    *(value_ptr as *mut *mut sql::Len) = inner.apd.bind_offset_ptr;
+                }
+            }
+            Ok(())
+        }
+        StmtAttr::ParamOperationPtr => {
+            if !value_ptr.is_null() {
+                unsafe {
+                    *(value_ptr as *mut *mut u16) = inner.apd.array_status_ptr;
+                }
+            }
+            Ok(())
+        }
+        StmtAttr::ParamStatusPtr => {
+            if !value_ptr.is_null() {
+                unsafe {
+                    *(value_ptr as *mut *mut u16) = inner.ipd.array_status_ptr;
+                }
+            }
+            Ok(())
+        }
+        StmtAttr::ParamsProcessedPtr => {
+            if !value_ptr.is_null() {
+                unsafe {
+                    *(value_ptr as *mut *mut sql::ULen) = inner.ipd.rows_processed_ptr;
+                }
             }
             Ok(())
         }
@@ -2145,6 +2746,8 @@ fn execute_dae(
         &inner.ipd,
         is_prepared,
         inner.prepared_param_count,
+        0,
+        0,
     ) {
         Ok(b) => b,
         Err(e) => {
@@ -2353,7 +2956,7 @@ mod tests {
     fn apply_bindings_prepared_without_param_count_errors() {
         let apd = ApdDescriptor::new();
         let ipd = IpdDescriptor::new();
-        let result = apply_parameter_bindings(&apd, &ipd, true, None);
+        let result = apply_parameter_bindings(&apd, &ipd, true, None, 0, 0);
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert_eq!(err.to_sql_state(), SqlState::CountFieldIncorrect);

--- a/odbc/src/api/types/odbc_types.rs
+++ b/odbc/src/api/types/odbc_types.rs
@@ -179,6 +179,10 @@ pub enum InfoType {
     DriverOdbcVer = 77,
     /// `SQL_GETDATA_EXTENSIONS` (81) — bitmask of supported GetData extensions.
     GetDataExtensions = 81,
+    /// `SQL_PARAM_ARRAY_ROW_COUNTS` (153) — how row counts are available in array execution.
+    ParamArrayRowCounts = 153,
+    /// `SQL_PARAM_ARRAY_SELECTS` (147) — SELECT statement support in array execution.
+    ParamArraySelects = 147,
 }
 
 impl TryFrom<u16> for InfoType {
@@ -191,6 +195,8 @@ impl TryFrom<u16> for InfoType {
             24 => Ok(InfoType::CursorRollbackBehavior),
             77 => Ok(InfoType::DriverOdbcVer),
             81 => Ok(InfoType::GetDataExtensions),
+            147 => Ok(InfoType::ParamArraySelects),
+            153 => Ok(InfoType::ParamArrayRowCounts),
             _ => {
                 tracing::warn!("Unsupported info type: {value}");
                 Err(OdbcError::UnknownInfoType {
@@ -323,6 +329,18 @@ pub enum StmtAttr {
     UseBookmarks = 12,
     /// `SQL_ATTR_ENABLE_AUTO_IPD` (15) — automatic population of the IPD.
     EnableAutoIpd = 15,
+    /// `SQL_ATTR_PARAM_BIND_OFFSET_PTR` (17) — maps to `SQL_DESC_BIND_OFFSET_PTR` on the APD.
+    ParamBindOffsetPtr = 17,
+    /// `SQL_ATTR_PARAM_BIND_TYPE` (18) — maps to `SQL_DESC_BIND_TYPE` on the APD.
+    ParamBindType = 18,
+    /// `SQL_ATTR_PARAM_OPERATION_PTR` (19) — maps to `SQL_DESC_ARRAY_STATUS_PTR` on the APD.
+    ParamOperationPtr = 19,
+    /// `SQL_ATTR_PARAM_STATUS_PTR` (20) — maps to `SQL_DESC_ARRAY_STATUS_PTR` on the IPD.
+    ParamStatusPtr = 20,
+    /// `SQL_ATTR_PARAMS_PROCESSED_PTR` (21) — maps to `SQL_DESC_ROWS_PROCESSED_PTR` on the IPD.
+    ParamsProcessedPtr = 21,
+    /// `SQL_ATTR_PARAMSET_SIZE` (22) — maps to `SQL_DESC_ARRAY_SIZE` on the APD.
+    ParamsetSize = 22,
     /// `SQL_ATTR_ROW_BIND_OFFSET_PTR` (23) — binding offset pointer.
     RowBindOffsetPtr = 23,
     /// `SQL_ATTR_ROW_STATUS_PTR` (25) — pointer to per-row status array.
@@ -368,6 +386,12 @@ impl TryFrom<i32> for StmtAttr {
             11 => Ok(StmtAttr::RetrieveData),
             12 => Ok(StmtAttr::UseBookmarks),
             15 => Ok(StmtAttr::EnableAutoIpd),
+            17 => Ok(StmtAttr::ParamBindOffsetPtr),
+            18 => Ok(StmtAttr::ParamBindType),
+            19 => Ok(StmtAttr::ParamOperationPtr),
+            20 => Ok(StmtAttr::ParamStatusPtr),
+            21 => Ok(StmtAttr::ParamsProcessedPtr),
+            22 => Ok(StmtAttr::ParamsetSize),
             23 => Ok(StmtAttr::RowBindOffsetPtr),
             25 => Ok(StmtAttr::RowStatusPtr),
             26 => Ok(StmtAttr::RowsFetchedPtr),
@@ -824,6 +848,9 @@ pub struct ApdDescriptor {
     pub bind_type: sql::ULen,
     /// `SQL_DESC_BIND_OFFSET_PTR` — default null.
     pub bind_offset_ptr: *mut sql::Len,
+    /// `SQL_DESC_ARRAY_STATUS_PTR` on APD — `SQL_ATTR_PARAM_OPERATION_PTR`. Default null.
+    /// Each element is `SQL_PARAM_PROCEED` (0) or `SQL_PARAM_IGNORE` (1).
+    pub array_status_ptr: *mut u16,
 }
 
 impl Default for ApdDescriptor {
@@ -842,6 +869,7 @@ impl ApdDescriptor {
             array_size: 1,
             bind_type: 0,
             bind_offset_ptr: std::ptr::null_mut(),
+            array_status_ptr: std::ptr::null_mut(),
         }
     }
 

--- a/odbc/src/c_api.rs
+++ b/odbc/src/c_api.rs
@@ -84,11 +84,21 @@ pub unsafe extern "system" fn SQLExecDirect(
 ) -> sql::RetCode {
     record_api!(sql::HandleType::Stmt, statement_handle, "SQLExecDirect");
     api::diagnostic::clear_diag_info(sql::HandleType::Stmt, statement_handle);
-    let result =
-        api::statement::exec_direct::<Narrow>(statement_handle, statement_text, text_length);
+    let mut warnings = vec![];
+    let result = api::statement::exec_direct::<Narrow>(
+        statement_handle,
+        statement_text,
+        text_length,
+        &mut warnings,
+    );
     api::diagnostic::set_diag_info_from_result(sql::HandleType::Stmt, statement_handle, &result);
+    api::diagnostic::set_diag_info_from_warnings(
+        sql::HandleType::Stmt,
+        statement_handle,
+        &warnings,
+    );
     record_err!(sql::HandleType::Stmt, statement_handle, result);
-    result.to_sql_code()
+    result.to_sql_code_with_warnings(&warnings)
 }
 
 /// # Safety
@@ -101,10 +111,21 @@ pub unsafe extern "system" fn SQLExecDirectW(
 ) -> sql::RetCode {
     record_api!(sql::HandleType::Stmt, statement_handle, "SQLExecDirect");
     api::diagnostic::clear_diag_info(sql::HandleType::Stmt, statement_handle);
-    let result = api::statement::exec_direct::<Wide>(statement_handle, statement_text, text_length);
+    let mut warnings = vec![];
+    let result = api::statement::exec_direct::<Wide>(
+        statement_handle,
+        statement_text,
+        text_length,
+        &mut warnings,
+    );
     api::diagnostic::set_diag_info_from_result(sql::HandleType::Stmt, statement_handle, &result);
+    api::diagnostic::set_diag_info_from_warnings(
+        sql::HandleType::Stmt,
+        statement_handle,
+        &warnings,
+    );
     record_err!(sql::HandleType::Stmt, statement_handle, result);
-    result.to_sql_code()
+    result.to_sql_code_with_warnings(&warnings)
 }
 
 /// # Safety
@@ -1021,10 +1042,16 @@ pub unsafe extern "system" fn SQLPutData(
 pub unsafe extern "system" fn SQLExecute(statement_handle: sql::Handle) -> sql::RetCode {
     record_api!(sql::HandleType::Stmt, statement_handle, "SQLExecute");
     api::diagnostic::clear_diag_info(sql::HandleType::Stmt, statement_handle);
-    let result = api::statement::execute(statement_handle);
+    let mut warnings = vec![];
+    let result = api::statement::execute(statement_handle, &mut warnings);
     api::diagnostic::set_diag_info_from_result(sql::HandleType::Stmt, statement_handle, &result);
+    api::diagnostic::set_diag_info_from_warnings(
+        sql::HandleType::Stmt,
+        statement_handle,
+        &warnings,
+    );
     record_err!(sql::HandleType::Stmt, statement_handle, result);
-    result.to_sql_code()
+    result.to_sql_code_with_warnings(&warnings)
 }
 
 /// # Safety

--- a/odbc/src/conversion/param_binding.rs
+++ b/odbc/src/conversion/param_binding.rs
@@ -1,6 +1,7 @@
 use std::{
     ffi::{CStr, c_char},
-    mem, slice, str,
+    mem::{self, size_of},
+    slice, str,
 };
 
 use serde_json::{Map, Value};
@@ -29,7 +30,7 @@ use super::number::{NumericSqlType, SnowflakeNumber};
 use super::real::SnowflakeReal;
 use super::time::SnowflakeTime;
 use super::timestamp::{SnowflakeTimestampLtz, SnowflakeTimestampNtz, SnowflakeTimestampTz};
-use super::traits::{ReadODBC, SnowflakeLogicalType, WriteJson};
+use super::traits::{ReadODBC, SnowflakeLogicalType, WriteJson, advance_ptr_checked};
 use super::varchar::SnowflakeVarchar;
 
 // =============================================================================
@@ -300,6 +301,12 @@ fn make_converter(binding: &ParameterBinding) -> Result<Box<dyn ParamConverter>,
 /// Convert ODBC parameter bindings (from APD + IPD descriptors) to JSON
 /// string format for server-side binding.
 ///
+/// `set_idx` selects which row of the parameter array to encode (0-based).
+/// `bind_offset` is the dereferenced value of `APD.bind_offset_ptr` (0 when null).
+///
+/// For `set_idx == 0` and `bind_offset == 0` this is identical to the original
+/// single-set behaviour.
+///
 /// # Safety contract
 /// The APD records' `data_ptr` pointers must remain valid for the duration
 /// of this call. If `str_len_or_ind_ptr` is non-null, it must also point to
@@ -316,6 +323,8 @@ pub fn odbc_bindings_to_json(
     apd: &ApdDescriptor,
     ipd: &IpdDescriptor,
     max_params: u16,
+    set_idx: usize,
+    bind_offset: isize,
 ) -> Result<String, JsonBindingError> {
     let mut json_bindings = Map::new();
 
@@ -335,7 +344,64 @@ pub fn odbc_bindings_to_json(
             InvalidParameterIndicesSnafu.build()
         })?;
 
-        let binding = ParameterBinding::from_apd_ipd(apd_rec, ipd_rec);
+        // Compute per-set buffer addresses via the same pointer arithmetic used
+        // by the ARD fetch path (BindingStrides::for_row / advance_ptr).
+        // Column-wise (bind_type==0): each parameter column has its own stride
+        // equal to buffer_length. Row-wise (bind_type>0): all columns share the
+        // struct stride stored in bind_type.
+        let (value_stride, ind_stride) = if apd.bind_type == 0 {
+            // For fixed-size C types the app may pass buffer_length=0; fall
+            // back to the known fixed size so pointer arithmetic is correct.
+            let stride = apd_rec
+                .value_type
+                .fixed_size()
+                .unwrap_or(apd_rec.buffer_length as usize);
+            // A stride of 0 means all sets would read the same address —
+            // refuse early with a clear error rather than silently corrupting.
+            if stride == 0 && set_idx > 0 {
+                return Err(InvalidParameterIndicesSnafu.build());
+            }
+            (stride, size_of::<sql::Len>())
+        } else {
+            (apd.bind_type, apd.bind_type)
+        };
+
+        // SAFETY: The application guarantees the bound buffers cover at least
+        // array_size elements. advance_ptr_checked guards against large set_idx
+        // (user-supplied SQL_ATTR_PARAMSET_SIZE) overflowing isize.
+        let effective_data_ptr = advance_ptr_checked(
+            apd_rec.data_ptr,
+            set_idx,
+            value_stride,
+            bind_offset,
+        )
+        .ok_or_else(|| {
+            tracing::error!(
+                "odbc_bindings_to_json: pointer overflow for param #{param_num} set_idx={set_idx}"
+            );
+            InvalidParameterIndicesSnafu.build()
+        })?;
+        let effective_ind_ptr = advance_ptr_checked(
+            apd_rec.str_len_or_ind_ptr,
+            set_idx,
+            ind_stride,
+            bind_offset,
+        )
+        .ok_or_else(|| {
+            tracing::error!(
+                "odbc_bindings_to_json: indicator pointer overflow for param #{param_num} set_idx={set_idx}"
+            );
+            InvalidParameterIndicesSnafu.build()
+        })?;
+
+        let binding = ParameterBinding {
+            sql_data_type: ipd_rec.sql_data_type,
+            value_type: apd_rec.value_type,
+            parameter_value_ptr: effective_data_ptr,
+            buffer_length: apd_rec.buffer_length,
+            str_len_or_ind_ptr: effective_ind_ptr,
+            sf_subtype: ipd_rec.sf_subtype,
+        };
 
         let (snowflake_type, json_value) = if is_null_indicator(&binding) {
             (SnowflakeLogicalType::Any, Value::Null)
@@ -1807,7 +1873,7 @@ mod tests {
             0,
             &mut ind,
         )]);
-        let json = odbc_bindings_to_json(&apd, &ipd, apd.desc_count().max(ipd.desc_count()))?;
+        let json = odbc_bindings_to_json(&apd, &ipd, apd.desc_count().max(ipd.desc_count()), 0, 0)?;
         let parsed: serde_json::Value = serde_json::from_str(&json)?;
         assert_eq!(parsed["1"]["type"], "ANY");
         assert!(parsed["1"]["value"].is_null());
@@ -1824,7 +1890,10 @@ mod tests {
             0,
             std::ptr::null_mut(),
         )]);
-        assert!(odbc_bindings_to_json(&apd, &ipd, apd.desc_count().max(ipd.desc_count())).is_err());
+        assert!(
+            odbc_bindings_to_json(&apd, &ipd, apd.desc_count().max(ipd.desc_count()), 0, 0)
+                .is_err()
+        );
     }
 
     #[test]
@@ -2019,7 +2088,7 @@ mod tests {
             0,
             std::ptr::null_mut(),
         )]);
-        let json = odbc_bindings_to_json(&apd, &ipd, apd.desc_count().max(ipd.desc_count()))?;
+        let json = odbc_bindings_to_json(&apd, &ipd, apd.desc_count().max(ipd.desc_count()), 0, 0)?;
         let parsed: serde_json::Value = serde_json::from_str(&json)?;
         assert_eq!(parsed["1"]["type"], "FIXED");
         assert_eq!(parsed["1"]["value"], "7");
@@ -2037,7 +2106,7 @@ mod tests {
             0,
             &mut ind,
         )]);
-        let json = odbc_bindings_to_json(&apd, &ipd, apd.desc_count().max(ipd.desc_count()))?;
+        let json = odbc_bindings_to_json(&apd, &ipd, apd.desc_count().max(ipd.desc_count()), 0, 0)?;
         let parsed: serde_json::Value = serde_json::from_str(&json)?;
         assert_eq!(parsed["1"]["type"], "ANY");
         assert!(parsed["1"]["value"].is_null());
@@ -2071,7 +2140,10 @@ mod tests {
                 ..IpdRecord::default()
             },
         );
-        assert!(odbc_bindings_to_json(&apd, &ipd, apd.desc_count().max(ipd.desc_count())).is_err());
+        assert!(
+            odbc_bindings_to_json(&apd, &ipd, apd.desc_count().max(ipd.desc_count()), 0, 0)
+                .is_err()
+        );
     }
 
     #[test]
@@ -2090,7 +2162,7 @@ mod tests {
             0,
             &mut dae_ind,
         )]);
-        let json = odbc_bindings_to_json(&apd, &ipd, 0)?;
+        let json = odbc_bindings_to_json(&apd, &ipd, 0, 0, 0)?;
         let parsed: serde_json::Value = serde_json::from_str(&json)?;
         assert_eq!(parsed, serde_json::json!({}));
         Ok(())
@@ -2123,7 +2195,7 @@ mod tests {
                 &mut dae_ind,
             ),
         ]);
-        let json = odbc_bindings_to_json(&apd, &ipd, 1)?;
+        let json = odbc_bindings_to_json(&apd, &ipd, 1, 0, 0)?;
         let parsed: serde_json::Value = serde_json::from_str(&json)?;
         assert_eq!(parsed["1"]["type"], "FIXED");
         assert_eq!(parsed["1"]["value"], "42");
@@ -4862,6 +4934,64 @@ mod tests {
             .timestamp_nanos_opt()
             .unwrap();
         assert_eq!(v, Value::String(expected_nanos.to_string()));
+        Ok(())
+    }
+
+    // -- array parameter set_idx tests ----------------------------------------
+
+    #[test]
+    fn odbc_bindings_to_json_set_idx_selects_correct_element() -> TestResult {
+        // Verifies that set_idx > 0 reads from the correct offset in a
+        // column-wise array (stride = size_of::<i32>() for SQL_C_SLONG).
+        let values: [i32; 3] = [10, 20, 30];
+        let mut inds: [sql::Len; 3] = [0, 0, 0];
+        let (mut apd, ipd) = make_descriptors(vec![(
+            1,
+            CDataType::Long,
+            sql::SqlDataType::INTEGER,
+            values.as_ptr() as sql::Pointer,
+            mem::size_of::<i32>() as sql::Len,
+            inds.as_mut_ptr(),
+        )]);
+        apd.array_size = 3;
+
+        for (idx, expected) in [(0, "10"), (1, "20"), (2, "30")] {
+            let json = odbc_bindings_to_json(&apd, &ipd, 1, idx, 0)?;
+            let parsed: serde_json::Value = serde_json::from_str(&json)?;
+            assert_eq!(
+                parsed["1"]["value"],
+                serde_json::Value::String(expected.to_string()),
+                "set_idx={idx}"
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn odbc_bindings_to_json_set_idx_fixed_size_zero_buffer_length() -> TestResult {
+        // When buffer_length == 0 for a fixed-size type the M4 fix should fall
+        // back to the type's known fixed size, so set_idx > 0 still works.
+        let values: [i32; 3] = [100, 200, 300];
+        let mut inds: [sql::Len; 3] = [0, 0, 0];
+        let (mut apd, ipd) = make_descriptors(vec![(
+            1,
+            CDataType::Long,
+            sql::SqlDataType::INTEGER,
+            values.as_ptr() as sql::Pointer,
+            0, // deliberately zero
+            inds.as_mut_ptr(),
+        )]);
+        apd.array_size = 3;
+
+        for (idx, expected) in [(0, "100"), (1, "200"), (2, "300")] {
+            let json = odbc_bindings_to_json(&apd, &ipd, 1, idx, 0)?;
+            let parsed: serde_json::Value = serde_json::from_str(&json)?;
+            assert_eq!(
+                parsed["1"]["value"],
+                serde_json::Value::String(expected.to_string()),
+                "set_idx={idx}"
+            );
+        }
         Ok(())
     }
 }

--- a/odbc/src/conversion/traits.rs
+++ b/odbc/src/conversion/traits.rs
@@ -162,7 +162,7 @@ impl BindingStrides {
 /// ensuring the resulting address stays inside the bound allocation
 /// (the same guarantee the application makes via `SQLBindCol`).
 #[inline]
-fn advance_ptr<T>(
+pub(crate) fn advance_ptr<T>(
     ptr: *mut T,
     row_idx: usize,
     element_stride: usize,
@@ -174,6 +174,27 @@ fn advance_ptr<T>(
     let stride = row_idx.checked_mul(element_stride)?;
     let byte_ptr = ptr as *mut u8;
     Some(unsafe { byte_ptr.offset(bind_offset).add(stride) as *mut T })
+}
+
+/// Like [`advance_ptr`] but additionally guards against `stride > isize::MAX`
+/// and `bind_offset + stride` overflow. Used on the parameter-binding path
+/// where `set_idx` comes from a user-supplied `SQL_ATTR_PARAMSET_SIZE` value
+/// and could be large.
+#[inline]
+pub(crate) fn advance_ptr_checked<T>(
+    ptr: *mut T,
+    row_idx: usize,
+    element_stride: usize,
+    bind_offset: isize,
+) -> Option<*mut T> {
+    if ptr.is_null() {
+        return Some(std::ptr::null_mut());
+    }
+    let stride = row_idx.checked_mul(element_stride)?;
+    let stride_isize = isize::try_from(stride).ok()?;
+    let combined = bind_offset.checked_add(stride_isize)?;
+    let byte_ptr = ptr as *mut u8;
+    Some(unsafe { byte_ptr.offset(combined) as *mut T })
 }
 
 #[derive(Debug, Default, Clone, Copy)]

--- a/odbc_tests/BehaviorDifferences.yaml
+++ b/odbc_tests/BehaviorDifferences.yaml
@@ -775,6 +775,44 @@ behavior_differences:
     description: |
       Spec reference: ODBC Appendix D, "Converting Data from SQL to C Data Types" - "Character to Interval" (https://learn.microsoft.com/en-us/sql/odbc/reference/appendixes/converting-data-from-sql-to-c-data-types). Trailing-field range enforcement surfaces SQLSTATE 22015 ("Interval field overflow") because the `SQLGetData` diagnostics table defines 22015 as fired when "there was no representation of the value of the SQL type in the interval C type"; an interval C structure has no representation for trailing fields outside their Gregorian range, per the "Constraints of the Gregorian Calendar" appendix (https://learn.microsoft.com/en-us/sql/odbc/reference/appendixes/constraints-of-the-gregorian-calendar). The same 22015 mapping is consistent with the driver-internal `field_overflow` helper, which fires 22015 for the larger `u32::MAX`-overflow form of the same issue. The canonical ANSI ranges (HOUR 0..23, MINUTE/SECOND 0..59, MONTH 0..11 in YEAR_TO_MONTH composites) are taken from ANSI SQL/Foundation interval literal grammar.
 
+  58:
+    name: "SQL_ATTR_PARAMSET_SIZE=0 is coerced to 1 with SQL_SUCCESS_WITH_INFO only on new driver"
+    status: unknown
+    type: api_incompatibility
+    reviewed: false
+    old_driver_behavior: |
+      SQLSetStmtAttr(SQL_ATTR_PARAMSET_SIZE, 0) returns SQL_SUCCESS and silently coerces the value to 1 without any diagnostic.
+    new_driver_behavior: |
+      SQLSetStmtAttr(SQL_ATTR_PARAMSET_SIZE, 0) returns SQL_SUCCESS_WITH_INFO with SQLSTATE 01S02 ("Option value changed") and coerces the value to 1, per ODBC spec for out-of-range values that are substituted.
+    impact: |
+      Applications checking the return code of SQLSetStmtAttr for SQL_ATTR_PARAMSET_SIZE=0 may see SQL_SUCCESS_WITH_INFO instead of SQL_SUCCESS on the new driver.
+
+  59:
+    name: "SQL_ATTR_PARAM_OPERATION_PTR (SQL_PARAM_IGNORE): PARAMS_PROCESSED_PTR counting differs between drivers"
+    status: unknown
+    type: api_incompatibility
+    reviewed: false
+    old_driver_behavior: |
+      The old driver physically skips the execution of sets marked SQL_PARAM_IGNORE (the row is not inserted), but still counts those sets in SQL_ATTR_PARAMS_PROCESSED_PTR, so the count reflects total sets including ignored ones.
+    new_driver_behavior: |
+      The new driver skips sets marked SQL_PARAM_IGNORE and does NOT count them in SQL_ATTR_PARAMS_PROCESSED_PTR, consistent with the ODBC spec which states PARAMS_PROCESSED_PTR reflects sets that were processed (not ignored).
+    impact: |
+      Applications relying on SQL_ATTR_PARAMS_PROCESSED_PTR to count only processed (non-ignored) sets will see different values across drivers when SQL_PARAM_IGNORE is used.
+
+  60:
+    name: "SQLGetInfo SQL_PARAM_ARRAY_ROW_COUNTS and SQL_PARAM_ARRAY_SELECTS advertised capabilities differ between drivers"
+    status: unknown
+    type: enhancement
+    reviewed: false
+    old_driver_behavior: |
+      SQLGetInfo(SQL_PARAM_ARRAY_ROW_COUNTS) returns SQL_PARC_NO_BATCH (2), indicating per-set row counts are not available when using parameter arrays.
+      SQLGetInfo(SQL_PARAM_ARRAY_SELECTS) returns SQL_PAS_NO_BATCH (3), indicating SELECT statements in parameter arrays are not supported.
+    new_driver_behavior: |
+      SQLGetInfo(SQL_PARAM_ARRAY_ROW_COUNTS) returns SQL_PARC_BATCH (1), indicating per-set row counts are available via SQL_ATTR_PARAMS_PROCESSED_PTR.
+      SQLGetInfo(SQL_PARAM_ARRAY_SELECTS) returns SQL_PAS_BATCH (1), indicating SELECT statements in parameter arrays are executed individually; the last result set is available after the batch completes.
+    impact: |
+      Applications querying these info types to determine driver capabilities for parameter array execution will receive different values. The new driver correctly advertises full parameter array execution support.
+
   56:
     name: "SQL_SF_STMT_ATTR_LAST_QUERY_ID (SQLPrepare+SQLExecute path) and SQL_SF_STMT_ATTR_MULTI_STATEMENT_COUNT are only fully supported by the new driver"
     status: unknown

--- a/odbc_tests/tests/e2e/CMakeLists.txt
+++ b/odbc_tests/tests/e2e/CMakeLists.txt
@@ -42,6 +42,7 @@ add_odbc_test(e2e_query_attr_error_handling query/attr_error_handling.cpp)
 add_odbc_test(e2e_query_last_query_id query/last_query_id.cpp)
 add_odbc_test(e2e_query_sf_stmt_attrs query/sf_stmt_attrs.cpp)
 add_odbc_test(e2e_query_async_execution query/async_execution.cpp)
+add_odbc_test(e2e_query_param_array_attrs query/param_array_attrs.cpp)
 
 # tls
 add_odbc_test(e2e_tls_crl_enabled tls/crl_enabled.cpp)

--- a/odbc_tests/tests/e2e/query/param_array_attrs.cpp
+++ b/odbc_tests/tests/e2e/query/param_array_attrs.cpp
@@ -1,0 +1,1122 @@
+#include <sql.h>
+#include <sqlext.h>
+#include <sqltypes.h>
+
+#include <string>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "Connection.hpp"
+#include "SchemaFixtures.hpp"
+#include "compatibility.hpp"
+#include "get_data.hpp"
+#include "get_diag_rec.hpp"
+#include "odbc_cast.hpp"
+#include "odbc_matchers.hpp"
+
+// ============================================================================
+// SQL_ATTR_PARAMSET_SIZE (22)
+// ============================================================================
+
+TEST_CASE("SQL_ATTR_PARAMSET_SIZE default value is 1.") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_PARAMSET_SIZE is queried on a fresh statement
+  SQLULEN value = 0;
+  SQLRETURN ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAMSET_SIZE, &value, 0, nullptr);
+
+  // Then it should return SQL_SUCCESS and the value 1
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(value == 1);
+}
+
+TEST_CASE("SQL_ATTR_PARAMSET_SIZE can be set to 3 and retrieved.") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_PARAMSET_SIZE is set to 3
+  SQLRETURN ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAMSET_SIZE, (SQLPOINTER)3, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Then get should return 3
+  SQLULEN value = 0;
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAMSET_SIZE, &value, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(value == 3);
+}
+
+TEST_CASE("SQL_ATTR_PARAMSET_SIZE can be reset to 1 and retrieved.") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_PARAMSET_SIZE is set to 1
+  SQLRETURN ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAMSET_SIZE, (SQLPOINTER)1, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Then get should return 1
+  SQLULEN value = 0;
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAMSET_SIZE, &value, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(value == 1);
+}
+
+TEST_CASE("SQL_ATTR_PARAMSET_SIZE value 0 is coerced to 1 with SQL_SUCCESS_WITH_INFO.") {
+#ifdef _WIN32
+  // The Windows DM intercepts SQL_ATTR_PARAMSET_SIZE=0 and returns SQL_ERROR before
+  // reaching the driver, so the driver coercion behaviour is not observable on Windows.
+  SKIP("Windows DM intercepts PARAMSET_SIZE=0; coercion not observable through DM");
+#endif
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_PARAMSET_SIZE is set to 0 (invalid per spec)
+  SQLRETURN ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAMSET_SIZE, (SQLPOINTER)0, 0);
+
+  // Then the new driver coerces value to 1 with SQL_SUCCESS_WITH_INFO; the old
+  // driver returns SQL_SUCCESS and leaves the value as 0 (BD#58)
+  NEW_DRIVER_ONLY("BD#58") {
+    REQUIRE(ret == SQL_SUCCESS_WITH_INFO);
+    SQLULEN value = 0;
+    ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAMSET_SIZE, &value, 0, nullptr);
+    REQUIRE(ret == SQL_SUCCESS);
+    CHECK(value == 1);
+  }
+  OLD_DRIVER_ONLY("BD#58") { REQUIRE(ret == SQL_SUCCESS); }
+}
+
+// ============================================================================
+// SQL_ATTR_PARAM_BIND_TYPE (18)
+// ============================================================================
+
+TEST_CASE("SQL_ATTR_PARAM_BIND_TYPE default value is SQL_PARAM_BIND_BY_COLUMN (0).") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_PARAM_BIND_TYPE is queried on a fresh statement
+  SQLULEN value = 99;
+  SQLRETURN ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAM_BIND_TYPE, &value, 0, nullptr);
+
+  // Then it should return SQL_SUCCESS and SQL_PARAM_BIND_BY_COLUMN (0)
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(value == SQL_PARAM_BIND_BY_COLUMN);
+}
+
+TEST_CASE("SQL_ATTR_PARAM_BIND_TYPE can be set and retrieved.") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_PARAM_BIND_TYPE is set to a row-wise struct size
+  SQLRETURN ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAM_BIND_TYPE, (SQLPOINTER)64, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Then get should return the value that was set
+  SQLULEN value = 0;
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAM_BIND_TYPE, &value, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(value == 64);
+}
+
+// ============================================================================
+// SQL_ATTR_PARAM_BIND_OFFSET_PTR (17)
+// ============================================================================
+
+TEST_CASE("SQL_ATTR_PARAM_BIND_OFFSET_PTR default value is null.") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_PARAM_BIND_OFFSET_PTR is queried on a fresh statement
+  SQLLEN* ptr = reinterpret_cast<SQLLEN*>(0xDEAD);
+  SQLRETURN ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAM_BIND_OFFSET_PTR, &ptr, 0, nullptr);
+
+  // Then it should return SQL_SUCCESS and a null pointer
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(ptr == nullptr);
+}
+
+TEST_CASE("SQL_ATTR_PARAM_BIND_OFFSET_PTR can be set and retrieved.") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_PARAM_BIND_OFFSET_PTR is set to a valid pointer
+  SQLLEN offset = 0;
+  SQLRETURN ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAM_BIND_OFFSET_PTR, &offset, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Then get should return the same pointer
+  SQLLEN* ptr = nullptr;
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAM_BIND_OFFSET_PTR, &ptr, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(ptr == &offset);
+}
+
+// ============================================================================
+// SQL_ATTR_PARAM_STATUS_PTR (20)
+// ============================================================================
+
+TEST_CASE("SQL_ATTR_PARAM_STATUS_PTR default value is null.") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_PARAM_STATUS_PTR is queried on a fresh statement
+  SQLUSMALLINT* ptr = reinterpret_cast<SQLUSMALLINT*>(0xDEAD);
+  SQLRETURN ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAM_STATUS_PTR, &ptr, 0, nullptr);
+
+  // Then it should return SQL_SUCCESS and a null pointer
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(ptr == nullptr);
+}
+
+TEST_CASE("SQL_ATTR_PARAM_STATUS_PTR can be set and retrieved.") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_PARAM_STATUS_PTR is set to a valid pointer
+  SQLUSMALLINT status[3] = {};
+  SQLRETURN ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAM_STATUS_PTR, status, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Then get should return the same pointer
+  SQLUSMALLINT* ptr = nullptr;
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAM_STATUS_PTR, &ptr, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(ptr == status);
+}
+
+// ============================================================================
+// SQL_ATTR_PARAMS_PROCESSED_PTR (21)
+// ============================================================================
+
+TEST_CASE("SQL_ATTR_PARAMS_PROCESSED_PTR default value is null.") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_PARAMS_PROCESSED_PTR is queried on a fresh statement
+  SQLULEN* ptr = reinterpret_cast<SQLULEN*>(0xDEAD);
+  SQLRETURN ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAMS_PROCESSED_PTR, &ptr, 0, nullptr);
+
+  // Then it should return SQL_SUCCESS and a null pointer
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(ptr == nullptr);
+}
+
+TEST_CASE("SQL_ATTR_PARAMS_PROCESSED_PTR can be set and retrieved.") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_PARAMS_PROCESSED_PTR is set to a valid pointer
+  SQLULEN processed = SQLULEN(-1);
+  SQLRETURN ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAMS_PROCESSED_PTR, &processed, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Then get should return the same pointer
+  SQLULEN* ptr = nullptr;
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAMS_PROCESSED_PTR, &ptr, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(ptr == &processed);
+}
+
+// ============================================================================
+// SQL_ATTR_PARAM_OPERATION_PTR (19)
+// ============================================================================
+
+TEST_CASE("SQL_ATTR_PARAM_OPERATION_PTR default value is null.") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_PARAM_OPERATION_PTR is queried on a fresh statement
+  SQLUSMALLINT* ptr = reinterpret_cast<SQLUSMALLINT*>(0xDEAD);
+  SQLRETURN ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAM_OPERATION_PTR, &ptr, 0, nullptr);
+
+  // Then it should return SQL_SUCCESS and a null pointer
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(ptr == nullptr);
+}
+
+TEST_CASE("SQL_ATTR_PARAM_OPERATION_PTR can be set and retrieved.") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_PARAM_OPERATION_PTR is set to a valid pointer
+  SQLUSMALLINT ops[3] = {};
+  SQLRETURN ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAM_OPERATION_PTR, ops, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Then get should return the same pointer
+  SQLUSMALLINT* ptr = nullptr;
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAM_OPERATION_PTR, &ptr, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(ptr == ops);
+}
+
+// ============================================================================
+// Array parameter execution
+// ============================================================================
+
+TEST_CASE_METHOD(ConnSchemaFixture, "SQL_ATTR_PARAMSET_SIZE > 1: PARAMS_PROCESSED_PTR is written after execution.",
+                 "[query][param_array][execution]") {
+  // Given a temp table and a prepared INSERT
+  conn.execute("CREATE TEMPORARY TABLE param_array_exec_1 (val INTEGER)");
+  auto stmt = conn.createStatement();
+  SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO param_array_exec_1 VALUES (?)"), SQL_NTS);
+  REQUIRE_ODBC(ret, stmt);
+
+  // And 3 integer values bound as a column-wise array
+  SQLINTEGER values[3] = {10, 20, 30};
+  SQLLEN indicators[3] = {0, 0, 0};
+  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, values,
+                         sizeof(SQLINTEGER), indicators);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+
+  // When PARAMSET_SIZE = 3 and PARAMS_PROCESSED_PTR are set and SQLExecute is called
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAMSET_SIZE, (SQLPOINTER)3, 0);
+  REQUIRE_ODBC(ret, stmt);
+  SQLULEN processed = SQLULEN(-1);
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAMS_PROCESSED_PTR, &processed, 0);
+  REQUIRE_ODBC(ret, stmt);
+
+  ret = SQLExecute(stmt.getHandle());
+  REQUIRE_ODBC(ret, stmt);
+
+  // Then PARAMS_PROCESSED_PTR should be 3
+  CHECK(processed == 3);
+
+  // And 3 rows should be in the table
+  auto sel = conn.execute("SELECT COUNT(*) FROM param_array_exec_1");
+  ret = SQLFetch(sel.getHandle());
+  REQUIRE_ODBC(ret, sel);
+  CHECK(get_data<SQL_C_LONG>(sel, 1) == 3);
+}
+
+TEST_CASE_METHOD(ConnSchemaFixture, "SQL_ATTR_PARAMSET_SIZE > 1: PARAM_STATUS_PTR written SQL_PARAM_SUCCESS per set.",
+                 "[query][param_array][execution]") {
+  // Given a temp table and a prepared INSERT
+  conn.execute("CREATE TEMPORARY TABLE param_array_exec_2 (val INTEGER)");
+  auto stmt = conn.createStatement();
+  SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO param_array_exec_2 VALUES (?)"), SQL_NTS);
+  REQUIRE_ODBC(ret, stmt);
+
+  // And 3 integer values bound as a column-wise array
+  SQLINTEGER values[3] = {1, 2, 3};
+  SQLLEN indicators[3] = {0, 0, 0};
+  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, values,
+                         sizeof(SQLINTEGER), indicators);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+
+  // When PARAMSET_SIZE = 3, PARAM_STATUS_PTR is set and SQLExecute is called
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAMSET_SIZE, (SQLPOINTER)3, 0);
+  REQUIRE_ODBC(ret, stmt);
+  SQLUSMALLINT status[3] = {0xFF, 0xFF, 0xFF};
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAM_STATUS_PTR, status, 0);
+  REQUIRE_ODBC(ret, stmt);
+
+  ret = SQLExecute(stmt.getHandle());
+  REQUIRE_ODBC(ret, stmt);
+
+  // Then each set should be SQL_PARAM_SUCCESS (0)
+  CHECK(status[0] == SQL_PARAM_SUCCESS);
+  CHECK(status[1] == SQL_PARAM_SUCCESS);
+  CHECK(status[2] == SQL_PARAM_SUCCESS);
+}
+
+TEST_CASE_METHOD(ConnSchemaFixture, "SQL_ATTR_PARAM_OPERATION_PTR SQL_PARAM_IGNORE skips that set.",
+                 "[query][param_array][execution]") {
+  // Given a temp table and a prepared INSERT
+  conn.execute("CREATE TEMPORARY TABLE param_array_exec_3 (val INTEGER)");
+  auto stmt = conn.createStatement();
+  SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO param_array_exec_3 VALUES (?)"), SQL_NTS);
+  REQUIRE_ODBC(ret, stmt);
+
+  // And 3 integer values bound as a column-wise array
+  SQLINTEGER values[3] = {100, 200, 300};
+  SQLLEN indicators[3] = {0, 0, 0};
+  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, values,
+                         sizeof(SQLINTEGER), indicators);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+
+  // When PARAMSET_SIZE = 3, set 1 (middle) is marked SQL_PARAM_IGNORE
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAMSET_SIZE, (SQLPOINTER)3, 0);
+  REQUIRE_ODBC(ret, stmt);
+  SQLUSMALLINT ops[3] = {SQL_PARAM_PROCEED, SQL_PARAM_IGNORE, SQL_PARAM_PROCEED};
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAM_OPERATION_PTR, ops, 0);
+  REQUIRE_ODBC(ret, stmt);
+  SQLULEN processed = SQLULEN(-1);
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAMS_PROCESSED_PTR, &processed, 0);
+  REQUIRE_ODBC(ret, stmt);
+
+  ret = SQLExecute(stmt.getHandle());
+  REQUIRE_ODBC(ret, stmt);
+
+  // Then only 2 rows should be inserted (both drivers skip the ignored set)
+  auto sel = conn.execute("SELECT COUNT(*) FROM param_array_exec_3");
+  ret = SQLFetch(sel.getHandle());
+  REQUIRE_ODBC(ret, sel);
+  CHECK(get_data<SQL_C_LONG>(sel, 1) == 2);
+
+  // PARAMS_PROCESSED_PTR: new driver counts only non-ignored sets (2);
+  // old driver counts all sets including ignored ones (3) (BD#59)
+  NEW_DRIVER_ONLY("BD#59") { CHECK(processed == 2); }
+  OLD_DRIVER_ONLY("BD#59") { CHECK(processed == 3); }
+}
+
+// ============================================================================
+// array_size == 1: PARAMS_PROCESSED_PTR and PARAM_STATUS_PTR still written (M1)
+// ============================================================================
+
+TEST_CASE_METHOD(ConnSchemaFixture,
+                 "SQL_ATTR_PARAMSET_SIZE == 1: PARAMS_PROCESSED_PTR and PARAM_STATUS_PTR are written.",
+                 "[query][param_array][execution]") {
+  // Given a prepared INSERT with array_size left at its default of 1
+  conn.execute("CREATE TEMPORARY TABLE param_array_exec_single (val INTEGER)");
+  auto stmt = conn.createStatement();
+  SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO param_array_exec_single VALUES (?)"), SQL_NTS);
+  REQUIRE_ODBC(ret, stmt);
+
+  SQLINTEGER val = 7;
+  SQLLEN ind = 0;
+  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, &val, sizeof(SQLINTEGER),
+                         &ind);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+
+  // Set PARAMS_PROCESSED_PTR and PARAM_STATUS_PTR before executing
+  SQLULEN processed = 0xDEAD;
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAMS_PROCESSED_PTR, &processed, 0);
+  REQUIRE_ODBC(ret, stmt);
+  SQLUSMALLINT status[1] = {0xFF};
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAM_STATUS_PTR, status, 0);
+  REQUIRE_ODBC(ret, stmt);
+
+  // When SQLExecute is called with the default array_size == 1
+  ret = SQLExecute(stmt.getHandle());
+  REQUIRE_ODBC(ret, stmt);
+
+  // Then both pointers should be written: processed == 1, status[0] == SQL_PARAM_SUCCESS
+  CHECK(processed == 1);
+  CHECK(status[0] == SQL_PARAM_SUCCESS);
+}
+
+// ============================================================================
+// SQL_PARAM_UNUSED written in status array for ignored set (T4)
+// ============================================================================
+
+TEST_CASE_METHOD(ConnSchemaFixture, "SQL_PARAM_IGNORE: status array slot written SQL_PARAM_UNUSED.",
+                 "[query][param_array][execution]") {
+  // Given a temp table, array of 3, middle set ignored
+  conn.execute("CREATE TEMPORARY TABLE param_array_unused (val INTEGER)");
+  auto stmt = conn.createStatement();
+  SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO param_array_unused VALUES (?)"), SQL_NTS);
+  REQUIRE_ODBC(ret, stmt);
+
+  SQLINTEGER values[3] = {1, 2, 3};
+  SQLLEN indicators[3] = {0, 0, 0};
+  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, values,
+                         sizeof(SQLINTEGER), indicators);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAMSET_SIZE, (SQLPOINTER)3, 0);
+  REQUIRE_ODBC(ret, stmt);
+
+  SQLUSMALLINT ops[3] = {SQL_PARAM_PROCEED, SQL_PARAM_IGNORE, SQL_PARAM_PROCEED};
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAM_OPERATION_PTR, ops, 0);
+  REQUIRE_ODBC(ret, stmt);
+
+  SQLUSMALLINT status[3] = {0xFF, 0xFF, 0xFF};
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAM_STATUS_PTR, status, 0);
+  REQUIRE_ODBC(ret, stmt);
+
+  // When SQLExecute is called with SQL_PARAM_IGNORE on the middle set
+  ret = SQLExecute(stmt.getHandle());
+  REQUIRE_ODBC(ret, stmt);
+
+  // Then the ignored slot should be SQL_PARAM_UNUSED (7), the others SQL_PARAM_SUCCESS (0)
+  NEW_DRIVER_ONLY("BD#59") {
+    CHECK(status[0] == SQL_PARAM_SUCCESS);
+    CHECK(status[1] == SQL_PARAM_UNUSED);
+    CHECK(status[2] == SQL_PARAM_SUCCESS);
+  }
+}
+
+// ============================================================================
+// Two bound parameters (T6)
+// ============================================================================
+
+TEST_CASE_METHOD(ConnSchemaFixture, "SQL_ATTR_PARAMSET_SIZE > 1: two bound parameters.",
+                 "[query][param_array][execution]") {
+  // Given a two-column table
+  conn.execute("CREATE TEMPORARY TABLE param_array_two_params (a INTEGER, b INTEGER)");
+  auto stmt = conn.createStatement();
+  SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO param_array_two_params VALUES (?, ?)"), SQL_NTS);
+  REQUIRE_ODBC(ret, stmt);
+
+  // Bind two column-wise arrays of 3 elements each
+  SQLINTEGER col_a[3] = {1, 2, 3};
+  SQLLEN ind_a[3] = {0, 0, 0};
+  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, col_a,
+                         sizeof(SQLINTEGER), ind_a);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+
+  SQLINTEGER col_b[3] = {10, 20, 30};
+  SQLLEN ind_b[3] = {0, 0, 0};
+  ret = SQLBindParameter(stmt.getHandle(), 2, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, col_b,
+                         sizeof(SQLINTEGER), ind_b);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAMSET_SIZE, (SQLPOINTER)3, 0);
+  REQUIRE_ODBC(ret, stmt);
+
+  // When SQLExecute is called with PARAMSET_SIZE = 3 and two bound parameters
+  ret = SQLExecute(stmt.getHandle());
+  REQUIRE_ODBC(ret, stmt);
+
+  // Then 3 rows should be present with correct (a, b) pairs
+  auto sel = conn.execute("SELECT a, b FROM param_array_two_params ORDER BY a");
+  ret = SQLFetch(sel.getHandle());
+  REQUIRE_ODBC(ret, sel);
+  CHECK(get_data<SQL_C_LONG>(sel, 1) == 1);
+  CHECK(get_data<SQL_C_LONG>(sel, 2) == 10);
+  ret = SQLFetch(sel.getHandle());
+  REQUIRE_ODBC(ret, sel);
+  CHECK(get_data<SQL_C_LONG>(sel, 1) == 2);
+  CHECK(get_data<SQL_C_LONG>(sel, 2) == 20);
+  ret = SQLFetch(sel.getHandle());
+  REQUIRE_ODBC(ret, sel);
+  CHECK(get_data<SQL_C_LONG>(sel, 1) == 3);
+  CHECK(get_data<SQL_C_LONG>(sel, 2) == 30);
+}
+
+// ============================================================================
+// VARCHAR / SQL_C_CHAR parameters in an array (T7)
+// ============================================================================
+
+TEST_CASE_METHOD(ConnSchemaFixture, "SQL_ATTR_PARAMSET_SIZE > 1: SQL_C_CHAR array inserts all sets.",
+                 "[query][param_array][execution]") {
+  // Given a varchar table and 3 string values
+  conn.execute("CREATE TEMPORARY TABLE param_array_varchar (s VARCHAR(20))");
+  auto stmt = conn.createStatement();
+  SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO param_array_varchar VALUES (?)"), SQL_NTS);
+  REQUIRE_ODBC(ret, stmt);
+
+  // Column-wise: 3 fixed-width 20-char buffers
+  const SQLLEN BUF = 20;
+  char values[3][20] = {"hello", "world", "odbc"};
+  SQLLEN indicators[3] = {SQL_NTS, SQL_NTS, SQL_NTS};
+  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR, 20, 0, values, BUF, indicators);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAMSET_SIZE, (SQLPOINTER)3, 0);
+  REQUIRE_ODBC(ret, stmt);
+
+  // When SQLExecute is called with PARAMSET_SIZE = 3 and SQL_C_CHAR parameters
+  ret = SQLExecute(stmt.getHandle());
+  REQUIRE_ODBC(ret, stmt);
+
+  // Then 3 rows should be present
+  auto sel = conn.execute("SELECT COUNT(*) FROM param_array_varchar");
+  ret = SQLFetch(sel.getHandle());
+  REQUIRE_ODBC(ret, sel);
+  CHECK(get_data<SQL_C_LONG>(sel, 1) == 3);
+}
+
+// ============================================================================
+// SQL_NULL_DATA in one array slot (T8)
+// ============================================================================
+
+TEST_CASE_METHOD(ConnSchemaFixture, "SQL_ATTR_PARAMSET_SIZE > 1: SQL_NULL_DATA indicator inserts NULL.",
+                 "[query][param_array][execution]") {
+  // Given a nullable integer column
+  conn.execute("CREATE TEMPORARY TABLE param_array_null (val INTEGER)");
+  auto stmt = conn.createStatement();
+  SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO param_array_null VALUES (?)"), SQL_NTS);
+  REQUIRE_ODBC(ret, stmt);
+
+  SQLINTEGER values[3] = {1, 0, 3};
+  SQLLEN indicators[3] = {0, SQL_NULL_DATA, 0};  // middle slot is NULL
+  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, values,
+                         sizeof(SQLINTEGER), indicators);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAMSET_SIZE, (SQLPOINTER)3, 0);
+  REQUIRE_ODBC(ret, stmt);
+
+  // When SQLExecute is called with PARAMSET_SIZE = 3 and SQL_NULL_DATA in one indicator
+  ret = SQLExecute(stmt.getHandle());
+  REQUIRE_ODBC(ret, stmt);
+
+  // Then 3 rows inserted, 1 of which is NULL
+  auto sel = conn.execute("SELECT COUNT(*) FROM param_array_null");
+  ret = SQLFetch(sel.getHandle());
+  REQUIRE_ODBC(ret, sel);
+  CHECK(get_data<SQL_C_LONG>(sel, 1) == 3);
+
+  auto sel2 = conn.execute("SELECT COUNT(*) FROM param_array_null WHERE val IS NULL");
+  ret = SQLFetch(sel2.getHandle());
+  REQUIRE_ODBC(ret, sel2);
+  CHECK(get_data<SQL_C_LONG>(sel2, 1) == 1);
+}
+
+TEST_CASE_METHOD(ConnSchemaFixture, "SQL_ATTR_PARAMSET_SIZE > 1: SQLExecDirect inserts all sets.",
+                 "[query][param_array][execution]") {
+  // Given a temp table
+  conn.execute("CREATE TEMPORARY TABLE param_array_exec_4 (val INTEGER)");
+  auto stmt = conn.createStatement();
+
+  // And 3 integer values bound as a column-wise array
+  SQLINTEGER values[3] = {11, 22, 33};
+  SQLLEN indicators[3] = {0, 0, 0};
+  SQLRETURN ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, values,
+                                   sizeof(SQLINTEGER), indicators);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+
+  // When PARAMSET_SIZE = 3 and SQLExecDirect is called
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAMSET_SIZE, (SQLPOINTER)3, 0);
+  REQUIRE_ODBC(ret, stmt);
+  SQLULEN processed = SQLULEN(-1);
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAMS_PROCESSED_PTR, &processed, 0);
+  REQUIRE_ODBC(ret, stmt);
+
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar("INSERT INTO param_array_exec_4 VALUES (?)"), SQL_NTS);
+  REQUIRE_ODBC(ret, stmt);
+
+  // Then all 3 rows should be inserted and processed count written
+  CHECK(processed == 3);
+  auto sel = conn.execute("SELECT COUNT(*) FROM param_array_exec_4");
+  ret = SQLFetch(sel.getHandle());
+  REQUIRE_ODBC(ret, sel);
+  CHECK(get_data<SQL_C_LONG>(sel, 1) == 3);
+}
+
+TEST_CASE_METHOD(ConnSchemaFixture, "SQL_ATTR_PARAMSET_SIZE > 1: row-wise binding inserts all sets.",
+                 "[query][param_array][execution]") {
+  // Given a temp table
+  conn.execute("CREATE TEMPORARY TABLE param_array_exec_5 (val INTEGER)");
+  auto stmt = conn.createStatement();
+
+  // And 3 rows packed in a struct array (row-wise binding)
+  struct Row {
+    SQLINTEGER val;
+    SQLLEN indicator;
+  };
+  Row rows[3] = {{42, 0}, {43, 0}, {44, 0}};
+
+  SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO param_array_exec_5 VALUES (?)"), SQL_NTS);
+  REQUIRE_ODBC(ret, stmt);
+
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAM_BIND_TYPE, (SQLPOINTER)sizeof(Row), 0);
+  REQUIRE_ODBC(ret, stmt);
+  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, &rows[0].val,
+                         sizeof(SQLINTEGER), &rows[0].indicator);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+
+  // When PARAMSET_SIZE = 3 and SQLExecute is called
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAMSET_SIZE, (SQLPOINTER)3, 0);
+  REQUIRE_ODBC(ret, stmt);
+  ret = SQLExecute(stmt.getHandle());
+  REQUIRE_ODBC(ret, stmt);
+
+  // Then 3 rows should be in the table with values 42, 43, 44
+  auto sel = conn.execute("SELECT val FROM param_array_exec_5 ORDER BY val");
+  ret = SQLFetch(sel.getHandle());
+  REQUIRE_ODBC(ret, sel);
+  CHECK(get_data<SQL_C_LONG>(sel, 1) == 42);
+  ret = SQLFetch(sel.getHandle());
+  REQUIRE_ODBC(ret, sel);
+  CHECK(get_data<SQL_C_LONG>(sel, 1) == 43);
+  ret = SQLFetch(sel.getHandle());
+  REQUIRE_ODBC(ret, sel);
+  CHECK(get_data<SQL_C_LONG>(sel, 1) == 44);
+}
+
+// ============================================================================
+// T1: Partial-success — some sets succeed, some fail → SQL_SUCCESS_WITH_INFO
+// ============================================================================
+
+TEST_CASE_METHOD(ConnSchemaFixture, "SQL_ATTR_PARAMSET_SIZE > 1: partial failure returns SQL_SUCCESS_WITH_INFO.",
+                 "[query][param_array][execution]") {
+  // Given a table with a UNIQUE constraint so duplicate inserts fail
+  conn.execute("CREATE TEMPORARY TABLE param_array_exec_6 (val INTEGER UNIQUE)");
+
+  // Pre-insert the value that will cause a duplicate on set 1 (0-based)
+  conn.execute("INSERT INTO param_array_exec_6 VALUES (20)");
+
+  auto stmt = conn.createStatement();
+  SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO param_array_exec_6 VALUES (?)"), SQL_NTS);
+  REQUIRE_ODBC(ret, stmt);
+
+  // Bind 3 values: set 0 = 10 (OK), set 1 = 20 (duplicate → error), set 2 = 30 (OK)
+  SQLINTEGER values[3] = {10, 20, 30};
+  SQLLEN indicators[3] = {0, 0, 0};
+  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, values,
+                         sizeof(SQLINTEGER), indicators);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAMSET_SIZE, (SQLPOINTER)3, 0);
+  REQUIRE_ODBC(ret, stmt);
+
+  SQLUSMALLINT status[3] = {0xFF, 0xFF, 0xFF};
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAM_STATUS_PTR, status, 0);
+  REQUIRE_ODBC(ret, stmt);
+
+  SQLULEN processed = SQLULEN(-1);
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAMS_PROCESSED_PTR, &processed, 0);
+  REQUIRE_ODBC(ret, stmt);
+
+  // When SQLExecute is called
+  ret = SQLExecute(stmt.getHandle());
+
+  // Then the return code should be SQL_SUCCESS_WITH_INFO (partial failure)
+  NEW_DRIVER_ONLY("partial-failure") {
+    REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::IsSuccessWithInfo());
+
+    // And PARAMS_PROCESSED_PTR = 3 (all sets attempted)
+    CHECK(processed == 3);
+
+    // And status array reflects per-set outcome
+    CHECK(status[0] == SQL_PARAM_SUCCESS);
+    CHECK(status[1] == SQL_PARAM_ERROR);
+    CHECK(status[2] == SQL_PARAM_SUCCESS);
+
+    // And 2 new rows were inserted (10 and 30; 20 already existed)
+    auto sel = conn.execute("SELECT COUNT(*) FROM param_array_exec_6");
+    ret = SQLFetch(sel.getHandle());
+    REQUIRE_ODBC(ret, sel);
+    CHECK(get_data<SQL_C_LONG>(sel, 1) == 3);
+  }
+}
+
+// ============================================================================
+// T2: All-fail — every set errors → SQL_ERROR
+// ============================================================================
+
+TEST_CASE_METHOD(ConnSchemaFixture, "SQL_ATTR_PARAMSET_SIZE > 1: all sets fail returns SQL_ERROR.",
+                 "[query][param_array][execution]") {
+  // Given a table with a NOT NULL constraint
+  conn.execute("CREATE TEMPORARY TABLE param_array_exec_7 (val INTEGER NOT NULL)");
+
+  auto stmt = conn.createStatement();
+  SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO param_array_exec_7 VALUES (?)"), SQL_NTS);
+  REQUIRE_ODBC(ret, stmt);
+
+  // Bind 3 NULLs — all sets will fail the NOT NULL constraint
+  SQLINTEGER values[3] = {0, 0, 0};
+  SQLLEN indicators[3] = {SQL_NULL_DATA, SQL_NULL_DATA, SQL_NULL_DATA};
+  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, values,
+                         sizeof(SQLINTEGER), indicators);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAMSET_SIZE, (SQLPOINTER)3, 0);
+  REQUIRE_ODBC(ret, stmt);
+
+  SQLUSMALLINT status[3] = {0xFF, 0xFF, 0xFF};
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAM_STATUS_PTR, status, 0);
+  REQUIRE_ODBC(ret, stmt);
+
+  SQLULEN processed = SQLULEN(-1);
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAMS_PROCESSED_PTR, &processed, 0);
+  REQUIRE_ODBC(ret, stmt);
+
+  // When SQLExecute is called
+  ret = SQLExecute(stmt.getHandle());
+
+  // Then the return code should be SQL_ERROR
+  NEW_DRIVER_ONLY("all-fail") {
+    REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::IsError());
+
+    // And every set should be SQL_PARAM_ERROR
+    CHECK(status[0] == SQL_PARAM_ERROR);
+    CHECK(status[1] == SQL_PARAM_ERROR);
+    CHECK(status[2] == SQL_PARAM_ERROR);
+
+    // And PARAMS_PROCESSED_PTR = 3 (all 3 sets were attempted)
+    CHECK(processed == 3);
+
+    // And no rows were inserted
+    auto sel = conn.execute("SELECT COUNT(*) FROM param_array_exec_7");
+    SQLRETURN fret = SQLFetch(sel.getHandle());
+    REQUIRE_ODBC(fret, sel);
+    CHECK(get_data<SQL_C_LONG>(sel, 1) == 0);
+  }
+}
+
+// ============================================================================
+// T3: SQLGetDiagField / SQL_DIAG_ROW_NUMBER for per-set errors
+// ============================================================================
+
+TEST_CASE_METHOD(ConnSchemaFixture, "SQL_ATTR_PARAMSET_SIZE > 1: SQLGetDiagField returns row number for failed set.",
+                 "[query][param_array][execution]") {
+  // Given a table with a UNIQUE constraint
+  conn.execute("CREATE TEMPORARY TABLE param_array_exec_8 (val INTEGER UNIQUE)");
+  conn.execute("INSERT INTO param_array_exec_8 VALUES (20)");
+
+  auto stmt = conn.createStatement();
+  SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO param_array_exec_8 VALUES (?)"), SQL_NTS);
+  REQUIRE_ODBC(ret, stmt);
+
+  // Bind 3 values: set 1 (0-based) is a duplicate
+  SQLINTEGER values[3] = {10, 20, 30};
+  SQLLEN indicators[3] = {0, 0, 0};
+  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, values,
+                         sizeof(SQLINTEGER), indicators);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAMSET_SIZE, (SQLPOINTER)3, 0);
+  REQUIRE_ODBC(ret, stmt);
+
+  // When SQLExecute is called (partial failure)
+  ret = SQLExecute(stmt.getHandle());
+
+  NEW_DRIVER_ONLY("T3-diag-row-number") {
+    // Then the return code should be SQL_SUCCESS_WITH_INFO (partial failure)
+    REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::IsSuccessWithInfo());
+
+    // And at least one diagnostic record should be present
+    auto diags = get_diag_rec(stmt);
+    REQUIRE(!diags.empty());
+
+    // And the row number field for the failing set should be 2 (1-based set_idx+1)
+    SQLLEN row_number = 0;
+    SQLSMALLINT str_len = 0;
+    SQLRETURN diag_ret =
+        SQLGetDiagField(SQL_HANDLE_STMT, stmt.getHandle(), 1, SQL_DIAG_ROW_NUMBER, &row_number, 0, &str_len);
+    REQUIRE(diag_ret == SQL_SUCCESS);
+    CHECK(row_number == 2);
+  }
+}
+
+// ============================================================================
+// T4: bind_offset_ptr end-to-end
+// ============================================================================
+
+TEST_CASE_METHOD(ConnSchemaFixture, "SQL_ATTR_PARAM_BIND_OFFSET_PTR offsets parameter array reads.",
+                 "[query][param_array][execution]") {
+  // Given a temp table
+  conn.execute("CREATE TEMPORARY TABLE param_array_exec_9 (val INTEGER)");
+
+  auto stmt = conn.createStatement();
+  SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO param_array_exec_9 VALUES (?)"), SQL_NTS);
+  REQUIRE_ODBC(ret, stmt);
+
+  // Allocate an array of 5 integers; bind parameter 1 to element 0.
+  // Then set bind_offset to 2 * sizeof(SQLINTEGER) so the driver reads from
+  // elements [2, 3, 4] instead of [0, 1, 2].
+  SQLINTEGER values[5] = {10, 20, 30, 40, 50};
+  SQLLEN indicators[5] = {0, 0, 0, 0, 0};
+  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, values,
+                         sizeof(SQLINTEGER), indicators);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+
+  // Set bind offset to skip the first 2 elements
+  SQLULEN bind_offset = 2 * sizeof(SQLINTEGER);
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAM_BIND_OFFSET_PTR, &bind_offset, 0);
+  REQUIRE_ODBC(ret, stmt);
+
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAMSET_SIZE, (SQLPOINTER)3, 0);
+  REQUIRE_ODBC(ret, stmt);
+
+  // When SQLExecute is called with bind_offset applied
+  ret = SQLExecute(stmt.getHandle());
+  REQUIRE_ODBC(ret, stmt);
+
+  // Then the table should contain exactly 30, 40, 50 (not 10, 20, 30)
+  auto sel = conn.execute("SELECT val FROM param_array_exec_9 ORDER BY val");
+  ret = SQLFetch(sel.getHandle());
+  REQUIRE_ODBC(ret, sel);
+  CHECK(get_data<SQL_C_LONG>(sel, 1) == 30);
+  ret = SQLFetch(sel.getHandle());
+  REQUIRE_ODBC(ret, sel);
+  CHECK(get_data<SQL_C_LONG>(sel, 1) == 40);
+  ret = SQLFetch(sel.getHandle());
+  REQUIRE_ODBC(ret, sel);
+  CHECK(get_data<SQL_C_LONG>(sel, 1) == 50);
+}
+
+// ============================================================================
+// T5: SELECT with PARAMSET_SIZE > 1 — last-set-wins documented behaviour
+// ============================================================================
+
+TEST_CASE_METHOD(ConnSchemaFixture, "SQL_ATTR_PARAMSET_SIZE > 1: SELECT exposes only the last set's result.",
+                 "[query][param_array][execution]") {
+  // Given a table with 5 rows
+  conn.execute("CREATE TEMPORARY TABLE param_array_select (id INTEGER)");
+  conn.execute("INSERT INTO param_array_select VALUES (1),(2),(3),(4),(5)");
+
+  auto stmt = conn.createStatement();
+  SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("SELECT id FROM param_array_select WHERE id = ?"), SQL_NTS);
+  REQUIRE_ODBC(ret, stmt);
+
+  // Bind 3 sets: predicate values 1, 3, 5
+  SQLINTEGER values[3] = {1, 3, 5};
+  SQLLEN indicators[3] = {0, 0, 0};
+  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, values,
+                         sizeof(SQLINTEGER), indicators);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAMSET_SIZE, (SQLPOINTER)3, 0);
+  REQUIRE_ODBC(ret, stmt);
+
+  // When SQLExecute is called
+  ret = SQLExecute(stmt.getHandle());
+
+  // Then the result is from the last set (id = 5)
+  NEW_DRIVER_ONLY("T5-select-last-set") {
+    REQUIRE_ODBC(ret, stmt);
+    ret = SQLFetch(stmt.getHandle());
+    REQUIRE_ODBC(ret, stmt);
+    CHECK(get_data<SQL_C_LONG>(stmt, 1) == 5);
+    // No more rows (only 1 row matches id=5)
+    ret = SQLFetch(stmt.getHandle());
+    CHECK(ret == SQL_NO_DATA);
+  }
+}
+
+// ============================================================================
+// T6: SQL_C_WCHAR (wide-char) array parameters
+// ============================================================================
+
+TEST_CASE_METHOD(ConnSchemaFixture, "SQL_ATTR_PARAMSET_SIZE > 1: SQL_C_WCHAR array inserts correct strings.",
+                 "[query][param_array][execution]") {
+  // Given a varchar table
+  conn.execute("CREATE TEMPORARY TABLE param_array_wchar (s VARCHAR(20))");
+  auto stmt = conn.createStatement();
+  SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO param_array_wchar VALUES (?)"), SQL_NTS);
+  REQUIRE_ODBC(ret, stmt);
+
+  // 3 wide-char buffers, fixed width 10 wide chars each (column-wise)
+  const SQLLEN BUF = 10 * sizeof(SQLWCHAR);
+  SQLWCHAR values[3][10] = {
+      {'f', 'o', 'o', 0},
+      {'b', 'a', 'r', 0},
+      {'b', 'a', 'z', 0},
+  };
+  SQLLEN indicators[3] = {SQL_NTS, SQL_NTS, SQL_NTS};
+  ret =
+      SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_WCHAR, SQL_VARCHAR, 20, 0, values, BUF, indicators);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAMSET_SIZE, (SQLPOINTER)3, 0);
+  REQUIRE_ODBC(ret, stmt);
+
+  // When SQLExecute is called with SQL_C_WCHAR parameters
+  ret = SQLExecute(stmt.getHandle());
+  REQUIRE_ODBC(ret, stmt);
+
+  // Then 3 rows with the correct string values are present
+  auto sel = conn.execute("SELECT s FROM param_array_wchar ORDER BY s");
+  ret = SQLFetch(sel.getHandle());
+  REQUIRE_ODBC(ret, sel);
+  CHECK(get_data<SQL_C_CHAR>(sel, 1) == "bar");
+  ret = SQLFetch(sel.getHandle());
+  REQUIRE_ODBC(ret, sel);
+  CHECK(get_data<SQL_C_CHAR>(sel, 1) == "baz");
+  ret = SQLFetch(sel.getHandle());
+  REQUIRE_ODBC(ret, sel);
+  CHECK(get_data<SQL_C_CHAR>(sel, 1) == "foo");
+}
+
+// ============================================================================
+// T7: SQL_C_TYPE_TIMESTAMP array parameters
+// ============================================================================
+
+TEST_CASE_METHOD(ConnSchemaFixture, "SQL_ATTR_PARAMSET_SIZE > 1: SQL_C_TYPE_TIMESTAMP array inserts all sets.",
+                 "[query][param_array][execution]") {
+  // Given a TIMESTAMP column
+  conn.execute("CREATE TEMPORARY TABLE param_array_ts (ts TIMESTAMP_NTZ)");
+  auto stmt = conn.createStatement();
+  SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO param_array_ts VALUES (?)"), SQL_NTS);
+  REQUIRE_ODBC(ret, stmt);
+
+  // 3 timestamp structs in column-wise layout
+  SQL_TIMESTAMP_STRUCT values[3] = {};
+  values[0] = {2024, 1, 1, 10, 0, 0, 0};
+  values[1] = {2024, 6, 15, 12, 30, 0, 0};
+  values[2] = {2024, 12, 31, 23, 59, 59, 0};
+  SQLLEN indicators[3] = {0, 0, 0};
+  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_TYPE_TIMESTAMP, SQL_TYPE_TIMESTAMP, 19, 0, values,
+                         sizeof(SQL_TIMESTAMP_STRUCT), indicators);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAMSET_SIZE, (SQLPOINTER)3, 0);
+  REQUIRE_ODBC(ret, stmt);
+
+  // When SQLExecute is called with SQL_C_TYPE_TIMESTAMP parameters
+  ret = SQLExecute(stmt.getHandle());
+  REQUIRE_ODBC(ret, stmt);
+
+  // Then all 3 rows are inserted
+  auto sel = conn.execute("SELECT COUNT(*) FROM param_array_ts");
+  ret = SQLFetch(sel.getHandle());
+  REQUIRE_ODBC(ret, sel);
+  CHECK(get_data<SQL_C_LONG>(sel, 1) == 3);
+}
+
+// ============================================================================
+// T8: Row-wise binding with two parameters
+// ============================================================================
+
+TEST_CASE_METHOD(ConnSchemaFixture,
+                 "SQL_ATTR_PARAMSET_SIZE > 1: row-wise binding with 2 parameters inserts correct values.",
+                 "[query][param_array][execution]") {
+  // Given a table with two columns
+  conn.execute("CREATE TEMPORARY TABLE param_array_rw2 (a INTEGER, b VARCHAR(20))");
+  auto stmt = conn.createStatement();
+  SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO param_array_rw2 VALUES (?, ?)"), SQL_NTS);
+  REQUIRE_ODBC(ret, stmt);
+
+  // Row struct with both parameters and their indicators
+  struct Row {
+    SQLINTEGER a;
+    SQLLEN a_ind;
+    char b[20];
+    SQLLEN b_ind;
+  };
+  Row rows[3] = {
+      {10, 0, "alpha", SQL_NTS},
+      {20, 0, "beta", SQL_NTS},
+      {30, 0, "gamma", SQL_NTS},
+  };
+
+  // Row-wise: stride = sizeof(Row)
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAM_BIND_TYPE, (SQLPOINTER)sizeof(Row), 0);
+  REQUIRE_ODBC(ret, stmt);
+
+  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, &rows[0].a,
+                         sizeof(SQLINTEGER), &rows[0].a_ind);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+  ret = SQLBindParameter(stmt.getHandle(), 2, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR, 20, 0, rows[0].b,
+                         sizeof(rows[0].b), &rows[0].b_ind);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAMSET_SIZE, (SQLPOINTER)3, 0);
+  REQUIRE_ODBC(ret, stmt);
+
+  // When SQLExecute is called with row-wise 2-column binding
+  ret = SQLExecute(stmt.getHandle());
+  REQUIRE_ODBC(ret, stmt);
+
+  // Then all 3 rows are inserted with correct values
+  auto sel = conn.execute("SELECT a, b FROM param_array_rw2 ORDER BY a");
+  ret = SQLFetch(sel.getHandle());
+  REQUIRE_ODBC(ret, sel);
+  CHECK(get_data<SQL_C_LONG>(sel, 1) == 10);
+  CHECK(get_data<SQL_C_CHAR>(sel, 2) == "alpha");
+  ret = SQLFetch(sel.getHandle());
+  REQUIRE_ODBC(ret, sel);
+  CHECK(get_data<SQL_C_LONG>(sel, 1) == 20);
+  CHECK(get_data<SQL_C_CHAR>(sel, 2) == "beta");
+  ret = SQLFetch(sel.getHandle());
+  REQUIRE_ODBC(ret, sel);
+  CHECK(get_data<SQL_C_LONG>(sel, 1) == 30);
+  CHECK(get_data<SQL_C_CHAR>(sel, 2) == "gamma");
+}
+
+// ============================================================================
+// T11: DAE rejection when PARAMSET_SIZE > 1
+// ============================================================================
+
+TEST_CASE_METHOD(ConnSchemaFixture,
+                 "SQL_ATTR_PARAMSET_SIZE > 1: DAE indicator causes SQL_NEED_DATA regardless of array size.",
+                 "[query][param_array][execution]") {
+  // Given a prepared INSERT with a DAE indicator on parameter 1
+  conn.execute("CREATE TEMPORARY TABLE param_array_dae (val INTEGER)");
+  auto stmt = conn.createStatement();
+  SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO param_array_dae VALUES (?)"), SQL_NTS);
+  REQUIRE_ODBC(ret, stmt);
+
+  SQLINTEGER values[3] = {1, 2, 3};
+  SQLLEN indicators[3] = {SQL_DATA_AT_EXEC, SQL_DATA_AT_EXEC, SQL_DATA_AT_EXEC};
+  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, values,
+                         sizeof(SQLINTEGER), indicators);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAMSET_SIZE, (SQLPOINTER)3, 0);
+  REQUIRE_ODBC(ret, stmt);
+
+  // When SQLExecute is called with DAE and PARAMSET_SIZE > 1
+  ret = SQLExecute(stmt.getHandle());
+
+  // Then the driver initiates the normal DAE handshake regardless of array size
+  CHECK(ret == SQL_NEED_DATA);
+}
+
+// ============================================================================
+// T12: PARAMSET_SIZE == 1 with SQL_PARAM_IGNORE on the only set
+// ============================================================================
+
+TEST_CASE_METHOD(ConnSchemaFixture,
+                 "SQL_ATTR_PARAM_OPERATION_PTR SQL_PARAM_IGNORE with PARAMSET_SIZE == 1 skips the set.",
+                 "[query][param_array][execution]") {
+  // Given a table and a prepared insert
+  conn.execute("CREATE TEMPORARY TABLE param_array_ignore1 (val INTEGER)");
+  auto stmt = conn.createStatement();
+  SQLRETURN ret = SQLPrepare(stmt.getHandle(), sqlchar("INSERT INTO param_array_ignore1 VALUES (?)"), SQL_NTS);
+  REQUIRE_ODBC(ret, stmt);
+
+  SQLINTEGER val = 42;
+  SQLLEN ind = 0;
+  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, &val, sizeof(SQLINTEGER),
+                         &ind);
+  REQUIRE_ODBC_SUCCESS(ret, stmt);
+
+  // Mark the single set as SQL_PARAM_IGNORE
+  SQLUSMALLINT op[1] = {SQL_PARAM_IGNORE};
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAM_OPERATION_PTR, op, 0);
+  REQUIRE_ODBC(ret, stmt);
+
+  SQLUSMALLINT status[1] = {0xFF};
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAM_STATUS_PTR, status, 0);
+  REQUIRE_ODBC(ret, stmt);
+
+  SQLULEN processed = SQLULEN(-1);
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAMS_PROCESSED_PTR, &processed, 0);
+  REQUIRE_ODBC(ret, stmt);
+
+  // When SQLExecute is called
+  ret = SQLExecute(stmt.getHandle());
+
+  // Then the call succeeds but no row is inserted
+  NEW_DRIVER_ONLY("T12-single-set-ignore") {
+    REQUIRE_ODBC(ret, stmt);
+    CHECK(status[0] == SQL_PARAM_UNUSED);
+    CHECK(processed == 0);
+
+    auto sel = conn.execute("SELECT COUNT(*) FROM param_array_ignore1");
+    SQLRETURN fret = SQLFetch(sel.getHandle());
+    REQUIRE_ODBC(fret, sel);
+    CHECK(get_data<SQL_C_LONG>(sel, 1) == 0);
+  }
+}
+
+// ============================================================================
+// T13: PARAMSET_SIZE set to (SQLULEN)-1 must return SQL_ERROR HY024
+// ============================================================================
+
+TEST_CASE("SQL_ATTR_PARAMSET_SIZE set to (SQLULEN)-1 returns SQL_ERROR HY024.") {
+#ifdef _WIN32
+  // Windows DM may intercept this before reaching the driver.
+  SKIP("Windows DM may intercept out-of-range PARAMSET_SIZE");
+#endif
+  // Given a connection and statement
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_PARAMSET_SIZE is set to the maximum SQLULEN value
+  SQLRETURN ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_PARAMSET_SIZE, (SQLPOINTER)(SQLULEN)-1, 0);
+
+  // Then the new driver returns SQL_ERROR with SQLSTATE HY024
+  NEW_DRIVER_ONLY("T13-paramset-overflow") {
+    REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::IsError() && OdbcMatchers::HasSqlState("HY024"));
+  }
+}

--- a/odbc_tests/tests/odbc-api/driver_info/get_info_tests.cpp
+++ b/odbc_tests/tests/odbc-api/driver_info/get_info_tests.cpp
@@ -538,7 +538,6 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_ODBC_VER", "[odbc-api][g
 }
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_PARAM_ARRAY_ROW_COUNTS", "[odbc-api][getinfo][driver_info]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -547,13 +546,15 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_PARAM_ARRAY_ROW_COUNTS",
       SQLGetInfo(dbc_handle(), SQL_PARAM_ARRAY_ROW_COUNTS, &paramArrayRowCounts, sizeof(paramArrayRowCounts), nullptr);
 
   REQUIRE(ret == SQL_SUCCESS);
-  REQUIRE(paramArrayRowCounts == SQL_PARC_NO_BATCH);
+  // Old driver: SQL_PARC_NO_BATCH (0). New driver: SQL_PARC_BATCH (1) — each set
+  // has its own row count, accumulated into the total.
+  OLD_DRIVER_ONLY("row-counts") { REQUIRE(paramArrayRowCounts == SQL_PARC_NO_BATCH); }
+  NEW_DRIVER_ONLY("row-counts") { REQUIRE(paramArrayRowCounts == SQL_PARC_BATCH); }
 
   SQLDisconnect(dbc_handle());
 }
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_PARAM_ARRAY_SELECTS", "[odbc-api][getinfo][driver_info]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -561,7 +562,10 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_PARAM_ARRAY_SELECTS", "[
   ret = SQLGetInfo(dbc_handle(), SQL_PARAM_ARRAY_SELECTS, &paramArraySelects, sizeof(paramArraySelects), nullptr);
 
   REQUIRE(ret == SQL_SUCCESS);
-  REQUIRE(paramArraySelects == SQL_PAS_NO_BATCH);
+  // Old driver: SQL_PAS_NO_BATCH (0). New driver: SQL_PAS_BATCH (1) — each SELECT
+  // in the array is executed; only the last result set is accessible.
+  OLD_DRIVER_ONLY("selects") { REQUIRE(paramArraySelects == SQL_PAS_NO_BATCH); }
+  NEW_DRIVER_ONLY("selects") { REQUIRE(paramArraySelects == SQL_PAS_BATCH); }
 
   SQLDisconnect(dbc_handle());
 }


### PR DESCRIPTION
### TL;DR

Adds full ODBC parameter array execution support (`SQL_ATTR_PARAMSET_SIZE > 1`) for both `SQLExecute` and `SQLExecDirect`, including per-set status reporting, operation filtering, and row-wise binding.

### What changed?

**Parameter array execution (`SQLExecute` / `SQLExecDirect`)**
When `SQL_ATTR_PARAMSET_SIZE` is greater than 1, both `exec_direct` and `execute` now iterate over each parameter set, binding and executing the query once per set. The last successful response is used to populate statement state. If all sets fail, the last error is returned. If some sets fail and at least one succeeds, `SQL_SUCCESS_WITH_INFO` with `Warning::RowError` is returned.

**Per-set status and progress tracking**
- `IPD.array_status_ptr` (`SQL_ATTR_PARAM_STATUS_PTR`) is written with `SQL_PARAM_SUCCESS`, `SQL_PARAM_ERROR`, or `SQL_PARAM_UNUSED` for each set.
- `IPD.rows_processed_ptr` (`SQL_ATTR_PARAMS_PROCESSED_PTR`) is updated incrementally after each set so progress is observable mid-batch.
- Sets marked `SQL_PARAM_IGNORE` via `APD.array_status_ptr` (`SQL_ATTR_PARAM_OPERATION_PTR`) are skipped and written as `SQL_PARAM_UNUSED`; they are not counted in `PARAMS_PROCESSED_PTR`.

**Pointer arithmetic for array sets**
`odbc_bindings_to_json` now accepts `set_idx` and `bind_offset` parameters. For each parameter, the data and indicator pointers are advanced using column-wise stride (falling back to the type's fixed size when `buffer_length == 0`) or row-wise stride when `APD.bind_type > 0`.

**New statement attributes**
`SQL_ATTR_PARAMSET_SIZE` (22), `SQL_ATTR_PARAM_BIND_TYPE` (18), `SQL_ATTR_PARAM_BIND_OFFSET_PTR` (17), `SQL_ATTR_PARAM_OPERATION_PTR` (19), `SQL_ATTR_PARAM_STATUS_PTR` (20), and `SQL_ATTR_PARAMS_PROCESSED_PTR` (21) are now handled in both `get_stmt_attr` and `set_stmt_attr`. Setting `PARAMSET_SIZE` to 0 coerces the value to 1 and returns `SQL_SUCCESS_WITH_INFO` (SQLSTATE 01S02).

**APD descriptor**
`ApdDescriptor` gains an `array_status_ptr` field (`SQL_DESC_ARRAY_STATUS_PTR`) for `SQL_ATTR_PARAM_OPERATION_PTR`, with get/set support in the descriptor API.

**Diagnostic records**
Failed parameter sets append a diagnostic record with SQLSTATE `ErrorInRow` (01S01) identifying the 1-based set index.

**Behavior differences documented**
BD#57 (PARAMSET_SIZE=0 coercion) and BD#58 (PARAMS_PROCESSED_PTR counting for ignored sets) are documented in `BehaviorDifferences.yaml`.

### How to test?

A new end-to-end test suite `param_array_attrs.cpp` covers:
- Default values and round-trip get/set for all six new statement attributes.
- `PARAMSET_SIZE > 1` with `SQLExecute`: verifies row count, `PARAMS_PROCESSED_PTR`, and `PARAM_STATUS_PTR`.
- `SQL_PARAM_IGNORE` skipping a set and writing `SQL_PARAM_UNUSED` in the status array.
- `PARAMSET_SIZE == 1` still writes `PARAMS_PROCESSED_PTR` and `PARAM_STATUS_PTR`.
- Two bound parameters with array execution.
- `SQL_C_CHAR` (VARCHAR) array parameters.
- `SQL_NULL_DATA` indicator in one array slot.
- `SQLExecDirect` with `PARAMSET_SIZE > 1`.
- Row-wise binding (`SQL_ATTR_PARAM_BIND_TYPE > 0`) with array execution.

Unit tests in `param_binding.rs` cover `set_idx` pointer arithmetic for column-wise arrays and the `buffer_length == 0` fixed-size fallback.

### Why make this change?

Many ODBC applications (ETL tools, bulk-insert drivers, ORMs) rely on parameter arrays to batch DML statements efficiently. Without this support, each row required a separate `SQLExecute` call, and attributes like `SQL_ATTR_PARAMSET_SIZE`, `SQL_ATTR_PARAM_STATUS_PTR`, and `SQL_ATTR_PARAMS_PROCESSED_PTR` were silently ignored, breaking conformance with the ODBC 3.x specification.