### PR TITLE
NO-SNOW: Build only the wheels needed by active test cells

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -47,6 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.read.outputs.matrix }}
+      wheel-targets: ${{ steps.read.outputs.wheel-targets }}
     steps:
       - uses: actions/checkout@v4
       - id: read
@@ -56,14 +57,21 @@ jobs:
           python ci/test_matrix/generate_matrix.py \
             --driver python --event "$GITHUB_EVENT_NAME" --labels "$LABELS" --emit-active \
             >> "$GITHUB_OUTPUT"
+          python ci/test_matrix/generate_matrix.py \
+            --driver python --event "$GITHUB_EVENT_NAME" --emit-wheel-targets \
+            >> "$GITHUB_OUTPUT"
 
-  # ── Build all wheels via shared reusable workflow ────────────────────
+  # ── Build wheels via shared reusable workflow ────────────────────────
+  # Only builds wheels actually needed by the active test cells for the
+  # current event level (PR builds fewer wheels than merge/nightly).
   build_wheels:
-    needs: detect-changes
-    if: github.event_name == 'push' || needs.detect-changes.outputs.run_python == 'true'
+    needs: [detect-changes, load-python-matrix]
+    if: |
+      (github.event_name == 'push' || needs.detect-changes.outputs.run_python == 'true')
+      && needs.load-python-matrix.outputs.wheel-targets != '{}'
     uses: ./.github/workflows/_build-python-wheels.yml
     with:
-      targets: '{"linux_x86": ["3.13"], "linux_aarch": ["3.11","3.14"], "macos_arm": ["3.12","3.14"], "macos_x86": ["3.11","3.12","3.13","3.14"], "windows_x86": ["3.11","3.12","3.14"], "windows_arm": ["3.11","3.12"]}'
+      targets: ${{ needs.load-python-matrix.outputs.wheel-targets }}
 
   # Packaging tests - verify sdist can be built and installed from source
   packaging_tests:
@@ -547,9 +555,11 @@ jobs:
   # @pytest.mark.flaky (excluded from every other job by the default
   # `-m "not flaky"` in python/pyproject.toml addopts). Failures here do
   # not gate merges and the job is intentionally omitted from python-status.
+  # Merge-only: the hardcoded manylinux_x86_64 py3.13 wheel is only
+  # guaranteed to be built at merge level (PR builds a minimal wheel set).
   python_flaky_tests:
     needs: [detect-changes, build_wheels]
-    if: github.event_name == 'push' || needs.detect-changes.outputs.run_python == 'true'
+    if: github.event_name == 'merge_group' && needs.detect-changes.outputs.run_python == 'true'
     runs-on: ubuntu-latest
     name: python_flaky_tests (ubuntu-latest, py3.13, aws)
     continue-on-error: true

--- a/ci/test_matrix/generate_matrix.py
+++ b/ci/test_matrix/generate_matrix.py
@@ -622,6 +622,39 @@ def emit_active(driver: str, event: str | None, labels: list[str] | None = None)
     print(f"matrix={json.dumps(active)}")
 
 
+def emit_wheel_targets(driver: str, event: str | None) -> None:
+    """
+    Print `wheel-targets=<json>` — the minimal _build-python-wheels.yml
+    ``targets`` object for the test cells active at the current event level.
+
+    Only considers rows that need a pre-built wheel (sdist-only rows are
+    ignored). The output maps platform target keys (e.g. "linux_x86") to
+    lists of Python version strings, matching the schema expected by the
+    reusable workflow's ``targets`` input.
+    """
+    model_path = MODELS_DIR / f"{driver}.py"
+    gha_rows = generate(model_path, driver)
+    level = level_for_event(event)
+    active = filter_active(gha_rows, level)
+
+    artifact_to_target: dict[str, str] = {
+        p["wheel_artifact"]: p["target"] for p in PYTHON_PLATFORM.values()
+    }
+
+    targets: dict[str, set[str]] = {}
+    for row in active:
+        artifact = row.get("wheel_artifact")
+        py = row.get("py")
+        if not artifact or not py:
+            continue
+        target_key = artifact_to_target.get(artifact)
+        if target_key:
+            targets.setdefault(target_key, set()).add(py)
+
+    result = {k: sorted(v) for k, v in sorted(targets.items())}
+    print(f"wheel-targets={json.dumps(result)}")
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Pairwise CI matrix generator")
     group = parser.add_mutually_exclusive_group(required=True)
@@ -645,6 +678,12 @@ def main() -> None:
         help="Print 'matrix=<json>' for the active level (requires --driver and --event). "
              "Used inside CI workflow steps to feed strategy.matrix.include.",
     )
+    parser.add_argument(
+        "--emit-wheel-targets",
+        action="store_true",
+        help="Print 'wheel-targets=<json>' — the minimal _build-python-wheels.yml targets "
+             "object for the active test cells (requires --driver python and --event).",
+    )
     args = parser.parse_args()
 
     if args.emit_active:
@@ -652,6 +691,12 @@ def main() -> None:
             parser.error("--emit-active requires --driver and is incompatible with --all")
         labels = [l.strip() for l in args.labels.split(",") if l.strip()]
         emit_active(args.driver, args.event, labels)
+        return
+
+    if args.emit_wheel_targets:
+        if args.all or args.driver != "python":
+            parser.error("--emit-wheel-targets requires --driver python and is incompatible with --all")
+        emit_wheel_targets(args.driver, args.event)
         return
 
     drivers = ["odbc", "python", "core"] if args.all else [args.driver]

--- a/ci/test_matrix/mappings/python.py
+++ b/ci/test_matrix/mappings/python.py
@@ -11,18 +11,22 @@ Per-row keys:
   wheels         (set[str], required) Python versions for which a wheel is
                  actually built. The contract with _build-python-wheels.yml's
                  `targets` argument — keep in sync.
+  target         (str, required) Platform key used by _build-python-wheels.yml's
+                 `targets` input (e.g. "linux_x86", "macos_arm"). Used by
+                 generate_matrix.py --emit-wheel-targets to produce the minimal
+                 wheel-build JSON for the active test cells.
 
 SDIST_PY is a set of Python versions that always install from sdist
 (no wheels are built for them — currently 3.10).
 """
 
 PYTHON_PLATFORM: dict[tuple[str, str], dict] = {
-    ("ubuntu",  "x64"): {"wheel_artifact": "manylinux_x86_64", "wheels": {"3.13"}},
-    ("ubuntu",  "arm"): {"wheel_artifact": "manylinux_aarch64", "wheels": {"3.11", "3.14"}},
-    ("macos",   "arm"): {"wheel_artifact": "macosx_arm64",     "wheels": {"3.12", "3.14"}},
-    ("macos",   "x64"): {"wheel_artifact": "macosx_x86_64",    "wheels": {"3.11", "3.12", "3.13", "3.14"}},
-    ("windows", "x64"): {"wheel_artifact": "win_amd64",        "wheels": {"3.11", "3.12", "3.14"}},
-    ("windows", "arm"): {"wheel_artifact": "win_arm64",        "wheels": {"3.11", "3.12"}},
+    ("ubuntu",  "x64"): {"wheel_artifact": "manylinux_x86_64",  "wheels": {"3.13"},                          "target": "linux_x86"},
+    ("ubuntu",  "arm"): {"wheel_artifact": "manylinux_aarch64", "wheels": {"3.11", "3.14"},                   "target": "linux_aarch"},
+    ("macos",   "arm"): {"wheel_artifact": "macosx_arm64",      "wheels": {"3.12", "3.14"},                   "target": "macos_arm"},
+    ("macos",   "x64"): {"wheel_artifact": "macosx_x86_64",     "wheels": {"3.11", "3.12", "3.13", "3.14"},  "target": "macos_x86"},
+    ("windows", "x64"): {"wheel_artifact": "win_amd64",         "wheels": {"3.11", "3.12", "3.14"},           "target": "windows_x86"},
+    ("windows", "arm"): {"wheel_artifact": "win_arm64",         "wheels": {"3.11", "3.12"},                   "target": "windows_arm"},
 }
 
 SDIST_PY: set[str] = {"3.10"}

--- a/ci/test_matrix/test_generate_matrix.py
+++ b/ci/test_matrix/test_generate_matrix.py
@@ -14,7 +14,7 @@ import itertools
 import sys
 import tempfile
 import unittest
-from contextlib import redirect_stderr
+from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
@@ -1047,6 +1047,79 @@ class LabelResolutionTests(unittest.TestCase):
             gm.level_for_event_and_labels("schedule", ["ci:scope-merge"]),
             "nightly",
         )
+
+
+# ---------------------------------------------------------------------------
+# Wheel-target emission
+# ---------------------------------------------------------------------------
+
+class WheelTargetTests(unittest.TestCase):
+    """emit_wheel_targets produces the minimal _build-python-wheels.yml targets."""
+
+    @staticmethod
+    def _capture_wheel_targets(event: str) -> dict:
+        """Run emit_wheel_targets and parse the JSON from stdout."""
+        import json
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            gm.emit_wheel_targets("python", event)
+        line = buf.getvalue().strip()
+        prefix = "wheel-targets="
+        assert line.startswith(prefix), f"unexpected output: {line}"
+        return json.loads(line[len(prefix):])
+
+    def test_pr_targets_match_pr_cells(self) -> None:
+        """Every PR wheel target must trace back to a PR_CELLS entry, and
+        every non-sdist PR cell must have a corresponding wheel target."""
+        targets = self._capture_wheel_targets("pull_request")
+
+        _, _, _, pr_cells, _ = gm.load_model(gm.MODELS_DIR / "python.py")
+        expected: dict[str, set[str]] = {}
+        for cell in pr_cells:
+            py = cell["PyVersion"]
+            if py in gm.SDIST_PY:
+                continue
+            plat = gm.PYTHON_PLATFORM.get((cell["OS"], cell["Arch"]))
+            if plat is None or py not in plat["wheels"]:
+                continue
+            expected.setdefault(plat["target"], set()).add(py)
+
+        self.assertEqual(
+            {k: set(v) for k, v in targets.items()},
+            expected,
+            "PR wheel targets should exactly match the wheels needed by PR_CELLS",
+        )
+
+    def test_merge_superset_of_pr(self) -> None:
+        pr = self._capture_wheel_targets("pull_request")
+        merge = self._capture_wheel_targets("merge_group")
+        for platform, versions in pr.items():
+            self.assertIn(platform, merge, f"{platform} in PR but missing from merge")
+            for v in versions:
+                self.assertIn(
+                    v, merge[platform],
+                    f"{platform} py{v} in PR but missing from merge",
+                )
+
+    def test_nightly_covers_all_python_platform_wheels(self) -> None:
+        targets = self._capture_wheel_targets("schedule")
+        for (os_, arch), plat in gm.PYTHON_PLATFORM.items():
+            target_key = plat["target"]
+            self.assertIn(target_key, targets, f"missing {target_key}")
+            for v in plat["wheels"]:
+                self.assertIn(
+                    v, targets[target_key],
+                    f"{target_key} py{v} missing at nightly level",
+                )
+
+    def test_sdist_versions_excluded(self) -> None:
+        targets = self._capture_wheel_targets("schedule")
+        for v in gm.SDIST_PY:
+            for versions in targets.values():
+                self.assertNotIn(
+                    v, versions,
+                    f"sdist-only version {v} should never appear in wheel targets",
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Build only the wheels actually needed by the active test cells instead of the full nightly set
- PRs now build ~2 wheels on 2 platforms instead of ~14 wheels on 6 platforms
- Platforms with no active test cells are not spawned at all (fixes the empty mac_x86 worker issue)

## Context
The `_build-python-wheels.yml` targets were hardcoded to the full nightly wheel matrix regardless of event type. Since `load-python-matrix` already computes which test cells are active for the current event, we can derive the minimal wheel set from those cells and pass it dynamically.

Changes:
- **`ci/test_matrix/mappings/python.py`**: Added `target` field to `PYTHON_PLATFORM` entries, bridging the naming gap between test matrix `wheel_artifact` names and `_build-python-wheels.yml` target keys
- **`ci/test_matrix/generate_matrix.py`**: Added `emit_wheel_targets()` + `--emit-wheel-targets` CLI flag that scans active test cells and outputs the minimal wheel-build JSON
- **`.github/workflows/test-python.yml`**: `load-python-matrix` now also emits `wheel-targets`; `build_wheels` consumes the dynamic targets instead of the hardcoded set; `python_flaky_tests` restricted to `merge_group` since its hardcoded `manylinux_x86_64_py3.13` wheel is not guaranteed at PR level
- **`ci/test_matrix/test_generate_matrix.py`**: 4 new tests covering PR-minimal targets, merge superset property, nightly full coverage, and sdist exclusion

## Test plan
- Ran `--emit-wheel-targets` for pull_request -> `{"linux_x86": ["3.13"], "windows_x86": ["3.14"]}` (2 platforms vs 6)
- Ran for merge_group -> 6 platforms with only needed versions
- Ran for schedule -> full nightly set matching `PYTHON_PLATFORM.wheels`
- All 50 tests pass (`python -m pytest ci/test_matrix/test_generate_matrix.py -q`)