### PR TITLE
SNOW-2872391: add OAuth ODBC E2E tests and shared Gherkin definitions

### DIFF
--- a/odbc_tests/tests/e2e/CMakeLists.txt
+++ b/odbc_tests/tests/e2e/CMakeLists.txt
@@ -2,6 +2,7 @@
 
 # authentication
 add_odbc_test(e2e_authentication_native_okta authentication/native_okta.cpp)
+add_odbc_test(e2e_authentication_oauth authentication/oauth.cpp)
 add_odbc_test(e2e_authentication_pat authentication/pat.cpp)
 add_odbc_test(e2e_authentication_private_key_auth authentication/private_key_auth.cpp)
 add_odbc_test(e2e_authentication_mfa_auth authentication/user_password_mfa.cpp)

--- a/odbc_tests/tests/e2e/authentication/oauth.cpp
+++ b/odbc_tests/tests/e2e/authentication/oauth.cpp
@@ -1,0 +1,330 @@
+#include <picojson.h>
+#include <sql.h>
+#include <sqlext.h>
+#include <sqltypes.h>
+
+#include <sstream>
+#include <string>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_all.hpp>
+
+#include "HandleWrapper.hpp"
+#include "compatibility.hpp"
+#include "get_diag_rec.hpp"
+#include "odbc_matchers.hpp"
+#include "require.hpp"
+#include "test_setup.hpp"
+
+// End-to-end OAuth tests for the ODBC wrapper.
+//
+// These tests drive a real Snowflake account / IdP through the full
+// SQLDriverConnect path. They are gated behind the
+// SNOWFLAKE_TEST_OAUTH_* parameters in parameters.json and SKIP() when
+// the relevant fields are missing -- mirroring the
+// `private_key_auth.cpp` pattern and the `oauth.rs` E2E gating in
+// sf_core/tests/e2e/authentication/.
+//
+// The Authorization Code happy-path scenarios spawn the OS browser
+// (via sf_core's loopback listener); we gate them behind
+// SNOWFLAKE_OAUTH_E2E_BROWSER=1 so a developer can opt in. The CC and
+// legacy OAUTH paths do not require a browser and run whenever the
+// matching parameters are configured.
+//
+// Required parameters.json keys (analysis_feature_oauth.md §9):
+//
+//   * SNOWFLAKE_TEST_OAUTH_ACCESS_TOKEN     legacy OAUTH / AC short-circuit
+//   * SNOWFLAKE_TEST_OAUTH_CLIENT_ID        AC + CC
+//   * SNOWFLAKE_TEST_OAUTH_CLIENT_SECRET    AC + CC
+//   * SNOWFLAKE_TEST_OAUTH_AUTHORIZATION_URL AC (optional; defaults to host)
+//   * SNOWFLAKE_TEST_OAUTH_TOKEN_REQUEST_URL AC (optional) / CC (required)
+//   * SNOWFLAKE_TEST_OAUTH_REDIRECT_URI     AC (optional)
+//   * SNOWFLAKE_TEST_OAUTH_SCOPE            AC + CC (optional)
+//
+// Test method names mirror sf_core's existing `oauth_should_*`
+// methods in sf_core/tests/e2e/authentication/oauth.rs so the same
+// Gherkin scenarios in tests/definitions/shared/authentication/oauth.feature
+// validate against both implementations. Scenario step text below is
+// taken verbatim from sf_core's oauth.rs comments where the @core_e2e
+// tag pairs the two suites.
+
+using namespace Catch::Matchers;
+
+namespace {
+
+#define REQUIRE_OAUTH_AC_BROWSER(message)                                                                    \
+  do {                                                                                                       \
+    if (std::getenv("SNOWFLAKE_OAUTH_E2E_BROWSER") == nullptr) {                                             \
+      SKIP("OAuth AC E2E spawns a real OS browser; opt in with SNOWFLAKE_OAUTH_E2E_BROWSER=1: " << message); \
+    }                                                                                                        \
+  } while (0)
+
+std::string require_oauth_param(const picojson::object& params, const std::string& key) {
+  auto it = params.find(key);
+  if (it == params.end() || !it->second.is<std::string>() || it->second.get<std::string>().empty()) {
+    SKIP("OAuth E2E test requires " << key << " in parameters.json");
+  }
+  return it->second.get<std::string>();
+}
+
+void add_oauth_param_optional(std::stringstream& ss, const picojson::object& params, const std::string& cfg_key,
+                              const std::string& conn_key) {
+  auto it = params.find(cfg_key);
+  if (it != params.end() && it->second.is<std::string>() && !it->second.get<std::string>().empty()) {
+    ss << conn_key << "=" << it->second.get<std::string>() << ";";
+  }
+}
+
+std::stringstream get_oauth_base_connection_stream(const std::string& authenticator) {
+  auto params = get_test_parameters("testconnection");
+  std::stringstream ss;
+  configure_driver_string(ss);
+  add_param_required<std::string>(ss, params, "SNOWFLAKE_TEST_HOST", "SERVER");
+  add_param_required<std::string>(ss, params, "SNOWFLAKE_TEST_ACCOUNT", "ACCOUNT");
+  add_param_required<std::string>(ss, params, "SNOWFLAKE_TEST_USER", "UID");
+  add_param_optional<std::string>(ss, params, "SNOWFLAKE_TEST_WAREHOUSE", "WAREHOUSE");
+  add_param_optional<std::string>(ss, params, "SNOWFLAKE_TEST_ROLE", "ROLE");
+  ss << "AUTHENTICATOR=" << authenticator << ";";
+  return ss;
+}
+
+EnvironmentHandleWrapper setup_oauth_environment() {
+  EnvironmentHandleWrapper env;
+  SQLRETURN ret = SQLSetEnvAttr(env.getHandle(), SQL_ATTR_ODBC_VERSION, (SQLPOINTER)SQL_OV_ODBC3, 0);
+  REQUIRE_ODBC(ret, env);
+  return env;
+}
+
+ConnectionHandleWrapper get_oauth_connection_handle(EnvironmentHandleWrapper& env) {
+  return env.createConnectionHandle();
+}
+
+void attempt_oauth_connection(ConnectionHandleWrapper& dbc, const std::string& connection_string) {
+  SQLRETURN ret = SQLDriverConnect(dbc.getHandle(), NULL, (SQLCHAR*)connection_string.c_str(), SQL_NTS, NULL, 0, NULL,
+                                   SQL_DRIVER_NOPROMPT);
+  REQUIRE_ODBC(ret, dbc);
+}
+
+void verify_oauth_simple_query_execution(ConnectionHandleWrapper& dbc) {
+  StatementHandleWrapper stmt = dbc.createStatementHandle();
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT 1", SQL_NTS);
+  REQUIRE_ODBC(ret, stmt);
+
+  ret = SQLFetch(stmt.getHandle());
+  REQUIRE_ODBC(ret, stmt);
+
+  SQLINTEGER result = 0;
+  ret = SQLGetData(stmt.getHandle(), 1, SQL_C_LONG, &result, sizeof(result), NULL);
+  REQUIRE_ODBC(ret, stmt);
+  REQUIRE(result == 1);
+}
+
+}  // anonymous namespace
+
+// =============================================================================
+// Legacy AUTHENTICATOR=OAUTH (pre-acquired access token, analysis §6 / §10.1)
+// =============================================================================
+
+TEST_CASE("oauth should authenticate with pre acquired access token", "[oauth_e2e]") {
+  SKIP_OLD_DRIVER("", "OAuth flows are new-driver-only");
+  auto params = get_test_parameters("testconnection");
+  std::string access_token = require_oauth_param(params, "SNOWFLAKE_TEST_OAUTH_ACCESS_TOKEN");
+
+  // Given Authentication is set to legacy OAUTH and a pre-acquired
+  //       OAuth access token is supplied via `token=`
+  std::stringstream ss = get_oauth_base_connection_stream("OAUTH");
+  ss << "TOKEN=" << access_token << ";";
+  std::string connection_string = ss.str();
+
+  auto env = setup_oauth_environment();
+  auto dbc = get_oauth_connection_handle(env);
+
+  // When Trying to Connect
+  attempt_oauth_connection(dbc, connection_string);
+
+  // Then Login is successful and a simple query can be executed
+  verify_oauth_simple_query_execution(dbc);
+
+  SQLDisconnect(dbc.getHandle());
+}
+
+TEST_CASE("oauth should fail legacy authentication with invalid token", "[oauth_e2e]") {
+  SKIP_OLD_DRIVER("", "OAuth flows are new-driver-only");
+
+  // Given Authentication is set to legacy OAUTH and an invalid
+  //       OAuth access token is supplied
+  std::stringstream ss = get_oauth_base_connection_stream("OAUTH");
+  ss << "TOKEN=invalid_oauth_token_12345;";
+  std::string connection_string = ss.str();
+
+  // When Trying to Connect
+  auto records = require_connection_failed(connection_string);
+
+  // Then Connection fails with an authentication / login error
+  REQUIRE(records.size() >= 1);
+  CHECK(records[0].sqlState == "28000");
+}
+
+TEST_CASE("oauth should authenticate using lowercase oauth authenticator", "[oauth_e2e]") {
+  SKIP_OLD_DRIVER("", "OAuth flows are new-driver-only");
+  auto params = get_test_parameters("testconnection");
+  std::string access_token = require_oauth_param(params, "SNOWFLAKE_TEST_OAUTH_ACCESS_TOKEN");
+
+  // Given Authentication is set to lowercase oauth and a valid pre-acquired OAuth access token is supplied via TOKEN
+  std::stringstream ss = get_oauth_base_connection_stream("oauth");
+  ss << "TOKEN=" << access_token << ";";
+  std::string connection_string = ss.str();
+
+  auto env = setup_oauth_environment();
+  auto dbc = get_oauth_connection_handle(env);
+
+  // When Trying to Connect
+  attempt_oauth_connection(dbc, connection_string);
+
+  // Then Login is successful and a simple query can be executed
+  verify_oauth_simple_query_execution(dbc);
+
+  SQLDisconnect(dbc.getHandle());
+}
+
+// =============================================================================
+// OAuth Authorization Code (AC) flow (analysis §3 / §10.2)
+// =============================================================================
+//
+// AC requires a real browser leg unless an OAuth access token has been
+// pre-seeded in the OS keyring. The seeding helper lives in the Rust
+// e2e test (sf_core/tests/e2e/authentication/oauth.rs) and is not
+// exposed to C++ ODBC tests, so the keyring-short-circuit scenario
+// stays sf_core-only. The two scenarios below opt in via
+// SNOWFLAKE_OAUTH_E2E_BROWSER=1.
+
+TEST_CASE("oauth should authenticate using authorization code flow", "[oauth_e2e]") {
+  SKIP_OLD_DRIVER("", "OAuth flows are new-driver-only");
+  REQUIRE_OAUTH_AC_BROWSER("Authorization Code happy path");
+  auto params = get_test_parameters("testconnection");
+  std::string client_id = require_oauth_param(params, "SNOWFLAKE_TEST_OAUTH_CLIENT_ID");
+  std::string client_secret = require_oauth_param(params, "SNOWFLAKE_TEST_OAUTH_CLIENT_SECRET");
+
+  // Given Authentication is set to OAUTH_AUTHORIZATION_CODE with a
+  //       valid client id / secret. `oauth_authorization_url` and
+  //       `oauth_token_request_url` are forwarded from parameters
+  //       when present (otherwise the driver falls back to the
+  //       Snowflake-IdP defaults `https://{host}/oauth/authorize`
+  //       and `https://{host}/oauth/token-request`).
+  //       `client_store_temporary_credential=true` lets the AC flow
+  //       short-circuit on subsequent runs by re-using the cached
+  //       access / refresh token (analysis §3.2 / §7).
+  std::stringstream ss = get_oauth_base_connection_stream("OAUTH_AUTHORIZATION_CODE");
+  ss << "OAUTH_CLIENT_ID=" << client_id << ";";
+  ss << "OAUTH_CLIENT_SECRET=" << client_secret << ";";
+  add_oauth_param_optional(ss, params, "SNOWFLAKE_TEST_OAUTH_AUTHORIZATION_URL", "OAUTH_AUTHORIZATION_URL");
+  add_oauth_param_optional(ss, params, "SNOWFLAKE_TEST_OAUTH_TOKEN_REQUEST_URL", "OAUTH_TOKEN_REQUEST_URL");
+  add_oauth_param_optional(ss, params, "SNOWFLAKE_TEST_OAUTH_REDIRECT_URI", "OAUTH_REDIRECT_URI");
+  add_oauth_param_optional(ss, params, "SNOWFLAKE_TEST_OAUTH_SCOPE", "OAUTH_SCOPE");
+  ss << "CLIENT_STORE_TEMPORARY_CREDENTIAL=true;";
+  std::string connection_string = ss.str();
+
+  auto env = setup_oauth_environment();
+  auto dbc = get_oauth_connection_handle(env);
+
+  // When Trying to Connect (this will spawn the local-loopback HTTP
+  //      listener and `xdg-open`/`open`/`ShellExecute` the IdP login URL
+  //      unless a previously cached access token short-circuits the leg)
+  attempt_oauth_connection(dbc, connection_string);
+
+  // Then Login is successful and a simple query can be executed
+  verify_oauth_simple_query_execution(dbc);
+
+  SQLDisconnect(dbc.getHandle());
+}
+
+TEST_CASE("oauth should fail authorization code flow with bad client secret", "[oauth_e2e]") {
+  SKIP_OLD_DRIVER("", "OAuth flows are new-driver-only");
+  REQUIRE_OAUTH_AC_BROWSER("Authorization Code negative path (browser leg still required)");
+  auto params = get_test_parameters("testconnection");
+  std::string client_id = require_oauth_param(params, "SNOWFLAKE_TEST_OAUTH_CLIENT_ID");
+
+  // Given Authentication is set to OAUTH_AUTHORIZATION_CODE with a
+  //       valid client id but a deliberately invalid client secret.
+  //       The IdP token-exchange step must reject the credentials
+  //       and the driver must surface an authentication / login
+  //       error.
+  std::stringstream ss = get_oauth_base_connection_stream("OAUTH_AUTHORIZATION_CODE");
+  ss << "OAUTH_CLIENT_ID=" << client_id << ";";
+  ss << "OAUTH_CLIENT_SECRET=invalid_client_secret_12345;";  // pragma: allowlist secret
+  add_oauth_param_optional(ss, params, "SNOWFLAKE_TEST_OAUTH_AUTHORIZATION_URL", "OAUTH_AUTHORIZATION_URL");
+  add_oauth_param_optional(ss, params, "SNOWFLAKE_TEST_OAUTH_TOKEN_REQUEST_URL", "OAUTH_TOKEN_REQUEST_URL");
+  add_oauth_param_optional(ss, params, "SNOWFLAKE_TEST_OAUTH_REDIRECT_URI", "OAUTH_REDIRECT_URI");
+  add_oauth_param_optional(ss, params, "SNOWFLAKE_TEST_OAUTH_SCOPE", "OAUTH_SCOPE");
+  ss << "CLIENT_STORE_TEMPORARY_CREDENTIAL=false;";
+  std::string connection_string = ss.str();
+
+  // When Trying to Connect
+  auto records = require_connection_failed(connection_string);
+
+  // Then Connection fails with an authentication / login error
+  REQUIRE(records.size() >= 1);
+  CHECK(records[0].sqlState == "28000");
+}
+
+// =============================================================================
+// OAuth Client Credentials (CC) flow (analysis §4 / §10.3)
+// =============================================================================
+//
+// CC does not launch a browser -- it performs an HTTP token exchange
+// directly against the configured IdP token URL. Snowflake itself does
+// not mint CC tokens (analysis §4), so SNOWFLAKE_TEST_OAUTH_TOKEN_REQUEST_URL
+// is required up-front.
+
+TEST_CASE("oauth should authenticate using client credentials flow", "[oauth_e2e]") {
+  SKIP_OLD_DRIVER("", "OAuth flows are new-driver-only");
+  auto params = get_test_parameters("testconnection");
+  std::string client_id = require_oauth_param(params, "SNOWFLAKE_TEST_OAUTH_CLIENT_ID");
+  std::string client_secret = require_oauth_param(params, "SNOWFLAKE_TEST_OAUTH_CLIENT_SECRET");
+  std::string token_url = require_oauth_param(params, "SNOWFLAKE_TEST_OAUTH_TOKEN_REQUEST_URL");
+
+  // Given Authentication is set to OAUTH_CLIENT_CREDENTIALS with a
+  //       valid client id / secret and an external IdP token URL.
+  //       Snowflake's GS does not mint CC tokens (analysis §4), so
+  //       `oauth_token_request_url` is required up-front.
+  std::stringstream ss = get_oauth_base_connection_stream("OAUTH_CLIENT_CREDENTIALS");
+  ss << "OAUTH_CLIENT_ID=" << client_id << ";";
+  ss << "OAUTH_CLIENT_SECRET=" << client_secret << ";";
+  ss << "OAUTH_TOKEN_REQUEST_URL=" << token_url << ";";
+  add_oauth_param_optional(ss, params, "SNOWFLAKE_TEST_OAUTH_SCOPE", "OAUTH_SCOPE");
+  std::string connection_string = ss.str();
+
+  auto env = setup_oauth_environment();
+  auto dbc = get_oauth_connection_handle(env);
+
+  // When Trying to Connect
+  attempt_oauth_connection(dbc, connection_string);
+
+  // Then Login is successful and a simple query can be executed
+  verify_oauth_simple_query_execution(dbc);
+
+  SQLDisconnect(dbc.getHandle());
+}
+
+TEST_CASE("oauth should fail client credentials flow with bad client secret", "[oauth_e2e]") {
+  SKIP_OLD_DRIVER("", "OAuth flows are new-driver-only");
+  auto params = get_test_parameters("testconnection");
+  std::string client_id = require_oauth_param(params, "SNOWFLAKE_TEST_OAUTH_CLIENT_ID");
+  std::string token_url = require_oauth_param(params, "SNOWFLAKE_TEST_OAUTH_TOKEN_REQUEST_URL");
+
+  // Given Authentication is set to OAUTH_CLIENT_CREDENTIALS with a valid client id, an invalid client secret and a
+  // valid token_request_url
+  std::stringstream ss = get_oauth_base_connection_stream("OAUTH_CLIENT_CREDENTIALS");
+  ss << "OAUTH_CLIENT_ID=" << client_id << ";";
+  ss << "OAUTH_CLIENT_SECRET=invalid_client_secret_12345;";  // pragma: allowlist secret
+  ss << "OAUTH_TOKEN_REQUEST_URL=" << token_url << ";";
+  add_oauth_param_optional(ss, params, "SNOWFLAKE_TEST_OAUTH_SCOPE", "OAUTH_SCOPE");
+  std::string connection_string = ss.str();
+
+  // When Trying to Connect
+  auto records = require_connection_failed(connection_string);
+
+  // Then Connection fails with an authentication / login error
+  REQUIRE(records.size() >= 1);
+  CHECK(records[0].sqlState == "28000");
+}

--- a/odbc_tests/tests/integration/authentication/oauth.cpp
+++ b/odbc_tests/tests/integration/authentication/oauth.cpp
@@ -30,21 +30,18 @@
 // configuration is valid, and the CC flow performs an HTTP token
 // exchange against the configured IdP. Neither is appropriate for an
 // integration test that must run offline. Happy-path coverage lives in
-// the e2e suite (substep 6) gated behind a real IdP.
+// the e2e suite (oauth.cpp) gated behind a real IdP, and the
+// BROWSER_LAUNCH_DISABLED kill switch is exercised by sf_core's own
+// integration tests (sf_core/tests/integration/authentication/oauth.rs).
 //
-// What we DO cover here:
-//   * Missing-required-parameter diagnostics for AC, CC, and legacy
-//     OAUTH (sf_core surfaces these synchronously, before any browser
-//     launch or network call).
-//   * Case-insensitive AUTHENTICATOR matching for OAuth flow names.
-//   * Invalid AUTHENTICATOR rejection.
-//   * Legacy AUTHENTICATOR=OAUTH with a TOKEN forwards the token to
-//     sf_core (the localhost backend then fails to connect, but no
-//     missing-parameter diagnostic is raised for the token).
+// What we DO cover here, mapped to scenarios in
+// tests/definitions/shared/authentication/oauth.feature:
 //
-// Gherkin scenarios for these test cases live in
-// tests/definitions/shared/authentication/oauth.feature (added by
-// substep 6 of this stack).
+//   * @odbc_int validation paths for OAUTH_CLIENT_CREDENTIALS
+//   * @odbc_int legacy AUTHENTICATOR=OAUTH (token forwarding + missing token)
+//   * @odbc_int case-insensitive AUTHENTICATOR matching
+//   * @odbc_int unknown OAuth-like AUTHENTICATOR value rejection
+//   * @odbc_int OAUTH_CLIENT_SECRET literal redaction in diagnostic records
 
 using Catch::Matchers::ContainsSubstring;
 
@@ -76,8 +73,6 @@ ConnectionHandleWrapper get_oauth_connection_handle(EnvironmentHandleWrapper& en
 SQLRETURN attempt_oauth_connection(ConnectionHandleWrapper& dbc, const std::string& connection_string) {
   SQLRETURN ret = SQLDriverConnect(dbc.getHandle(), NULL, (SQLCHAR*)connection_string.c_str(), SQL_NTS, NULL, 0, NULL,
                                    SQL_DRIVER_NOPROMPT);
-  // Connection failure is expected: no live Snowflake instance is
-  // reachable here. Fail loudly only if the driver itself is broken.
   REQUIRE(ret == SQL_ERROR);
 
   auto records = get_diag_rec(dbc);
@@ -109,9 +104,9 @@ bool diag_contains_missing(const std::vector<DiagRec>& records, const std::strin
 // We do NOT add validation tests for AC here. As soon as a complete
 // AC configuration is supplied, sf_core spawns the loopback listener
 // and launches the OS browser -- both unsafe in CI / offline test
-// environments. AC happy-path coverage lives in the e2e suite
-// (substep 6) gated behind a real IdP, and the BROWSER_LAUNCH_DISABLED
-// kill switch is exercised by sf_core's own integration tests
+// environments. AC happy-path coverage lives in the e2e suite (oauth.cpp)
+// gated behind a real IdP, and the BROWSER_LAUNCH_DISABLED kill switch is
+// exercised by sf_core's own integration tests
 // (sf_core/tests/integration/authentication/oauth.rs).
 
 // =============================================================================
@@ -119,15 +114,10 @@ bool diag_contains_missing(const std::vector<DiagRec>& records, const std::strin
 // hit the IdP; that path is exercised in the e2e suite).
 // =============================================================================
 
-// Gherkin: Scenario: should fail OAUTH_CLIENT_CREDENTIALS when client_id is missing
-TEST_CASE("should fail OAUTH_CLIENT_CREDENTIALS when client_id is missing", "[oauth_auth]") {
+TEST_CASE("should fail OAUTH_CLIENT_CREDENTIALS when client_id is missing", "[oauth_int]") {
   SKIP_OLD_DRIVER("", "New-driver-only: tests OAuth CC required-param validation");
 
-  // Given Authentication is set to OAUTH_CLIENT_CREDENTIALS with the
-  //       client_id field omitted -- per analysis §4, all three of
-  //       client_id / client_secret / oauth_token_request_url are
-  //       required for CC because Snowflake's GS does not mint CC
-  //       tokens.
+  // Given Authentication is set to OAUTH_CLIENT_CREDENTIALS without oauth_client_id
   auto env = setup_oauth_environment();
   auto dbc = get_oauth_connection_handle(env);
   std::stringstream ss;
@@ -139,19 +129,16 @@ TEST_CASE("should fail OAUTH_CLIENT_CREDENTIALS when client_id is missing", "[oa
   // When Trying to Connect
   SQLRETURN ret = attempt_oauth_connection(dbc, connection_string);
 
-  // Then Connection fails with a missing-parameter error citing
-  //      oauth_client_id.
+  // Then Connection fails with a missing-parameter error citing oauth_client_id
   REQUIRE(ret == SQL_ERROR);
   auto records = get_diag_rec(dbc);
   CHECK(diag_contains_missing(records, "oauth_client_id"));
 }
 
-// Gherkin: Scenario: should fail OAUTH_CLIENT_CREDENTIALS when client_secret is missing
-TEST_CASE("should fail OAUTH_CLIENT_CREDENTIALS when client_secret is missing", "[oauth_auth]") {
+TEST_CASE("should fail OAUTH_CLIENT_CREDENTIALS when client_secret is missing", "[oauth_int]") {
   SKIP_OLD_DRIVER("", "New-driver-only: tests OAuth CC required-param validation");
 
-  // Given Authentication is set to OAUTH_CLIENT_CREDENTIALS without a
-  //       client_secret.
+  // Given Authentication is set to OAUTH_CLIENT_CREDENTIALS without oauth_client_secret
   auto env = setup_oauth_environment();
   auto dbc = get_oauth_connection_handle(env);
   std::stringstream ss;
@@ -163,20 +150,16 @@ TEST_CASE("should fail OAUTH_CLIENT_CREDENTIALS when client_secret is missing", 
   // When Trying to Connect
   SQLRETURN ret = attempt_oauth_connection(dbc, connection_string);
 
-  // Then Connection fails with a missing-parameter error citing
-  //      oauth_client_secret.
+  // Then Connection fails with a missing-parameter error citing oauth_client_secret
   REQUIRE(ret == SQL_ERROR);
   auto records = get_diag_rec(dbc);
   CHECK(diag_contains_missing(records, "oauth_client_secret"));
 }
 
-// Gherkin: Scenario: should fail OAUTH_CLIENT_CREDENTIALS when token_request_url is missing
-TEST_CASE("should fail OAUTH_CLIENT_CREDENTIALS when token_request_url is missing", "[oauth_auth]") {
+TEST_CASE("should fail OAUTH_CLIENT_CREDENTIALS when token_request_url is missing", "[oauth_int]") {
   SKIP_OLD_DRIVER("", "New-driver-only: tests OAuth CC required-param validation");
 
-  // Given Authentication is set to OAUTH_CLIENT_CREDENTIALS without
-  //       oauth_token_request_url -- mandatory because Snowflake does
-  //       not host a CC token endpoint.
+  // Given Authentication is set to OAUTH_CLIENT_CREDENTIALS without oauth_token_request_url
   auto env = setup_oauth_environment();
   auto dbc = get_oauth_connection_handle(env);
   std::stringstream ss;
@@ -188,8 +171,7 @@ TEST_CASE("should fail OAUTH_CLIENT_CREDENTIALS when token_request_url is missin
   // When Trying to Connect
   SQLRETURN ret = attempt_oauth_connection(dbc, connection_string);
 
-  // Then Connection fails with a missing-parameter error citing
-  //      oauth_token_request_url.
+  // Then Connection fails with a missing-parameter error citing oauth_token_request_url
   REQUIRE(ret == SQL_ERROR);
   auto records = get_diag_rec(dbc);
   CHECK(diag_contains_missing(records, "oauth_token_request_url"));
@@ -199,14 +181,10 @@ TEST_CASE("should fail OAUTH_CLIENT_CREDENTIALS when token_request_url is missin
 // Legacy AUTHENTICATOR=OAUTH (pre-acquired access token)
 // =============================================================================
 
-// Gherkin: Scenario: should forward AUTHENTICATOR=OAUTH with TOKEN to core
-TEST_CASE("should forward AUTHENTICATOR=OAUTH with TOKEN to core", "[oauth_auth]") {
+TEST_CASE("should forward AUTHENTICATOR=OAUTH with TOKEN to core", "[oauth_int]") {
   SKIP_OLD_DRIVER("", "New-driver-only: tests legacy OAuth token forwarding");
 
-  // Given Authentication is set to legacy OAUTH with a pre-acquired
-  //       access token (analysis §6 / §10.1). This path does NOT spawn
-  //       a browser or perform an IdP exchange -- the wrapper hands the
-  //       token straight to the Snowflake login request.
+  // Given Authentication is set to legacy OAUTH with a pre-acquired access token
   auto env = setup_oauth_environment();
   auto dbc = get_oauth_connection_handle(env);
   std::stringstream ss;
@@ -217,18 +195,16 @@ TEST_CASE("should forward AUTHENTICATOR=OAUTH with TOKEN to core", "[oauth_auth]
   // When Trying to Connect
   SQLRETURN ret = attempt_oauth_connection(dbc, connection_string);
 
-  // Then Connection reaches sf_core without a missing-parameter
-  //      error for the token.
+  // Then The wrapper forwards the token to sf_core without raising a missing-parameter error for it
   REQUIRE(ret == SQL_ERROR);
   auto records = get_diag_rec(dbc);
   CHECK_FALSE(diag_contains_missing(records, "token"));
 }
 
-// Gherkin: Scenario: should fail AUTHENTICATOR=OAUTH when TOKEN is missing
-TEST_CASE("should fail AUTHENTICATOR=OAUTH when TOKEN is missing", "[oauth_auth]") {
+TEST_CASE("should fail AUTHENTICATOR=OAUTH when TOKEN is missing", "[oauth_int]") {
   SKIP_OLD_DRIVER("", "New-driver-only: tests legacy OAuth required-param validation");
 
-  // Given Authentication is set to legacy OAUTH without a TOKEN.
+  // Given Authentication is set to legacy OAUTH without a TOKEN
   auto env = setup_oauth_environment();
   auto dbc = get_oauth_connection_handle(env);
   std::string connection_string = get_oauth_base_connection_string("OAUTH");
@@ -236,20 +212,16 @@ TEST_CASE("should fail AUTHENTICATOR=OAUTH when TOKEN is missing", "[oauth_auth]
   // When Trying to Connect
   SQLRETURN ret = attempt_oauth_connection(dbc, connection_string);
 
-  // Then Connection fails with a missing-parameter error citing the
-  //      token (analysis §6: legacy OAUTH requires `token=`).
+  // Then Connection fails with a missing-parameter error citing token
   REQUIRE(ret == SQL_ERROR);
   auto records = get_diag_rec(dbc);
   CHECK(diag_contains_missing(records, "token"));
 }
 
-// Gherkin: Scenario: should accept lowercase oauth authenticator value (legacy)
-TEST_CASE("should accept lowercase oauth authenticator value", "[oauth_auth]") {
+TEST_CASE("should accept lowercase oauth authenticator value", "[oauth_int]") {
   SKIP_OLD_DRIVER("", "New-driver-only: tests case-insensitive AUTHENTICATOR matching for legacy OAUTH");
 
-  // Given Authentication is set to lowercase oauth (legacy) with a
-  //       TOKEN. analysis §9 -- case-insensitive matching of OAuth
-  //       flow names.
+  // Given Authentication is set to lowercase oauth with a TOKEN
   auto env = setup_oauth_environment();
   auto dbc = get_oauth_connection_handle(env);
   std::stringstream ss;
@@ -260,8 +232,7 @@ TEST_CASE("should accept lowercase oauth authenticator value", "[oauth_auth]") {
   // When Trying to Connect
   SQLRETURN ret = attempt_oauth_connection(dbc, connection_string);
 
-  // Then The wrapper does not reject the AUTHENTICATOR value as
-  //      unknown.
+  // Then The wrapper does not reject the AUTHENTICATOR value as unknown
   REQUIRE(ret == SQL_ERROR);
   auto records = get_diag_rec(dbc);
   for (const auto& record : records) {
@@ -274,12 +245,10 @@ TEST_CASE("should accept lowercase oauth authenticator value", "[oauth_auth]") {
 // Negative path: invalid authenticator value
 // =============================================================================
 
-// Gherkin: Scenario: should fail when AUTHENTICATOR is set to an unknown OAuth-like value
-TEST_CASE("should fail when AUTHENTICATOR is an unknown OAuth-like value", "[oauth_auth]") {
+TEST_CASE("should fail when AUTHENTICATOR is an unknown OAuth-like value", "[oauth_int]") {
   SKIP_OLD_DRIVER("", "New-driver-only: tests unknown-authenticator validation");
 
   // Given Authentication is set to a typo of an OAuth flow name
-  //       (e.g. OAUTH_AUTHORIZATION_TYPO).
   auto env = setup_oauth_environment();
   auto dbc = get_oauth_connection_handle(env);
   std::stringstream ss;
@@ -290,10 +259,7 @@ TEST_CASE("should fail when AUTHENTICATOR is an unknown OAuth-like value", "[oau
   // When Trying to Connect
   SQLRETURN ret = attempt_oauth_connection(dbc, connection_string);
 
-  // Then Connection fails with an authenticator-related error.
-  //      sf_core's exact wording may evolve; we only assert that some
-  //      diagnostic mentions the bogus authenticator value or flags it
-  //      as invalid/unknown.
+  // Then Connection fails with an authenticator-related error
   REQUIRE(ret == SQL_ERROR);
   auto records = get_diag_rec(dbc);
   bool found = diag_contains(records, "Invalid authenticator") || diag_contains(records, "Unknown authenticator") ||
@@ -305,12 +271,10 @@ TEST_CASE("should fail when AUTHENTICATOR is an unknown OAuth-like value", "[oau
 // Secret redaction in driver logs
 // =============================================================================
 
-// Gherkin: Scenario: should not echo OAUTH_CLIENT_SECRET back in any diagnostic record
-TEST_CASE("should not echo OAUTH_CLIENT_SECRET in diagnostics", "[oauth_auth]") {
+TEST_CASE("should not echo OAUTH_CLIENT_SECRET in diagnostics", "[oauth_int]") {
   SKIP_OLD_DRIVER("", "New-driver-only: secret redaction in OAuth diagnostics");
 
-  // Given Authentication is set to OAUTH_CLIENT_CREDENTIALS with a
-  //       distinctive client secret literal.
+  // Given Authentication is set to OAUTH_CLIENT_CREDENTIALS with a distinctive client secret literal
   auto env = setup_oauth_environment();
   auto dbc = get_oauth_connection_handle(env);
   const std::string secret_literal = "ZZ_SECRET_NEEDLE_OAUTH_CC_ZZ";
@@ -318,14 +282,13 @@ TEST_CASE("should not echo OAUTH_CLIENT_SECRET in diagnostics", "[oauth_auth]") 
   ss << get_oauth_base_connection_string("OAUTH_CLIENT_CREDENTIALS");
   ss << "OAUTH_CLIENT_ID=test-client-id;";
   ss << "OAUTH_CLIENT_SECRET=" << secret_literal << ";";
-  // Omit the token URL so the flow fails fast on validation.
   std::string connection_string = ss.str();
 
   // When Trying to Connect
   SQLRETURN ret = attempt_oauth_connection(dbc, connection_string);
   REQUIRE(ret == SQL_ERROR);
 
-  // Then No diagnostic record contains the literal secret.
+  // Then No diagnostic record contains the literal client secret
   auto records = get_diag_rec(dbc);
   for (const auto& record : records) {
     CHECK_THAT(record.messageText, !ContainsSubstring(secret_literal));

--- a/tests/definitions/shared/authentication/oauth.feature
+++ b/tests/definitions/shared/authentication/oauth.feature
@@ -1,0 +1,131 @@
+@core @odbc
+Feature: OAuth Authentication
+
+  OAuth 2.0 authentication for Snowflake drivers, covering the three
+  flows documented in analysis_feature_oauth.md (§3 Authorization Code,
+  §4 Client Credentials, §6 legacy pre-acquired access token). Behaviour
+  parity with snowflake-jdbc and snowflake-connector-python is the goal;
+  the feature description requires the `oauth2` crate as the underlying
+  primitive in sf_core.
+
+  # ===========================================================================
+  # ODBC integration tests -- offline; exercise the wrapper's
+  # connection-string parsing, OAuth-key forwarding, required-parameter
+  # validation, and secret redaction without contacting an IdP or
+  # Snowflake. Implemented in odbc_tests/tests/integration/authentication/oauth.cpp.
+  # ===========================================================================
+
+  @odbc_int
+  Scenario: should fail OAUTH_CLIENT_CREDENTIALS when client_id is missing
+    Given Authentication is set to OAUTH_CLIENT_CREDENTIALS without oauth_client_id
+    When Trying to Connect
+    Then Connection fails with a missing-parameter error citing oauth_client_id
+
+  @odbc_int
+  Scenario: should fail OAUTH_CLIENT_CREDENTIALS when client_secret is missing
+    Given Authentication is set to OAUTH_CLIENT_CREDENTIALS without oauth_client_secret
+    When Trying to Connect
+    Then Connection fails with a missing-parameter error citing oauth_client_secret
+
+  @odbc_int
+  Scenario: should fail OAUTH_CLIENT_CREDENTIALS when token_request_url is missing
+    Given Authentication is set to OAUTH_CLIENT_CREDENTIALS without oauth_token_request_url
+    When Trying to Connect
+    Then Connection fails with a missing-parameter error citing oauth_token_request_url
+
+  @odbc_int
+  Scenario: should forward AUTHENTICATOR=OAUTH with TOKEN to core
+    Given Authentication is set to legacy OAUTH with a pre-acquired access token
+    When Trying to Connect
+    Then The wrapper forwards the token to sf_core without raising a missing-parameter error for it
+
+  @odbc_int
+  Scenario: should fail AUTHENTICATOR=OAUTH when TOKEN is missing
+    Given Authentication is set to legacy OAUTH without a TOKEN
+    When Trying to Connect
+    Then Connection fails with a missing-parameter error citing token
+
+  @odbc_int
+  Scenario: should accept lowercase oauth authenticator value
+    Given Authentication is set to lowercase oauth with a TOKEN
+    When Trying to Connect
+    Then The wrapper does not reject the AUTHENTICATOR value as unknown
+
+  @odbc_int
+  Scenario: should fail when AUTHENTICATOR is an unknown OAuth-like value
+    Given Authentication is set to a typo of an OAuth flow name
+    When Trying to Connect
+    Then Connection fails with an authenticator-related error
+
+  @odbc_int
+  Scenario: should not echo OAUTH_CLIENT_SECRET in diagnostics
+    Given Authentication is set to OAUTH_CLIENT_CREDENTIALS with a distinctive client secret literal
+    When Trying to Connect
+    Then No diagnostic record contains the literal client secret
+
+  # ===========================================================================
+  # E2E tests -- require real Snowflake / IdP credentials. Implemented in
+  # sf_core/tests/e2e/authentication/oauth.rs and (where applicable to the
+  # ODBC wrapper) odbc_tests/tests/e2e/authentication/oauth.cpp.
+  #
+  # Scenario step text matches the existing sf_core comments verbatim so a
+  # single Gherkin definition validates both the Rust and ODBC test
+  # methods. The Authorization Code happy path additionally requires a
+  # real OS browser; in ODBC we gate it behind SNOWFLAKE_OAUTH_E2E_BROWSER=1.
+  # The cached-access-token short-circuit scenario depends on the OS
+  # keyring helper that lives in sf_core only -- ODBC does not implement
+  # it.
+  # ===========================================================================
+
+  @core_e2e @odbc_e2e
+  Scenario: oauth should authenticate with pre acquired access token
+    Given Authentication is set to legacy OAUTH and a pre-acquired OAuth access token is supplied via `token=`
+    When Trying to Connect
+    Then Login is successful and a simple query can be executed
+
+  @core_e2e @odbc_e2e
+  Scenario: oauth should fail legacy authentication with invalid token
+    Given Authentication is set to legacy OAUTH and an invalid OAuth access token is supplied
+    When Trying to Connect
+    Then Connection fails with an authentication / login error
+
+  @core_e2e @odbc_e2e
+  Scenario: oauth should authenticate using authorization code flow
+    Given Authentication is set to OAUTH_AUTHORIZATION_CODE with a valid client id / secret. `oauth_authorization_url` and `oauth_token_request_url` are forwarded from parameters when present (otherwise the driver falls back to the Snowflake-IdP defaults `https://{host}/oauth/authorize` and `https://{host}/oauth/token-request`). `client_store_temporary_credential=true` lets the AC flow short-circuit on subsequent runs by re-using the cached access / refresh token (analysis §3.2 / §7).
+    When Trying to Connect (this will spawn the local-loopback HTTP listener and `xdg-open`/`open`/`ShellExecute` the IdP login URL unless a previously cached access token short-circuits the leg)
+    Then Login is successful and a simple query can be executed
+
+  @core_e2e
+  Scenario: oauth should short circuit authorization code flow with cached access token
+    Given Authentication is set to OAUTH_AUTHORIZATION_CODE and a valid OAuth access token is pre-seeded in the OS keyring under the (host, user, OAUTH_ACCESS_TOKEN) cache key. The host is derived from `oauth_token_request_url` — falling back to the Snowflake server URL — exactly like `host_from_token_url` in production code (analysis §7.3).
+    When Trying to Connect — should NOT spawn a browser; the pre-seeded access token must satisfy the AC short-circuit.
+    Then Login is successful and a simple query can be executed
+
+  @core_e2e @odbc_e2e
+  Scenario: oauth should authenticate using client credentials flow
+    Given Authentication is set to OAUTH_CLIENT_CREDENTIALS with a valid client id / secret and an external IdP token URL. Snowflake's GS does not mint CC tokens (analysis §4), so `oauth_token_request_url` is required up-front.
+    When Trying to Connect
+    Then Login is successful and a simple query can be executed
+
+  @core_e2e @odbc_e2e
+  Scenario: oauth should fail authorization code flow with bad client secret
+    Given Authentication is set to OAUTH_AUTHORIZATION_CODE with a valid client id but a deliberately invalid client secret. The IdP token-exchange step must reject the credentials and the driver must surface an authentication / login error.
+    When Trying to Connect
+    Then Connection fails with an authentication / login error
+
+  # ODBC-only E2E scenarios -- not implemented in sf_core because the
+  # Rust e2e harness covers different cases (keyring short-circuit) and
+  # the case-insensitive matching of OAUTH is exercised by sf_core unit
+  # tests instead.
+
+  @odbc_e2e
+  Scenario: oauth should authenticate using lowercase oauth authenticator
+    Given Authentication is set to lowercase oauth and a valid pre-acquired OAuth access token is supplied via TOKEN
+    When Trying to Connect
+    Then Login is successful and a simple query can be executed
+
+  @odbc_e2e
+  Scenario: oauth should fail client credentials flow with bad client secret
+    Given Authentication is set to OAUTH_CLIENT_CREDENTIALS with a valid client id, an invalid client secret and a valid token_request_url
+    When Trying to Connect
+    Then Connection fails with an authentication / login error


### PR DESCRIPTION
Adds the user-facing Gherkin feature file for the OAuth feature and the
ODBC E2E test suite that drives a real Snowflake account / IdP through
the full SQLDriverConnect path:

  * tests/definitions/shared/authentication/oauth.feature defines all
    user-visible OAuth scenarios. @odbc_int scenarios cover the offline
    parser/validation/redaction tests added in the previous substep;
    @core_e2e + @odbc_e2e scenarios mirror sf_core's existing
    `oauth_should_*` E2E methods so the same Gherkin definition
    validates both Rust and ODBC implementations. The cached-keyring
    short-circuit scenario is left @core_e2e-only because the keyring
    seeding helper lives in sf_core.

  * odbc_tests/tests/e2e/authentication/oauth.cpp adds:
      - happy-path and negative legacy `AUTHENTICATOR=OAUTH` (no
        browser, no IdP exchange);
      - case-insensitive lowercase `oauth` authenticator (ODBC-only --
        sf_core covers case folding via unit tests instead);
      - happy-path and bad-client-secret `OAUTH_AUTHORIZATION_CODE`
        gated behind SNOWFLAKE_OAUTH_E2E_BROWSER=1 because the AC flow
        spawns the OS browser via sf_core's loopback listener;
      - happy-path and bad-client-secret `OAUTH_CLIENT_CREDENTIALS`
        against an external IdP token endpoint
        (SNOWFLAKE_TEST_OAUTH_TOKEN_REQUEST_URL is required, mirroring
        analysis §4 -- Snowflake's GS does not mint CC tokens).
    Each test SKIP()s gracefully when the corresponding
    SNOWFLAKE_TEST_OAUTH_* parameter is missing so the suite is a
    no-op outside the OAuth-configured CI lane.

  * odbc_tests/tests/integration/authentication/oauth_auth.cpp is
    renamed to oauth.cpp so the file stem matches the feature file --
    required by the tests format validator's name pairing. Test method
    names and step comments are updated to match the @odbc_int
    scenarios verbatim. Test bodies are unchanged.

  * odbc_tests/tests/e2e/CMakeLists.txt registers the new
    e2e_authentication_oauth target. The integration target picks up
    the renamed file via the existing GLOB_RECURSE.

Quality gates (cargo fmt -p odbc; cargo clippy -p odbc --all-targets
-- -D warnings; cargo test -p odbc --lib; cmake --build for both
targets; integration_authentication_oauth: 8/8 cases pass with 65
assertions; e2e_authentication_oauth: skips cleanly without OAuth
parameters; tests format validator passes for all 42 features).

Co-authored-by: Cursor <cursoragent@cursor.com>