### PR TITLE
SNOW-3535355: python - fix connector logger propagation for external log capture

### DIFF
--- a/python/src/snowflake/connector/__init__.py
+++ b/python/src/snowflake/connector/__init__.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 from typing import Any
 
 from . import util_text  # noqa: F401 - backward compatibility re-exports
-from ._internal.api_client.c_api import register_default_logger_callback  # noqa: F401
 from ._internal.decorators import pep249
 from .connection import Connection, SnowflakeConnection
 from .connection_config import ConnectionConfig

--- a/python/src/snowflake/connector/_internal/api_client/__init__.py
+++ b/python/src/snowflake/connector/_internal/api_client/__init__.py
@@ -1,7 +1,6 @@
 """Initialize the core API with the default logger callback."""
 
-import logging
-
+from ..logging import get_connector_logger
 from .c_api import c_logger_callback, sf_core_init
 
 
@@ -10,4 +9,4 @@ sf_core_init(c_logger_callback)
 from snowflake.connector.version import __version__  # noqa: E402
 
 
-logging.getLogger("snowflake.connector").info("Python connector starting v%s", __version__)
+get_connector_logger().info("Python connector starting v%s", __version__)

--- a/python/src/snowflake/connector/_internal/logging.py
+++ b/python/src/snowflake/connector/_internal/logging.py
@@ -12,15 +12,17 @@ import logging
 CONNECTOR_LOGGER_NAME = "snowflake.connector"
 SF_CORE_LOGGER_NAME = "snowflake.connector._core"
 
-# Set up loggers once at module load:
-# - Disable propagation to prevent duplicate logs via parent loggers
-# - Add NullHandler as a fallback (good practice for library loggers)
+# Set up loggers once at module load with NullHandler (standard library practice
+# per https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library).
+# Propagation is left ON so that external log capture (e.g. pytest caplog, root-level
+# handlers configured by the application) works out of the box -- matching
+# the behavior of snowflake-connector-python.
+# When setup_logging() is called explicitly, propagation is turned OFF on the
+# loggers that receive a dedicated handler to prevent duplicate output.
 _sf_core_logger = logging.getLogger(SF_CORE_LOGGER_NAME)
-_sf_core_logger.propagate = False
 _sf_core_logger.addHandler(logging.NullHandler())
 
 _connector_logger = logging.getLogger(CONNECTOR_LOGGER_NAME)
-_connector_logger.propagate = False
 _connector_logger.addHandler(logging.NullHandler())
 
 
@@ -49,9 +51,31 @@ def setup_logging(
     snowflake.connector logger and the sf_core logger (which receives
     logs from the native Rust library).
 
-    Handlers are only added if the logger has no handlers or only has
-    NullHandler(s). This prevents duplicate handlers if setup_logging
-    is called multiple times.
+    Propagation behaviour
+    ---------------------
+    By default (before this function is called) both loggers have
+    ``propagate=True``.  This means log records bubble up to the root
+    logger so that application-level handlers and test frameworks such as
+    ``pytest caplog`` capture connector output without any extra
+    configuration.
+
+    When this function adds a dedicated StreamHandler to a logger it also
+    sets ``propagate=False`` on that logger to prevent every message from
+    appearing twice — once via the dedicated handler and once via the root
+    handler chain.
+
+    **The propagate flag is only changed when a handler is actually added.**
+    If the logger already has a non-NullHandler (meaning the caller has
+    configured it themselves), this function leaves ``propagate`` and the
+    existing handler untouched and only updates the logger's *level*.
+    This respects application-level logging configuration while still
+    honouring the requested verbosity.
+
+    Summary:
+      * No prior handler → adds StreamHandler, sets propagate=False.
+      * Prior non-Null handler exists → updates level only, propagate unchanged.
+      * Called multiple times with no prior handler → second call is a no-op
+        for handler/propagation (handler already present from the first call).
 
     Args:
         level: Logging level for the snowflake.connector logger.
@@ -70,22 +94,21 @@ def setup_logging(
     if format_string is None:
         format_string = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 
-    # Create formatter
     formatter = logging.Formatter(format_string)
-
-    # Create handler
     handler = logging.StreamHandler(stream)  # type: ignore [arg-type]
     handler.setFormatter(formatter)
 
-    # Configure snowflake.connector logger
+    # Level is always updated regardless of whether a handler is added.
     _connector_logger.setLevel(level)
     if _needs_handler(_connector_logger):
+        # No real handler yet: attach ours and stop propagation to avoid duplicate output via the root logger.
         _connector_logger.addHandler(handler)
+        _connector_logger.propagate = False
 
-    # Configure sf_core logger with explicit INFO level
     _sf_core_logger.setLevel(sf_core_level)
     if _needs_handler(_sf_core_logger):
         _sf_core_logger.addHandler(handler)
+        _sf_core_logger.propagate = False
 
 
 def get_connector_logger() -> logging.Logger:

--- a/python/src/snowflake/connector/_internal/snow_logging.py
+++ b/python/src/snowflake/connector/_internal/snow_logging.py
@@ -1,3 +1,13 @@
+"""Logger adapter used exclusively by the bundled nanoarrow C++ extension.
+
+The extension imports this module via pybind (see
+``_internal/nanoarrow_cpp/Logging/logging.cpp``) and calls
+``SnowLogger.log()`` so it can pass C++-side file / function / line
+information through Python's logging machinery. Pure-Python code does
+not use this adapter — it goes through ``_internal/logging.py`` and
+``logging.getLogger(__name__)`` instead.
+"""
+
 from __future__ import annotations
 
 import logging

--- a/python/tests/e2e/session/test_close.py
+++ b/python/tests/e2e/session/test_close.py
@@ -17,6 +17,7 @@ import warnings
 import pytest
 
 from tests.private_key_helper import get_test_private_key_path
+from tests.wiremock_client import WiremockClient
 
 
 def assert_logout_request_format(logout_request: dict) -> None:
@@ -47,82 +48,84 @@ class TestLogoutPythonWrapper:
     # 3. "And Connection close metrics are recorded in telemetry" is empty — telemetry
     #    recording is not yet implemented (SNOW-2912513).
     def test_should_send_logout_when_server_session_keep_alive_is_none_and_auto_detection_false(
-        self, int_test_connection_factory, wiremock
+        self, int_test_connection_factory
     ):
         """Verify that logout is sent when auto-detection is disabled."""
-        # Setup Wiremock mappings
-        wiremock.add_mapping("auth/login_success_jwt.json")
-        wiremock.add_mapping("session/logout_success.json")
+        with WiremockClient().start() as wiremock:
+            # Setup Wiremock mappings
+            wiremock.add_mapping("auth/login_success_jwt.json")
+            wiremock.add_mapping("session/logout_success.json")
 
-        # Capture warnings
-        with warnings.catch_warnings(record=True) as captured_warnings:
-            warnings.simplefilter("always")
+            # Capture warnings
+            with warnings.catch_warnings(record=True) as captured_warnings:
+                warnings.simplefilter("always")
 
-            # Given Snowflake Python client is created with server_session_keep_alive set to none
-            server_session_keep_alive_param = None
+                # Given Snowflake Python client is created with server_session_keep_alive set to none
+                server_session_keep_alive_param = None
 
-            # And enable_server_session_keep_alive_auto_detection is set to false
-            conn = int_test_connection_factory(
-                server_url=wiremock.http_url(),
-                server_session_keep_alive=server_session_keep_alive_param,
-                enable_server_session_keep_alive_auto_detection=False,
+                # And enable_server_session_keep_alive_auto_detection is set to false
+                conn = int_test_connection_factory(
+                    server_url=wiremock.http_url(),
+                    server_session_keep_alive=server_session_keep_alive_param,
+                    enable_server_session_keep_alive_auto_detection=False,
+                )
+
+                # When Client closes connection
+                conn.close()
+
+            # Then Auto-detection is not performed
+            assert conn.is_closed(), "Connection closed: auto-detection was not invoked to prevent logout"
+
+            # And Logout request is sent
+            logout_requests = wiremock.get_logout_requests()
+
+            assert len(logout_requests) == 1, (
+                f"Should send logout request with auto_detection=False, got {len(logout_requests)} requests"
             )
 
-            # When Client closes connection
-            conn.close()
+            assert_logout_request_format(logout_requests[0])
 
-        # Then Auto-detection is not performed
-        assert conn.is_closed(), "Connection closed: auto-detection was not invoked to prevent logout"
+            # And Connection close metrics are recorded in telemetry
+            pass  # TODO(SNOW-2912513): telemetry not yet implemented — step unverified
 
-        # And Logout request is sent
-        logout_requests = wiremock.get_logout_requests()
+            # And No deprecation warning is emitted
+            deprecation_warnings = [
+                w for w in captured_warnings if issubclass(w.category, (FutureWarning, DeprecationWarning))
+            ]
+            assert len(deprecation_warnings) == 0, (
+                f"Should not emit deprecation warning, got: {[str(w.message) for w in deprecation_warnings]}"
+            )
 
-        assert len(logout_requests) == 1, (
-            f"Should send logout request with auto_detection=False, got {len(logout_requests)} requests"
-        )
-
-        assert_logout_request_format(logout_requests[0])
-
-        # And Connection close metrics are recorded in telemetry
-        pass  # TODO(SNOW-2912513): telemetry not yet implemented — step unverified
-
-        # And No deprecation warning is emitted
-        deprecation_warnings = [
-            w for w in captured_warnings if issubclass(w.category, (FutureWarning, DeprecationWarning))
-        ]
-        assert len(deprecation_warnings) == 0, (
-            f"Should not emit deprecation warning, got: {[str(w.message) for w in deprecation_warnings]}"
-        )
-
-        assert conn.is_closed()
+            assert conn.is_closed()
 
     @pytest.mark.skip_reference(reason="core_proxy fixture imports _internal")
     def test_should_pass_correct_parameters_when_server_session_keep_alive_is_none_and_auto_detection_true(
-        self, int_test_connection_factory, core_proxy, wiremock
+        self, int_test_connection_factory, core_proxy
     ):
         """Verify Python wrapper passes None keep-alive and True auto-detection to Core.
 
         Phase 2 (SNOW-2314152) truth table: server_session_keep_alive=None + enable_auto_detection=True
         → no Phase 2 (SNOW-2314152) remap (only False + True triggers remap) → Core receives None + True.
         """
-        wiremock.add_mapping("auth/login_success_jwt.json")
-        wiremock.add_mapping("session/logout_success.json")
+        with WiremockClient().start() as wiremock:
+            wiremock.add_mapping("auth/login_success_jwt.json")
+            wiremock.add_mapping("session/logout_success.json")
 
-        with warnings.catch_warnings(record=True) as captured_warnings:
-            warnings.simplefilter("always")
+            with warnings.catch_warnings(record=True) as captured_warnings:
+                warnings.simplefilter("always")
 
-            # Given Snowflake Python client is created with server_session_keep_alive set to none
-            server_session_keep_alive_param = None
+                # Given Snowflake Python client is created with server_session_keep_alive set to none
+                server_session_keep_alive_param = None
 
-            # And enable_server_session_keep_alive_auto_detection is set to true
-            conn = int_test_connection_factory(
-                server_url=wiremock.http_url(),
-                server_session_keep_alive=server_session_keep_alive_param,
-                enable_server_session_keep_alive_auto_detection=True,
-            )
+                # And enable_server_session_keep_alive_auto_detection is set to true
+                conn = int_test_connection_factory(
+                    server_url=wiremock.http_url(),
+                    server_session_keep_alive=server_session_keep_alive_param,
+                    enable_server_session_keep_alive_auto_detection=True,
+                )
 
-        # When Client closes connection
-        conn.close()
+            # When Client closes connection
+            conn.close()
 
         # Then server_session_keep_alive none is passed to Core
         options = core_proxy.get_options_sent()
@@ -142,7 +145,7 @@ class TestLogoutPythonWrapper:
 
     @pytest.mark.skip_reference(reason="core_proxy fixture imports _internal")
     def test_should_remap_server_session_keep_alive_false_to_none_when_auto_detection_defaults_to_true(
-        self, int_test_connection_factory, core_proxy, wiremock
+        self, int_test_connection_factory, core_proxy
     ):
         """Verify Python wrapper remaps False keep-alive to None when auto-detection is True (default).
 
@@ -150,73 +153,75 @@ class TestLogoutPythonWrapper:
         → Phase 2 (SNOW-2314152) remap: False + True → None so Core checks registry (legacy Python behavior).
         Default True is required for Phase 2 backward compat (SNOW-2314152).
         """
-        wiremock.add_mapping("auth/login_success_jwt.json")
-        wiremock.add_mapping("session/logout_success.json")
+        with WiremockClient().start() as wiremock:
+            wiremock.add_mapping("auth/login_success_jwt.json")
+            wiremock.add_mapping("session/logout_success.json")
 
-        # Given Snowflake Python client is created with server_session_keep_alive set to false
-        with warnings.catch_warnings(record=True) as captured_warnings:
-            warnings.simplefilter("always")
-            conn = int_test_connection_factory(
-                server_url=wiremock.http_url(),
-                server_session_keep_alive=False,
+            # Given Snowflake Python client is created with server_session_keep_alive set to false
+            with warnings.catch_warnings(record=True) as captured_warnings:
+                warnings.simplefilter("always")
+                conn = int_test_connection_factory(
+                    server_url=wiremock.http_url(),
+                    server_session_keep_alive=False,
+                )
+
+            # When Client closes connection
+            conn.close()
+
+            # Then server_session_keep_alive false is remapped to none
+            options = core_proxy.get_options_sent()
+            assert "server_session_keep_alive" not in options, (
+                "False + auto_detection=True (default) → remap → None → not sent to Core"
             )
 
-        # When Client closes connection
-        conn.close()
+            future_warnings = [w for w in captured_warnings if issubclass(w.category, FutureWarning)]
 
-        # Then server_session_keep_alive false is remapped to none
-        options = core_proxy.get_options_sent()
-        assert "server_session_keep_alive" not in options, (
-            "False + auto_detection=True (default) → remap → None → not sent to Core"
-        )
+            # And Deprecation warning is emitted
+            assert any("server_session_keep_alive=False" in str(w.message) for w in future_warnings), (
+                f"Expected FutureWarning about server_session_keep_alive=False, "
+                f"got: {[str(w.message) for w in captured_warnings]}"
+            )
 
-        future_warnings = [w for w in captured_warnings if issubclass(w.category, FutureWarning)]
+            # And Warning mentions that false will force logout in Phase 3 (SNOW-2314152)
+            assert any("always logout" in str(w.message) for w in future_warnings), (
+                f"Warning should mention Phase 3 (SNOW-2314152) 'always logout' behavior, "
+                f"got: {[str(w.message) for w in future_warnings]}"
+            )
 
-        # And Deprecation warning is emitted
-        assert any("server_session_keep_alive=False" in str(w.message) for w in future_warnings), (
-            f"Expected FutureWarning about server_session_keep_alive=False, "
-            f"got: {[str(w.message) for w in captured_warnings]}"
-        )
-
-        # And Warning mentions that false will force logout in Phase 3 (SNOW-2314152)
-        assert any("always logout" in str(w.message) for w in future_warnings), (
-            f"Warning should mention Phase 3 (SNOW-2314152) 'always logout' behavior, "
-            f"got: {[str(w.message) for w in future_warnings]}"
-        )
-
-        # Verify logout was actually sent to Core (False = explicit logout)
-        logout_requests = wiremock.get_logout_requests()
-        assert len(logout_requests) == 1, (
-            f"server_session_keep_alive=False should send exactly one logout request, got {len(logout_requests)}"
-        )
+            # Verify logout was actually sent to Core (False = explicit logout)
+            logout_requests = wiremock.get_logout_requests()
+            assert len(logout_requests) == 1, (
+                f"server_session_keep_alive=False should send exactly one logout request, got {len(logout_requests)}"
+            )
 
     @pytest.mark.skip_reference(reason="core_proxy fixture imports _internal")
     def test_should_pass_server_session_keep_alive_false_to_core_when_auto_detection_explicitly_disabled(
-        self, int_test_connection_factory, core_proxy, wiremock
+        self, int_test_connection_factory, core_proxy
     ):
         """Verify Python wrapper passes False to Core when auto_detection is explicitly disabled.
 
         False + auto_detection=False (explicit) → no Phase 2 (SNOW-2314152) remap → Core receives False (force logout).
         No deprecation warning: user opted out of auto-detection consciously.
         """
-        wiremock.add_mapping("auth/login_success_jwt.json")
-        wiremock.add_mapping("session/logout_success.json")
+        with WiremockClient().start() as wiremock:
+            wiremock.add_mapping("auth/login_success_jwt.json")
+            wiremock.add_mapping("session/logout_success.json")
 
-        with warnings.catch_warnings(record=True) as captured_warnings:
-            warnings.simplefilter("always")
+            with warnings.catch_warnings(record=True) as captured_warnings:
+                warnings.simplefilter("always")
 
-            # Given Snowflake Python client is created with server_session_keep_alive set to false
-            server_session_keep_alive_param = False
+                # Given Snowflake Python client is created with server_session_keep_alive set to false
+                server_session_keep_alive_param = False
 
-            # And enable_server_session_keep_alive_auto_detection is set to false
-            conn = int_test_connection_factory(
-                server_url=wiremock.http_url(),
-                server_session_keep_alive=server_session_keep_alive_param,
-                enable_server_session_keep_alive_auto_detection=False,
-            )
+                # And enable_server_session_keep_alive_auto_detection is set to false
+                conn = int_test_connection_factory(
+                    server_url=wiremock.http_url(),
+                    server_session_keep_alive=server_session_keep_alive_param,
+                    enable_server_session_keep_alive_auto_detection=False,
+                )
 
-        # When Client closes connection
-        conn.close()
+            # When Client closes connection
+            conn.close()
 
         # Then server_session_keep_alive false is passed to Core
         options = core_proxy.get_options_sent()
@@ -240,145 +245,136 @@ class TestLogoutPythonWrapper:
         ids=["auto_detection_true", "auto_detection_false"],
     )
     def test_should_skip_logout_when_server_session_keep_alive_is_true_regardless_of_auto_detection(
-        self, int_test_connection_factory, core_proxy, auto_detection: bool, wiremock
+        self, int_test_connection_factory, core_proxy, auto_detection: bool
     ) -> None:
         """Verify no logout is sent when server_session_keep_alive=True, regardless of auto_detection.
 
         Phase 2 (SNOW-2314152) truth table: True + any auto_detection → no logout, no deprecation.
         Core receives server_session_keep_alive=True and skips the logout request.
         """
-        wiremock.add_mapping("auth/login_success_jwt.json")
+        with WiremockClient().start() as wiremock:
+            wiremock.add_mapping("auth/login_success_jwt.json")
 
-        with warnings.catch_warnings(record=True) as captured_warnings:
-            warnings.simplefilter("always")
+            with warnings.catch_warnings(record=True) as captured_warnings:
+                warnings.simplefilter("always")
 
-            # Given Snowflake Python client is created with server_session_keep_alive set to true
-            server_session_keep_alive_param = True
+                # Given Snowflake Python client is created with server_session_keep_alive set to true
+                server_session_keep_alive_param = True
 
-            # And enable_server_session_keep_alive_auto_detection is set to <auto_detection>
-            conn = int_test_connection_factory(
-                server_url=wiremock.http_url(),
-                server_session_keep_alive=server_session_keep_alive_param,
-                enable_server_session_keep_alive_auto_detection=auto_detection,
+                # And enable_server_session_keep_alive_auto_detection is set to <auto_detection>
+                conn = int_test_connection_factory(
+                    server_url=wiremock.http_url(),
+                    server_session_keep_alive=server_session_keep_alive_param,
+                    enable_server_session_keep_alive_auto_detection=auto_detection,
+                )
+
+                # When Connection is closed
+                conn.close()
+
+            # Then No logout request is sent
+            logout_requests = wiremock.get_logout_requests()
+            assert len(logout_requests) == 0, (
+                f"Expected no logout when server_session_keep_alive=True "
+                f"(auto_detection={auto_detection}), got {len(logout_requests)} requests"
             )
 
-            # When Connection is closed
-            conn.close()
+            # And server_session_keep_alive true is passed to Core
+            options = core_proxy.get_options_sent()
+            assert options.get("server_session_keep_alive") is True, (
+                f"Expected server_session_keep_alive=True passed to Core, "
+                f"got {options.get('server_session_keep_alive')!r}"
+            )
 
-        # Then No logout request is sent
-        logout_requests = wiremock.get_logout_requests()
-        assert len(logout_requests) == 0, (
-            f"Expected no logout when server_session_keep_alive=True "
-            f"(auto_detection={auto_detection}), got {len(logout_requests)} requests"
-        )
-
-        # And server_session_keep_alive true is passed to Core
-        options = core_proxy.get_options_sent()
-        assert options.get("server_session_keep_alive") is True, (
-            f"Expected server_session_keep_alive=True passed to Core, got {options.get('server_session_keep_alive')!r}"
-        )
-
-        # And No deprecation warning is emitted
-        deprecation_warnings = [
-            w for w in captured_warnings if issubclass(w.category, (FutureWarning, DeprecationWarning))
-        ]
-        assert len(deprecation_warnings) == 0, (
-            f"server_session_keep_alive=True should not emit deprecation warning, "
-            f"got: {[str(w.message) for w in deprecation_warnings]}"
-        )
+            # And No deprecation warning is emitted
+            deprecation_warnings = [
+                w for w in captured_warnings if issubclass(w.category, (FutureWarning, DeprecationWarning))
+            ]
+            assert len(deprecation_warnings) == 0, (
+                f"server_session_keep_alive=True should not emit deprecation warning, "
+                f"got: {[str(w.message) for w in deprecation_warnings]}"
+            )
 
     @pytest.mark.skip_reference(reason="core_proxy fixture imports _internal")
-    def test_should_use_python_default_15_second_timeout_and_3_max_retries(self, int_test_connection_factory, wiremock):
+    def test_should_use_python_default_15_second_timeout_and_3_max_retries(self, int_test_connection_factory):
         """Verify default logout uses 15s timeout and 3 max attempts (Core defaults)."""
-        wiremock.add_mapping("auth/login_success_jwt.json")
-        wiremock.add_mapping("session/logout_500_always.json")
+        with WiremockClient().start() as wiremock:
+            wiremock.add_mapping("auth/login_success_jwt.json")
+            wiremock.add_mapping("session/logout_500_always.json")
 
-        # Given Snowflake Python client is created with default timeout configuration
-        conn = int_test_connection_factory(server_url=wiremock.http_url())
+            # Given Snowflake Python client is created with default timeout configuration
+            conn = int_test_connection_factory(server_url=wiremock.http_url())
 
-        # When Connection is closed
-        start = time.monotonic()
-        conn.close()  # BestEffort — won't raise despite 500s
-        elapsed = time.monotonic() - start
+            # When Connection is closed
+            start = time.monotonic()
+            conn.close()  # BestEffort — won't raise despite 500s
+            elapsed = time.monotonic() - start
 
-        # Then Logout completes within 15 seconds
-        DEFAULT_LOGOUT_TIMEOUT = 15
-        SCHEDULING_TOLERANCE = 2  # backoff jitter + OS scheduling overhead
-        assert elapsed < DEFAULT_LOGOUT_TIMEOUT + SCHEDULING_TOLERANCE, (
-            f"Expected completion within {DEFAULT_LOGOUT_TIMEOUT}s + {SCHEDULING_TOLERANCE}s tolerance, "
-            f"took {elapsed:.1f}s"
-        )
+            # Then Logout completes within 15 seconds
+            DEFAULT_LOGOUT_TIMEOUT = 15
+            SCHEDULING_TOLERANCE = 2  # backoff jitter + OS scheduling overhead
+            assert elapsed < DEFAULT_LOGOUT_TIMEOUT + SCHEDULING_TOLERANCE, (
+                f"Expected completion within {DEFAULT_LOGOUT_TIMEOUT}s + {SCHEDULING_TOLERANCE}s tolerance, "
+                f"took {elapsed:.1f}s"
+            )
 
-        # And Logout retries up to 3 times on failure
-        logout_requests = wiremock.get_logout_requests()
-        assert len(logout_requests) == 3, f"Expected 3 attempts (default max_attempts), got {len(logout_requests)}"
+            # And Logout retries up to 3 times on failure
+            logout_requests = wiremock.get_logout_requests()
+            assert len(logout_requests) == 3, f"Expected 3 attempts (default max_attempts), got {len(logout_requests)}"
 
     @pytest.mark.skip_reference(reason="core_proxy fixture imports _internal")
     def test_should_use_best_effort_error_handling_strategy_by_default(
-        self, int_test_connection_factory, core_proxy, tmp_path, wiremock
+        self, int_test_connection_factory, core_proxy, caplog
     ):
         """Verify close() does not raise when server returns 500 on all logout attempts.
 
         Best-effort strategy: close() succeeds even if logout fails.
         All retries (max_attempts=3) are exhausted, then Core reports WARN and returns ok.
         """
-        wiremock.add_mapping("auth/login_success_jwt.json")
+        with WiremockClient().start() as wiremock:
+            wiremock.add_mapping("auth/login_success_jwt.json")
 
-        # Given Snowflake Python client is created with default parameters
-        conn = int_test_connection_factory(server_url=wiremock.http_url())
+            # Given Snowflake Python client is created with default parameters
+            conn = int_test_connection_factory(server_url=wiremock.http_url())
 
-        # And Server will return 500 Internal Server Error on logout on all attempts
-        wiremock.add_mapping("session/logout_500_always.json")
+            # And Server will return 500 Internal Server Error on logout on all attempts
+            wiremock.add_mapping("session/logout_500_always.json")
 
-        # Capture Core logs to a temp file. We use a file instead of pytest caplog
-        # because the Rust→Python FFI log bridge (sf_core_init_logger callback in
-        # c_api.py) writes to the snowflake.connector._core logger which has
-        # propagate=False and NullHandler by default — caplog can't intercept it
-        # without reconfiguring propagation. A FileHandler on the logger directly
-        # captures the FFI-bridged logs.
-        log_file = tmp_path / "core.log"
-        core_logger = logging.getLogger("snowflake.connector._core")
-        handler = logging.FileHandler(str(log_file))
-        handler.setLevel(logging.WARNING)
-        handler.setFormatter(logging.Formatter("%(levelname)s %(message)s"))
-        core_logger.addHandler(handler)
-        original_level = core_logger.level
-        core_logger.setLevel(logging.WARNING)
+            # Capture Core logs via caplog. The Rust→Python FFI log bridge writes
+            # to the snowflake.connector._core logger which now propagates to
+            # the root logger by default, so caplog intercepts it directly.
+            with caplog.at_level(logging.WARNING, logger="snowflake.connector._core"):
+                # When Connection is closed
+                conn.close()  # Must NOT raise with best-effort strategy
 
-        try:
-            # When Connection is closed
-            conn.close()  # Must NOT raise with best-effort strategy
-        finally:
-            core_logger.removeHandler(handler)
-            core_logger.setLevel(original_level)
-            handler.close()
+            # Then Logout attempts are bounded by the default retry limit
+            logout_requests = wiremock.get_logout_requests()
+            assert len(logout_requests) <= 3, (
+                f"Expected at most 3 logout attempts (default max_attempts), got {len(logout_requests)}"
+            )
 
-        # Then Logout attempts are bounded by the default retry limit
-        logout_requests = wiremock.get_logout_requests()
-        assert len(logout_requests) <= 3, (
-            f"Expected at most 3 logout attempts (default max_attempts), got {len(logout_requests)}"
-        )
+            # And No further requests are sent after retry limit is reached
+            assert len(logout_requests) == 3, (
+                f"Expected exactly {3} attempts (limit hit, no more sent). Got {len(logout_requests)}"
+            )
 
-        # And No further requests are sent after retry limit is reached
-        assert len(logout_requests) == 3, (
-            f"Expected exactly {3} attempts (limit hit, no more sent). Got {len(logout_requests)}"
-        )
+            # And Error is logged as WARN
+            core_warnings = [
+                r for r in caplog.records if r.name == "snowflake.connector._core" and r.levelno >= logging.WARNING
+            ]
+            assert any("Logout failed" in r.message for r in core_warnings), (
+                f"Expected WARNING log with 'Logout failed' from Core.\n"
+                f"Captured sf_core records: {[r.message for r in core_warnings]}"
+            )
 
-        # And Error is logged as WARN
-        log_content = log_file.read_text()
-        assert "WARNING" in log_content and "Logout failed" in log_content, (
-            f"Expected WARNING log with 'Logout failed' from Core.\nCaptured:\n{log_content}"
-        )
+            # And close() method does not raise exception
+            pass  # proven by conn.close() completing without exception in the try block above
 
-        # And close() method does not raise exception
-        pass  # proven by conn.close() completing without exception in the try block above
+            # And Connection cleanup succeeds
+            assert conn.is_closed()
 
-        # And Connection cleanup succeeds
-        assert conn.is_closed()
-
-        # And Error handling strategy is best-effort by default
-        options = core_proxy.get_options_sent()
-        assert options.get("logout_error_strategy") == "best_effort", "Default error strategy should be BEST_EFFORT"
+            # And Error handling strategy is best-effort by default
+            options = core_proxy.get_options_sent()
+            assert options.get("logout_error_strategy") == "best_effort", "Default error strategy should be BEST_EFFORT"
 
 
 class TestLogoutRetryBehavior:
@@ -388,59 +384,61 @@ class TestLogoutRetryBehavior:
     retries a failed logout request.
     """
 
-    @pytest.mark.skip_reference(reason="Old connector does not retry logout on 503")
+    @pytest.mark.skip_reference(reason="Old connector (v4.3.0) does not retry logout on 503")
     def test_should_retry_logout_on_transient_failure_when_close_called_with_default_retry(
-        self, int_test_connection_factory, wiremock
+        self, int_test_connection_factory
     ):
         """Verify close() retries a failed logout and sends two requests on transient 503."""
-        wiremock.add_mapping("auth/login_success_jwt.json")
+        with WiremockClient().start() as wiremock:
+            wiremock.add_mapping("auth/login_success_jwt.json")
 
-        # Given Snowflake Python client is logged in
-        conn = int_test_connection_factory(server_url=wiremock.http_url())
+            # Given Snowflake Python client is logged in
+            conn = int_test_connection_factory(server_url=wiremock.http_url())
 
-        # And Server will return 503 on first logout attempt then succeed
-        wiremock.add_mapping("session/logout_503_then_success.json")
+            # And Server will return 503 on first logout attempt then succeed
+            wiremock.add_mapping("session/logout_503_then_success.json")
 
-        # When close() is called with default parameters
-        conn.close()
+            # When close() is called with default parameters
+            conn.close()
 
-        # Then Logout succeeds after retry
-        assert conn.is_closed(), "Connection should be closed after successful retry"
+            # Then Logout succeeds after retry
+            assert conn.is_closed(), "Connection should be closed after successful retry"
 
-        # And Two logout requests were sent to server
-        logout_requests = wiremock.get_logout_requests()
-        assert len(logout_requests) == 2, (
-            f"Expected 2 logout requests (1 failure + 1 success), got {len(logout_requests)}"
-        )
+            # And Two logout requests were sent to server
+            logout_requests = wiremock.get_logout_requests()
+            assert len(logout_requests) == 2, (
+                f"Expected 2 logout requests (1 failure + 1 success), got {len(logout_requests)}"
+            )
 
     def test_should_not_retry_logout_on_transient_failure_when_close_called_with_retry_false(
-        self, int_test_connection_factory, wiremock
+        self, int_test_connection_factory
     ):
         """Verify close(retry=False) sends exactly one logout request and does not retry."""
-        wiremock.add_mapping("auth/login_success_jwt.json")
+        with WiremockClient().start() as wiremock:
+            wiremock.add_mapping("auth/login_success_jwt.json")
 
-        # Given Snowflake Python client is logged in
-        conn = int_test_connection_factory(server_url=wiremock.http_url())
+            # Given Snowflake Python client is logged in
+            conn = int_test_connection_factory(server_url=wiremock.http_url())
 
-        # And Server will return 503 on first logout attempt then succeed
-        wiremock.add_mapping("session/logout_503_then_success.json")
+            # And Server will return 503 on first logout attempt then succeed
+            wiremock.add_mapping("session/logout_503_then_success.json")
 
-        # When close(retry=False) is called
-        conn.close(retry=False)
+            # When close(retry=False) is called
+            conn.close(retry=False)
 
-        # Then Logout is not retried
-        logout_requests = wiremock.get_logout_requests()
-        assert len(logout_requests) == 1, (
-            f"retry=False should prevent retries despite 503, got {len(logout_requests)} requests"
-        )
+            # Then Logout is not retried
+            logout_requests = wiremock.get_logout_requests()
+            assert len(logout_requests) == 1, (
+                f"retry=False should prevent retries despite 503, got {len(logout_requests)} requests"
+            )
 
-        # And Only one logout request was sent to server
-        assert_logout_request_format(logout_requests[0])
+            # And Only one logout request was sent to server
+            assert_logout_request_format(logout_requests[0])
 
-        # And Error is handled according to best-effort strategy
-        assert conn.is_closed(), (
-            "Connection should be closed: best-effort strategy suppresses error from single failed attempt"
-        )
+            # And Error is handled according to best-effort strategy
+            assert conn.is_closed(), (
+                "Connection should be closed: best-effort strategy suppresses error from single failed attempt"
+            )
 
 
 _SIGABRT = -6
@@ -476,68 +474,69 @@ class TestAutoCleanup:
 
     # test_should_have_auto_cleanup_enabled_by_default moved to integ (uses core_mock)
 
-    def test_should_unregister_atexit_handler_when_close_called_explicitly(self, int_test_connection_factory, wiremock):
+    def test_should_unregister_atexit_handler_when_close_called_explicitly(self, int_test_connection_factory):
         """Verify close() unregisters atexit handler so process exit doesn't trigger second close."""
-        wiremock.add_mapping("auth/login_success_jwt.json")
-        wiremock.add_mapping("session/logout_success.json")
+        with WiremockClient().start() as wiremock:
+            wiremock.add_mapping("auth/login_success_jwt.json")
+            wiremock.add_mapping("session/logout_success.json")
 
-        wiremock_url = wiremock.http_url()
-        private_key_path = get_test_private_key_path()
+            wiremock_url = wiremock.http_url()
+            private_key_path = get_test_private_key_path()
 
-        # Given Snowflake Python client is created with auto_cleanup enabled
-        subprocess_code = textwrap.dedent(f"""\
-            import atexit
-            from snowflake.connector.connection import Connection
-            conn = Connection(
-                user="test_user",
-                account="test_account",
-                database="test_database",
-                schema="test_schema",
-                warehouse="test_warehouse",
-                role="test_role",
-                server_url="{wiremock_url}",
-                authenticator="SNOWFLAKE_JWT",
-                private_key_file=r"{private_key_path}",
-                auto_cleanup=True,
-                enable_server_session_keep_alive_auto_detection=False,
-            )
+            # Given Snowflake Python client is created with auto_cleanup enabled
+            subprocess_code = textwrap.dedent(f"""\
+                import atexit
+                from snowflake.connector.connection import Connection
+                conn = Connection(
+                    user="test_user",
+                    account="test_account",
+                    database="test_database",
+                    schema="test_schema",
+                    warehouse="test_warehouse",
+                    role="test_role",
+                    server_url="{wiremock_url}",
+                    authenticator="SNOWFLAKE_JWT",
+                    private_key_file=r"{private_key_path}",
+                    auto_cleanup=True,
+                    enable_server_session_keep_alive_auto_detection=False,
+                )
+                # And atexit handler is registered at connection init
+                assert conn.auto_cleanup is True, "auto_cleanup must be True for atexit.register to fire"
+                print("ATEXIT_REGISTERED")
+                # When close() is called explicitly
+                orig = atexit.unregister
+                def _spy(f): orig(f); print("ATEXIT_UNREGISTERED")
+                atexit.unregister = _spy
+                conn.close()
+                print("CLOSE_CALLED")
+            """)
+
             # And atexit handler is registered at connection init
-            assert conn.auto_cleanup is True, "auto_cleanup must be True for atexit.register to fire"
-            print("ATEXIT_REGISTERED")
+            result = subprocess.run(
+                [sys.executable, "-c", subprocess_code],
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+            _assert_subprocess_ok(result)
+            assert "ATEXIT_REGISTERED" in result.stdout, "Subprocess must confirm atexit registration"
+
             # When close() is called explicitly
-            orig = atexit.unregister
-            def _spy(f): orig(f); print("ATEXIT_UNREGISTERED")
-            atexit.unregister = _spy
-            conn.close()
-            print("CLOSE_CALLED")
-        """)
+            assert "CLOSE_CALLED" in result.stdout, "Subprocess must confirm close() was called"
 
-        # And atexit handler is registered at connection init
-        result = subprocess.run(
-            [sys.executable, "-c", subprocess_code],
-            capture_output=True,
-            text=True,
-            timeout=120,
-        )
-        _assert_subprocess_ok(result)
-        assert "ATEXIT_REGISTERED" in result.stdout, "Subprocess must confirm atexit registration"
+            # Then atexit handler is unregistered
+            assert "ATEXIT_UNREGISTERED" in result.stdout, "conn.close() must call atexit.unregister()"
+            logout_requests = wiremock.get_logout_requests()
 
-        # When close() is called explicitly
-        assert "CLOSE_CALLED" in result.stdout, "Subprocess must confirm close() was called"
-
-        # Then atexit handler is unregistered
-        assert "ATEXIT_UNREGISTERED" in result.stdout, "conn.close() must call atexit.unregister()"
-        logout_requests = wiremock.get_logout_requests()
-
-        # And Subsequent process exit will not trigger second close
-        assert len(logout_requests) == 1, (
-            f"Expected exactly 1 logout (from close()), not 2 (close + atexit). "
-            f"Got {len(logout_requests)}: unregister failed or atexit fired despite close()."
-        )
+            # And Subsequent process exit will not trigger second close
+            assert len(logout_requests) == 1, (
+                f"Expected exactly 1 logout (from close()), not 2 (close + atexit). "
+                f"Got {len(logout_requests)}: unregister failed or atexit fired despite close()."
+            )
 
     # This test spawns 2 subprocesses × 120s timeout each (240s worst case).
     # CI timeout must be >= 300s.
-    def test_should_call_close_with_retry_false_from_atexit_handler(self, int_test_connection_factory, wiremock):
+    def test_should_call_close_with_retry_false_from_atexit_handler(self, int_test_connection_factory):
         """Verify atexit handler calls close(retry=False), no retries, exceptions suppressed."""
         private_key_path = get_test_private_key_path()
 
@@ -562,74 +561,144 @@ class TestAutoCleanup:
         # Phase A: process exits with leaked connection; first logout attempt returns 503, second
         # attempt returns 200. With retry=False, the 503 is never retried (len==1). This
         # distinguishes retry=False (len==1) from retry=True (len==2: 503 + retry 200).
-        wiremock.add_mapping("auth/login_success_jwt.json")
-        wiremock.add_mapping("session/logout_503_then_success.json")
+        with WiremockClient().start() as wiremock:
+            wiremock.add_mapping("auth/login_success_jwt.json")
+            wiremock.add_mapping("session/logout_503_then_success.json")
 
-        # Given Snowflake Python client is created with auto_cleanup enabled
-        subprocess_code = _build_subprocess_code(wiremock.http_url())
+            # Given Snowflake Python client is created with auto_cleanup enabled
+            subprocess_code = _build_subprocess_code(wiremock.http_url())
 
-        # And Connection was not closed explicitly
-        assert "conn.close()" not in subprocess_code
+            # And Connection was not closed explicitly
+            assert "conn.close()" not in subprocess_code
 
-        # When Process exits
-        result = subprocess.run(
-            [sys.executable, "-c", subprocess_code],
-            capture_output=True,
-            text=True,
-            timeout=120,
-        )
-        _assert_subprocess_ok(result)
+            # When Process exits
+            result = subprocess.run(
+                [sys.executable, "-c", subprocess_code],
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+            _assert_subprocess_ok(result)
 
-        # Then atexit handler calls close(retry=False)
-        logout_requests = wiremock.get_logout_requests()
+            # Then atexit handler calls close(retry=False)
+            logout_requests = wiremock.get_logout_requests()
 
-        # 503 is retried under retry=True (→ len==2) but not under retry=False (→ len==1).
-        # And No retries are attempted during atexit close
-        assert len(logout_requests) == 1, (
-            f"retry=False: 503 must not be retried (retry=True would push count to 2), "
-            f"got {len(logout_requests)} requests"
-        )
+            # 503 is retried under retry=True (→ len==2) but not under retry=False (→ len==1).
+            # And No retries are attempted during atexit close
+            assert len(logout_requests) == 1, (
+                f"retry=False: 503 must not be retried (retry=True would push count to 2), "
+                f"got {len(logout_requests)} requests"
+            )
 
-        # And Session is logged out if conditions allow
-        assert_logout_request_format(logout_requests[0])
+            # And Session is logged out if conditions allow
+            assert_logout_request_format(logout_requests[0])
 
-        # Phase B: server error — atexit handler must not crash the process. Reset state on
-        # the shared wiremock so Phase A's captured requests and mappings don't bleed in.
-        wiremock.reset()
-        wiremock.add_mapping("auth/login_success_jwt.json")
-        wiremock.add_mapping("session/logout_500_always.json")
+        # Phase B: server error — atexit handler must not crash the process
+        with WiremockClient().start() as wiremock2:
+            wiremock2.add_mapping("auth/login_success_jwt.json")
+            wiremock2.add_mapping("session/logout_500_always.json")
 
-        # And All exceptions during atexit close are suppressed
-        subprocess_code_b = _build_subprocess_code(wiremock.http_url())
-        result_b = subprocess.run(
-            [sys.executable, "-c", subprocess_code_b],
-            capture_output=True,
-            text=True,
-            timeout=120,
-        )
-        _assert_subprocess_ok(result_b)
-        assert len(wiremock.get_logout_requests()) >= 1, (
-            "Phase B must reach the logout endpoint to prove exception suppression"
-        )
+            # And All exceptions during atexit close are suppressed
+            subprocess_code_b = _build_subprocess_code(wiremock2.http_url())
+            result_b = subprocess.run(
+                [sys.executable, "-c", subprocess_code_b],
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+            _assert_subprocess_ok(result_b)
+            assert len(wiremock2.get_logout_requests()) >= 1, (
+                "Phase B must reach the logout endpoint to prove exception suppression"
+            )
 
     def test_should_emit_deprecation_warning_only_once_when_multiple_auto_cleanup_handlers_run_during_process_exit(
-        self, int_test_connection_factory, wiremock
+        self, int_test_connection_factory
     ):
         """Verify warning deduplication: 10 leaked connections emit only 1 FutureWarning."""
-        wiremock.add_mapping("auth/login_success_jwt.json")
-        # logout_503_then_success: first request → 503, then 200.
-        # Proves retry=False: the 503 is not retried (total stays 10, not 11+).
-        wiremock.add_mapping("session/logout_503_then_success.json")
+        with WiremockClient().start() as wiremock:
+            wiremock.add_mapping("auth/login_success_jwt.json")
+            # logout_503_then_success: first request → 503, then 200.
+            # Proves retry=False: the 503 is not retried (total stays 10, not 11+).
+            wiremock.add_mapping("session/logout_503_then_success.json")
 
-        wiremock_url = wiremock.http_url()
-        private_key_path = get_test_private_key_path()
+            wiremock_url = wiremock.http_url()
+            private_key_path = get_test_private_key_path()
 
-        # Given A separate Python subprocess is spawned
-        subprocess_code = textwrap.dedent(f"""\
-            import sys
-            from snowflake.connector.connection import Connection
-            connections = []
-            for i in range(10):
+            # Given A separate Python subprocess is spawned
+            subprocess_code = textwrap.dedent(f"""\
+                import sys
+                from snowflake.connector.connection import Connection
+                connections = []
+                for i in range(10):
+                    conn = Connection(
+                        user="test_user",
+                        account="test_account",
+                        database="test_database",
+                        schema="test_schema",
+                        warehouse="test_warehouse",
+                        role="test_role",
+                        server_url="{wiremock_url}",
+                        authenticator="SNOWFLAKE_JWT",
+                        private_key_file=r"{private_key_path}",
+                        auto_cleanup=True,
+                        enable_server_session_keep_alive_auto_detection=False,
+                    )
+                    connections.append(conn)
+            """)
+
+            # And 10 Snowflake clients are created with auto_cleanup enabled
+            assert subprocess_code.count("auto_cleanup=True") == 1
+
+            # And None of the connections are explicitly closed
+            assert "conn.close()" not in subprocess_code
+
+            # When The subprocess exits
+            result = subprocess.run(
+                [sys.executable, "-c", subprocess_code],
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+            # Then Auto-cleanup is triggered for all 10 leaked connections
+            logout_requests = wiremock.get_logout_requests()
+            assert len(logout_requests) == 10, (
+                f"Expected 10 logout requests (one per leaked connection), got {len(logout_requests)}"
+            )
+
+            # retry=False → 503 is not retried → total stays at 10 (step above) and the 503
+            # is visible in the journal. retry=True → 503 would trigger a retry → 11+ total.
+            # Both (a) total==10 and (b) one got 503 together prove retry=False was used.
+            # And Each auto-cleanup close is invoked with retry false
+            responses_503 = [r for r in logout_requests if r.get("response", {}).get("status") == 503]
+            assert len(responses_503) == 1, (
+                f"Expected exactly 1 connection to receive 503 (retry=False: not retried). "
+                f"Got {len(responses_503)} 503 responses out of {len(logout_requests)} total. "
+                f"If retry=True, the 503 retry would push total to 11+."
+            )
+
+            # And Deprecation warning is emitted only once per process
+            warning_text = "Auto-cleanup at exit will be disabled"
+            warning_count = result.stderr.count(warning_text)
+            assert warning_count == 1, (
+                f"FutureWarning should be emitted exactly once per process (deduplication), "
+                f"got {warning_count} occurrences.\nstderr:\n{result.stderr}"
+            )
+
+    def test_should_not_register_atexit_handler_when_auto_cleanup_explicitly_disabled(
+        self, int_test_connection_factory
+    ):
+        """Verify auto_cleanup=False prevents atexit registration entirely."""
+        with WiremockClient().start() as wiremock:
+            wiremock.add_mapping("auth/login_success_jwt.json")
+
+            wiremock_url = wiremock.http_url()
+            private_key_path = get_test_private_key_path()
+
+            # Given Snowflake Python client is created with auto_cleanup set to false
+            subprocess_code = textwrap.dedent(f"""\
+                import warnings
+                warnings.filterwarnings("ignore", category=FutureWarning)
+                from snowflake.connector.connection import Connection
                 conn = Connection(
                     user="test_user",
                     account="test_account",
@@ -640,101 +709,33 @@ class TestAutoCleanup:
                     server_url="{wiremock_url}",
                     authenticator="SNOWFLAKE_JWT",
                     private_key_file=r"{private_key_path}",
-                    auto_cleanup=True,
+                    auto_cleanup=False,
                     enable_server_session_keep_alive_auto_detection=False,
                 )
-                connections.append(conn)
-        """)
+            """)
 
-        # And 10 Snowflake clients are created with auto_cleanup enabled
-        assert subprocess_code.count("auto_cleanup=True") == 1
+            # And Connection is not explicitly closed
+            assert "conn.close()" not in subprocess_code
 
-        # And None of the connections are explicitly closed
-        assert "conn.close()" not in subprocess_code
-
-        # When The subprocess exits
-        result = subprocess.run(
-            [sys.executable, "-c", subprocess_code],
-            capture_output=True,
-            text=True,
-            timeout=120,
-        )
-        # Then Auto-cleanup is triggered for all 10 leaked connections
-        logout_requests = wiremock.get_logout_requests()
-        assert len(logout_requests) == 10, (
-            f"Expected 10 logout requests (one per leaked connection), got {len(logout_requests)}"
-        )
-
-        # retry=False → 503 is not retried → total stays at 10 (step above) and the 503
-        # is visible in the journal. retry=True → 503 would trigger a retry → 11+ total.
-        # Both (a) total==10 and (b) one got 503 together prove retry=False was used.
-        # And Each auto-cleanup close is invoked with retry false
-        responses_503 = [r for r in logout_requests if r.get("response", {}).get("status") == 503]
-        assert len(responses_503) == 1, (
-            f"Expected exactly 1 connection to receive 503 (retry=False: not retried). "
-            f"Got {len(responses_503)} 503 responses out of {len(logout_requests)} total. "
-            f"If retry=True, the 503 retry would push total to 11+."
-        )
-
-        # And Deprecation warning is emitted only once per process
-        warning_text = "Auto-cleanup at exit will be disabled"
-        warning_count = result.stderr.count(warning_text)
-        assert warning_count == 1, (
-            f"FutureWarning should be emitted exactly once per process (deduplication), "
-            f"got {warning_count} occurrences.\nstderr:\n{result.stderr}"
-        )
-
-    def test_should_not_register_atexit_handler_when_auto_cleanup_explicitly_disabled(
-        self, int_test_connection_factory, wiremock
-    ):
-        """Verify auto_cleanup=False prevents atexit registration entirely."""
-        wiremock.add_mapping("auth/login_success_jwt.json")
-
-        wiremock_url = wiremock.http_url()
-        private_key_path = get_test_private_key_path()
-
-        # Given Snowflake Python client is created with auto_cleanup set to false
-        subprocess_code = textwrap.dedent(f"""\
-            import warnings
-            warnings.filterwarnings("ignore", category=FutureWarning)
-            from snowflake.connector.connection import Connection
-            conn = Connection(
-                user="test_user",
-                account="test_account",
-                database="test_database",
-                schema="test_schema",
-                warehouse="test_warehouse",
-                role="test_role",
-                server_url="{wiremock_url}",
-                authenticator="SNOWFLAKE_JWT",
-                private_key_file=r"{private_key_path}",
-                auto_cleanup=False,
-                enable_server_session_keep_alive_auto_detection=False,
+            # When Process exits
+            result = subprocess.run(
+                [sys.executable, "-c", subprocess_code],
+                capture_output=True,
+                text=True,
+                timeout=120,
             )
-        """)
+            _assert_subprocess_ok(result)
 
-        # And Connection is not explicitly closed
-        assert "conn.close()" not in subprocess_code
+            # Then No atexit handler was registered
+            logout_requests = wiremock.get_logout_requests()
 
-        # When Process exits
-        result = subprocess.run(
-            [sys.executable, "-c", subprocess_code],
-            capture_output=True,
-            text=True,
-            timeout=120,
-        )
-        _assert_subprocess_ok(result)
-
-        # Then No atexit handler was registered
-        logout_requests = wiremock.get_logout_requests()
-
-        # And No automatic close is performed
-        assert len(logout_requests) == 0, (
-            "auto_cleanup=False must not register an atexit handler: no logout expected on process exit"
-        )
+            # And No automatic close is performed
+            assert len(logout_requests) == 0, (
+                "auto_cleanup=False must not register an atexit handler: no logout expected on process exit"
+            )
 
     def test_should_emit_telemetry_and_warn_when_connection_leaked_at_process_exit(
-        self, int_test_connection_factory, wiremock
+        self, int_test_connection_factory
     ) -> None:
         """Leak detection: WARN + telemetry when connection not closed before exit.
 
@@ -742,31 +743,32 @@ class TestAutoCleanup:
         WARN is currently the FutureWarning emitted by _close_at_process_exit();
         a proper logger.warning() call will be added under SNOW-2912513.
         """
-        wiremock.add_mapping("auth/login_success_jwt.json")
-        wiremock.add_mapping("session/logout_success.json")
+        with WiremockClient().start() as wiremock:
+            wiremock.add_mapping("auth/login_success_jwt.json")
+            wiremock.add_mapping("session/logout_success.json")
 
-        with warnings.catch_warnings(record=True) as captured_warnings:
-            warnings.simplefilter("always")
+            with warnings.catch_warnings(record=True) as captured_warnings:
+                warnings.simplefilter("always")
 
-            # Given Snowflake Python client is logged in
-            conn = int_test_connection_factory(server_url=wiremock.http_url())
+                # Given Snowflake Python client is logged in
+                conn = int_test_connection_factory(server_url=wiremock.http_url())
 
-            # And Connection is not explicitly closed
-            assert not conn.is_closed()
+                # And Connection is not explicitly closed
+                assert not conn.is_closed()
 
-            # When Process exit is detected
-            conn._close_at_process_exit()
+                # When Process exit is detected
+                conn._close_at_process_exit()
 
-        # Current: FutureWarning via warnings.warn(); logger.warning() pending SNOW-2912513.
-        # Then Leak detection emits WARN log
-        leak_warnings = [
-            w
-            for w in captured_warnings
-            if issubclass(w.category, FutureWarning) and "not explicitly closed" in str(w.message)
-        ]
-        assert len(leak_warnings) == 1, f"Expected 1 leak detection FutureWarning, got {len(leak_warnings)}"
+            # Current: FutureWarning via warnings.warn(); logger.warning() pending SNOW-2912513.
+            # Then Leak detection emits WARN log
+            leak_warnings = [
+                w
+                for w in captured_warnings
+                if issubclass(w.category, FutureWarning) and "not explicitly closed" in str(w.message)
+            ]
+            assert len(leak_warnings) == 1, f"Expected 1 leak detection FutureWarning, got {len(leak_warnings)}"
 
-        # And Telemetry event is sent with leak information
-        pass  # TODO(SNOW-2912513): telemetry not yet implemented
-        # And Connection details are included for debugging
-        pass  # TODO(SNOW-2912513): connection details are part of telemetry above
+            # And Telemetry event is sent with leak information
+            pass  # TODO(SNOW-2912513): telemetry not yet implemented
+            # And Connection details are included for debugging
+            pass  # TODO(SNOW-2912513): connection details are part of telemetry above

--- a/python/tests/unit/test_log_propagation.py
+++ b/python/tests/unit/test_log_propagation.py
@@ -1,0 +1,181 @@
+"""
+Verify that connector and sf_core logs propagate correctly.
+
+Tests cover two concerns:
+1. Logs from ``snowflake.connector`` and ``snowflake.connector._core`` are
+   visible to pytest's ``caplog`` fixture (propagation to root must be ON).
+2. ``setup_logging()`` does not produce duplicate output (propagation is
+   turned OFF once a dedicated handler is attached).
+
+This directly addresses the snowflake-sqlalchemy failures in
+test_outer_lateral_join / test_lateral_join_without_condition, where
+assertions on ``caplog.text`` failed because ``propagate = False`` on the
+``snowflake.connector`` logger blocked logs from reaching caplog.
+"""
+
+import io
+import logging
+
+import pytest
+
+from snowflake.connector._internal.logging import setup_logging
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def _child_logger():
+    """Return a logger in the snowflake.connector subtree, like cursor._base."""
+    return logging.getLogger("snowflake.connector.cursor._base")
+
+
+# ── 1.  caplog captures connector logs (the SA-test scenario) ────────────────
+
+
+class TestCaplogCapture:
+    """Connector debug logs must propagate to the root logger so that
+    pytest's ``caplog`` fixture can capture them."""
+
+    def test_child_logger_captured_by_caplog(self, caplog):
+        """A child logger (e.g. cursor._base) should appear in caplog.text."""
+        child = _child_logger()
+        with caplog.at_level(logging.DEBUG):
+            child.debug("query: [SELECT 1]")
+        assert "query: [SELECT 1]" in caplog.text
+
+    def test_connector_logger_captured_by_caplog(self, caplog):
+        """The snowflake.connector logger itself should appear in caplog.text."""
+        logger = logging.getLogger("snowflake.connector")
+        with caplog.at_level(logging.DEBUG):
+            logger.debug("connector level message")
+        assert "connector level message" in caplog.text
+
+    def test_sf_core_logger_captured_by_caplog(self, caplog):
+        """The sf_core logger should appear in caplog.text."""
+        logger = logging.getLogger("snowflake.connector._core")
+        with caplog.at_level(logging.DEBUG):
+            logger.debug("sf_core message")
+        assert "sf_core message" in caplog.text
+
+
+# ── 2.  FFI callback → caplog (sf_core Rust bridge) ─────────────────────────
+
+
+class TestSfCoreCallbackPropagation:
+    """The Rust→Python FFI logger callback must produce records that reach
+    caplog via propagation, just like any other Python logger."""
+
+    def test_ffi_callback_record_captured_by_caplog(self, caplog):
+        """Simulate the FFI callback path and verify caplog receives the record.
+
+        This exercises the same code path as ``logger_callback`` in
+        ``c_api.py``: ``makeRecord`` + ``handle`` on the sf_core logger.
+        """
+        sf_core_logger = logging.getLogger("snowflake.connector._core")
+
+        with caplog.at_level(logging.DEBUG):
+            record = sf_core_logger.makeRecord(
+                sf_core_logger.name,
+                logging.WARNING,
+                "http_client.rs",
+                42,
+                "Simulated Rust warning from sf_core",
+                (),
+                None,
+                func="execute_request",
+            )
+            sf_core_logger.handle(record)
+
+        assert "Simulated Rust warning from sf_core" in caplog.text
+        matching = [r for r in caplog.records if "Simulated Rust warning" in r.message]
+        assert len(matching) == 1
+        assert matching[0].name == "snowflake.connector._core"
+        assert matching[0].filename == "http_client.rs"
+
+
+# ── 3.  setup_logging() must not cause duplicate output ──────────────────────
+
+
+class TestNoDuplicateLogsWithSetupLogging:
+    """When the user explicitly calls ``setup_logging()``, messages must
+    appear exactly once in its stream -- even though propagation was on
+    before the call."""
+
+    @pytest.fixture(autouse=True)
+    def _restore_loggers(self):
+        """Snapshot and restore handler lists so tests are isolated."""
+        conn = logging.getLogger("snowflake.connector")
+        core = logging.getLogger("snowflake.connector._core")
+        orig = {
+            "conn_handlers": list(conn.handlers),
+            "conn_level": conn.level,
+            "conn_propagate": conn.propagate,
+            "core_handlers": list(core.handlers),
+            "core_level": core.level,
+            "core_propagate": core.propagate,
+        }
+        yield
+        conn.handlers = orig["conn_handlers"]
+        conn.setLevel(orig["conn_level"])
+        conn.propagate = orig["conn_propagate"]
+        core.handlers = orig["core_handlers"]
+        core.setLevel(orig["core_level"])
+        core.propagate = orig["core_propagate"]
+
+    def test_setup_logging_no_duplicates(self):
+        """After setup_logging(), each message appears exactly once."""
+        stream = io.StringIO()
+        setup_logging(level=logging.DEBUG, stream=stream)
+
+        child = _child_logger()
+        child.debug("unique-token-12345")
+
+        lines = [line for line in stream.getvalue().splitlines() if "unique-token-12345" in line]
+        assert len(lines) == 1, f"Expected 1 occurrence, got {len(lines)}: {lines}"
+
+    def test_setup_logging_with_root_handler_no_duplicates(self):
+        """Even if the root logger also has a handler, setup_logging()'s
+        stream should still only get each message once."""
+
+        # Simulate a root-level handler (e.g. basicConfig or a framework).
+        root_stream = io.StringIO()
+        root_handler = logging.StreamHandler(root_stream)
+        root_handler.setLevel(logging.DEBUG)
+        root_logger = logging.getLogger()
+        root_logger.addHandler(root_handler)
+        old_root_level = root_logger.level
+        root_logger.setLevel(logging.DEBUG)
+
+        try:
+            our_stream = io.StringIO()
+            setup_logging(level=logging.DEBUG, stream=our_stream)
+
+            child = _child_logger()
+            child.debug("dedup-token-99999")
+
+            our_lines = [line for line in our_stream.getvalue().splitlines() if "dedup-token-99999" in line]
+            assert len(our_lines) == 1, f"setup_logging stream got {len(our_lines)} copies: {our_lines}"
+        finally:
+            root_logger.removeHandler(root_handler)
+            root_logger.setLevel(old_root_level)
+
+    def test_setup_logging_ffi_callback_no_duplicates(self):
+        """After setup_logging(), sf_core FFI callback records appear
+        exactly once in the setup_logging stream."""
+        stream = io.StringIO()
+        setup_logging(level=logging.DEBUG, sf_core_level=logging.DEBUG, stream=stream)
+
+        sf_core_logger = logging.getLogger("snowflake.connector._core")
+        record = sf_core_logger.makeRecord(
+            sf_core_logger.name,
+            logging.WARNING,
+            "retry.rs",
+            100,
+            "ffi-dedup-token-77777",
+            (),
+            None,
+        )
+        sf_core_logger.handle(record)
+
+        lines = [line for line in stream.getvalue().splitlines() if "ffi-dedup-token-77777" in line]
+        assert len(lines) == 1, f"Expected 1 occurrence, got {len(lines)}: {lines}"

--- a/python/tests/unit/test_logging.py
+++ b/python/tests/unit/test_logging.py
@@ -60,15 +60,15 @@ class TestGetLoggers:
 class TestLoggerConfiguration:
     """Test that loggers are configured correctly at module load."""
 
-    def test_sf_core_logger_propagate_disabled(self):
-        """Test that sf_core logger has propagation disabled."""
+    def test_sf_core_logger_propagate_enabled(self):
+        """Test that sf_core logger propagates by default (before setup_logging)."""
         logger = get_sf_core_logger()
-        assert logger.propagate is False
+        assert logger.propagate is True
 
-    def test_connector_logger_propagate_disabled(self):
-        """Test that connector logger has propagation disabled."""
+    def test_connector_logger_propagate_enabled(self):
+        """Test that connector logger propagates by default (before setup_logging)."""
         logger = get_connector_logger()
-        assert logger.propagate is False
+        assert logger.propagate is True
 
     def test_sf_core_logger_has_null_handler(self):
         """Test that sf_core logger has a NullHandler."""
@@ -92,11 +92,13 @@ class TestSetupLogging:
         connector_logger = get_connector_logger()
         sf_core_logger = get_sf_core_logger()
 
-        # Store original handlers
+        # Store original state
         original_connector_handlers = list(connector_logger.handlers)
         original_sf_core_handlers = list(sf_core_logger.handlers)
         original_connector_level = connector_logger.level
         original_sf_core_level = sf_core_logger.level
+        original_connector_propagate = connector_logger.propagate
+        original_sf_core_propagate = sf_core_logger.propagate
 
         yield
 
@@ -105,6 +107,8 @@ class TestSetupLogging:
         sf_core_logger.handlers = original_sf_core_handlers
         connector_logger.setLevel(original_connector_level)
         sf_core_logger.setLevel(original_sf_core_level)
+        connector_logger.propagate = original_connector_propagate
+        sf_core_logger.propagate = original_sf_core_propagate
 
     def test_setup_logging_sets_connector_level(self):
         """Test that setup_logging sets the connector logger level."""
@@ -219,6 +223,19 @@ class TestSetupLogging:
         # Handler count should not increase after the second call
         assert connector_handlers_after_second == connector_handlers_after_first
         assert sf_core_handlers_after_second == sf_core_handlers_after_first
+
+    def test_setup_logging_disables_propagation(self):
+        """Test that setup_logging disables propagation to prevent duplicates."""
+        connector_logger = get_connector_logger()
+        sf_core_logger = get_sf_core_logger()
+
+        assert connector_logger.propagate is True
+        assert sf_core_logger.propagate is True
+
+        setup_logging()
+
+        assert connector_logger.propagate is False
+        assert sf_core_logger.propagate is False
 
     def test_setup_logging_skips_handler_if_non_null_handler_exists(self):
         """Test that setup_logging skips adding handler if a non-NullHandler already exists."""


### PR DESCRIPTION
### TL;DR

Fix log propagation so that `snowflake.connector` and `snowflake.connector._core` loggers propagate to the root logger by default, enabling `pytest caplog` and application-level handlers to capture connector logs without extra configuration.

### What changed?

Both `snowflake.connector` and `snowflake.connector._core` loggers now have `propagate=True` by default (matching standard Python library logging practice). Previously, propagation was disabled at module load, which silently blocked `pytest caplog` and any root-level log handlers from seeing connector output.

`setup_logging()` now only disables propagation on a logger when it actually attaches a dedicated `StreamHandler` to that logger. This prevents duplicate output (once via the dedicated handler, once via the root handler chain) while leaving propagation intact when the application has configured its own handlers. The level is always updated regardless.

The `register_default_logger_callback` export was removed from the top-level `__init__.py`, and the startup info log now goes through `get_connector_logger()` instead of `logging.getLogger("snowflake.connector")` directly.

E2E tests in `test_close.py` were refactored to instantiate `WiremockClient` inline via a context manager rather than relying on a shared `wiremock` fixture parameter. This makes each test self-contained and eliminates state bleed between test phases. The best-effort error handling test was also simplified to use `caplog` directly now that propagation is enabled, removing the need for a temporary `FileHandler` workaround.

A new test file `test_log_propagation.py` was added covering:

- `caplog` capturing logs from `snowflake.connector`, `snowflake.connector._core`, and child loggers
- The Rust→Python FFI callback path producing records visible to `caplog`
- `setup_logging()` producing no duplicate output even when a root-level handler is present

### Why make this change?

The previous `propagate=False` default caused silent failures in downstream libraries (e.g. snowflake-sqlalchemy) whose tests asserted on `caplog.text` for connector log output. Because propagation was disabled, those records never reached the root logger and `caplog` captured nothing, causing test assertions to fail. The fix aligns the connector with the standard Python logging guidance for libraries: add a `NullHandler` and leave propagation on, letting the application or test framework decide where logs go.