### PR TITLE
SNOW-2872391: wire OAuth helpers into ODBC connection string + DSN setup

### DIFF
--- a/odbc/src/api/connection.rs
+++ b/odbc/src/api/connection.rs
@@ -10,6 +10,7 @@ use crate::api::error::{
     InvalidConnectionStringSnafu, InvalidCursorStateSnafu, InvalidPortSnafu, NullPointerSnafu,
     OdbcRuntimeSnafu, ReadOnlyAttributeSnafu, UnknownAttributeSnafu, UnsupportedAttributeSnafu,
 };
+use crate::api::oauth;
 use crate::api::runtime::global;
 use crate::api::{
     ConnectionState, GetDataExtensions, OdbcResult, conn_from_handle,
@@ -65,6 +66,14 @@ fn normalize_connection_string_option(
     let upper = key.to_ascii_uppercase();
     if upper == "DRIVER" {
         return None;
+    }
+
+    // Forward known OAuth keys with their explicit `sf_core` canonical
+    // (lowercase) name instead of relying on the catch-all uppercase
+    // passthrough + alias resolution. Owning the mapping here keeps the
+    // OAuth surface self-documenting on the wrapper side.
+    if let Some(canonical) = oauth::canonical_name(&upper) {
+        return Some((canonical.to_owned(), value.into()));
     }
 
     match upper.as_str() {
@@ -207,25 +216,10 @@ fn connect_with_params(
     connection_handle: sql::Handle,
     params: HashMap<String, String>,
 ) -> OdbcResult<()> {
-    {
-        const REDACTED_KEYS: &[&str] = &[
-            "PWD",
-            "TOKEN",
-            "PRIV_KEY_FILE_PWD",
-            "PRIV_KEY_PWD",
-            "PRIV_KEY_BASE64",
-            "PASSCODE",
-        ];
-        let redacted_map: HashMap<&String, &str> = params
-            .iter()
-            .map(|(k, v)| {
-                let is_sensitive = REDACTED_KEYS.iter().any(|r| k.eq_ignore_ascii_case(r));
-                let v = if is_sensitive { "****" } else { v.as_str() };
-                (k, v)
-            })
-            .collect();
-        tracing::info!("connect_with_params: params={:?}", redacted_map);
-    }
+    tracing::info!(
+        "connect_with_params: params={:?}",
+        oauth::redacted_param_map(&params)
+    );
 
     let mut options = normalize_connection_string_options(params);
     if let Some(config_setting::Value::StringValue(raw_port)) = options
@@ -1370,6 +1364,63 @@ mod tests {
             Some("true")
         );
         assert!(!options.contains_key("CLIENT_STORE_TEMPORARY_CREDENTIAL"));
+    }
+
+    #[test]
+    fn normalize_connection_string_options_forwards_oauth_keys_with_canonical_names() {
+        let options = normalize_connection_string_options(HashMap::from([
+            ("OAUTH_CLIENT_ID".to_owned(), "client-123".to_owned()),
+            ("OAUTH_CLIENT_SECRET".to_owned(), "shhh".to_owned()),
+            (
+                "OAUTH_REDIRECT_URI".to_owned(),
+                "http://127.0.0.1:0".to_owned(),
+            ),
+            ("oauth_scope".to_owned(), "session:role:R".to_owned()),
+        ]));
+
+        // OAuth keys must be forwarded with their lowercase `sf_core`
+        // canonical name (not the original SCREAMING_SNAKE form).
+        assert_eq!(
+            config_string(&options, "oauth_client_id"),
+            Some("client-123")
+        );
+        assert_eq!(config_string(&options, "oauth_client_secret"), Some("shhh"));
+        assert_eq!(
+            config_string(&options, "oauth_redirect_uri"),
+            Some("http://127.0.0.1:0")
+        );
+        assert_eq!(
+            config_string(&options, "oauth_scope"),
+            Some("session:role:R")
+        );
+        for upper in [
+            "OAUTH_CLIENT_ID",
+            "OAUTH_CLIENT_SECRET",
+            "OAUTH_REDIRECT_URI",
+            "OAUTH_SCOPE",
+        ] {
+            assert!(
+                !options.contains_key(upper),
+                "{upper} must not be forwarded as the uppercase passthrough form"
+            );
+        }
+    }
+
+    #[test]
+    fn redacted_param_map_hides_oauth_client_secret_in_logs() {
+        // Wiring guard: the connection-string log line must never
+        // expose the OAUTH_CLIENT_SECRET value, regardless of the
+        // case the caller used.
+        let params = HashMap::from([
+            ("UID".to_owned(), "joe".to_owned()),
+            ("oauth_client_secret".to_owned(), "do-not-log".to_owned()),
+        ]);
+        let redacted = oauth::redacted_param_map(&params);
+        let rendered = format!("{redacted:?}");
+        assert!(
+            !rendered.contains("do-not-log"),
+            "redacted param map leaked the OAuth client secret: {rendered}"
+        );
     }
 
     #[test]

--- a/odbc/src/api/error.rs
+++ b/odbc/src/api/error.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use crate::{
-    api::{InfoType, SqlState, diagnostic::DiagnosticRecord},
+    api::{InfoType, SqlState, diagnostic::DiagnosticRecord, oauth},
     conversion::error::JsonBindingError,
     conversion::{ConversionError, error::WriteOdbcError},
 };
@@ -469,6 +469,12 @@ static AUTHENTICATOR_PARAMETERS: LazyLock<HashSet<String>> = LazyLock::new(|| {
     set.insert("AUTHENTICATOR".to_string());
     set.insert("USER".to_string());
     set.insert("PASSWORD".to_string());
+    // Pull every recognised OAuth DSN key from the OAuth helper so a
+    // future addition to `oauth::ALL_OAUTH_KEYS` automatically updates
+    // the set used for SQLSTATE classification of auth-time errors.
+    for &k in oauth::ALL_OAUTH_KEYS {
+        set.insert(k.to_string());
+    }
     set
 });
 

--- a/odbc/src/api/oauth.rs
+++ b/odbc/src/api/oauth.rs
@@ -16,6 +16,11 @@
 //! * never persist OAuth secrets to the DSN registry,
 //! * redact OAuth secrets from logs.
 //!
+//! The wrapper composes its connection-string-level redaction list
+//! ([`SENSITIVE_LOGGING_KEYS`]) from both the legacy PWD-style secrets
+//! and the OAuth secret list so [`redacted_param_map`] is the single
+//! place to update when a new sensitive key joins either family.
+//!
 //! The key list mirrors `analysis_feature_oauth.md` §9 (configuration
 //! matrix) and matches the `param_registry` aliases in
 //! `sf_core::config::param_registry`. All ODBC keys here are the
@@ -227,6 +232,56 @@ pub fn should_persist_to_dsn(key: &str) -> bool {
     !is_sensitive_oauth_key(key)
 }
 
+/// Combined list of connection-string keys that must be redacted at
+/// the wrapper's logging boundary (`connect_with_params`). It joins
+/// the legacy PWD-style secrets recognised by the ODBC layer with the
+/// OAuth secret list, so adding a new sensitive OAuth key in
+/// [`SENSITIVE_OAUTH_KEYS`] automatically flows through to log
+/// redaction without touching `connection.rs`.
+pub const SENSITIVE_LOGGING_KEYS: &[&str] = &[
+    // Pre-OAuth keys: kept here verbatim so the wrapper has a single
+    // grep target for "things that must never appear in logs".
+    "PWD",
+    "PRIV_KEY_FILE_PWD",
+    "PRIV_KEY_PWD",
+    "PRIV_KEY_BASE64",
+    "PASSCODE",
+    // OAuth keys (OAUTH_CLIENT_SECRET + TOKEN). TOKEN was already in
+    // the legacy redaction list; routing it through the OAuth list
+    // keeps the source of truth in one place.
+    OAUTH_CLIENT_SECRET,
+    TOKEN,
+];
+
+/// Returns a borrowed view of `params` with the value of every
+/// sensitive key (OAuth secrets + legacy PWD-style secrets) replaced
+/// by `"****"`. Non-sensitive entries borrow their value from
+/// `params`; redacted entries use the static `"****"` placeholder, so
+/// no allocation is performed in either branch.
+///
+/// Use this at every connection-string logging boundary so OAuth
+/// client secrets and access tokens never reach `tracing` sinks.
+/// Centralising the policy here means future additions to
+/// [`SENSITIVE_LOGGING_KEYS`] update every call site automatically.
+pub fn redacted_param_map(
+    params: &std::collections::HashMap<String, String>,
+) -> std::collections::HashMap<&String, std::borrow::Cow<'_, str>> {
+    params
+        .iter()
+        .map(|(k, v)| {
+            let is_sensitive = SENSITIVE_LOGGING_KEYS
+                .iter()
+                .any(|r| k.eq_ignore_ascii_case(r));
+            let value: std::borrow::Cow<'_, str> = if is_sensitive {
+                std::borrow::Cow::Borrowed("****")
+            } else {
+                std::borrow::Cow::Borrowed(v.as_str())
+            };
+            (k, value)
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -319,6 +374,68 @@ mod tests {
         assert!(should_persist_to_dsn("OAUTH_REDIRECT_URI"));
         assert!(should_persist_to_dsn("OAUTH_SCOPE"));
         assert!(should_persist_to_dsn("UID"));
+    }
+
+    #[test]
+    fn redacted_param_map_redacts_legacy_and_oauth_secrets() {
+        use std::collections::HashMap;
+        let params: HashMap<String, String> = [
+            ("UID", "joe"),
+            ("PWD", "hunter2"),
+            ("PRIV_KEY_FILE_PWD", "kpwd"),
+            ("PRIV_KEY_PWD", "kpwd2"),
+            ("PRIV_KEY_BASE64", "AAA="),
+            ("PASSCODE", "123456"),
+            ("OAUTH_CLIENT_ID", "abc"),
+            ("OAUTH_CLIENT_SECRET", "shhh"),
+            ("TOKEN", "jwt.value"),
+        ]
+        .into_iter()
+        .map(|(k, v)| (k.to_owned(), v.to_owned()))
+        .collect();
+
+        let redacted = redacted_param_map(&params);
+
+        assert_eq!(
+            redacted.get(&"UID".to_owned()).map(|v| v.as_ref()),
+            Some("joe")
+        );
+        assert_eq!(
+            redacted
+                .get(&"OAUTH_CLIENT_ID".to_owned())
+                .map(|v| v.as_ref()),
+            Some("abc")
+        );
+        for sensitive in SENSITIVE_LOGGING_KEYS {
+            let key = sensitive.to_string();
+            assert_eq!(
+                redacted.get(&key).map(|v| v.as_ref()),
+                Some("****"),
+                "expected key {sensitive} to be redacted"
+            );
+        }
+    }
+
+    #[test]
+    fn redacted_param_map_redaction_is_case_insensitive() {
+        use std::collections::HashMap;
+        let params: HashMap<String, String> = [
+            ("oauth_client_secret", "shhh"),
+            ("Pwd", "hunter2"),
+            ("token", "jwt.value"),
+        ]
+        .into_iter()
+        .map(|(k, v)| (k.to_owned(), v.to_owned()))
+        .collect();
+
+        let redacted = redacted_param_map(&params);
+        for k in params.keys() {
+            assert_eq!(
+                redacted.get(k).map(|v| v.as_ref()),
+                Some("****"),
+                "expected key {k} to be redacted regardless of case"
+            );
+        }
     }
 
     #[test]

--- a/odbc/src/setup_common.rs
+++ b/odbc/src/setup_common.rs
@@ -6,6 +6,8 @@
 
 #![cfg(target_os = "windows")]
 
+use crate::api::oauth;
+
 // ---------------------------------------------------------------------------
 // odbccp32.dll — ODBC Installer API (raw-dylib, no import lib needed)
 // ---------------------------------------------------------------------------
@@ -82,7 +84,11 @@ pub(crate) unsafe fn read_dsn_value(dsn: &str, key: &str) -> String {
 /// Write a DSN and its key/value fields to the ODBC registry.
 ///
 /// Skips `DSN` and `PWD` keys (DSN is implicit in the section name;
-/// PWD must never be persisted).  Returns `false` if any write fails.
+/// PWD must never be persisted).  Also delegates to
+/// [`oauth::should_persist_to_dsn`] so OAuth secrets
+/// (`OAUTH_CLIENT_SECRET`, `TOKEN`) never reach the on-disk registry —
+/// they are only ever read from the dialog into the in-memory test
+/// connection string.  Returns `false` if any write fails.
 pub(crate) unsafe fn write_dsn_values(
     dsn: &str,
     driver: &str,
@@ -96,7 +102,10 @@ pub(crate) unsafe fn write_dsn_values(
     let odbc_ini = to_wide("odbc.ini");
     let mut ok = true;
     for (key, value) in fields {
-        if key.eq_ignore_ascii_case("DSN") || key.eq_ignore_ascii_case("PWD") {
+        if key.eq_ignore_ascii_case("DSN")
+            || key.eq_ignore_ascii_case("PWD")
+            || !oauth::should_persist_to_dsn(key)
+        {
             continue;
         }
         let key_w = to_wide(key);


### PR DESCRIPTION
Centralised refactor that lets every connection-string and DSN-setup
boundary in the ODBC wrapper consult `odbc::api::oauth` for the OAuth
key list, redaction policy, canonical naming, and DSN-skip rule.

* `oauth::redacted_param_map` + `oauth::SENSITIVE_LOGGING_KEYS`: new
  combined redaction helper that joins the legacy PWD-style sensitive
  keys with the OAuth secret list. `connect_with_params` now calls
  this instead of an inline `REDACTED_KEYS` block, so future sensitive
  keys are added in one place.
* `connection::normalize_connection_string_option`: an `if let` early
  in the function forwards every key in `oauth::ALL_OAUTH_KEYS` with
  its explicit `sf_core` canonical (lowercase) name, replacing the
  catch-all uppercase passthrough for the OAuth surface.
* `error::AUTHENTICATOR_PARAMETERS`: extended with all 10 OAuth keys
  driven from `oauth::ALL_OAUTH_KEYS`, so SQLSTATE classification of
  auth-time errors covers the OAuth params and any future addition is
  picked up automatically.
* `setup_common::write_dsn_values`: now also calls
  `oauth::should_persist_to_dsn(key)`, ensuring `OAUTH_CLIENT_SECRET`
  and `TOKEN` are entered into the in-memory test connection string
  via `FIELD_MAP` but never persisted to the DSN registry.

Co-authored-by: Cursor <cursoragent@cursor.com>