### PR TITLE
ci: fix shared filter triggering full CI fanout for every PR

### DIFF
--- a/.github/workflows/detect-changes.yml
+++ b/.github/workflows/detect-changes.yml
@@ -198,28 +198,36 @@ jobs:
               - '.buildkite/**'
               - 'scripts/decode_secrets.*'
               - 'scripts/shared/**'
-              # `ci/**` covers Dockerfiles, Jenkinsfiles, the matrix
-              # generator engine, shared mappings, etc. Per-driver
-              # ci/test_matrix/{models,mappings}/<driver>.py are excluded
-              # here and listed under each driver's filter above so that
-              # editing only python.py (for example) no longer triggers
-              # JDBC/ODBC/core test runs.
-              - 'ci/**'
-              - '!ci/test_matrix/models/core.py'
-              - '!ci/test_matrix/models/odbc.py'
-              - '!ci/test_matrix/models/python.py'
-              - '!ci/test_matrix/mappings/core.py'
-              - '!ci/test_matrix/mappings/odbc.py'
-              - '!ci/test_matrix/mappings/python.py'
+              # Truly-shared `ci/` files only. Negation patterns ('!path') are
+              # NOT used here: dorny/paths-filter@v3 runs with the default
+              # `predicate-quantifier: some`, which treats negations as
+              # standalone matches, not exclusions — every unrelated file
+              # would match a `!foo.py` rule and flip `shared=true`. List
+              # truly-shared paths explicitly. Per-driver `ci/test_matrix/
+              # {models,mappings}/<driver>.py` belong in each language's
+              # filter above; they are intentionally not listed here.
+              - 'ci/Dockerfile.*'
+              - 'ci/Jenkinsfile.*'
+              - 'ci/select_tests.py'
+              - 'ci/test-matrix.yml'
+              - 'ci/test_revocation.sh'
+              - 'ci/upload_test_results.sh'
+              - 'ci/test_matrix/generate_matrix.py'
+              - 'ci/test_matrix/test_generate_matrix.py'
+              - 'ci/test_matrix/mappings/__init__.py'
+              - 'ci/test_matrix/mappings/shared.py'
+              - 'ci/test_matrix/models/__init__.py'
+            # Negation patterns are NOT used here for the same reason as in
+            # `shared`: under `predicate-quantifier: some` (the default), a
+            # `!path` rule matches every file *except* `path`, which would
+            # flip `docs_only=true` for every non-doc change. List positive
+            # docs patterns only and rely on the AND-of-everything-else-false
+            # guard in the `Compute combined conditions` step below to avoid
+            # treating mixed PRs as docs-only.
             docs_only:
               - '**/*.md'
               - 'LICENSE'
               - '.github/CODEOWNERS'
-              - '**/*.txt'
-              - '!**/requirements.txt'
-              - '!**/CMakeLists.txt'
-              - '!**/*.yml'
-              - '!**/*.yaml'
 
       - name: Compute combined conditions
         id: computed


### PR DESCRIPTION
## Summary

- `dorny/paths-filter@v3` runs with the default `predicate-quantifier: some`. Under that mode, a `!path` pattern matches every file *except* `path` — it does NOT exclude.
- The six `!ci/test_matrix/{models,mappings}/{core,odbc,python}.py` rules added in #1158 silently flipped `shared=true` for **every** PR (any unrelated file trivially differs from `!core.py`), forcing `run_odbc`/`run_python`/`run_jdbc`/`run_rust_core` to true on every PR after #1158 landed.
- Replace `ci/**` + the six negations with an explicit allowlist of truly-shared `ci/` files. Apply the same fix to `docs_only` (had the identical `!**/requirements.txt` bug).

## Repro

PR #1179 only touched `nodejs/**` and `.cursor/commands/*.md` yet ran ODBC + Python CI:
[detect-changes log](https://github.com/snowflakedb/universal-driver/actions/runs/25863338500/job/75998712357?pr=1179) shows `Filter shared = true` matching all three files via the negation patterns.

## Test plan

- [x] YAML parses cleanly
- [x] Manual simulation: PR #1179's three files no longer match `shared`
- [x] `Cargo.toml`, `ci/Dockerfile.*`, `ci/Jenkinsfile.*`, `ci/select_tests.py`, `ci/test_matrix/generate_matrix.py`, `ci/test-matrix.yml`, `ci/upload_test_results.sh`, `.github/workflows/detect-changes.yml` still match `shared`
- [x] Per-driver matrix files (`ci/test_matrix/{models,mappings}/{core,odbc,python}.py`) correctly do **not** match `shared` (they're listed in each language's own filter)
- [ ] On this PR, expect `run_python`/`run_odbc`/`run_jdbc`/`run_rust_core` to be `true` because `.github/workflows/detect-changes.yml` itself is in the `shared` filter — this PR is the canonical case where the fanout *should* happen

🤖 Generated with [Claude Code](https://claude.com/claude-code)