### PR TITLE
NO-SNOW: ODBC CI: gate packaging builds on installer path changes

### DIFF
--- a/.github/workflows/detect-changes.yml
+++ b/.github/workflows/detect-changes.yml
@@ -61,6 +61,9 @@ on:
       run_nodejs_reference:
         description: "True if Node.js reference tests should run (e2e tests changed)"
         value: ${{ jobs.detect.outputs.run_nodejs_reference }}
+      run_odbc_packaging:
+        description: "True if ODBC packaging (MSI/RPM/DMG) should run"
+        value: ${{ jobs.detect.outputs.run_odbc_packaging }}
 
 jobs:
   detect:
@@ -86,6 +89,7 @@ jobs:
       run_odbc_reference: ${{ steps.computed.outputs.run_odbc_reference }}
       run_python_reference: ${{ steps.computed.outputs.run_python_reference }}
       run_nodejs_reference: ${{ steps.computed.outputs.run_nodejs_reference }}
+      run_odbc_packaging: ${{ steps.computed.outputs.run_odbc_packaging }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -155,6 +159,10 @@ jobs:
               - 'ci/reference-odbc-checksums'
               - 'ci/test_matrix/models/odbc.py'
               - 'ci/test_matrix/mappings/odbc.py'
+            odbc_packaging:
+              - 'odbc/installer/**'
+              - 'ci/Dockerfile.rocky-rpm-build'
+              - '.github/workflows/_build-odbc-packages.yml'
             python:
               - 'python/**'
               - 'pep249_dbapi/**'
@@ -326,6 +334,13 @@ jobs:
             echo "run_nodejs_reference=false" >> $GITHUB_OUTPUT
           fi
 
+          # ODBC packaging should run if installer/packaging files changed
+          if [[ "${{ steps.filter.outputs.odbc_packaging }}" == "true" ]]; then
+            echo "run_odbc_packaging=true" >> $GITHUB_OUTPUT
+          else
+            echo "run_odbc_packaging=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Output summary
         run: |
           echo "### Change Detection Summary" >> $GITHUB_STEP_SUMMARY
@@ -336,6 +351,7 @@ jobs:
           echo "| Core | ${{ steps.filter.outputs.core }} |" >> $GITHUB_STEP_SUMMARY
           echo "| JDBC | ${{ steps.filter.outputs.jdbc }} |" >> $GITHUB_STEP_SUMMARY
           echo "| ODBC | ${{ steps.filter.outputs.odbc }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| ODBC Packaging | ${{ steps.filter.outputs.odbc_packaging }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Python | ${{ steps.filter.outputs.python }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Python Packaging | ${{ steps.filter.outputs.python_packaging }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Node.js | ${{ steps.filter.outputs.nodejs }} |" >> $GITHUB_STEP_SUMMARY
@@ -350,6 +366,7 @@ jobs:
           echo "| JDBC Reference | ${{ steps.computed.outputs.run_jdbc_reference }} |" >> $GITHUB_STEP_SUMMARY
           echo "| ODBC | ${{ steps.computed.outputs.run_odbc }} |" >> $GITHUB_STEP_SUMMARY
           echo "| ODBC Reference | ${{ steps.computed.outputs.run_odbc_reference }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| ODBC Packaging | ${{ steps.computed.outputs.run_odbc_packaging }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Python Reference | ${{ steps.computed.outputs.run_python_reference }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Python | ${{ steps.computed.outputs.run_python }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Python Packaging | ${{ steps.computed.outputs.run_python_packaging }} |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -114,7 +114,7 @@ jobs:
 
   build_odbc_packages:
     needs: detect-changes
-    if: github.event_name == 'push' || needs.detect-changes.outputs.run_odbc == 'true'
+    if: github.event_name == 'push' || needs.detect-changes.outputs.run_odbc_packaging == 'true'
     uses: ./.github/workflows/_build-odbc-packages.yml
     with:
       # WiX Toolset git ref to build from source inside _build-odbc-packages.yml.


### PR DESCRIPTION
## Summary

- Adds `odbc_packaging` path filter to `detect-changes.yml` matching `odbc/installer/**`, `ci/Dockerfile.rocky-rpm-build`, and `_build-odbc-packages.yml`
- Adds `run_odbc_packaging` computed output — fires only when installer paths change
- Changes `build_odbc_packages` in `test-odbc.yml` to use `run_odbc_packaging` instead of `run_odbc`

This skips MSI/RPM/DMG packaging jobs on PRs that only touch driver code or tests, saving macOS + Windows runner capacity. Packaging always runs on push to main via the `github.event_name == 'push'` guard.

## Test plan

- [ ] PR that only touches `odbc_tests/` → packaging is skipped
- [ ] PR that touches `odbc/installer/` → packaging runs
- [ ] Push to main → packaging always runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)