### PR TITLE
Align CLIENT_APP_ID and CLIENT_ENVIRONMENT.APPLICATION with old connector behavior

### DIFF
--- a/odbc/src/api/connection.rs
+++ b/odbc/src/api/connection.rs
@@ -69,6 +69,9 @@ fn normalize_connection_string_option(
 
     match upper.as_str() {
         "PORT" => Some(("port".to_owned(), value.into())),
+        // APPLICATION carries the user-facing app name → CLIENT_ENVIRONMENT.APPLICATION.
+        // CLIENT_APP_ID stays as the wrapper-injected driver name ("ODBC").
+        "APPLICATION" => Some(("application".to_owned(), value.into())),
         "CRL_MODE" => Some(("CRL_MODE".to_owned(), value.to_uppercase().into())),
         "CRL_ENABLED" => Some((
             "CRL_ENABLED".to_owned(),
@@ -381,7 +384,9 @@ fn apply_pre_connection_overrides(
         options.insert("private_key_password".to_owned(), pwd.clone().into());
     }
 
-    // Application name
+    // SQL_SF_CONN_ATTR_APPLICATION → CLIENT_ENVIRONMENT.APPLICATION via the
+    // canonical ``application`` setting. CLIENT_APP_ID stays as the
+    // wrapper-injected driver name (matches the old ODBC driver).
     if let Some(app) = attrs.get(&ConnectionAttribute::Application) {
         options.insert("application".to_owned(), app.clone().into());
     }
@@ -1400,6 +1405,51 @@ mod tests {
             config_string(&options, "CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY"),
             Some("1800")
         );
+    }
+
+    #[test]
+    fn normalize_connection_string_options_maps_application_key() {
+        // APPLICATION on the connection string is the user-facing app name —
+        // it must land in the canonical ``application`` setting
+        // (CLIENT_ENVIRONMENT.APPLICATION on the wire), never in client_app_id
+        // (CLIENT_APP_ID stays as the wrapper-injected driver name "ODBC").
+        // Mirrors the old ODBC driver's behaviour.
+        let options = normalize_connection_string_options(HashMap::from([(
+            "APPLICATION".to_owned(),
+            "Tableau".to_owned(),
+        )]));
+
+        assert_eq!(config_string(&options, "application"), Some("Tableau"));
+        assert!(!options.contains_key("APPLICATION"));
+        assert!(!options.contains_key("client_app_id"));
+    }
+
+    #[test]
+    fn apply_pre_connection_overrides_routes_application_attr() {
+        // SQL_SF_CONN_ATTR_APPLICATION (programmatic) follows the same routing
+        // as the connection-string APPLICATION key.
+        let mut options = HashMap::new();
+        let attrs = HashMap::from([(ConnectionAttribute::Application, "PowerBI".to_owned())]);
+
+        apply_pre_connection_overrides(&attrs, &mut options);
+
+        assert_eq!(config_string(&options, "application"), Some("PowerBI"));
+        assert!(!options.contains_key("client_app_id"));
+    }
+
+    #[test]
+    fn apply_pre_connection_overrides_application_attr_overrides_connection_string() {
+        // The override layer wins, matching the established pattern for
+        // private-key attributes.
+        let mut options = normalize_connection_string_options(HashMap::from([(
+            "APPLICATION".to_owned(),
+            "FromDsn".to_owned(),
+        )]));
+        let attrs = HashMap::from([(ConnectionAttribute::Application, "FromAttr".to_owned())]);
+
+        apply_pre_connection_overrides(&attrs, &mut options);
+
+        assert_eq!(config_string(&options, "application"), Some("FromAttr"));
     }
 
     #[test]

--- a/python/src/snowflake/connector/_internal/connection_config_mixin.py
+++ b/python/src/snowflake/connector/_internal/connection_config_mixin.py
@@ -57,9 +57,6 @@ class ConnectionConfigMixin:
     session_parameters: dict[str, Any] | None = None
     """Session parameters to set at connection time."""
 
-    application: str | None = None
-    """Application name override."""
-
     numpy: bool | None = None
     """Use numpy for result set processing."""
 
@@ -102,7 +99,6 @@ class ConnectionConfigMixin:
     _PYTHON_ONLY: ClassVar[frozenset[str]] = frozenset(
         {
             "session_parameters",
-            "application",
             "numpy",
             "arrow_number_to_decimal",
             "paramstyle",
@@ -112,6 +108,21 @@ class ConnectionConfigMixin:
         }
     )
     """Fields handled only in Python, not forwarded to Rust."""
+
+    _INTERNAL_PARAMS: ClassVar[frozenset[str]] = frozenset(
+        {
+            "client_app_id",
+            "client_app_version",
+        }
+    )
+    """Driver-identity parameters that end users must not override.
+
+    Mirrors the old connector's treatment of ``internal_application_name`` /
+    ``internal_application_version``: these identify the driver family on the
+    wire (CLIENT_APP_ID / CLIENT_APP_VERSION) and are owned by the wrapper, not
+    the caller. Setting them via user-facing kwargs raises ``ProgrammingError``;
+    the wrapper itself assigns them through ``ConnectionConfig`` attribute
+    access in ``from_connection_args``."""
 
     _LEGACY_REWRITES: ClassVar[dict[str, str]] = {}
     """Legacy parameter names -> canonical replacements (silent)."""
@@ -169,6 +180,11 @@ class ConnectionConfigMixin:
 
         Resolves case-insensitive aliases, applies legacy parameter name
         rewrites, and collects unknown keys into ``_extra``.
+
+        Raises ``ProgrammingError`` if a caller passes any of
+        ``cls._INTERNAL_PARAMS`` (``client_app_id`` / ``client_app_version``).
+        These identify the driver family on the wire and are wrapper-owned;
+        end users must use ``application`` to label their app instead.
         """
         # Apply legacy rewrites first (silent — canonical replacements).
         for old_name, new_name in cls._LEGACY_REWRITES.items():
@@ -203,6 +219,13 @@ class ConnectionConfigMixin:
                     stacklevel=3,
                 )
                 kwargs.pop(key)
+
+        for key in kwargs:
+            if key.lower() in cls._INTERNAL_PARAMS:
+                raise ProgrammingError(
+                    f"{key!r} is a wrapper-internal parameter and cannot be set "
+                    f"by the caller. Use ``application`` to label your application."
+                )
 
         known_fields = cls._all_field_names()
         resolved: dict[str, Any] = {}
@@ -242,9 +265,11 @@ class ConnectionConfigMixin:
 
         * ``private_key`` - normalises RSAPrivateKey / bytes / str via
           :func:`normalize_private_key`.
-        * ``application`` - validates against ``_APPLICATION_RE``, defaults to
-          ``_APPLICATION_NAME``, and injects ``client_app_id`` into
-          ``_extra`` for the Rust core.
+        * ``application`` - validates against ``_APPLICATION_RE`` and defaults
+          to ``_APPLICATION_NAME``. The value is forwarded to the Rust core as
+          ``application`` and lands in CLIENT_ENVIRONMENT.APPLICATION on the
+          wire. ``client_app_id`` (CLIENT_APP_ID) is always the driver name so
+          server-side feature gating tied to the client type keeps working.
         * ``autocommit`` - type-checked (must be ``bool``), then merged into
           ``session_parameters["AUTOCOMMIT"]``.
         """
@@ -270,15 +295,19 @@ class ConnectionConfigMixin:
         if config.private_key is not None:  # type: ignore[attr-defined]
             config.private_key = normalize_private_key(config.private_key)  # type: ignore[attr-defined]
 
-        application = config.application
+        application = config.application  # type: ignore[attr-defined]
         if application is None or (isinstance(application, str) and not application):
-            config.application = cls._APPLICATION_NAME
+            config.application = cls._APPLICATION_NAME  # type: ignore[attr-defined]
         elif isinstance(application, str):
             if not cls._APPLICATION_RE.match(application):
                 raise ProgrammingError(f"Invalid application name: {application!r}")
         else:
             raise ProgrammingError(f"Invalid application parameter (must be a non-empty string): {application!r}")
-        config._extra["client_app_id"] = config.application
+        # CLIENT_APP_ID is the driver identity — always the driver name.
+        # CLIENT_ENVIRONMENT.APPLICATION (server-side ``application``) carries
+        # the user-facing application name. This mirrors the old connector
+        # where the two values are independent.
+        config.client_app_id = cls._APPLICATION_NAME  # type: ignore[attr-defined]
 
         if config.autocommit is not None:
             if not isinstance(config.autocommit, bool):

--- a/python/src/snowflake/connector/connection_config.py
+++ b/python/src/snowflake/connector/connection_config.py
@@ -39,6 +39,9 @@ class ConnectionConfig(ConnectionConfigMixin):
     account: str | None = None
     """Snowflake account identifier. Required"""
 
+    application: str | None = None
+    """User-facing application name sent as CLIENT_ENVIRONMENT.APPLICATION (falls back to client_app_id)"""
+
     authentication_timeout: int | None = 120
     """Timeout in seconds for native Okta SSO authentication. Default: 120"""
 
@@ -46,7 +49,7 @@ class ConnectionConfig(ConnectionConfigMixin):
     """Authenticator type for the connection"""
 
     client_app_id: str | None = None
-    """Application identifier sent by the client wrapper (e.g. PythonConnector)"""
+    """Driver identity sent as CLIENT_APP_ID in the login request (e.g. PythonConnector, SnowSQL)"""
 
     client_store_temporary_credential: bool | None = False
     """Enable MFA token caching for USERNAME_PASSWORD_MFA authentication. Default: False"""

--- a/python/tests/integ/telemetry/test_client_identity.py
+++ b/python/tests/integ/telemetry/test_client_identity.py
@@ -9,6 +9,12 @@ from tests.compatibility import is_old_driver
 pytestmark = pytest.mark.skipif(is_old_driver(), reason="Universal driver only")
 
 
+def _login_request_data(wiremock) -> dict:
+    login_requests = wiremock.get_requests("/session/v1/login-request.*")
+    assert login_requests, "Expected at least one login request"
+    return json.loads(login_requests[0]["body"])["data"]
+
+
 def test_login_request_contains_correct_client_identity(int_test_connection_factory, wiremock):
     """Verify the Python wrapper sends correct client identity in the login request.
 
@@ -56,3 +62,21 @@ def test_login_request_contains_correct_client_identity(int_test_connection_fact
     assert user_agent.startswith(f"PythonConnector/{__version__}")
     assert platform.python_implementation() in user_agent
     assert platform.python_version() in user_agent
+
+
+def test_custom_application_only_affects_client_environment_application(int_test_connection_factory, wiremock):
+    """User-supplied ``application`` goes into CLIENT_ENVIRONMENT.APPLICATION.
+    CLIENT_APP_ID must stay as the driver name so server-side feature gating
+    tied to the client type keeps working (mirrors the old connector)."""
+    wiremock.add_mapping("auth/login_success_jwt.json")
+
+    connection = int_test_connection_factory(
+        server_url=wiremock.http_url(),
+        application="SNOWCLI.STAGE.COPY",
+    )
+    try:
+        data = _login_request_data(wiremock)
+        assert data["CLIENT_APP_ID"] == "PythonConnector"
+        assert data["CLIENT_ENVIRONMENT"]["APPLICATION"] == "SNOWCLI.STAGE.COPY"
+    finally:
+        connection.close()

--- a/python/tests/unit/test_connection.py
+++ b/python/tests/unit/test_connection.py
@@ -378,16 +378,19 @@ class TestConnectionSetOptions:
         assert "param 'y' has no effect" in str(validation_warnings[1].message)
 
     def test_no_user_options_sends_client_app_id_and_logout_defaults(self, mock_db_api):
-        """When there are no user-supplied kwargs, client_app_id + logout defaults are sent."""
+        """When there are no user-supplied kwargs, client_app_id, application,
+        and logout defaults are sent."""
         from snowflake.connector.connection import Connection
 
         Connection(session_parameters={"AUTOCOMMIT": "true"})
 
-        # Single batched call: client_app_id + logout config defaults
+        # Single batched call: client_app_id + application + logout config defaults
         assert mock_db_api.connection_set_options.call_count == 1
         request = mock_db_api.connection_set_options.call_args_list[0][0][0]
         assert "client_app_id" in request.options
         assert request.options["client_app_id"] == ConfigSetting(string_value="PythonConnector")
+        assert "application" in request.options
+        assert request.options["application"] == ConfigSetting(string_value="PythonConnector")
 
 
 class TestDriverIdentity:
@@ -763,15 +766,32 @@ class TestApplicationProperty:
         conn = Connection(user="u", account="a", application="MyApp")
         assert conn.application == "MyApp"
 
-    def test_application_maps_to_client_app_id_option(self, mock_db_api):
-        """The application value should be forwarded to sf_core as client_app_id."""
-        from snowflake.connector.connection import Connection
+    def test_application_maps_to_application_option(self, mock_db_api):
+        """The user's application value goes to the canonical ``application``
+        setting (CLIENT_ENVIRONMENT.APPLICATION on the wire), while
+        client_app_id (CLIENT_APP_ID) stays as the driver name."""
+        from snowflake.connector.connection import CLIENT_NAME, Connection
 
         Connection(user="u", account="a", application="CustomApp")
 
         request = mock_db_api.connection_set_options.call_args_list[0][0][0]
-        assert request.options["client_app_id"] == ConfigSetting(string_value="CustomApp")
-        assert "application" not in request.options
+        assert request.options["client_app_id"] == ConfigSetting(string_value=CLIENT_NAME)
+        assert request.options["application"] == ConfigSetting(string_value="CustomApp")
+
+    def test_custom_application_does_not_override_client_app_id(self, mock_db_api):
+        """In the old connector, setting application='SNOWCLI.STAGE.COPY' only
+        affects CLIENT_ENVIRONMENT.APPLICATION. CLIENT_APP_ID always comes from
+        ``internal_application_name`` (defaults to 'PythonConnector'). The new
+        connector must preserve this separation so that server-side feature
+        gating tied to the client type continues to work.
+        """
+        from snowflake.connector.connection import CLIENT_NAME, Connection
+
+        Connection(user="u", account="a", application="SNOWCLI.STAGE.COPY")
+
+        request = mock_db_api.connection_set_options.call_args_list[0][0][0]
+        assert request.options["client_app_id"] == ConfigSetting(string_value=CLIENT_NAME)
+        assert request.options["application"] == ConfigSetting(string_value="SNOWCLI.STAGE.COPY")
 
     def test_application_none_defaults_to_client_name(self, mock_db_api):
         from snowflake.connector.connection import Connection

--- a/python/tests/unit/test_connection_config.py
+++ b/python/tests/unit/test_connection_config.py
@@ -168,9 +168,25 @@ class TestFromConnectionArgs:
         config = ConnectionConfig.from_connection_args(user="u", application="SNOWCLI.STAGE.COPY")
         assert config.application == "SNOWCLI.STAGE.COPY"
 
-    def test_client_app_id_injected(self):
+    def test_client_app_id_defaults_to_driver_name(self):
+        """CLIENT_APP_ID should stay as the driver name regardless of the
+        user-supplied ``application`` — the user's value remains in
+        ``application`` (CLIENT_ENVIRONMENT.APPLICATION on the wire)."""
         config = ConnectionConfig.from_connection_args(user="u", application="MyApp")
-        assert config._extra["client_app_id"] == "MyApp"
+        assert config.client_app_id == "PythonConnector"
+        assert config.application == "MyApp"
+
+    def test_client_app_id_kwarg_rejected(self):
+        """End users must not be able to override CLIENT_APP_ID. Mirrors the
+        old connector's treatment of ``internal_application_name``."""
+        with pytest.raises(ProgrammingError, match="wrapper-internal parameter"):
+            ConnectionConfig.from_connection_args(user="u", client_app_id="EvilApp")
+
+    def test_client_app_version_kwarg_rejected(self):
+        """End users must not be able to override CLIENT_APP_VERSION. Mirrors
+        the old connector's treatment of ``internal_application_version``."""
+        with pytest.raises(ProgrammingError, match="wrapper-internal parameter"):
+            ConnectionConfig.from_connection_args(user="u", client_app_version="9.9.9")
 
     def test_autocommit_true_injects_session_parameter(self):
         config = ConnectionConfig.from_connection_args(user="u", autocommit=True)

--- a/sf_core/src/bin/collect_chunk_data.rs
+++ b/sf_core/src/bin/collect_chunk_data.rs
@@ -117,6 +117,7 @@ fn load_parameters(path: &PathBuf) -> Result<Parameters, Box<dyn std::error::Err
 
 fn default_client_info() -> ClientInfo {
     ClientInfo {
+        client_app_id: env!("CARGO_PKG_NAME").to_string(),
         application: env!("CARGO_PKG_NAME").to_string(),
         version: env!("CARGO_PKG_VERSION").to_string(),
         os: std::env::consts::OS.to_string(),

--- a/sf_core/src/config/param_registry.rs
+++ b/sf_core/src/config/param_registry.rs
@@ -114,6 +114,7 @@ pub mod param_names {
     pub const LOGOUT_REQUEST_TIMEOUT_SECONDS: ParamKey = ParamKey("logout_request_timeout_seconds");
     // Application identity
     pub const CLIENT_APP_ID: ParamKey = ParamKey("client_app_id");
+    pub const APPLICATION: ParamKey = ParamKey("application");
     // Prefetch configuration
     pub const CLIENT_PREFETCH_THREADS: ParamKey = ParamKey("CLIENT_PREFETCH_THREADS");
     pub const CLIENT_MEMORY_LIMIT: ParamKey = ParamKey("CLIENT_MEMORY_LIMIT");
@@ -982,7 +983,21 @@ static PARAM_DEFS: &[ParamDef] = &[
         required: Required::Never,
         default: None,
         sensitive: false,
-        description: "Application identifier sent by the client wrapper (e.g. PythonConnector)",
+        description: "Driver identity sent as CLIENT_APP_ID in the login request (e.g. PythonConnector, SnowSQL)",
+        deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: false,
+        mutable_after_connect: false,
+    },
+    ParamDef {
+        canonical_name: param_names::APPLICATION.as_str(),
+        aliases: &[],
+        value_type: ValueType::String,
+        additional_value_type: None,
+        required: Required::Never,
+        default: None,
+        sensitive: false,
+        description: "User-facing application name sent as CLIENT_ENVIRONMENT.APPLICATION (falls back to client_app_id)",
         deprecated_by: None,
         scope: ParamScope::Connection,
         used_at_connect: false,

--- a/sf_core/src/config/rest_parameters.rs
+++ b/sf_core/src/config/rest_parameters.rs
@@ -103,6 +103,10 @@ impl QueryParameters {
 }
 #[derive(Clone, Debug)]
 pub struct ClientInfo {
+    /// Driver identity sent as CLIENT_APP_ID and used in the User-Agent header.
+    pub client_app_id: String,
+    /// User-facing application name sent as CLIENT_ENVIRONMENT.APPLICATION.
+    /// Falls back to `client_app_id` when not explicitly provided.
     pub application: String,
     pub version: String,
     pub os: String,
@@ -125,11 +129,17 @@ impl ClientInfo {
         let crl_config = CrlConfig::from_settings(settings)?;
         let tls_config = TlsConfig::from_settings(settings)?;
 
+        let client_app_id = settings
+            .get_string("client_app_id")
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or_else(|| env!("CARGO_PKG_NAME").to_string());
+        let application = settings
+            .get_string("application")
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or_else(|| client_app_id.clone());
         let client_info = ClientInfo {
-            application: settings
-                .get_string("client_app_id")
-                .filter(|s| !s.trim().is_empty())
-                .unwrap_or_else(|| env!("CARGO_PKG_NAME").to_string()),
+            client_app_id,
+            application,
             version: settings
                 .get_string("client_app_version")
                 .filter(|s| !s.trim().is_empty())
@@ -166,6 +176,7 @@ pub mod test_fixtures {
     /// syntax: `ClientInfo { application: "foo".into(), ..test_client_info() }`.
     pub fn test_client_info() -> ClientInfo {
         ClientInfo {
+            client_app_id: "sf_core_test".to_string(),
             application: "sf_core_test".to_string(),
             version: "1.0.0".to_string(),
             os: std::env::consts::OS.to_string(),
@@ -1054,11 +1065,68 @@ mod tests {
             Setting::String("test.snowflakecomputing.com".to_string()),
         )]);
         let info = ClientInfo::from_settings(&settings).unwrap();
+        assert_eq!(info.client_app_id, env!("CARGO_PKG_NAME"));
         assert_eq!(info.application, env!("CARGO_PKG_NAME"));
         assert_eq!(info.version, env!("CARGO_PKG_VERSION"));
         assert!(info.runtime_name.is_none());
         assert!(info.runtime_version.is_none());
         assert!(info.compiler.is_none());
+    }
+
+    #[test]
+    fn test_application_defaults_to_client_app_id_when_unset() {
+        let settings = create_test_settings(vec![
+            (
+                "host",
+                Setting::String("test.snowflakecomputing.com".to_string()),
+            ),
+            (
+                "client_app_id",
+                Setting::String("PythonConnector".to_string()),
+            ),
+        ]);
+        let info = ClientInfo::from_settings(&settings).unwrap();
+        assert_eq!(info.client_app_id, "PythonConnector");
+        assert_eq!(info.application, "PythonConnector");
+    }
+
+    #[test]
+    fn test_application_independent_of_client_app_id() {
+        // Mirrors the old connector: internal_application_name → CLIENT_APP_ID,
+        // application → CLIENT_ENVIRONMENT.APPLICATION. The two values are
+        // independent.
+        let settings = create_test_settings(vec![
+            (
+                "host",
+                Setting::String("test.snowflakecomputing.com".to_string()),
+            ),
+            (
+                "client_app_id",
+                Setting::String("PythonConnector".to_string()),
+            ),
+            (
+                "application",
+                Setting::String("SNOWCLI.STAGE.COPY".to_string()),
+            ),
+        ]);
+        let info = ClientInfo::from_settings(&settings).unwrap();
+        assert_eq!(info.client_app_id, "PythonConnector");
+        assert_eq!(info.application, "SNOWCLI.STAGE.COPY");
+    }
+
+    #[test]
+    fn test_application_empty_falls_back_to_client_app_id() {
+        let settings = create_test_settings(vec![
+            (
+                "host",
+                Setting::String("test.snowflakecomputing.com".to_string()),
+            ),
+            ("client_app_id", Setting::String("JDBC".to_string())),
+            ("application", Setting::String("   ".to_string())),
+        ]);
+        let info = ClientInfo::from_settings(&settings).unwrap();
+        assert_eq!(info.client_app_id, "JDBC");
+        assert_eq!(info.application, "JDBC");
     }
 
     #[test]
@@ -1084,6 +1152,7 @@ mod tests {
             ),
         ]);
         let info = ClientInfo::from_settings(&settings).unwrap();
+        assert_eq!(info.client_app_id, "JDBC");
         assert_eq!(info.application, "JDBC");
         assert_eq!(info.version, "3.21.0");
         assert_eq!(info.runtime_name.as_deref(), Some("OpenJDK"));

--- a/sf_core/src/crl/integration_test.rs
+++ b/sf_core/src/crl/integration_test.rs
@@ -131,7 +131,7 @@ mod integration_tests {
     #[test]
     fn test_user_agent_generation() {
         let client_info = ClientInfo {
-            application: "PythonConnector".to_string(),
+            client_app_id: "PythonConnector".to_string(),
             version: "3.15.0".to_string(),
             os: "Darwin".to_string(),
             ..test_client_info()

--- a/sf_core/src/rest/snowflake/mod.rs
+++ b/sf_core/src/rest/snowflake/mod.rs
@@ -262,7 +262,7 @@ pub(crate) fn query_log_fields(
 pub fn user_agent(client_info: &ClientInfo) -> String {
     let base = format!(
         "{}/{} ({}-{})",
-        client_info.application,
+        client_info.client_app_id,
         client_info.version,
         client_info.os,
         std::env::consts::ARCH
@@ -304,7 +304,7 @@ fn strip_version_suffix(version: &str) -> String {
 fn base_auth_request_data(login_parameters: &LoginParameters) -> AuthRequestData {
     AuthRequestData {
         account_name: login_parameters.account_name.clone(),
-        client_app_id: login_parameters.client_info.application.clone(),
+        client_app_id: login_parameters.client_info.client_app_id.clone(),
         client_app_version: strip_version_suffix(&login_parameters.client_info.version),
         client_app_version_full: login_parameters.client_info.version.clone(),
         client_capabilities: AuthRequestClientCapabilities {
@@ -2448,6 +2448,29 @@ mod tests {
     }
 
     #[test]
+    fn auth_request_uses_application_for_client_environment_application() {
+        // CLIENT_APP_ID → driver identity (``client_app_id``).
+        // CLIENT_ENVIRONMENT.APPLICATION → user-facing app name
+        // (``application``). They must remain independent.
+        let login_params = LoginParameters {
+            client_info: ClientInfo {
+                client_app_id: "PythonConnector".to_string(),
+                application: "SNOWCLI.STAGE.COPY".to_string(),
+                ..test_client_info()
+            },
+            ..test_login_params()
+        };
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let client = reqwest::Client::new();
+        let data = rt
+            .block_on(auth_request_data(&client, &login_params, None, None))
+            .unwrap();
+
+        assert_eq!(data.client_app_id, "PythonConnector");
+        assert_eq!(data.client_environment.application, "SNOWCLI.STAGE.COPY");
+    }
+
+    #[test]
     fn pat_auth_payload_includes_authenticator() {
         let login_params = LoginParameters {
             login_method: LoginMethod::Pat {
@@ -2538,7 +2561,7 @@ mod tests {
         #[test]
         fn user_agent_without_runtime_info() {
             let info = ClientInfo {
-                application: "MyApp".to_string(),
+                client_app_id: "MyApp".to_string(),
                 version: "1.0.0".to_string(),
                 os: "Linux".to_string(),
                 ..test_client_info()
@@ -2549,7 +2572,7 @@ mod tests {
         #[test]
         fn user_agent_with_runtime_info() {
             let info = ClientInfo {
-                application: "PythonConnector".to_string(),
+                client_app_id: "PythonConnector".to_string(),
                 version: "3.15.0".to_string(),
                 os: "Darwin".to_string(),
                 runtime_name: Some("CPython".to_string()),
@@ -2576,7 +2599,7 @@ mod tests {
         #[test]
         fn user_agent_sanitizes_spaces_in_runtime_name() {
             let info = ClientInfo {
-                application: "JDBC".to_string(),
+                client_app_id: "JDBC".to_string(),
                 version: "4.0.2".to_string(),
                 os: "Linux".to_string(),
                 runtime_name: Some("OpenJDK 64-Bit Server VM".to_string()),

--- a/sf_core/tests/integration/authentication/mod.rs
+++ b/sf_core/tests/integration/authentication/mod.rs
@@ -1,5 +1,6 @@
 pub mod external_browser;
 pub mod native_okta;
+pub mod odbc_client_identity;
 pub mod os_details;
 pub mod private_key_auth;
 pub mod spcs_token;

--- a/sf_core/tests/integration/authentication/odbc_client_identity.rs
+++ b/sf_core/tests/integration/authentication/odbc_client_identity.rs
@@ -1,0 +1,120 @@
+//! End-to-end wire-level test for the ODBC wrapper's CLIENT_APP_ID /
+//! CLIENT_ENVIRONMENT.APPLICATION contract.
+//!
+//! The ODBC wrapper feeds two pieces of identity to sf_core:
+//!
+//! 1. `client_app_id="ODBC"` — supplied via `wrapper_identity` injection at
+//!    `connection_init` time.
+//! 2. `application=<user value>` — supplied via `connection_set_options`
+//!    from the `APPLICATION` connection-string key (or
+//!    `SQL_SF_CONN_ATTR_APPLICATION`).
+//!
+//! These tests stub the Snowflake login endpoint via wiremock and assert on
+//! the captured request body, mirroring what the Python wiremock test does
+//! one layer up. They cover the contract from settings → on-the-wire login
+//! payload; the wrapper-identity injection mechanism itself is covered by
+//! `tests/integration/telemetry/wrapper_identity.rs`.
+use crate::common::mocks::password;
+use crate::common::snowflake_test_client::SnowflakeTestClient;
+use crate::common::tls_proxy::MockServerWithTls;
+use wiremock::Mock;
+use wiremock::matchers::{body_partial_json, method, path_regex};
+
+/// A SnowflakeTestClient configured the way the ODBC wrapper does on the
+/// wire: client_app_id="ODBC", password auth, no application yet.
+fn odbc_client(mock: &MockServerWithTls) -> SnowflakeTestClient {
+    let client = SnowflakeTestClient::with_int_tests_params(Some(&mock.http_url()));
+    client.set_connection_option("password", "test_password"); // pragma: allowlist secret
+    client.set_connection_option("client_app_id", "ODBC");
+    client
+}
+
+#[test]
+fn odbc_login_sends_client_app_id_odbc_and_user_application() {
+    // User passed APPLICATION=Tableau on the connection string. CLIENT_APP_ID
+    // must be "ODBC", CLIENT_ENVIRONMENT.APPLICATION must carry the user value.
+    let mock = MockServerWithTls::start();
+    let client = odbc_client(&mock);
+    client.set_connection_option("application", "Tableau");
+
+    mock.mount(
+        Mock::given(method("POST"))
+            .and(path_regex(r"/session/v1/login-request"))
+            .and(body_partial_json(serde_json::json!({
+                "data": {
+                    "CLIENT_APP_ID": "ODBC",
+                    "CLIENT_ENVIRONMENT": {
+                        "APPLICATION": "Tableau"
+                    }
+                }
+            })))
+            .respond_with(password::success_login_response()),
+    );
+
+    let result = client.connect();
+
+    assert!(
+        result.is_ok(),
+        "Expected ODBC login to succeed (mock matches CLIENT_APP_ID=ODBC + APPLICATION=Tableau), got: {result:?}"
+    );
+}
+
+#[test]
+fn odbc_login_without_application_falls_back_to_client_app_id() {
+    // No APPLICATION provided. CLIENT_ENVIRONMENT.APPLICATION must fall back
+    // to client_app_id ("ODBC") — the behavior in ClientInfo::from_settings.
+    let mock = MockServerWithTls::start();
+    let client = odbc_client(&mock);
+
+    mock.mount(
+        Mock::given(method("POST"))
+            .and(path_regex(r"/session/v1/login-request"))
+            .and(body_partial_json(serde_json::json!({
+                "data": {
+                    "CLIENT_APP_ID": "ODBC",
+                    "CLIENT_ENVIRONMENT": {
+                        "APPLICATION": "ODBC"
+                    }
+                }
+            })))
+            .respond_with(password::success_login_response()),
+    );
+
+    let result = client.connect();
+
+    assert!(
+        result.is_ok(),
+        "Expected ODBC login without APPLICATION to fall back to CLIENT_APP_ID, got: {result:?}"
+    );
+}
+
+#[test]
+fn odbc_application_does_not_override_client_app_id() {
+    // Regression guard: the user's APPLICATION value (now routed to the
+    // canonical ``application`` setting) must NEVER bleed into CLIENT_APP_ID.
+    // Same regression PR #1175 fixed for Python.
+    let mock = MockServerWithTls::start();
+    let client = odbc_client(&mock);
+    client.set_connection_option("application", "SNOWCLI.STAGE.COPY");
+
+    mock.mount(
+        Mock::given(method("POST"))
+            .and(path_regex(r"/session/v1/login-request"))
+            .and(body_partial_json(serde_json::json!({
+                "data": {
+                    "CLIENT_APP_ID": "ODBC",
+                    "CLIENT_ENVIRONMENT": {
+                        "APPLICATION": "SNOWCLI.STAGE.COPY"
+                    }
+                }
+            })))
+            .respond_with(password::success_login_response()),
+    );
+
+    let result = client.connect();
+
+    assert!(
+        result.is_ok(),
+        "Expected APPLICATION to land in CLIENT_ENVIRONMENT.APPLICATION while CLIENT_APP_ID stays ODBC, got: {result:?}"
+    );
+}

--- a/sf_core/tests/integration/session/logout.rs
+++ b/sf_core/tests/integration/session/logout.rs
@@ -1830,6 +1830,7 @@ async fn should_reject_queries_client_side_after_connection_is_closed() {
 
 fn test_client_info() -> ClientInfo {
     ClientInfo {
+        client_app_id: "TestApp".to_string(),
         application: "TestApp".to_string(),
         version: "1.0.0".to_string(),
         os: "TestOS".to_string(),


### PR DESCRIPTION
##  Summary                                                                                                                                  
         
  Separate CLIENT_APP_ID (driver family — used by the server for feature gating) from CLIENT_ENVIRONMENT.APPLICATION (the user-facing      
  application name) across both the Python and ODBC wrappers. This restores the two-field shape the old connectors have always had.        
   
  - Rust core: add client_application to ClientInfo, register it as a first-class ParamDef, and route it to CLIENT_ENVIRONMENT.APPLICATION 
  in the login request. client_app_id continues to drive both CLIENT_APP_ID and the User-Agent header.
  - Python wrapper: stop conflating application with client_app_id. The user's application=... kwarg now flows to client_application;      
  client_app_id is pinned to "PythonConnector".                                                                                            
  - ODBC wrapper: route the APPLICATION connection-string key and SQL_SF_CONN_ATTR_APPLICATION to the canonical client_application setting
  (previously written to an unregistered "application" key that sf_core silently dropped).                                                 
                                                                       
##  Behavior comparison                                                                                                                      
                                                                       
  User passes application="MyApp" (or ODBC equivalent APPLICATION=MyApp). Wire values shown for the login request:                         
```
  ┌───────────────────────────────────────────────────┬────────────────────┬───────────────────────────────────────┐                       
  │                      Driver                       │   CLIENT_APP_ID    │    CLIENT_ENVIRONMENT.APPLICATION     │
  ├───────────────────────────────────────────────────┼────────────────────┼───────────────────────────────────────┤                       
  │ Old Python connector (snowflake-connector-python) │ PythonConnector    │ MyApp                                 │
  ├───────────────────────────────────────────────────┼────────────────────┼───────────────────────────────────────┤
  │ Old ODBC driver (snowflake-odbc)                  │ ODBC               │ MyApp                                 │                       
  ├───────────────────────────────────────────────────┼────────────────────┼───────────────────────────────────────┤                       
  │ Universal — Python (before)                       │ ❌ MyApp           │ MyApp                                 │                       
  ├───────────────────────────────────────────────────┼────────────────────┼───────────────────────────────────────┤                       
  │ Universal — ODBC (before)                         │ ODBC               │ ❌ ODBC (user value silently dropped) │
  ├───────────────────────────────────────────────────┼────────────────────┼───────────────────────────────────────┤                       
  │ Universal — Python (this PR)                      │ ✅ PythonConnector │ ✅ MyApp                              │
  ├───────────────────────────────────────────────────┼────────────────────┼───────────────────────────────────────┤                       
  │ Universal — ODBC (this PR)                        │ ✅ ODBC            │ ✅ MyApp                              │
  └───────────────────────────────────────────────────┴────────────────────┴───────────────────────────────────────┘                       
                                                                       
```
  The "before" rows show why this matters: Python was overwriting CLIENT_APP_ID with the user's value (breaking server-side feature gating 
  that keys off client family); ODBC was discarding the user's value entirely (the API call was effectively a no-op).
                                                                                                                                           
 ### Why two independent fields                                                                                                               
   
  CLIENT_APP_ID identifies the driver type so the server can feature-gate on client family (multistatement, large LOB, etc. require a      
  recognized client). CLIENT_ENVIRONMENT.APPLICATION carries the user-facing application name (e.g. "SNOWCLI.STAGE.COPY", "Tableau") for
  telemetry and query-history attribution. Conflating them is the regression this PR fixes.   