### PR TITLE
SNOW-3530279: support validate_default_parameters connection parameter

### DIFF
--- a/clippy
+++ b/clippy
@@ -1,0 +1,1 @@
+/Users/asolarski/repo/2/universal-driver

--- a/python/BehaviorDifferences.yaml
+++ b/python/BehaviorDifferences.yaml
@@ -111,6 +111,20 @@ behavior_differences:
         `ProgrammingError("No results available (already consumed or not produced by this query)", errno=252009)` (`ER_NO_DATA_FOUND`).
       OLD driver: The same calls have no guard, so they raise `TypeError` because the cursor's internal result state is `None`.
 
+  24:
+    name: "validate_default_parameters skips client-side kwarg name/type warnings"
+    description: |
+      NEW driver: `validate_default_parameters` only controls server-side validation
+        (sends `CLIENT_VALIDATE_DEFAULT_PARAMETERS` session parameter so Snowflake
+        validates default database, schema, and warehouse at login). Client-side
+        parameter name and type checking is handled by the Rust core's param registry
+        for all connections regardless of this flag.
+      OLD driver: When `validate_default_parameters=True`, the connector also iterates
+        all connection kwargs and emits `UserWarning` for unknown parameter names or
+        type mismatches against `DEFAULT_CONFIGURATION`. This client-side validation
+        is not replicated because the Rust param registry already provides equivalent
+        coverage (unknown parameter warnings, type coercion) unconditionally.
+
   23:
     name: "Connection does not expose a public connect() method"
     description: |

--- a/python/src/snowflake/connector/connection.py
+++ b/python/src/snowflake/connector/connection.py
@@ -166,6 +166,13 @@ class Connection(ErrorHandlerMixin):
         # ``ConnectionConfig`` so it is never forwarded to the Rust core.
         self.auto_cleanup: bool = True if self.config.auto_cleanup is None else bool(self.config.auto_cleanup)
 
+        # Controls whether `query % params` is applied even when params is
+        # empty (e.g. {} or ()).  When True, doubled percents (`%%`) are
+        # unescaped to `%`.  The SQLAlchemy dialect toggles this in pre_exec /
+        # post_exec for compiled statements that use pyformat paramstyle.
+        # Defaults to False to match the old connector's behavior.
+        self._interpolate_empty_sequences: bool = False
+
         self.db_api = database_driver_client()
         self.db_handle: DatabaseHandle | None = self.db_api.database_new(DatabaseNewRequest()).db_handle
         self.db_api.database_init(DatabaseInitRequest(db_handle=self.db_handle))
@@ -802,8 +809,15 @@ class Connection(ErrorHandlerMixin):
 
     @property
     def validate_default_parameters(self) -> bool:
-        """Whether to validate default connection parameters at connect time."""
-        raise NotImplementedError("validate_default_parameters is not yet implemented")
+        """Whether to validate default connection parameters at connect time.
+
+        When True, the server validates that default database, schema, and
+        warehouse exist at login.  The old connector also performs client-side
+        kwarg name/type checks; the universal driver delegates parameter
+        validation to the Rust core's param registry instead (see BD#24).
+        """
+        val = self.config.validate_default_parameters
+        return bool(val) if val is not None else False
 
     @property
     def insecure_mode(self) -> bool:

--- a/python/src/snowflake/connector/connection_config.py
+++ b/python/src/snowflake/connector/connection_config.py
@@ -152,6 +152,9 @@ class ConnectionConfig:
     user: str | None = None
     """Login username. Required"""
 
+    validate_default_parameters: bool | None = False
+    """Ask the server to validate default database, schema, and warehouse at login. Default: False"""
+
     verify_certificates: bool | None = True
     """Whether to verify TLS certificates. Default: True"""
 
@@ -327,6 +330,7 @@ class ConnectionConfig:
             "session_parameters",
             "token",
             "user",
+            "validate_default_parameters",
             "verify_certificates",
             "verify_hostname",
             "warehouse",

--- a/sf_core/src/apis/database_driver_v1/connection.rs
+++ b/sf_core/src/apis/database_driver_v1/connection.rs
@@ -184,13 +184,16 @@ impl DatabaseDriverV1 {
                     client_info.platforms = self.platforms().await.clone();
                     client_info.os_details = self.os_details().cloned();
                     let init_params = conn.init_session_parameters.clone();
+                    let validate_defaults = resolved
+                        .get_bool(param_names::VALIDATE_DEFAULT_PARAMETERS)
+                        .unwrap_or(false);
                     let resolved_snapshot = resolved.clone();
 
                     // Forward unrecognized settings as session parameters so
                     // drivers can set arbitrary Snowflake session params
                     // via regular connection options.
                     let unknown_settings = collect_unknown_settings(&conn.connection_seed);
-                    let init_params = match init_params {
+                    let mut init_params = match init_params {
                         Some(explicit) => {
                             // Normalize explicit keys to uppercase so precedence
                             // is case-insensitive (unknown settings are uppercased).
@@ -207,6 +210,15 @@ impl DatabaseDriverV1 {
                         None if !unknown_settings.is_empty() => Some(unknown_settings),
                         None => None,
                     };
+
+                    // When validate_default_parameters is enabled, tell the
+                    // server to validate default database/schema/warehouse.
+                    if validate_defaults {
+                        init_params
+                            .get_or_insert_with(HashMap::new)
+                            .entry("CLIENT_VALIDATE_DEFAULT_PARAMETERS".to_string())
+                            .or_insert_with(|| "true".to_string());
+                    }
 
                     (
                         config,

--- a/sf_core/src/config/param_registry.rs
+++ b/sf_core/src/config/param_registry.rs
@@ -102,6 +102,8 @@ pub mod param_names {
     // Prefetch configuration
     pub const CLIENT_PREFETCH_THREADS: ParamKey = ParamKey("CLIENT_PREFETCH_THREADS");
     pub const CLIENT_MEMORY_LIMIT: ParamKey = ParamKey("CLIENT_MEMORY_LIMIT");
+    // Validation
+    pub const VALIDATE_DEFAULT_PARAMETERS: ParamKey = ParamKey("validate_default_parameters");
 }
 
 /// Which API layer owns writes for a parameter.
@@ -872,6 +874,21 @@ static PARAM_DEFS: &[ParamDef] = &[
         scope: ParamScope::Session,
         used_at_connect: false,
         mutable_after_connect: true,
+    },
+    // ── Validation ────────────────────────────────────────────────────
+    ParamDef {
+        canonical_name: param_names::VALIDATE_DEFAULT_PARAMETERS.as_str(),
+        aliases: &["VALIDATE_DEFAULT_PARAMETERS"],
+        value_type: ValueType::Bool,
+        additional_value_type: None,
+        required: Required::Never,
+        default: Some(|| Setting::Bool(false)),
+        sensitive: false,
+        description: "Ask the server to validate default database, schema, and warehouse at login",
+        deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: true,
+        mutable_after_connect: false,
     },
 ];
 


### PR DESCRIPTION
## Summary
- Register `validate_default_parameters` as a boolean connection parameter (default `false`) in the Rust param registry
- When enabled, the Rust core injects `CLIENT_VALIDATE_DEFAULT_PARAMETERS=true` into session parameters at login, causing Snowflake to validate that the default database, schema, and warehouse exist
- Replace `NotImplementedError` on the Python `Connection.validate_default_parameters` property with a real getter
- Add the field to `ConnectionConfig` so it flows through `to_proto_options` to Rust
- Document BD#24: client-side kwarg name/type warnings from the old connector are not replicated because the Rust param registry already provides equivalent coverage unconditionally

## Context
The old `snowflake-connector-python` exposes `validate_default_parameters` which does two things: (1) server-side validation of default database/schema/warehouse at login via `CLIENT_VALIDATE_DEFAULT_PARAMETERS` session param, and (2) client-side kwarg name/type checking against `DEFAULT_CONFIGURATION`. This PR implements (1) properly through the param registry. The Rust core's existing unknown-parameter warnings and type coercion cover (2) without needing the flag.

Fixes `test_boolean_query_argument_parsing` in snowflake-sqlalchemy which asserts `connection.validate_default_parameters is True`.

## Test plan
- `cargo check -p sf_core` passes (compilation verified)
- All pre-commit hooks pass (Rust fmt, clippy, cargo check, Python ruff + mypy, param_defs export)
- Trigger snowflake-sqlalchemy `test_with_ud.yml` workflow to verify `test_boolean_query_argument_parsing` passes