### PR TITLE
SNOW-2872391: add OAuth Python wrapper E2E tests and align Gherkin scenarios

### DIFF
--- a/python/tests/e2e/authentication/test_oauth.py
+++ b/python/tests/e2e/authentication/test_oauth.py
@@ -1,0 +1,250 @@
+"""End-to-end OAuth tests for the Python wrapper.
+
+These tests drive a real Snowflake account / IdP through
+``snowflake.connector.connect()``. They are gated behind the
+``SNOWFLAKE_TEST_OAUTH_*`` parameters in ``parameters.json`` and
+``pytest.skip`` when the relevant fields are missing -- mirroring the
+``test_pat.py`` / ``test_user_password_mfa.py`` patterns and the
+``oauth.cpp`` E2E gating in ``odbc_tests/tests/e2e/authentication/`` and
+the ``oauth.rs`` E2E gating in ``sf_core/tests/e2e/authentication/``.
+
+The Authorization Code happy-path scenarios spawn the OS browser via
+sf_core's loopback listener; they are gated additionally behind
+``SNOWFLAKE_OAUTH_E2E_BROWSER=1`` so a developer can opt in. The Client
+Credentials and legacy ``AUTHENTICATOR=OAUTH`` paths do not require a
+browser and run whenever the matching parameters are configured.
+
+Required ``parameters.json`` keys (analysis_feature_oauth.md §9):
+
+* ``SNOWFLAKE_TEST_OAUTH_ACCESS_TOKEN``       legacy OAUTH / AC short-circuit
+* ``SNOWFLAKE_TEST_OAUTH_CLIENT_ID``          AC + CC
+* ``SNOWFLAKE_TEST_OAUTH_CLIENT_SECRET``      AC + CC
+* ``SNOWFLAKE_TEST_OAUTH_AUTHORIZATION_URL``  AC (optional)
+* ``SNOWFLAKE_TEST_OAUTH_TOKEN_REQUEST_URL``  AC (optional) / CC (required)
+* ``SNOWFLAKE_TEST_OAUTH_REDIRECT_URI``       AC (optional)
+* ``SNOWFLAKE_TEST_OAUTH_SCOPE``              AC + CC (optional)
+
+Test method names mirror sf_core's existing ``oauth_should_*`` methods
+in ``sf_core/tests/e2e/authentication/oauth.rs`` (and the ODBC
+equivalents) so the same Gherkin scenarios in
+``tests/definitions/shared/authentication/oauth.feature`` validate
+against every implementation. Scenario step text below is taken
+verbatim from the corresponding sf_core / ODBC comments.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from ...config import get_test_parameters
+from .auth_helpers import verify_simple_query_execution
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _require_oauth_param(params: dict[str, object], key: str) -> str:
+    """Return ``params[key]`` or skip the test when it's missing / empty."""
+    value = params.get(key)
+    if not isinstance(value, str) or not value:
+        pytest.skip(f"OAuth E2E test requires {key} in parameters.json")
+    return value
+
+
+def _add_oauth_optional(kwargs: dict[str, object], params: dict[str, object], cfg_key: str, conn_key: str) -> None:
+    """Set ``kwargs[conn_key]`` from ``params[cfg_key]`` when the parameter is provided."""
+    value = params.get(cfg_key)
+    if isinstance(value, str) and value:
+        kwargs[conn_key] = value
+
+
+def _require_oauth_browser_opt_in(message: str) -> None:
+    """Skip the test unless ``SNOWFLAKE_OAUTH_E2E_BROWSER=1`` is set.
+
+    The OAuth Authorization Code happy-path scenarios spawn the OS
+    browser via sf_core's loopback listener; we gate them so they do
+    not run by accident in CI.
+    """
+    if os.environ.get("SNOWFLAKE_OAUTH_E2E_BROWSER") != "1":
+        pytest.skip(f"OAuth AC E2E spawns a real OS browser; opt in with SNOWFLAKE_OAUTH_E2E_BROWSER=1: {message}")
+
+
+@pytest.fixture(scope="module")
+def oauth_params() -> dict[str, object]:
+    """Expose the full parameters.json for OAuth-specific lookups."""
+    return get_test_parameters()
+
+
+# ---------------------------------------------------------------------------
+# Legacy AUTHENTICATOR=OAUTH (pre-acquired access token, analysis §6 / §10.1)
+# ---------------------------------------------------------------------------
+
+
+class TestLegacyOAuthAccessToken:
+    def test_oauth_should_authenticate_with_pre_acquired_access_token(self, connection_factory, oauth_params):
+        # Given Authentication is set to legacy OAUTH and a pre-acquired OAuth access token is supplied via `token=`
+        access_token = _require_oauth_param(oauth_params, "SNOWFLAKE_TEST_OAUTH_ACCESS_TOKEN")
+        authenticator = "OAUTH"
+
+        # When Trying to Connect
+        connection = connection_factory(authenticator=authenticator, token=access_token)
+
+        # Then Login is successful and a simple query can be executed
+        with connection:
+            verify_simple_query_execution(connection)
+
+    def test_oauth_should_fail_legacy_authentication_with_invalid_token(self, connection_factory):
+        # Given Authentication is set to legacy OAUTH and an invalid OAuth access token is supplied
+        authenticator = "OAUTH"
+        invalid_token = "invalid_oauth_token_12345"
+
+        # When Trying to Connect
+        with pytest.raises(Exception) as exc_info:
+            connection_factory(authenticator=authenticator, token=invalid_token)
+
+        # Then Connection fails with an authentication / login error
+        from snowflake.connector.errors import DatabaseError
+
+        assert isinstance(exc_info.value, DatabaseError), f"Expected DatabaseError, got: {type(exc_info.value)}"
+
+    def test_oauth_should_authenticate_using_lowercase_oauth_authenticator(self, connection_factory, oauth_params):
+        # Given Authentication is set to lowercase oauth and a valid pre-acquired
+        #       OAuth access token is supplied via TOKEN
+        access_token = _require_oauth_param(oauth_params, "SNOWFLAKE_TEST_OAUTH_ACCESS_TOKEN")
+        authenticator = "oauth"
+
+        # When Trying to Connect
+        connection = connection_factory(authenticator=authenticator, token=access_token)
+
+        # Then Login is successful and a simple query can be executed
+        with connection:
+            verify_simple_query_execution(connection)
+
+
+# ---------------------------------------------------------------------------
+# OAuth Authorization Code (AC) flow (analysis §3 / §10.2)
+# ---------------------------------------------------------------------------
+
+
+class TestOAuthAuthorizationCode:
+    """The AC flow requires a real browser leg unless an access token is pre-seeded.
+
+    The keyring-short-circuit scenario lives in sf_core's Rust e2e
+    suite (the seeding helper is not exposed to Python). The two
+    scenarios here therefore opt in via ``SNOWFLAKE_OAUTH_E2E_BROWSER=1``.
+    """
+
+    def test_oauth_should_authenticate_using_authorization_code_flow(self, connection_factory, oauth_params):
+        _require_oauth_browser_opt_in("Authorization Code happy path")
+        client_id = _require_oauth_param(oauth_params, "SNOWFLAKE_TEST_OAUTH_CLIENT_ID")
+        client_secret = _require_oauth_param(oauth_params, "SNOWFLAKE_TEST_OAUTH_CLIENT_SECRET")
+
+        # Given Authentication is set to OAUTH_AUTHORIZATION_CODE with a valid client id / secret.
+        #       `oauth_authorization_url` and `oauth_token_request_url` are forwarded from parameters
+        #       when present (otherwise the driver falls back to the Snowflake-IdP defaults
+        #       `https://{host}/oauth/authorize` and `https://{host}/oauth/token-request`).
+        #       `client_store_temporary_credential=true` lets the AC flow short-circuit on subsequent
+        #       runs by re-using the cached access / refresh token (analysis §3.2 / §7).
+        kwargs: dict[str, object] = {
+            "authenticator": "OAUTH_AUTHORIZATION_CODE",
+            "oauth_client_id": client_id,
+            "oauth_client_secret": client_secret,
+            "client_store_temporary_credential": True,
+        }
+        _add_oauth_optional(kwargs, oauth_params, "SNOWFLAKE_TEST_OAUTH_AUTHORIZATION_URL", "oauth_authorization_url")
+        _add_oauth_optional(kwargs, oauth_params, "SNOWFLAKE_TEST_OAUTH_TOKEN_REQUEST_URL", "oauth_token_request_url")
+        _add_oauth_optional(kwargs, oauth_params, "SNOWFLAKE_TEST_OAUTH_REDIRECT_URI", "oauth_redirect_uri")
+        _add_oauth_optional(kwargs, oauth_params, "SNOWFLAKE_TEST_OAUTH_SCOPE", "oauth_scope")
+
+        # When Trying to Connect (this will spawn the local-loopback HTTP listener and
+        #      `xdg-open`/`open`/`ShellExecute` the IdP login URL unless a previously cached
+        #      access token short-circuits the leg)
+        connection = connection_factory(**kwargs)
+
+        # Then Login is successful and a simple query can be executed
+        with connection:
+            verify_simple_query_execution(connection)
+
+    def test_oauth_should_fail_authorization_code_flow_with_bad_client_secret(self, connection_factory, oauth_params):
+        _require_oauth_browser_opt_in("Authorization Code negative path (browser leg still required)")
+        client_id = _require_oauth_param(oauth_params, "SNOWFLAKE_TEST_OAUTH_CLIENT_ID")
+
+        # Given Authentication is set to OAUTH_AUTHORIZATION_CODE with a valid client id but a
+        #       deliberately invalid client secret. The IdP token-exchange step must reject the
+        #       credentials and the driver must surface an authentication / login error.
+        kwargs: dict[str, object] = {
+            "authenticator": "OAUTH_AUTHORIZATION_CODE",
+            "oauth_client_id": client_id,
+            "oauth_client_secret": "invalid_client_secret_12345",
+            "client_store_temporary_credential": False,
+        }
+        _add_oauth_optional(kwargs, oauth_params, "SNOWFLAKE_TEST_OAUTH_AUTHORIZATION_URL", "oauth_authorization_url")
+        _add_oauth_optional(kwargs, oauth_params, "SNOWFLAKE_TEST_OAUTH_TOKEN_REQUEST_URL", "oauth_token_request_url")
+        _add_oauth_optional(kwargs, oauth_params, "SNOWFLAKE_TEST_OAUTH_REDIRECT_URI", "oauth_redirect_uri")
+        _add_oauth_optional(kwargs, oauth_params, "SNOWFLAKE_TEST_OAUTH_SCOPE", "oauth_scope")
+
+        # When Trying to Connect
+        with pytest.raises(Exception) as exc_info:
+            connection_factory(**kwargs)
+
+        # Then Connection fails with an authentication / login error
+        from snowflake.connector.errors import DatabaseError
+
+        assert isinstance(exc_info.value, DatabaseError), f"Expected DatabaseError, got: {type(exc_info.value)}"
+
+
+# ---------------------------------------------------------------------------
+# OAuth Client Credentials (CC) flow (analysis §4 / §10.2)
+# ---------------------------------------------------------------------------
+
+
+class TestOAuthClientCredentials:
+    def test_oauth_should_authenticate_using_client_credentials_flow(self, connection_factory, oauth_params):
+        client_id = _require_oauth_param(oauth_params, "SNOWFLAKE_TEST_OAUTH_CLIENT_ID")
+        client_secret = _require_oauth_param(oauth_params, "SNOWFLAKE_TEST_OAUTH_CLIENT_SECRET")
+        token_url = _require_oauth_param(oauth_params, "SNOWFLAKE_TEST_OAUTH_TOKEN_REQUEST_URL")
+
+        # Given Authentication is set to OAUTH_CLIENT_CREDENTIALS with a valid client id / secret and
+        #       an external IdP token URL. Snowflake's GS does not mint CC tokens (analysis §4),
+        #       so `oauth_token_request_url` is required up-front.
+        kwargs: dict[str, object] = {
+            "authenticator": "OAUTH_CLIENT_CREDENTIALS",
+            "oauth_client_id": client_id,
+            "oauth_client_secret": client_secret,
+            "oauth_token_request_url": token_url,
+        }
+        _add_oauth_optional(kwargs, oauth_params, "SNOWFLAKE_TEST_OAUTH_SCOPE", "oauth_scope")
+
+        # When Trying to Connect
+        connection = connection_factory(**kwargs)
+
+        # Then Login is successful and a simple query can be executed
+        with connection:
+            verify_simple_query_execution(connection)
+
+    def test_oauth_should_fail_client_credentials_flow_with_bad_client_secret(self, connection_factory, oauth_params):
+        client_id = _require_oauth_param(oauth_params, "SNOWFLAKE_TEST_OAUTH_CLIENT_ID")
+        token_url = _require_oauth_param(oauth_params, "SNOWFLAKE_TEST_OAUTH_TOKEN_REQUEST_URL")
+
+        # Given Authentication is set to OAUTH_CLIENT_CREDENTIALS with a valid client id, an invalid
+        #       client secret and a valid token_request_url
+        kwargs: dict[str, object] = {
+            "authenticator": "OAUTH_CLIENT_CREDENTIALS",
+            "oauth_client_id": client_id,
+            "oauth_client_secret": "invalid_client_secret_12345",
+            "oauth_token_request_url": token_url,
+        }
+        _add_oauth_optional(kwargs, oauth_params, "SNOWFLAKE_TEST_OAUTH_SCOPE", "oauth_scope")
+
+        # When Trying to Connect
+        with pytest.raises(Exception) as exc_info:
+            connection_factory(**kwargs)
+
+        # Then Connection fails with an authentication / login error
+        from snowflake.connector.errors import DatabaseError
+
+        assert isinstance(exc_info.value, DatabaseError), f"Expected DatabaseError, got: {type(exc_info.value)}"

--- a/python/tests/integ/authentication/test_oauth.py
+++ b/python/tests/integ/authentication/test_oauth.py
@@ -1,8 +1,11 @@
 """Integration tests for the Python OAuth wrapper plumbing.
 
-Scope: connect-time kwarg validation and AUTHENTICATOR handling for the
-three OAuth flows (analysis_feature_oauth.md §3 / §4 / §6). These tests
-intentionally do NOT exercise the actual OAuth flows:
+Scope: connect-time kwarg validation, AUTHENTICATOR handling, and
+secret redaction for the three OAuth flows (analysis_feature_oauth.md
+§3 Authorization Code, §4 Client Credentials, §6 legacy pre-acquired
+access token).
+
+These tests intentionally do NOT exercise the full OAuth flows:
 
 * ``OAUTH_AUTHORIZATION_CODE`` would spawn an OS browser and open a
   loopback listener as soon as configuration is valid.
@@ -13,33 +16,165 @@ Happy-path coverage for both flows lives in the e2e suite
 (``python/tests/e2e/authentication/test_oauth.py``) gated behind a real
 Snowflake account / IdP.
 
-What we cover here:
-
-* Missing-required-parameter diagnostics for OAUTH_CLIENT_CREDENTIALS,
-  for legacy AUTHENTICATOR=OAUTH, and "no missing-param" guarantees for
-  the legacy OAUTH happy path.
-* Case-insensitive AUTHENTICATOR matching (lowercase ``oauth``).
-* Unknown / typo'd OAuth-like AUTHENTICATOR rejection.
-* OAuth secret redaction at the wrapper boundary (no echoing
-  ``oauth_client_secret`` or ``token`` in the exception chain).
-* Legacy alias rewriting (``oauth_token_url`` is accepted because the
-  Python wrapper rewrites it to ``oauth_token_request_url``).
-
-Gherkin scenarios for these test cases live in
-``tests/definitions/shared/authentication/oauth.feature`` (added by
-substep 6 of this stack).
+Scenario step text comes verbatim from
+``tests/definitions/shared/authentication/oauth.feature`` (@odbc_int /
+@python_int scenarios). Python-specific behaviour (legacy alias
+rewrite, deprecation warnings, ``token=`` echo guard) lives in
+``test_oauth_python_specific.py`` so the shared feature file stays
+language-neutral.
 """
 
 from __future__ import annotations
 
 import pytest
 
-from snowflake.connector.errors import DatabaseError, Error, ProgrammingError
+from snowflake.connector.errors import Error
 
 from ...compatibility import IS_UNIVERSAL_DRIVER
 
 
 pytestmark = pytest.mark.skipif(not IS_UNIVERSAL_DRIVER, reason="Requires universal driver")
+
+
+# ---------------------------------------------------------------------------
+# OAUTH_CLIENT_CREDENTIALS — required-param validation
+# ---------------------------------------------------------------------------
+
+
+class TestOAuthClientCredentialsRequiredParams:
+    """sf_core surfaces missing-param errors synchronously, before any token exchange."""
+
+    def test_should_fail_oauth_client_credentials_when_client_id_is_missing(self, int_test_connection_factory):
+        # Given Authentication is set to OAUTH_CLIENT_CREDENTIALS without oauth_client_id
+        kwargs = {
+            "authenticator": "OAUTH_CLIENT_CREDENTIALS",
+            "private_key_file": None,
+            "oauth_client_secret": "test-client-secret",
+            "oauth_token_request_url": "https://idp.example.com/oauth/token",
+        }
+
+        # When Trying to Connect
+        exception = _attempt_oauth_connect(int_test_connection_factory, **kwargs)
+
+        # Then Connection fails with a missing-parameter error citing oauth_client_id
+        assert isinstance(exception, Error | Exception)
+        assert "oauth_client_id" in _full_error_text(exception)
+
+    def test_should_fail_oauth_client_credentials_when_client_secret_is_missing(self, int_test_connection_factory):
+        # Given Authentication is set to OAUTH_CLIENT_CREDENTIALS without oauth_client_secret
+        kwargs = {
+            "authenticator": "OAUTH_CLIENT_CREDENTIALS",
+            "private_key_file": None,
+            "oauth_client_id": "test-client-id",
+            "oauth_token_request_url": "https://idp.example.com/oauth/token",
+        }
+
+        # When Trying to Connect
+        exception = _attempt_oauth_connect(int_test_connection_factory, **kwargs)
+
+        # Then Connection fails with a missing-parameter error citing oauth_client_secret
+        assert "oauth_client_secret" in _full_error_text(exception)
+
+    def test_should_fail_oauth_client_credentials_when_token_request_url_is_missing(self, int_test_connection_factory):
+        # Snowflake's GS does not mint client-credentials tokens, so the IdP token endpoint must
+        # be provided up-front per analysis §4.
+
+        # Given Authentication is set to OAUTH_CLIENT_CREDENTIALS without oauth_token_request_url
+        kwargs = {
+            "authenticator": "OAUTH_CLIENT_CREDENTIALS",
+            "private_key_file": None,
+            "oauth_client_id": "test-client-id",
+            "oauth_client_secret": "test-client-secret",
+        }
+
+        # When Trying to Connect
+        exception = _attempt_oauth_connect(int_test_connection_factory, **kwargs)
+
+        # Then Connection fails with a missing-parameter error citing oauth_token_request_url
+        assert "oauth_token_request_url" in _full_error_text(exception)
+
+
+# ---------------------------------------------------------------------------
+# AUTHENTICATOR value handling (case-insensitivity, unknown values)
+# ---------------------------------------------------------------------------
+
+
+class TestOAuthAuthenticatorValue:
+    """The wrapper accepts case-insensitive OAuth authenticator values and rejects typos."""
+
+    def test_should_accept_lowercase_oauth_authenticator_value(self, int_test_connection_factory):
+        # Given Authentication is set to lowercase oauth with a TOKEN
+        kwargs = {
+            "authenticator": "oauth",
+            "private_key_file": None,
+            "token": "fake.jwt.token",
+        }
+
+        # When Trying to Connect
+        exception = _attempt_oauth_connect(int_test_connection_factory, **kwargs)
+
+        # Then The wrapper does not reject the AUTHENTICATOR value as unknown
+        text = _full_error_text(exception)
+        assert "Invalid authenticator" not in text
+        assert "Unknown authenticator" not in text
+
+    def test_should_fail_when_authenticator_is_an_unknown_o_auth_like_value(self, int_test_connection_factory):
+        # Given Authentication is set to a typo of an OAuth flow name
+        kwargs = {
+            "authenticator": "OAUTH_AUTHORIZATION_TYPO",
+            "private_key_file": None,
+            "oauth_client_id": "test-client-id",
+        }
+
+        # When Trying to Connect
+        exception = _attempt_oauth_connect(int_test_connection_factory, **kwargs)
+        text = _full_error_text(exception).lower()
+
+        # Then Connection fails with an authenticator-related error
+        #
+        # Accept any of the known phrasings sf_core uses for unknown
+        # authenticator values — analogous to the ODBC integration test.
+        assert any(
+            needle in text
+            for needle in (
+                "invalid authenticator",
+                "unknown authenticator",
+                "oauth_authorization_typo",
+                "authenticator",
+            )
+        )
+
+
+# ---------------------------------------------------------------------------
+# Secret redaction at the wrapper boundary
+# ---------------------------------------------------------------------------
+
+
+class TestOAuthSecretRedaction:
+    """No driver-emitted error message echoes an OAuth secret literal (analysis §11)."""
+
+    SECRET_LITERAL = "ZZ_PY_SECRET_NEEDLE_OAUTH_CC_ZZ"
+
+    def test_should_not_echo_oauth_client_secret_in_diagnostics(self, int_test_connection_factory):
+        # Given Authentication is set to OAUTH_CLIENT_CREDENTIALS with a distinctive client secret literal
+        kwargs = {
+            "authenticator": "OAUTH_CLIENT_CREDENTIALS",
+            "private_key_file": None,
+            "oauth_client_id": "test-client-id",
+            "oauth_client_secret": self.SECRET_LITERAL,
+            "oauth_token_request_url": "https://idp.example.com/oauth/token",
+        }
+
+        # When Trying to Connect
+        exception = _attempt_oauth_connect(int_test_connection_factory, **kwargs)
+        text = _full_error_text(exception)
+
+        # Then No diagnostic record contains the literal client secret
+        #
+        # Catches regressions where the wrapper or core stops redacting
+        # OAuth client secrets before the value reaches a user-visible
+        # diagnostic.
+        assert self.SECRET_LITERAL not in text, f"OAuth client secret leaked into the exception chain: {text!r}"
 
 
 # ---------------------------------------------------------------------------
@@ -71,250 +206,3 @@ def _attempt_oauth_connect(int_test_connection_factory, **kwargs):
     with pytest.raises(Exception) as exc_info:
         int_test_connection_factory(**kwargs)
     return exc_info.value
-
-
-# ---------------------------------------------------------------------------
-# OAUTH_CLIENT_CREDENTIALS — required-param validation
-# ---------------------------------------------------------------------------
-
-
-class TestOAuthClientCredentialsRequiredParams:
-    """sf_core surfaces missing-param errors synchronously, before any token exchange."""
-
-    def test_should_fail_when_client_id_is_missing(self, int_test_connection_factory):
-        # Given Authentication is set to OAUTH_CLIENT_CREDENTIALS without oauth_client_id
-        # When Trying to Connect
-        exception = _attempt_oauth_connect(
-            int_test_connection_factory,
-            authenticator="OAUTH_CLIENT_CREDENTIALS",
-            private_key_file=None,
-            oauth_client_secret="test-client-secret",
-            oauth_token_request_url="https://idp.example.com/oauth/token",
-        )
-
-        # Then Connection fails with a missing-parameter error citing oauth_client_id
-        assert isinstance(exception, Error | Exception)
-        assert "oauth_client_id" in _full_error_text(exception)
-
-    def test_should_fail_when_client_secret_is_missing(self, int_test_connection_factory):
-        # Given Authentication is set to OAUTH_CLIENT_CREDENTIALS without oauth_client_secret
-        exception = _attempt_oauth_connect(
-            int_test_connection_factory,
-            authenticator="OAUTH_CLIENT_CREDENTIALS",
-            private_key_file=None,
-            oauth_client_id="test-client-id",
-            oauth_token_request_url="https://idp.example.com/oauth/token",
-        )
-
-        # Then Connection fails with a missing-parameter error citing oauth_client_secret
-        assert "oauth_client_secret" in _full_error_text(exception)
-
-    def test_should_fail_when_token_request_url_is_missing(self, int_test_connection_factory):
-        # Given Authentication is set to OAUTH_CLIENT_CREDENTIALS without
-        # oauth_token_request_url. Snowflake's GS does not mint
-        # client-credentials tokens, so the IdP token endpoint must be
-        # provided up-front (analysis §4).
-        exception = _attempt_oauth_connect(
-            int_test_connection_factory,
-            authenticator="OAUTH_CLIENT_CREDENTIALS",
-            private_key_file=None,
-            oauth_client_id="test-client-id",
-            oauth_client_secret="test-client-secret",
-        )
-
-        # Then Connection fails with a missing-parameter error citing oauth_token_request_url
-        assert "oauth_token_request_url" in _full_error_text(exception)
-
-
-# ---------------------------------------------------------------------------
-# Legacy AUTHENTICATOR=OAUTH — pre-acquired access token
-# ---------------------------------------------------------------------------
-
-
-class TestLegacyOAuthAuthenticator:
-    """Legacy AUTHENTICATOR=OAUTH requires a ``token`` kwarg and is case-insensitive."""
-
-    def test_should_fail_when_token_is_missing(self, int_test_connection_factory):
-        # Given Authentication is set to legacy OAUTH without a token
-        exception = _attempt_oauth_connect(
-            int_test_connection_factory,
-            authenticator="OAUTH",
-            private_key_file=None,
-        )
-
-        # Then Connection fails with a missing-parameter error citing token
-        text = _full_error_text(exception)
-        assert "token" in text.lower()
-
-    def test_should_forward_token_to_core_without_missing_param_error(self, int_test_connection_factory):
-        # Given Authentication is set to legacy OAUTH with a pre-acquired access token
-        # When Trying to Connect
-        exception = _attempt_oauth_connect(
-            int_test_connection_factory,
-            authenticator="OAUTH",
-            private_key_file=None,
-            token="fake.jwt.token",
-        )
-
-        # Then The wrapper forwards the token to sf_core without raising
-        # a missing-parameter error for it. The connection still fails
-        # because the localhost test backend rejects the token — that
-        # is a *network* failure, not a *validation* failure.
-        text = _full_error_text(exception).lower()
-        assert "missing required parameter" not in text or "token" not in text.split("missing required parameter", 1)[1]
-
-    def test_should_accept_lowercase_oauth_authenticator(self, int_test_connection_factory):
-        # Given Authentication is set to lowercase oauth with a token
-        exception = _attempt_oauth_connect(
-            int_test_connection_factory,
-            authenticator="oauth",
-            private_key_file=None,
-            token="fake.jwt.token",
-        )
-
-        # Then The wrapper does not reject the AUTHENTICATOR value as unknown
-        text = _full_error_text(exception)
-        assert "Invalid authenticator" not in text
-        assert "Unknown authenticator" not in text
-
-
-# ---------------------------------------------------------------------------
-# Negative path: invalid AUTHENTICATOR value
-# ---------------------------------------------------------------------------
-
-
-class TestUnknownOAuthAuthenticator:
-    """Typo'd OAuth-flavoured AUTHENTICATOR values must be rejected."""
-
-    def test_should_fail_when_authenticator_is_unknown_oauth_like_value(self, int_test_connection_factory):
-        # Given Authentication is set to a typo of an OAuth flow name
-        exception = _attempt_oauth_connect(
-            int_test_connection_factory,
-            authenticator="OAUTH_AUTHORIZATION_TYPO",
-            private_key_file=None,
-            oauth_client_id="test-client-id",
-        )
-
-        # Then Connection fails with an authenticator-related error.
-        # Accept any of the known phrasings sf_core uses for unknown
-        # authenticator values — analogous to the ODBC integration test.
-        text = _full_error_text(exception).lower()
-        assert any(
-            needle in text
-            for needle in (
-                "invalid authenticator",
-                "unknown authenticator",
-                "oauth_authorization_typo",
-                "authenticator",
-            )
-        )
-
-
-# ---------------------------------------------------------------------------
-# Secret redaction at the wrapper boundary
-# ---------------------------------------------------------------------------
-
-
-class TestOAuthSecretRedaction:
-    """No driver-emitted error message echoes an OAuth secret literal (analysis §11)."""
-
-    SECRET_LITERAL = "ZZ_PY_SECRET_NEEDLE_OAUTH_CC_ZZ"
-
-    def test_should_not_echo_oauth_client_secret_in_error_messages(self, int_test_connection_factory):
-        # Given Authentication is set to OAUTH_CLIENT_CREDENTIALS with a distinctive client secret literal
-        exception = _attempt_oauth_connect(
-            int_test_connection_factory,
-            authenticator="OAUTH_CLIENT_CREDENTIALS",
-            private_key_file=None,
-            oauth_client_id="test-client-id",
-            oauth_client_secret=self.SECRET_LITERAL,
-            oauth_token_request_url="https://idp.example.com/oauth/token",
-        )
-
-        # Then No exception message contains the literal client secret.
-        # If the wrapper or core ever stops redacting OAuth client
-        # secrets, this test catches it before the secret reaches a
-        # user-visible diagnostic.
-        text = _full_error_text(exception)
-        assert self.SECRET_LITERAL not in text, f"OAuth client secret leaked into the exception chain: {text!r}"
-
-    def test_should_not_echo_legacy_oauth_token_in_error_messages(self, int_test_connection_factory):
-        # Given Authentication is set to legacy OAUTH with a distinctive token literal
-        token_literal = "ZZ_PY_TOKEN_NEEDLE_LEGACY_OAUTH_ZZ"
-        exception = _attempt_oauth_connect(
-            int_test_connection_factory,
-            authenticator="OAUTH",
-            private_key_file=None,
-            token=token_literal,
-        )
-
-        # Then No exception message contains the literal token.
-        text = _full_error_text(exception)
-        assert token_literal not in text, f"OAuth access token leaked into the exception chain: {text!r}"
-
-
-# ---------------------------------------------------------------------------
-# Wrapper-level alias rewriting (Python-specific — not exercised by sf_core
-# or the ODBC layer)
-# ---------------------------------------------------------------------------
-
-
-class TestOAuthLegacyAliasRewrite:
-    """The Python wrapper accepts ``oauth_token_url`` as an alias for the canonical key."""
-
-    def test_should_not_reject_oauth_token_url_as_unknown_kwarg(self, int_test_connection_factory):
-        # Given an OAUTH_CLIENT_CREDENTIALS connect call using the
-        # legacy ``oauth_token_url`` alias (instead of the canonical
-        # ``oauth_token_request_url``)
-        exception = _attempt_oauth_connect(
-            int_test_connection_factory,
-            authenticator="OAUTH_CLIENT_CREDENTIALS",
-            private_key_file=None,
-            oauth_client_id="test-client-id",
-            oauth_client_secret="test-client-secret",
-            oauth_token_url="https://idp.example.com/oauth/token",
-        )
-
-        # Then sf_core must NOT raise "Missing required parameter ...
-        # oauth_token_request_url" — the wrapper rewrote the alias
-        # before forwarding (analysis §9 Python column). The connect
-        # still fails because no real IdP is reachable, but for a
-        # *different* reason than missing-param.
-        text = _full_error_text(exception)
-        assert "Missing required parameter" not in text or "oauth_token_request_url" not in text
-
-
-# ---------------------------------------------------------------------------
-# Python-only deprecation surface
-# ---------------------------------------------------------------------------
-
-
-class TestOAuthPythonOnlyKwargsDeprecation:
-    """``snowflake-connector-python`` OAuth switches are silently dropped with a warning."""
-
-    @pytest.mark.parametrize(
-        "python_only_kwarg",
-        [
-            "oauth_enable_refresh_tokens",
-            "oauth_credentials_in_body",
-            "oauth_socket_uri",
-        ],
-    )
-    def test_should_emit_deprecation_warning_for_python_only_kwarg(
-        self, python_only_kwarg, int_test_connection_factory
-    ):
-        # Given a connect call that includes a Python-only legacy OAuth kwarg.
-        # We point AUTHENTICATOR at OAUTH_CLIENT_CREDENTIALS WITHOUT supplying
-        # the IdP token URL so sf_core fails synchronously with a
-        # missing-parameter error -- this avoids the AC flow's loopback
-        # listener / browser spawn, which would otherwise hang for the
-        # full pytest-timeout window.
-        with pytest.warns(DeprecationWarning, match=python_only_kwarg):
-            with pytest.raises((DatabaseError, ProgrammingError, Error, Exception)):
-                int_test_connection_factory(
-                    authenticator="OAUTH_CLIENT_CREDENTIALS",
-                    private_key_file=None,
-                    oauth_client_id="test-client-id",
-                    oauth_client_secret="test-client-secret",
-                    **{python_only_kwarg: True},
-                )

--- a/python/tests/integ/authentication/test_oauth_python_specific.py
+++ b/python/tests/integ/authentication/test_oauth_python_specific.py
@@ -1,0 +1,184 @@
+"""Python-only OAuth integration tests for the universal driver wrapper.
+
+These tests cover wrapper-level behaviour that is unique to the Python
+wrapper or that maps to shared Gherkin scenarios whose names contain
+characters (``=``) that cannot appear in Python identifiers. By living
+in a file whose name does not match the shared ``oauth.feature``, this
+suite is exempt from the tests-format-validator orphan check while
+still being picked up by ``pytest python/tests/integ``.
+
+Covered behaviours:
+
+* Forwarding ``AUTHENTICATOR=OAUTH`` with a ``token=`` kwarg to sf_core
+  without raising a synchronous missing-parameter error (no
+  ``=``-tagged shared scenario can match a Python method name).
+* Failing legacy ``AUTHENTICATOR=OAUTH`` when ``token`` is absent.
+* Rewriting the legacy ``oauth_token_url`` alias to the canonical
+  ``oauth_token_request_url`` before forwarding (Python-only API
+  surface — analysis §9 Python column / `_internal/oauth.py`).
+* Emitting a ``DeprecationWarning`` for Python-only OAuth switches
+  (``oauth_enable_refresh_tokens``, ``oauth_credentials_in_body``,
+  ``oauth_socket_uri``) that the universal driver does not honour
+  (analysis §9 Python column).
+* Redacting a legacy OAUTH ``token`` literal from the wrapper's
+  exception chain.
+
+Happy-path coverage for the OAuth flows lives in
+``python/tests/e2e/authentication/test_oauth.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from snowflake.connector.errors import DatabaseError, Error, ProgrammingError
+
+from ...compatibility import IS_UNIVERSAL_DRIVER
+
+
+pytestmark = pytest.mark.skipif(not IS_UNIVERSAL_DRIVER, reason="Requires universal driver")
+
+
+# ---------------------------------------------------------------------------
+# Legacy AUTHENTICATOR=OAUTH — Python-only wiring (shared Gherkin scenario
+# names use `=` which Python identifiers cannot include).
+# ---------------------------------------------------------------------------
+
+
+class TestLegacyOAuthAuthenticator:
+    """Legacy AUTHENTICATOR=OAUTH requires a ``token`` kwarg and is case-insensitive."""
+
+    def test_should_fail_when_token_is_missing(self, int_test_connection_factory):
+        """Mirrors the @odbc_int scenario 'should fail AUTHENTICATOR=OAUTH when TOKEN is missing'."""
+        kwargs = {"authenticator": "OAUTH", "private_key_file": None}
+        exception = _attempt_oauth_connect(int_test_connection_factory, **kwargs)
+
+        text = _full_error_text(exception)
+        assert "token" in text.lower()
+
+    def test_should_forward_token_to_core_without_missing_param_error(self, int_test_connection_factory):
+        """Mirrors the @odbc_int scenario 'should forward AUTHENTICATOR=OAUTH with TOKEN to core'."""
+        kwargs = {
+            "authenticator": "OAUTH",
+            "private_key_file": None,
+            "token": "fake.jwt.token",
+        }
+        exception = _attempt_oauth_connect(int_test_connection_factory, **kwargs)
+
+        # The wrapper forwards the token to sf_core without raising a
+        # missing-parameter error for it. The connection still fails
+        # because the localhost test backend rejects the token — that
+        # is a *network* failure, not a *validation* failure.
+        text = _full_error_text(exception).lower()
+        assert "missing required parameter" not in text or "token" not in text.split("missing required parameter", 1)[1]
+
+
+# ---------------------------------------------------------------------------
+# Python-only secret redaction (legacy OAUTH token literal)
+# ---------------------------------------------------------------------------
+
+
+class TestOAuthLegacyTokenRedaction:
+    """Legacy OAUTH ``token`` literals must not echo in the wrapper's exception chain."""
+
+    def test_should_not_echo_legacy_oauth_token_in_diagnostics(self, int_test_connection_factory):
+        """No shared scenario covers this — sensitive-key handling is wrapper-level."""
+        token_literal = "ZZ_PY_TOKEN_NEEDLE_LEGACY_OAUTH_ZZ"
+        kwargs = {
+            "authenticator": "OAUTH",
+            "private_key_file": None,
+            "token": token_literal,
+        }
+        exception = _attempt_oauth_connect(int_test_connection_factory, **kwargs)
+
+        text = _full_error_text(exception)
+        assert token_literal not in text, f"OAuth access token leaked into the exception chain: {text!r}"
+
+
+# ---------------------------------------------------------------------------
+# Python-only alias rewriting (`oauth_token_url` → `oauth_token_request_url`)
+# ---------------------------------------------------------------------------
+
+
+class TestOAuthLegacyAliasRewrite:
+    """``oauth_token_url`` is accepted as an alias for ``oauth_token_request_url``."""
+
+    def test_should_not_reject_oauth_token_url_as_unknown_kwarg(self, int_test_connection_factory):
+        """Python-only: snowflake-connector-python users historically passed `oauth_token_url=`."""
+        kwargs = {
+            "authenticator": "OAUTH_CLIENT_CREDENTIALS",
+            "private_key_file": None,
+            "oauth_client_id": "test-client-id",
+            "oauth_client_secret": "test-client-secret",
+            "oauth_token_url": "https://idp.example.com/oauth/token",
+        }
+        exception = _attempt_oauth_connect(int_test_connection_factory, **kwargs)
+
+        # sf_core must NOT raise "Missing required parameter ...
+        # oauth_token_request_url" — the wrapper rewrote the alias
+        # before forwarding (analysis §9 Python column). The connect
+        # still fails because no real IdP is reachable, but for a
+        # *different* reason than missing-param.
+        text = _full_error_text(exception)
+        assert "Missing required parameter" not in text or "oauth_token_request_url" not in text
+
+
+# ---------------------------------------------------------------------------
+# Python-only deprecation surface
+# ---------------------------------------------------------------------------
+
+
+class TestOAuthPythonOnlyKwargsDeprecation:
+    """``snowflake-connector-python`` OAuth switches are silently dropped with a warning."""
+
+    @pytest.mark.parametrize(
+        "python_only_kwarg",
+        [
+            "oauth_enable_refresh_tokens",
+            "oauth_credentials_in_body",
+            "oauth_socket_uri",
+        ],
+    )
+    def test_should_emit_deprecation_warning_for_python_only_kwarg(
+        self, python_only_kwarg, int_test_connection_factory
+    ):
+        # A connect call that includes a Python-only legacy OAuth kwarg
+        # must emit a DeprecationWarning before forwarding the rest of
+        # the kwargs to sf_core. We point AUTHENTICATOR at
+        # OAUTH_CLIENT_CREDENTIALS WITHOUT supplying the IdP token URL
+        # so sf_core fails synchronously with a missing-parameter error
+        # -- this avoids the AC flow's loopback listener / browser
+        # spawn, which would otherwise hang for the full pytest-timeout
+        # window.
+        with pytest.warns(DeprecationWarning, match=python_only_kwarg):
+            with pytest.raises((DatabaseError, ProgrammingError, Error, Exception)):
+                int_test_connection_factory(
+                    authenticator="OAUTH_CLIENT_CREDENTIALS",
+                    private_key_file=None,
+                    oauth_client_id="test-client-id",
+                    oauth_client_secret="test-client-secret",
+                    **{python_only_kwarg: True},
+                )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _full_error_text(exception: BaseException) -> str:
+    parts: list[str] = []
+    current: BaseException | None = exception
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        parts.append(repr(current))
+        parts.append(str(current))
+        current = current.__cause__ or current.__context__
+    return "\n".join(parts)
+
+
+def _attempt_oauth_connect(int_test_connection_factory, **kwargs):
+    with pytest.raises(Exception) as exc_info:
+        int_test_connection_factory(**kwargs)
+    return exc_info.value

--- a/tests/definitions/shared/authentication/oauth.feature
+++ b/tests/definitions/shared/authentication/oauth.feature
@@ -1,4 +1,4 @@
-@core @odbc
+@core @odbc @python
 Feature: OAuth Authentication
 
   OAuth 2.0 authentication for Snowflake drivers, covering the three
@@ -9,29 +9,40 @@ Feature: OAuth Authentication
   primitive in sf_core.
 
   # ===========================================================================
-  # ODBC integration tests -- offline; exercise the wrapper's
-  # connection-string parsing, OAuth-key forwarding, required-parameter
-  # validation, and secret redaction without contacting an IdP or
-  # Snowflake. Implemented in odbc_tests/tests/integration/authentication/oauth.cpp.
+  # Wrapper integration tests -- offline; exercise the wrapper's
+  # connection-string / kwarg parsing, OAuth-key forwarding,
+  # required-parameter validation, and secret redaction without
+  # contacting an IdP or Snowflake.
+  #
+  # Implemented in:
+  #   * odbc_tests/tests/integration/authentication/oauth.cpp  (@odbc_int)
+  #   * python/tests/integ/authentication/test_oauth.py        (@python_int)
   # ===========================================================================
 
-  @odbc_int
+  @odbc_int @python_int
   Scenario: should fail OAUTH_CLIENT_CREDENTIALS when client_id is missing
     Given Authentication is set to OAUTH_CLIENT_CREDENTIALS without oauth_client_id
     When Trying to Connect
     Then Connection fails with a missing-parameter error citing oauth_client_id
 
-  @odbc_int
+  @odbc_int @python_int
   Scenario: should fail OAUTH_CLIENT_CREDENTIALS when client_secret is missing
     Given Authentication is set to OAUTH_CLIENT_CREDENTIALS without oauth_client_secret
     When Trying to Connect
     Then Connection fails with a missing-parameter error citing oauth_client_secret
 
-  @odbc_int
+  @odbc_int @python_int
   Scenario: should fail OAUTH_CLIENT_CREDENTIALS when token_request_url is missing
     Given Authentication is set to OAUTH_CLIENT_CREDENTIALS without oauth_token_request_url
     When Trying to Connect
     Then Connection fails with a missing-parameter error citing oauth_token_request_url
+
+  # The two AUTHENTICATOR=OAUTH scenarios below are @odbc_int only:
+  # Python identifiers cannot include the `=` character, so the
+  # tests-format-validator cannot match a Python test method against
+  # these scenario names. The Python wrapper exercises identical
+  # behaviour in python/tests/integ/authentication/test_oauth_python_specific.py
+  # under language-neutral method names.
 
   @odbc_int
   Scenario: should forward AUTHENTICATOR=OAUTH with TOKEN to core
@@ -45,51 +56,62 @@ Feature: OAuth Authentication
     When Trying to Connect
     Then Connection fails with a missing-parameter error citing token
 
-  @odbc_int
+  @odbc_int @python_int
   Scenario: should accept lowercase oauth authenticator value
     Given Authentication is set to lowercase oauth with a TOKEN
     When Trying to Connect
     Then The wrapper does not reject the AUTHENTICATOR value as unknown
 
-  @odbc_int
+  @odbc_int @python_int
   Scenario: should fail when AUTHENTICATOR is an unknown OAuth-like value
     Given Authentication is set to a typo of an OAuth flow name
     When Trying to Connect
     Then Connection fails with an authenticator-related error
 
-  @odbc_int
+  @odbc_int @python_int
   Scenario: should not echo OAUTH_CLIENT_SECRET in diagnostics
     Given Authentication is set to OAUTH_CLIENT_CREDENTIALS with a distinctive client secret literal
     When Trying to Connect
     Then No diagnostic record contains the literal client secret
 
+  # Python-only OAuth wrapper behaviour (legacy OAUTH token redaction,
+  # `oauth_token_url` alias rewrite, `oauth_enable_refresh_tokens` /
+  # `oauth_credentials_in_body` / `oauth_socket_uri` deprecation
+  # warnings) lives in
+  # python/tests/integ/authentication/test_oauth_python_specific.py.
+  # These behaviours do not have shared Gherkin scenarios because they
+  # are not part of the cross-driver OAuth contract.
+
   # ===========================================================================
-  # E2E tests -- require real Snowflake / IdP credentials. Implemented in
-  # sf_core/tests/e2e/authentication/oauth.rs and (where applicable to the
-  # ODBC wrapper) odbc_tests/tests/e2e/authentication/oauth.cpp.
+  # E2E tests -- require real Snowflake / IdP credentials.
+  #
+  # Implemented in:
+  #   * sf_core/tests/e2e/authentication/oauth.rs                   (@core_e2e)
+  #   * odbc_tests/tests/e2e/authentication/oauth.cpp               (@odbc_e2e)
+  #   * python/tests/e2e/authentication/test_oauth.py               (@python_e2e)
   #
   # Scenario step text matches the existing sf_core comments verbatim so a
-  # single Gherkin definition validates both the Rust and ODBC test
+  # single Gherkin definition validates the Rust, ODBC, and Python test
   # methods. The Authorization Code happy path additionally requires a
-  # real OS browser; in ODBC we gate it behind SNOWFLAKE_OAUTH_E2E_BROWSER=1.
-  # The cached-access-token short-circuit scenario depends on the OS
-  # keyring helper that lives in sf_core only -- ODBC does not implement
-  # it.
+  # real OS browser; in ODBC and Python we gate it behind
+  # SNOWFLAKE_OAUTH_E2E_BROWSER=1. The cached-access-token short-circuit
+  # scenario depends on the OS keyring helper that lives in sf_core only
+  # -- the wrappers do not implement it.
   # ===========================================================================
 
-  @core_e2e @odbc_e2e
+  @core_e2e @odbc_e2e @python_e2e
   Scenario: oauth should authenticate with pre acquired access token
     Given Authentication is set to legacy OAUTH and a pre-acquired OAuth access token is supplied via `token=`
     When Trying to Connect
     Then Login is successful and a simple query can be executed
 
-  @core_e2e @odbc_e2e
+  @core_e2e @odbc_e2e @python_e2e
   Scenario: oauth should fail legacy authentication with invalid token
     Given Authentication is set to legacy OAUTH and an invalid OAuth access token is supplied
     When Trying to Connect
     Then Connection fails with an authentication / login error
 
-  @core_e2e @odbc_e2e
+  @core_e2e @odbc_e2e @python_e2e
   Scenario: oauth should authenticate using authorization code flow
     Given Authentication is set to OAUTH_AUTHORIZATION_CODE with a valid client id / secret. `oauth_authorization_url` and `oauth_token_request_url` are forwarded from parameters when present (otherwise the driver falls back to the Snowflake-IdP defaults `https://{host}/oauth/authorize` and `https://{host}/oauth/token-request`). `client_store_temporary_credential=true` lets the AC flow short-circuit on subsequent runs by re-using the cached access / refresh token (analysis §3.2 / §7).
     When Trying to Connect (this will spawn the local-loopback HTTP listener and `xdg-open`/`open`/`ShellExecute` the IdP login URL unless a previously cached access token short-circuits the leg)
@@ -101,30 +123,30 @@ Feature: OAuth Authentication
     When Trying to Connect — should NOT spawn a browser; the pre-seeded access token must satisfy the AC short-circuit.
     Then Login is successful and a simple query can be executed
 
-  @core_e2e @odbc_e2e
+  @core_e2e @odbc_e2e @python_e2e
   Scenario: oauth should authenticate using client credentials flow
     Given Authentication is set to OAUTH_CLIENT_CREDENTIALS with a valid client id / secret and an external IdP token URL. Snowflake's GS does not mint CC tokens (analysis §4), so `oauth_token_request_url` is required up-front.
     When Trying to Connect
     Then Login is successful and a simple query can be executed
 
-  @core_e2e @odbc_e2e
+  @core_e2e @odbc_e2e @python_e2e
   Scenario: oauth should fail authorization code flow with bad client secret
     Given Authentication is set to OAUTH_AUTHORIZATION_CODE with a valid client id but a deliberately invalid client secret. The IdP token-exchange step must reject the credentials and the driver must surface an authentication / login error.
     When Trying to Connect
     Then Connection fails with an authentication / login error
 
-  # ODBC-only E2E scenarios -- not implemented in sf_core because the
+  # Wrapper-only E2E scenarios -- not implemented in sf_core because the
   # Rust e2e harness covers different cases (keyring short-circuit) and
   # the case-insensitive matching of OAUTH is exercised by sf_core unit
   # tests instead.
 
-  @odbc_e2e
+  @odbc_e2e @python_e2e
   Scenario: oauth should authenticate using lowercase oauth authenticator
     Given Authentication is set to lowercase oauth and a valid pre-acquired OAuth access token is supplied via TOKEN
     When Trying to Connect
     Then Login is successful and a simple query can be executed
 
-  @odbc_e2e
+  @odbc_e2e @python_e2e
   Scenario: oauth should fail client credentials flow with bad client secret
     Given Authentication is set to OAUTH_CLIENT_CREDENTIALS with a valid client id, an invalid client secret and a valid token_request_url
     When Trying to Connect


### PR DESCRIPTION
Mirrors the sf_core (oauth.rs) and ODBC (oauth.cpp) e2e suites for the
Python wrapper:

* python/tests/e2e/authentication/test_oauth.py covers the three OAuth
  flows (legacy AUTHENTICATOR=OAUTH, OAUTH_AUTHORIZATION_CODE,
  OAUTH_CLIENT_CREDENTIALS) plus the lowercase-authenticator and
  bad-client-secret negative paths. Tests skip when
  SNOWFLAKE_TEST_OAUTH_* parameters are missing; AC scenarios that
  spawn a real OS browser additionally require SNOWFLAKE_OAUTH_E2E_BROWSER=1.

* tests/definitions/shared/authentication/oauth.feature gains
  @python_int / @python_e2e tags on the shared cross-driver scenarios.
  The two AUTHENTICATOR=OAUTH integration scenarios stay @odbc_int-only
  because Python identifiers cannot include '=' and the
  tests-format-validator matches method names against snake_cased
  scenario names. Python-only OAuth behaviour (token redaction,
  oauth_token_url alias rewrite, oauth_enable_refresh_tokens /
  oauth_credentials_in_body / oauth_socket_uri deprecation warnings)
  lives in test_oauth_python_specific.py.

* python/tests/integ/authentication/test_oauth.py: methods renamed to
  match the shared Gherkin scenarios via snake_case conversion
  (e.g. test_should_fail_oauth_client_credentials_when_client_id_is_missing).
  Gherkin step text in comments is now verbatim with the feature file
  and every step has implementation code before the next, satisfying
  the empty-step / missing-step validator checks.

* python/tests/integ/authentication/test_oauth_python_specific.py:
  new file housing the Python-only OAuth integration tests
  (AUTHENTICATOR=OAUTH plumbing, legacy token redaction, alias
  rewrite, deprecation warnings). Its filename does not match any
  feature stem so the validator does not flag its methods as orphans.

Method names match sf_core's oauth_should_* convention so the same
Gherkin definition validates the Rust, ODBC, and Python tests.