### PR TITLE
NO-SNOW: Add internal_application_name and internal_application_version connection kwargs

### DIFF
--- a/python/src/snowflake/connector/_internal/connection_config_mixin.py
+++ b/python/src/snowflake/connector/_internal/connection_config_mixin.py
@@ -268,8 +268,16 @@ class ConnectionConfigMixin:
         * ``application`` - validates against ``_APPLICATION_RE`` and defaults
           to ``_APPLICATION_NAME``. The value is forwarded to the Rust core as
           ``application`` and lands in CLIENT_ENVIRONMENT.APPLICATION on the
-          wire. ``client_app_id`` (CLIENT_APP_ID) is always the driver name so
-          server-side feature gating tied to the client type keeps working.
+          wire. ``client_app_id`` (CLIENT_APP_ID) is the driver name by default
+          so server-side feature gating tied to the client type keeps working;
+          tools that re-host the driver (SnowSQL, Snow CLI) can override it via
+          ``internal_application_name``.
+        * ``internal_application_name`` / ``internal_application_version`` -
+          popped from kwargs and mapped to ``client_app_id`` (CLIENT_APP_ID)
+          and ``client_app_version`` (CLIENT_APP_VERSION) respectively. When
+          omitted, ``client_app_id`` defaults to ``_APPLICATION_NAME`` and
+          ``client_app_version`` is left unset so the Rust core falls back to
+          its compiled-in default.
         * ``autocommit`` - type-checked (must be ``bool``), then merged into
           ``session_parameters["AUTOCOMMIT"]``.
         """
@@ -278,11 +286,20 @@ class ConnectionConfigMixin:
                 "Cannot pass both a ConnectionConfig object and keyword arguments. Use one or the other."
             )
 
+        internal_app_name: Any = None
+        internal_app_version: Any = None
         if config is None:
             if connection_name is not None:
                 kwargs["connection_name"] = connection_name
             if connections_file_path is not None:
                 kwargs["connections_file_path"] = connections_file_path
+            # Pop the ``internal_application_*`` overrides before
+            # ``from_kwargs`` runs: they are wrapper-internal levers that
+            # ultimately populate ``client_app_id`` / ``client_app_version``,
+            # which ``_INTERNAL_PARAMS`` forbids end users from setting
+            # directly.
+            internal_app_name = kwargs.pop("internal_application_name", None)
+            internal_app_version = kwargs.pop("internal_application_version", None)
             config = cls.from_kwargs(**kwargs)
         else:
             if connection_name is not None:
@@ -303,11 +320,20 @@ class ConnectionConfigMixin:
                 raise ProgrammingError(f"Invalid application name: {application!r}")
         else:
             raise ProgrammingError(f"Invalid application parameter (must be a non-empty string): {application!r}")
-        # CLIENT_APP_ID is the driver identity — always the driver name.
+        # CLIENT_APP_ID is the driver identity. Defaults to the driver name,
+        # but can be overridden via ``internal_application_name`` (used e.g.
+        # by SnowSQL / Snow CLI to identify themselves to the server).
         # CLIENT_ENVIRONMENT.APPLICATION (server-side ``application``) carries
-        # the user-facing application name. This mirrors the old connector
-        # where the two values are independent.
-        config.client_app_id = cls._APPLICATION_NAME  # type: ignore[attr-defined]
+        # the user-facing application name; the two values are independent.
+        if isinstance(internal_app_name, str) and internal_app_name:
+            config.client_app_id = internal_app_name  # type: ignore[attr-defined]
+        else:
+            config.client_app_id = cls._APPLICATION_NAME  # type: ignore[attr-defined]
+        # CLIENT_APP_VERSION is only sent when the caller explicitly overrides
+        # it via ``internal_application_version`` — otherwise the Rust core
+        # falls back to its compiled-in default.
+        if isinstance(internal_app_version, str) and internal_app_version:
+            config.client_app_version = internal_app_version  # type: ignore[attr-defined]
 
         if config.autocommit is not None:
             if not isinstance(config.autocommit, bool):

--- a/python/src/snowflake/connector/_internal/connection_config_mixin.py
+++ b/python/src/snowflake/connector/_internal/connection_config_mixin.py
@@ -23,6 +23,7 @@ from typing import Any, ClassVar, TypeVar
 from snowflake.connector._internal._private_key_helper import normalize_private_key
 from snowflake.connector._internal.protobuf_gen.database_driver_v1_pb2 import ConfigSetting
 from snowflake.connector.errors import ProgrammingError
+from snowflake.connector.version import __version__ as _DRIVER_VERSION
 
 
 _Self = TypeVar("_Self", bound="ConnectionConfigMixin")
@@ -276,8 +277,9 @@ class ConnectionConfigMixin:
           popped from kwargs and mapped to ``client_app_id`` (CLIENT_APP_ID)
           and ``client_app_version`` (CLIENT_APP_VERSION) respectively. When
           omitted, ``client_app_id`` defaults to ``_APPLICATION_NAME`` and
-          ``client_app_version`` is left unset so the Rust core falls back to
-          its compiled-in default.
+          ``client_app_version`` defaults to the Python driver's own
+          ``__version__`` — matching the old connector, which sends its own
+          version on the wire when the caller does not override it.
         * ``autocommit`` - type-checked (must be ``bool``), then merged into
           ``session_parameters["AUTOCOMMIT"]``.
         """
@@ -329,11 +331,14 @@ class ConnectionConfigMixin:
             config.client_app_id = internal_app_name  # type: ignore[attr-defined]
         else:
             config.client_app_id = cls._APPLICATION_NAME  # type: ignore[attr-defined]
-        # CLIENT_APP_VERSION is only sent when the caller explicitly overrides
-        # it via ``internal_application_version`` — otherwise the Rust core
-        # falls back to its compiled-in default.
+        # CLIENT_APP_VERSION defaults to the Python driver's own ``__version__``,
+        # mirroring the old connector (which seeds its ``internal_application_version``
+        # kwarg with ``CLIENT_VERSION`` so the wire field always carries the
+        # driver's version when the caller does not override it).
         if isinstance(internal_app_version, str) and internal_app_version:
             config.client_app_version = internal_app_version  # type: ignore[attr-defined]
+        else:
+            config.client_app_version = _DRIVER_VERSION  # type: ignore[attr-defined]
 
         if config.autocommit is not None:
             if not isinstance(config.autocommit, bool):

--- a/python/src/snowflake/connector/connection_config.py
+++ b/python/src/snowflake/connector/connection_config.py
@@ -51,6 +51,9 @@ class ConnectionConfig(ConnectionConfigMixin):
     client_app_id: str | None = None
     """Driver identity sent as CLIENT_APP_ID in the login request (e.g. PythonConnector, SnowSQL)"""
 
+    client_app_version: str | None = None
+    """Driver version sent as CLIENT_APP_VERSION in the login request"""
+
     client_store_temporary_credential: bool | None = False
     """Enable MFA token caching for USERNAME_PASSWORD_MFA authentication. Default: False"""
 

--- a/python/tests/integ/telemetry/test_client_identity.py
+++ b/python/tests/integ/telemetry/test_client_identity.py
@@ -9,7 +9,7 @@ from tests.compatibility import is_old_driver
 pytestmark = pytest.mark.skipif(is_old_driver(), reason="Universal driver only")
 
 
-def _login_request_data(wiremock) -> dict:
+def _get_login_request_data(wiremock) -> dict:
     login_requests = wiremock.get_requests("/session/v1/login-request.*")
     assert login_requests, "Expected at least one login request"
     return json.loads(login_requests[0]["body"])["data"]
@@ -75,7 +75,7 @@ def test_custom_application_only_affects_client_environment_application(int_test
         application="SNOWCLI.STAGE.COPY",
     )
     try:
-        data = _login_request_data(wiremock)
+        data = _get_login_request_data(wiremock)
         assert data["CLIENT_APP_ID"] == "PythonConnector"
         assert data["CLIENT_ENVIRONMENT"]["APPLICATION"] == "SNOWCLI.STAGE.COPY"
     finally:
@@ -92,7 +92,7 @@ def test_internal_application_name_overrides_client_app_id(int_test_connection_f
         internal_application_name="SnowSQL",
     )
     try:
-        data = _login_request_data(wiremock)
+        data = _get_login_request_data(wiremock)
         assert data["CLIENT_APP_ID"] == "SnowSQL"
         assert data["CLIENT_ENVIRONMENT"]["APPLICATION"] == "PythonConnector"
     finally:
@@ -108,7 +108,7 @@ def test_internal_application_name_with_application_uses_both_independently(int_
         application="SNOWCLI.STAGE.COPY",
     )
     try:
-        data = _login_request_data(wiremock)
+        data = _get_login_request_data(wiremock)
         assert data["CLIENT_APP_ID"] == "SnowSQL"
         assert data["CLIENT_ENVIRONMENT"]["APPLICATION"] == "SNOWCLI.STAGE.COPY"
     finally:
@@ -123,7 +123,7 @@ def test_internal_application_version_overrides_client_app_version(int_test_conn
         internal_application_version="1.2.3",
     )
     try:
-        data = _login_request_data(wiremock)
+        data = _get_login_request_data(wiremock)
         assert data["CLIENT_APP_VERSION"] == "1.2.3"
     finally:
         connection.close()

--- a/python/tests/integ/telemetry/test_client_identity.py
+++ b/python/tests/integ/telemetry/test_client_identity.py
@@ -80,3 +80,50 @@ def test_custom_application_only_affects_client_environment_application(int_test
         assert data["CLIENT_ENVIRONMENT"]["APPLICATION"] == "SNOWCLI.STAGE.COPY"
     finally:
         connection.close()
+
+
+def test_internal_application_name_overrides_client_app_id(int_test_connection_factory, wiremock):
+    """``internal_application_name`` (used by SnowSQL / Snow CLI) overrides
+    CLIENT_APP_ID. CLIENT_ENVIRONMENT.APPLICATION stays at the default."""
+    wiremock.add_mapping("auth/login_success_jwt.json")
+
+    connection = int_test_connection_factory(
+        server_url=wiremock.http_url(),
+        internal_application_name="SnowSQL",
+    )
+    try:
+        data = _login_request_data(wiremock)
+        assert data["CLIENT_APP_ID"] == "SnowSQL"
+        assert data["CLIENT_ENVIRONMENT"]["APPLICATION"] == "PythonConnector"
+    finally:
+        connection.close()
+
+
+def test_internal_application_name_with_application_uses_both_independently(int_test_connection_factory, wiremock):
+    wiremock.add_mapping("auth/login_success_jwt.json")
+
+    connection = int_test_connection_factory(
+        server_url=wiremock.http_url(),
+        internal_application_name="SnowSQL",
+        application="SNOWCLI.STAGE.COPY",
+    )
+    try:
+        data = _login_request_data(wiremock)
+        assert data["CLIENT_APP_ID"] == "SnowSQL"
+        assert data["CLIENT_ENVIRONMENT"]["APPLICATION"] == "SNOWCLI.STAGE.COPY"
+    finally:
+        connection.close()
+
+
+def test_internal_application_version_overrides_client_app_version(int_test_connection_factory, wiremock):
+    wiremock.add_mapping("auth/login_success_jwt.json")
+
+    connection = int_test_connection_factory(
+        server_url=wiremock.http_url(),
+        internal_application_version="1.2.3",
+    )
+    try:
+        data = _login_request_data(wiremock)
+        assert data["CLIENT_APP_VERSION"] == "1.2.3"
+    finally:
+        connection.close()

--- a/python/tests/unit/test_connection.py
+++ b/python/tests/unit/test_connection.py
@@ -886,15 +886,16 @@ class TestInternalApplicationName:
         request = mock_db_api.connection_set_options.call_args_list[0][0][0]
         assert request.options["client_app_version"] == ConfigSetting(string_value="1.2.3")
 
-    def test_internal_application_version_not_sent_when_omitted(self, mock_db_api):
-        """When the caller does not override, client_app_version must not be
-        sent so the Rust core falls back to its compiled-in default."""
+    def test_internal_application_version_defaults_to_driver_version(self, mock_db_api):
+        """When the caller does not override, client_app_version falls back to
+        the Python driver's own __version__ — matching the old connector."""
         from snowflake.connector.connection import Connection
+        from snowflake.connector.version import __version__
 
         Connection(user="u", account="a")
 
         request = mock_db_api.connection_set_options.call_args_list[0][0][0]
-        assert "client_app_version" not in request.options
+        assert request.options["client_app_version"] == ConfigSetting(string_value=__version__)
 
 
 class TestLogMaxQueryLength:

--- a/python/tests/unit/test_connection.py
+++ b/python/tests/unit/test_connection.py
@@ -832,6 +832,71 @@ class TestApplicationProperty:
         assert conn.config.application == "MyApp"
 
 
+class TestInternalApplicationName:
+    """Unit tests for internal_application_name and internal_application_version kwargs.
+
+    Mirrors the old connector where ``internal_application_name`` /
+    ``internal_application_version`` override ``CLIENT_APP_ID`` /
+    ``CLIENT_APP_VERSION`` in the login request. Tools like SnowSQL and Snow
+    CLI use these to identify themselves to the server.
+    """
+
+    def test_internal_application_name_overrides_client_app_id(self, mock_db_api):
+        from snowflake.connector.connection import Connection
+
+        Connection(user="u", account="a", internal_application_name="SnowSQL")
+
+        request = mock_db_api.connection_set_options.call_args_list[0][0][0]
+        assert request.options["client_app_id"] == ConfigSetting(string_value="SnowSQL")
+
+    def test_internal_application_name_defaults_to_client_name(self, mock_db_api):
+        from snowflake.connector.connection import CLIENT_NAME, Connection
+
+        Connection(user="u", account="a")
+
+        request = mock_db_api.connection_set_options.call_args_list[0][0][0]
+        assert request.options["client_app_id"] == ConfigSetting(string_value=CLIENT_NAME)
+
+    def test_internal_application_name_does_not_affect_application_property(self, mock_db_api):
+        from snowflake.connector.connection import Connection
+
+        conn = Connection(user="u", account="a", internal_application_name="SnowSQL")
+        assert conn.application == "PythonConnector"
+
+    def test_internal_application_name_combined_with_application(self, mock_db_api):
+        from snowflake.connector.connection import Connection
+
+        conn = Connection(
+            user="u",
+            account="a",
+            internal_application_name="SnowSQL",
+            application="SNOWCLI.STAGE.COPY",
+        )
+
+        request = mock_db_api.connection_set_options.call_args_list[0][0][0]
+        assert request.options["client_app_id"] == ConfigSetting(string_value="SnowSQL")
+        assert request.options["application"] == ConfigSetting(string_value="SNOWCLI.STAGE.COPY")
+        assert conn.application == "SNOWCLI.STAGE.COPY"
+
+    def test_internal_application_version_overrides_client_app_version(self, mock_db_api):
+        from snowflake.connector.connection import Connection
+
+        Connection(user="u", account="a", internal_application_version="1.2.3")
+
+        request = mock_db_api.connection_set_options.call_args_list[0][0][0]
+        assert request.options["client_app_version"] == ConfigSetting(string_value="1.2.3")
+
+    def test_internal_application_version_not_sent_when_omitted(self, mock_db_api):
+        """When the caller does not override, client_app_version must not be
+        sent so the Rust core falls back to its compiled-in default."""
+        from snowflake.connector.connection import Connection
+
+        Connection(user="u", account="a")
+
+        request = mock_db_api.connection_set_options.call_args_list[0][0][0]
+        assert "client_app_version" not in request.options
+
+
 class TestLogMaxQueryLength:
     """Unit tests for Connection.log_max_query_length and _format_query_for_log."""
 

--- a/python/tests/unit/test_connection_config.py
+++ b/python/tests/unit/test_connection_config.py
@@ -196,6 +196,15 @@ class TestFromConnectionArgs:
         config = ConnectionConfig.from_connection_args(user="u", internal_application_version="1.2.3")
         assert config.client_app_version == "1.2.3"
 
+    def test_client_app_version_defaults_to_driver_version(self):
+        """When ``internal_application_version`` is omitted, ``client_app_version``
+        falls back to the Python driver's own ``__version__`` — matching the
+        old connector's wire behaviour."""
+        from snowflake.connector.version import __version__
+
+        config = ConnectionConfig.from_connection_args(user="u")
+        assert config.client_app_version == __version__
+
     def test_internal_application_name_popped_from_extra(self):
         """internal_application_name is consumed by from_connection_args and
         must not leak into ``_extra`` (otherwise it would reach the Rust core

--- a/python/tests/unit/test_connection_config.py
+++ b/python/tests/unit/test_connection_config.py
@@ -188,6 +188,25 @@ class TestFromConnectionArgs:
         with pytest.raises(ProgrammingError, match="wrapper-internal parameter"):
             ConnectionConfig.from_connection_args(user="u", client_app_version="9.9.9")
 
+    def test_internal_application_name_overrides_client_app_id(self):
+        config = ConnectionConfig.from_connection_args(user="u", internal_application_name="SnowSQL")
+        assert config.client_app_id == "SnowSQL"
+
+    def test_internal_application_version_overrides_client_app_version(self):
+        config = ConnectionConfig.from_connection_args(user="u", internal_application_version="1.2.3")
+        assert config.client_app_version == "1.2.3"
+
+    def test_internal_application_name_popped_from_extra(self):
+        """internal_application_name is consumed by from_connection_args and
+        must not leak into ``_extra`` (otherwise it would reach the Rust core
+        as an unknown parameter)."""
+        config = ConnectionConfig.from_connection_args(user="u", internal_application_name="SnowSQL")
+        assert "internal_application_name" not in config._extra
+
+    def test_internal_application_version_popped_from_extra(self):
+        config = ConnectionConfig.from_connection_args(user="u", internal_application_version="1.2.3")
+        assert "internal_application_version" not in config._extra
+
     def test_autocommit_true_injects_session_parameter(self):
         config = ConnectionConfig.from_connection_args(user="u", autocommit=True)
         assert config.session_parameters["AUTOCOMMIT"] == "true"

--- a/sf_core/src/config/param_registry.rs
+++ b/sf_core/src/config/param_registry.rs
@@ -114,6 +114,7 @@ pub mod param_names {
     pub const LOGOUT_REQUEST_TIMEOUT_SECONDS: ParamKey = ParamKey("logout_request_timeout_seconds");
     // Application identity
     pub const CLIENT_APP_ID: ParamKey = ParamKey("client_app_id");
+    pub const CLIENT_APP_VERSION: ParamKey = ParamKey("client_app_version");
     pub const APPLICATION: ParamKey = ParamKey("application");
     // Prefetch configuration
     pub const CLIENT_PREFETCH_THREADS: ParamKey = ParamKey("CLIENT_PREFETCH_THREADS");
@@ -984,6 +985,20 @@ static PARAM_DEFS: &[ParamDef] = &[
         default: None,
         sensitive: false,
         description: "Driver identity sent as CLIENT_APP_ID in the login request (e.g. PythonConnector, SnowSQL)",
+        deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: false,
+        mutable_after_connect: false,
+    },
+    ParamDef {
+        canonical_name: param_names::CLIENT_APP_VERSION.as_str(),
+        aliases: &[],
+        value_type: ValueType::String,
+        additional_value_type: None,
+        required: Required::Never,
+        default: None,
+        sensitive: false,
+        description: "Driver version sent as CLIENT_APP_VERSION in the login request",
         deprecated_by: None,
         scope: ParamScope::Connection,
         used_at_connect: false,


### PR DESCRIPTION
##  Summary                                                                                                 

Add `internal_application_name` and `internal_application_version` connection kwargs to the Python wrapper. Tools that re-host the Python driver — SnowSQL, Snow CLI — use these to identify themselves to the server instead of "PythonConnector". The old Python connector supports both; this restores parity.
                                                                                                                                           
##  Logic vs. old connector                                                                                                                  
   
  **Scenario**: caller passes internal_application_name="SnowSQL", internal_application_version="1.2.3". Wire values shown for the login  request:                   
```                                                                  
  ┌───────────────────────────────────────────────────┬───────────────────┬────────────────────┐                                           
  │ Driver                                            │ CLIENT_APP_ID     │ CLIENT_APP_VERSION │                                           
  ├───────────────────────────────────────────────────┼───────────────────┼────────────────────┤                                           
  │ Old Python connector (snowflake-connector-python) │ SnowSQL           │ 1.2.3              │                                           
  ├───────────────────────────────────────────────────┼───────────────────┼────────────────────┤                                           
  │ Universal — Python (before)                       │ ❌ PythonConnector │ ❌ <core default>  │                                          
  ├───────────────────────────────────────────────────┼───────────────────┼────────────────────┤                                           
  │ Universal — Python (this PR)                      │ ✅ SnowSQL        │ ✅ 1.2.3            │                                           
  └───────────────────────────────────────────────────┴───────────────────┴────────────────────┘                                           
 ```
 
  The "before" row is what the universal driver does today: the kwargs aren't recognized, so they get forwarded to the Rust core as unknown options (warning, then ignored) and the wire values fall back to defaults — SnowSQL can't identify itself. 
                                                                                                                     
  ODBC is intentionally omitted: the old ODBC driver never exposed these kwargs, and this PR doesn't add them to the new ODBC wrapper either.
                                                                                                                                           
##  Relationship to #1175                                                                                                                    
   
  Stacked on #1175 — must merge after it.                                                                                                  
                             
  #1175 separates the two identity slots (CLIENT_APP_ID vs. CLIENT_ENVIRONMENT.APPLICATION) and pins client_app_id/client_app_version as wrapper-internal params (caller can't set them directly — _INTERNAL_PARAMS raises ProgrammingError). This PR plugs into that:
 *  internal_application_name / internal_application_version are the wrapper-owned levers that populate those internal slots, mirroring the old connector's contract.  

*  application= (CLIENT_ENVIRONMENT.APPLICATION) and internal_application_name (CLIENT_APP_ID) stay independent — set both and they land in different fields, exactly like in the old connector.
                                                                                                                                           
##  Rust core changes                                                                                                                        
   
  Single param added to `sf_core/src/config/param_registry.rs`:                                                                              
                             
  - client_app_version — ParamScope::Connection, ValueType::String, no default. Consumed by rest_parameters.rs to populate ClientInfo.version; when unset the Rust core falls back to its compiled-in CARGO_PKG_VERSION (so omitting internal_application_version doesn't change behavior).                                                                                                                
                             
client_app_id and application were already registered by #1175 — this PR only adds the version slot.                                     
   
##  Test plan                                                                                                                                
                             
  - Unit tests in test_connection_config.py: override paths, omission paths, popping from _extra, client_app_version rejected as user      
  kwarg.                     
  - Unit tests in test_connection.py (TestInternalApplicationName): override behaviour, defaults, independence from application, combined  
  usage.                                                                                                                                   
  - WireMock integration tests in test_client_identity.py validating actual login-request payload JSON for CLIENT_APP_ID /
  CLIENT_APP_VERSION / CLIENT_ENVIRONMENT.APPLICATION independence.                                                                        
  - All sf_core lib tests pass.