### PR TITLE
feat(session): wire client_session_keep_alive[_heartbeat_frequency]

### DIFF
--- a/python/BehaviorDifferences.yaml
+++ b/python/BehaviorDifferences.yaml
@@ -222,20 +222,15 @@ behavior_differences:
       but has no effect and emits a `DeprecationWarning`.
 
   26:
-    name: "Post-connect assignment to client_session_keep_alive[_heartbeat_frequency] is a no-op"
+    name: "client_session_keep_alive[_heartbeat_frequency] setters removed"
     status: allowed
     type: api_incompatibility
     reviewed: false
     old_driver_behavior: |
       `Connection.client_session_keep_alive` and
-      `Connection.client_session_keep_alive_heartbeat_frequency` expose setters
-      that mutate connection state. In particular, setting
-      `client_session_keep_alive_heartbeat_frequency` re-validates and clamps
-      the value against the live `master_token_validity` window.
+      `Connection.client_session_keep_alive_heartbeat_frequency` expose
+      setters. In the old connector both setters wrote to a private attribute
+      having no effect on the live heartbeat thread either.
     new_driver_behavior: |
-      Both setters are retained for backward compatibility but emit a
-      `DeprecationWarning` on first external use. They write to the underlying
-      `ConnectionConfig` field, but the Universal Driver consumes these values
-      only at connect time: post-connect assignments do not start, stop, or
-      reschedule the running heartbeat task. Pass the values as constructor
-      kwargs instead.
+      Both attributes are read-only properties. Assignment raises
+      `AttributeError`.

--- a/python/BehaviorDifferences.yaml
+++ b/python/BehaviorDifferences.yaml
@@ -220,3 +220,22 @@ behavior_differences:
       chunk fetching from a thread pool to a process pool) has no equivalent: the universal driver
       always uses a thread pool. Passing `client_fetch_use_mp` is accepted for source compatibility
       but has no effect and emits a `DeprecationWarning`.
+
+  26:
+    name: "Post-connect assignment to client_session_keep_alive[_heartbeat_frequency] is a no-op"
+    status: allowed
+    type: api_incompatibility
+    reviewed: false
+    old_driver_behavior: |
+      `Connection.client_session_keep_alive` and
+      `Connection.client_session_keep_alive_heartbeat_frequency` expose setters
+      that mutate connection state. In particular, setting
+      `client_session_keep_alive_heartbeat_frequency` re-validates and clamps
+      the value against the live `master_token_validity` window.
+    new_driver_behavior: |
+      Both setters are retained for backward compatibility but emit a
+      `DeprecationWarning` on first external use. They write to the underlying
+      `ConnectionConfig` field, but the Universal Driver consumes these values
+      only at connect time: post-connect assignments do not start, stop, or
+      reschedule the running heartbeat task. Pass the values as constructor
+      kwargs instead.

--- a/python/src/snowflake/connector/connection.py
+++ b/python/src/snowflake/connector/connection.py
@@ -645,10 +645,33 @@ class Connection(ErrorHandlerMixin):
         """Whether to keep the session active with periodic heartbeat requests."""
         return self.config.client_session_keep_alive
 
+    @client_session_keep_alive.setter
+    @backward_compatibility
+    def client_session_keep_alive(self, value: bool | None) -> None:
+        """Setter retained for compatibility with snowflake-connector-python.
+
+        The Universal Driver consumes ``client_session_keep_alive`` only at
+        connect time, so assigning to this attribute on a live ``Connection``
+        does not start or stop the heartbeat task. Pass the value as a
+        constructor kwarg instead.
+        """
+        self.config.client_session_keep_alive = value
+
     @property
     def client_session_keep_alive_heartbeat_frequency(self) -> int | None:
         """The frequency in seconds of heartbeat requests when session keep-alive is enabled."""
         return self.config.client_session_keep_alive_heartbeat_frequency
+
+    @client_session_keep_alive_heartbeat_frequency.setter
+    @backward_compatibility
+    def client_session_keep_alive_heartbeat_frequency(self, value: int | None) -> None:
+        """Setter retained for compatibility with snowflake-connector-python.
+
+        The Universal Driver consumes the heartbeat frequency only at connect
+        time, so post-connect assignments do not reschedule the running
+        heartbeat task. Pass the value as a constructor kwarg instead.
+        """
+        self.config.client_session_keep_alive_heartbeat_frequency = value
 
     @property
     def client_prefetch_threads(self) -> int:

--- a/python/src/snowflake/connector/connection.py
+++ b/python/src/snowflake/connector/connection.py
@@ -643,20 +643,12 @@ class Connection(ErrorHandlerMixin):
     @property
     def client_session_keep_alive(self) -> bool | None:
         """Whether to keep the session active with periodic heartbeat requests."""
-        raise NotImplementedError("client_session_keep_alive is not yet implemented")
-
-    @client_session_keep_alive.setter
-    def client_session_keep_alive(self, value: bool) -> None:
-        raise NotImplementedError("client_session_keep_alive is not yet implemented")
+        return self.config.client_session_keep_alive
 
     @property
     def client_session_keep_alive_heartbeat_frequency(self) -> int | None:
         """The frequency in seconds of heartbeat requests when session keep-alive is enabled."""
-        raise NotImplementedError("client_session_keep_alive_heartbeat_frequency is not yet implemented")
-
-    @client_session_keep_alive_heartbeat_frequency.setter
-    def client_session_keep_alive_heartbeat_frequency(self, value: int) -> None:
-        raise NotImplementedError("client_session_keep_alive_heartbeat_frequency is not yet implemented")
+        return self.config.client_session_keep_alive_heartbeat_frequency
 
     @property
     def client_prefetch_threads(self) -> int:

--- a/python/src/snowflake/connector/connection.py
+++ b/python/src/snowflake/connector/connection.py
@@ -645,33 +645,10 @@ class Connection(ErrorHandlerMixin):
         """Whether to keep the session active with periodic heartbeat requests."""
         return self.config.client_session_keep_alive
 
-    @client_session_keep_alive.setter
-    @backward_compatibility
-    def client_session_keep_alive(self, value: bool | None) -> None:
-        """Setter retained for compatibility with snowflake-connector-python.
-
-        The Universal Driver consumes ``client_session_keep_alive`` only at
-        connect time, so assigning to this attribute on a live ``Connection``
-        does not start or stop the heartbeat task. Pass the value as a
-        constructor kwarg instead.
-        """
-        self.config.client_session_keep_alive = value
-
     @property
     def client_session_keep_alive_heartbeat_frequency(self) -> int | None:
         """The frequency in seconds of heartbeat requests when session keep-alive is enabled."""
         return self.config.client_session_keep_alive_heartbeat_frequency
-
-    @client_session_keep_alive_heartbeat_frequency.setter
-    @backward_compatibility
-    def client_session_keep_alive_heartbeat_frequency(self, value: int | None) -> None:
-        """Setter retained for compatibility with snowflake-connector-python.
-
-        The Universal Driver consumes the heartbeat frequency only at connect
-        time, so post-connect assignments do not reschedule the running
-        heartbeat task. Pass the value as a constructor kwarg instead.
-        """
-        self.config.client_session_keep_alive_heartbeat_frequency = value
 
     @property
     def client_prefetch_threads(self) -> int:

--- a/python/src/snowflake/connector/connection_config.py
+++ b/python/src/snowflake/connector/connection_config.py
@@ -169,6 +169,12 @@ class ConnectionConfig(ConnectionConfigMixin):
     client_prefetch_threads: int | None = 4
     """Number of concurrent chunk prefetch threads for result set downloading. Default: 4"""
 
+    client_session_keep_alive: bool | None = False
+    """Keep the session alive with periodic heartbeat requests. Default: False"""
+
+    client_session_keep_alive_heartbeat_frequency: int | None = None
+    """Heartbeat frequency in seconds (clamped to interval master_token_validity/16..master_token_validity/4)"""
+
     database: str | None = None
     """Default database to use"""
 
@@ -203,6 +209,8 @@ class ConnectionConfig(ConnectionConfigMixin):
     _PYTHON_TO_RUST_NAME: ClassVar[dict[str, str]] = {
         "client_memory_limit": "CLIENT_MEMORY_LIMIT",
         "client_prefetch_threads": "CLIENT_PREFETCH_THREADS",
+        "client_session_keep_alive": "CLIENT_SESSION_KEEP_ALIVE",
+        "client_session_keep_alive_heartbeat_frequency": "CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY",
         "passcode_in_password": "passcodeInPassword",
     }
     """Python field name -> Rust canonical name (only for names that differ)."""

--- a/python/tests/unit/test_connection.py
+++ b/python/tests/unit/test_connection.py
@@ -273,6 +273,22 @@ class TestClientSessionKeepAliveKwargUnit:
         assert conn.client_session_keep_alive is False
         assert conn.client_session_keep_alive_heartbeat_frequency is None
 
+    def test_keep_alive_setters_warn_and_write_to_config(self, connection):
+        # Setters are kept for backward compatibility but are no-ops on the
+        # live session. Assert they (a) emit DeprecationWarning on external
+        # use and (b) update the underlying ConnectionConfig field so a
+        # subsequent read returns the new value.
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always", DeprecationWarning)
+            connection.client_session_keep_alive = True
+            connection.client_session_keep_alive_heartbeat_frequency = 600
+
+        messages = [str(w.message) for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert any("client_session_keep_alive" in m for m in messages)
+        assert any("client_session_keep_alive_heartbeat_frequency" in m for m in messages)
+        assert connection.config.client_session_keep_alive is True
+        assert connection.config.client_session_keep_alive_heartbeat_frequency == 600
+
 
 class TestConnectionSetOptions:
     """Unit tests for the batched connection_set_options RPC during __init__."""

--- a/python/tests/unit/test_connection.py
+++ b/python/tests/unit/test_connection.py
@@ -235,6 +235,48 @@ class TestAutocommitKwargUnit:
         # If connection_set_session_parameters was not called at all, that's also correct
 
 
+class TestClientSessionKeepAliveKwargUnit:
+    """Unit tests for client_session_keep_alive[_heartbeat_frequency] kwargs."""
+
+    def test_keep_alive_kwargs_forwarded_to_set_options(self, mock_db_api):
+        from snowflake.connector.connection import Connection
+
+        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
+            Connection(
+                user="u",
+                account="a",
+                client_session_keep_alive=True,
+                client_session_keep_alive_heartbeat_frequency=1500,
+            )
+
+        request = mock_db_api.connection_set_options.call_args_list[0][0][0]
+        assert request.options["CLIENT_SESSION_KEEP_ALIVE"] == ConfigSetting(bool_value=True)
+        assert request.options["CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY"] == ConfigSetting(int_value=1500)
+
+    def test_keep_alive_properties_read_from_config(self, mock_db_api):
+        from snowflake.connector.connection import Connection
+
+        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
+            conn = Connection(
+                user="u",
+                account="a",
+                client_session_keep_alive=True,
+                client_session_keep_alive_heartbeat_frequency=900,
+            )
+
+        assert conn.client_session_keep_alive is True
+        assert conn.client_session_keep_alive_heartbeat_frequency == 900
+
+    def test_keep_alive_properties_default_none(self, mock_db_api):
+        from snowflake.connector.connection import Connection
+
+        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
+            conn = Connection(user="u", account="a")
+
+        assert conn.client_session_keep_alive is None
+        assert conn.client_session_keep_alive_heartbeat_frequency is None
+
+
 class TestConnectionSetOptions:
     """Unit tests for the batched connection_set_options RPC during __init__."""
 

--- a/python/tests/unit/test_connection.py
+++ b/python/tests/unit/test_connection.py
@@ -241,13 +241,12 @@ class TestClientSessionKeepAliveKwargUnit:
     def test_keep_alive_kwargs_forwarded_to_set_options(self, mock_db_api):
         from snowflake.connector.connection import Connection
 
-        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
-            Connection(
-                user="u",
-                account="a",
-                client_session_keep_alive=True,
-                client_session_keep_alive_heartbeat_frequency=1500,
-            )
+        Connection(
+            user="u",
+            account="a",
+            client_session_keep_alive=True,
+            client_session_keep_alive_heartbeat_frequency=1500,
+        )
 
         request = mock_db_api.connection_set_options.call_args_list[0][0][0]
         assert request.options["CLIENT_SESSION_KEEP_ALIVE"] == ConfigSetting(bool_value=True)
@@ -256,24 +255,22 @@ class TestClientSessionKeepAliveKwargUnit:
     def test_keep_alive_properties_read_from_config(self, mock_db_api):
         from snowflake.connector.connection import Connection
 
-        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
-            conn = Connection(
-                user="u",
-                account="a",
-                client_session_keep_alive=True,
-                client_session_keep_alive_heartbeat_frequency=900,
-            )
+        conn = Connection(
+            user="u",
+            account="a",
+            client_session_keep_alive=True,
+            client_session_keep_alive_heartbeat_frequency=900,
+        )
 
         assert conn.client_session_keep_alive is True
         assert conn.client_session_keep_alive_heartbeat_frequency == 900
 
-    def test_keep_alive_properties_default_none(self, mock_db_api):
+    def test_keep_alive_properties_defaults(self, mock_db_api):
         from snowflake.connector.connection import Connection
 
-        with patch("snowflake.connector.connection.database_driver_client", return_value=mock_db_api):
-            conn = Connection(user="u", account="a")
+        conn = Connection(user="u", account="a")
 
-        assert conn.client_session_keep_alive is None
+        assert conn.client_session_keep_alive is False
         assert conn.client_session_keep_alive_heartbeat_frequency is None
 
 

--- a/python/tests/unit/test_connection.py
+++ b/python/tests/unit/test_connection.py
@@ -273,21 +273,15 @@ class TestClientSessionKeepAliveKwargUnit:
         assert conn.client_session_keep_alive is False
         assert conn.client_session_keep_alive_heartbeat_frequency is None
 
-    def test_keep_alive_setters_warn_and_write_to_config(self, connection):
-        # Setters are kept for backward compatibility but are no-ops on the
-        # live session. Assert they (a) emit DeprecationWarning on external
-        # use and (b) update the underlying ConnectionConfig field so a
-        # subsequent read returns the new value.
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always", DeprecationWarning)
+    def test_keep_alive_attributes_are_read_only(self, connection):
+        # The old Python connector exposed setters but they were no-ops on
+        # the live heartbeat thread. The Universal Driver drops them so an
+        # accidental post-connect assignment fails loudly instead of being
+        # silently ignored.
+        with pytest.raises(AttributeError):
             connection.client_session_keep_alive = True
+        with pytest.raises(AttributeError):
             connection.client_session_keep_alive_heartbeat_frequency = 600
-
-        messages = [str(w.message) for w in caught if issubclass(w.category, DeprecationWarning)]
-        assert any("client_session_keep_alive" in m for m in messages)
-        assert any("client_session_keep_alive_heartbeat_frequency" in m for m in messages)
-        assert connection.config.client_session_keep_alive is True
-        assert connection.config.client_session_keep_alive_heartbeat_frequency == 600
 
 
 class TestConnectionSetOptions:

--- a/python/tests/unit/test_connection_config.py
+++ b/python/tests/unit/test_connection_config.py
@@ -228,10 +228,13 @@ class TestToOptions:
         assert opts["CLIENT_SESSION_KEEP_ALIVE"] is True
         assert opts["CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY"] == 1200
 
-    def test_client_session_keep_alive_unset_omits_from_options(self):
+    def test_client_session_keep_alive_defaults(self):
         config = ConnectionConfig()
         opts = config.to_options()
-        assert "CLIENT_SESSION_KEEP_ALIVE" not in opts
+        # Default is False (forwarded so the server sees the explicit choice).
+        assert opts["CLIENT_SESSION_KEEP_ALIVE"] is False
+        # Frequency stays None: the heartbeat scheduler computes the default
+        # from master_token_validity at runtime.
         assert "CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY" not in opts
 
     def test_includes_extra(self):

--- a/python/tests/unit/test_connection_config.py
+++ b/python/tests/unit/test_connection_config.py
@@ -98,6 +98,18 @@ class TestFromKwargs:
         assert config.user == "u"
         assert "client_fetch_use_mp" not in config._extra
 
+    def test_client_session_keep_alive_kwargs(self):
+        config = ConnectionConfig.from_kwargs(
+            client_session_keep_alive=True,
+            client_session_keep_alive_heartbeat_frequency=600,
+        )
+        assert config.client_session_keep_alive is True
+        assert config.client_session_keep_alive_heartbeat_frequency == 600
+
+    def test_client_session_keep_alive_upper_case_alias(self):
+        config = ConnectionConfig.from_kwargs(CLIENT_SESSION_KEEP_ALIVE=True)
+        assert config.client_session_keep_alive is True
+
 
 class TestFromConnectionArgs:
     """Test ConnectionConfig.from_connection_args factory method."""
@@ -206,6 +218,21 @@ class TestToOptions:
         opts = config.to_options()
         assert "passcodeInPassword" in opts
         assert "passcode_in_password" not in opts
+
+    def test_client_session_keep_alive_forwarded(self):
+        config = ConnectionConfig(
+            client_session_keep_alive=True,
+            client_session_keep_alive_heartbeat_frequency=1200,
+        )
+        opts = config.to_options()
+        assert opts["CLIENT_SESSION_KEEP_ALIVE"] is True
+        assert opts["CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY"] == 1200
+
+    def test_client_session_keep_alive_unset_omits_from_options(self):
+        config = ConnectionConfig()
+        opts = config.to_options()
+        assert "CLIENT_SESSION_KEEP_ALIVE" not in opts
+        assert "CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY" not in opts
 
     def test_includes_extra(self):
         config = ConnectionConfig(user="u")

--- a/sf_core/src/apis/database_driver_v1/connection.rs
+++ b/sf_core/src/apis/database_driver_v1/connection.rs
@@ -189,7 +189,27 @@ impl DatabaseDriverV1 {
                     // Forward unrecognized settings as session parameters so
                     // drivers can set arbitrary Snowflake session params
                     // via regular connection options.
-                    let unknown_settings = collect_unknown_settings(&conn.connection_seed);
+                    let mut unknown_settings = collect_unknown_settings(&conn.connection_seed);
+                    // `CLIENT_SESSION_KEEP_ALIVE` and
+                    // `CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY` are registered
+                    // params so they don't show up as "unknown"; mirror them into
+                    // login session parameters to match the Python connector.
+                    if let Some(v) = resolved.get_bool(param_names::CLIENT_SESSION_KEEP_ALIVE) {
+                        unknown_settings.insert(
+                            param_names::CLIENT_SESSION_KEEP_ALIVE.as_str().to_string(),
+                            v.to_string(),
+                        );
+                    }
+                    if let Some(v) =
+                        resolved.get_int(param_names::CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY)
+                    {
+                        unknown_settings.insert(
+                            param_names::CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY
+                                .as_str()
+                                .to_string(),
+                            v.to_string(),
+                        );
+                    }
                     let init_params = match init_params {
                         Some(explicit) => {
                             // Normalize explicit keys to uppercase so precedence
@@ -264,10 +284,16 @@ impl DatabaseDriverV1 {
                     role: login_result.role_name,
                 };
 
-                let keep_alive = merged_params
-                    .get(param_names::CLIENT_SESSION_KEEP_ALIVE.as_str())
-                    .map(|v| v.eq_ignore_ascii_case("true"))
+                // `CLIENT_SESSION_KEEP_ALIVE` and
+                // `CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY` are registered in
+                // the param registry (client-side, not forwarded to login as
+                // session parameters). Read them from the resolved snapshot.
+                let keep_alive = resolved_snapshot
+                    .get_bool(param_names::CLIENT_SESSION_KEEP_ALIVE)
                     .unwrap_or(false);
+                let heartbeat_frequency_secs = resolved_snapshot
+                    .get_int(param_names::CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY)
+                    .and_then(|v| u64::try_from(v).ok());
 
                 {
                     let logout_config = LogoutConfig::from_settings(&resolved_snapshot)
@@ -357,6 +383,7 @@ impl DatabaseDriverV1 {
                                 .await
                                 .as_ref()
                                 .and_then(|t| t.master_valid_for()),
+                            heartbeat_frequency_secs,
                         );
                         let handle = spawn_heartbeat_task(
                             conn.tokens.clone(),

--- a/sf_core/src/apis/database_driver_v1/connection.rs
+++ b/sf_core/src/apis/database_driver_v1/connection.rs
@@ -285,15 +285,18 @@ impl DatabaseDriverV1 {
                 };
 
                 // `CLIENT_SESSION_KEEP_ALIVE` and
-                // `CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY` are registered in
-                // the param registry (client-side, not forwarded to login as
-                // session parameters). Read them from the resolved snapshot.
-                let keep_alive = resolved_snapshot
-                    .get_bool(param_names::CLIENT_SESSION_KEEP_ALIVE)
+                // `CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY` are read from
+                // `merged_params` so the server-echoed value (or a server-side
+                // default) takes effect even when the client did not pass them
+                // explicitly. The client-mirrored values are already merged in
+                // above (init_params + login_result.session_parameters).
+                let keep_alive = merged_params
+                    .get(param_names::CLIENT_SESSION_KEEP_ALIVE.as_str())
+                    .map(|v| v.eq_ignore_ascii_case("true"))
                     .unwrap_or(false);
-                let heartbeat_frequency_secs = resolved_snapshot
-                    .get_int(param_names::CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY)
-                    .and_then(|v| u64::try_from(v).ok());
+                let heartbeat_frequency_secs = merged_params
+                    .get(param_names::CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY.as_str())
+                    .and_then(|v| v.parse::<u64>().ok());
 
                 {
                     let logout_config = LogoutConfig::from_settings(&resolved_snapshot)
@@ -382,7 +385,7 @@ impl DatabaseDriverV1 {
                                 .read()
                                 .await
                                 .as_ref()
-                                .and_then(|t| t.master_valid_for()),
+                                .and_then(|t| t.master_validity),
                             heartbeat_frequency_secs,
                         );
                         let handle = spawn_heartbeat_task(
@@ -2360,6 +2363,7 @@ mod tests {
                 session_id: 1,
                 session_expires_at: None,
                 master_expires_at: None,
+                master_validity: None,
             };
             *conn.tokens.write().await = Some(tokens);
         }
@@ -2538,6 +2542,7 @@ mod tests {
                 master_expires_at: Some(
                     std::time::Instant::now() + std::time::Duration::from_secs(14400),
                 ),
+                master_validity: Some(std::time::Duration::from_secs(14400)),
             };
             *conn.tokens.write().await = Some(tokens);
         }

--- a/sf_core/src/apis/database_driver_v1/heartbeat.rs
+++ b/sf_core/src/apis/database_driver_v1/heartbeat.rs
@@ -197,6 +197,7 @@ mod tests {
             session_id: 1,
             session_expires_at: None,
             master_expires_at: Some(std::time::Instant::now() + Duration::from_secs(14400)),
+            master_validity: Some(Duration::from_secs(14400)),
         }
     }
 

--- a/sf_core/src/apis/database_driver_v1/heartbeat.rs
+++ b/sf_core/src/apis/database_driver_v1/heartbeat.rs
@@ -69,12 +69,9 @@ pub fn compute_heartbeat_interval(
     let max = master / 4;
     let min = master / 16;
 
-    let interval = match user_frequency_secs {
-        None => min,
-        Some(secs) => Duration::from_secs(secs).clamp(min, max),
-    };
-
-    interval.min(MAX_HEARTBEAT_INTERVAL)
+    user_frequency_secs
+        .map_or(min, |s| Duration::from_secs(s).clamp(min, max))
+        .min(MAX_HEARTBEAT_INTERVAL)
 }
 
 /// Spawn a per-connection heartbeat background task.

--- a/sf_core/src/apis/database_driver_v1/heartbeat.rs
+++ b/sf_core/src/apis/database_driver_v1/heartbeat.rs
@@ -47,14 +47,34 @@ impl Drop for HeartbeatHandle {
     }
 }
 
-/// Compute the heartbeat interval from master token validity.
+/// Compute the heartbeat interval from master token validity and an optional
+/// user-requested frequency (in seconds).
 ///
-/// Returns `master_validity / 4`, capped at 3600s.
-/// Falls back to 3600s if `master_validity` is `None`.
-pub fn compute_heartbeat_interval(master_validity: Option<Duration>) -> Duration {
-    master_validity
-        .map(|v| (v / 4).min(MAX_HEARTBEAT_INTERVAL))
-        .unwrap_or(MAX_HEARTBEAT_INTERVAL)
+/// When `user_frequency_secs` is `None`, returns `master_validity / 16` —
+/// matching the Python connector's default
+/// (`_validate_client_session_keep_alive_heartbeat_frequency`).
+///
+/// When `user_frequency_secs` is provided, it is clamped to the closed range
+/// `[master_validity / 16, master_validity / 4]`.
+///
+/// In both cases the final value is capped at [`MAX_HEARTBEAT_INTERVAL`].
+/// When `master_validity` is `None` the master validity defaults to 4h
+/// (the Snowflake server default), giving `[900s, 3600s]`.
+pub fn compute_heartbeat_interval(
+    master_validity: Option<Duration>,
+    user_frequency_secs: Option<u64>,
+) -> Duration {
+    const DEFAULT_MASTER_VALIDITY: Duration = Duration::from_secs(4 * 3600);
+    let master = master_validity.unwrap_or(DEFAULT_MASTER_VALIDITY);
+    let max = master / 4;
+    let min = master / 16;
+
+    let interval = match user_frequency_secs {
+        None => min,
+        Some(secs) => Duration::from_secs(secs).clamp(min, max),
+    };
+
+    interval.min(MAX_HEARTBEAT_INTERVAL)
 }
 
 /// Spawn a per-connection heartbeat background task.
@@ -184,26 +204,44 @@ mod tests {
     }
 
     #[test]
-    fn compute_interval_default() {
-        let interval = compute_heartbeat_interval(None);
+    fn compute_interval_default_uses_master_over_16() {
+        // No master validity, no user frequency -> default_master / 16 = 14400 / 16 = 900s.
+        let interval = compute_heartbeat_interval(None, None);
+        assert_eq!(interval, Duration::from_secs(900));
+    }
+
+    #[test]
+    fn compute_interval_default_from_validity() {
+        // validity / 16
+        let interval = compute_heartbeat_interval(Some(Duration::from_secs(14400)), None);
+        assert_eq!(interval, Duration::from_secs(900));
+    }
+
+    #[test]
+    fn compute_interval_user_value_within_range() {
+        // 1800 is within [900, 3600] for master=14400.
+        let interval = compute_heartbeat_interval(Some(Duration::from_secs(14400)), Some(1800));
+        assert_eq!(interval, Duration::from_secs(1800));
+    }
+
+    #[test]
+    fn compute_interval_user_value_clamped_to_min() {
+        // 100 is below 900; clamp up.
+        let interval = compute_heartbeat_interval(Some(Duration::from_secs(14400)), Some(100));
+        assert_eq!(interval, Duration::from_secs(900));
+    }
+
+    #[test]
+    fn compute_interval_user_value_clamped_to_max() {
+        // 9000 is above 3600; clamp down.
+        let interval = compute_heartbeat_interval(Some(Duration::from_secs(14400)), Some(9000));
         assert_eq!(interval, Duration::from_secs(3600));
     }
 
     #[test]
-    fn compute_interval_from_validity() {
-        let interval = compute_heartbeat_interval(Some(Duration::from_secs(14400)));
-        assert_eq!(interval, Duration::from_secs(3600));
-    }
-
-    #[test]
-    fn compute_interval_no_bottom_clamp() {
-        let interval = compute_heartbeat_interval(Some(Duration::from_secs(100)));
-        assert_eq!(interval, Duration::from_secs(25));
-    }
-
-    #[test]
-    fn compute_interval_clamp_max() {
-        let interval = compute_heartbeat_interval(Some(Duration::from_secs(100_000)));
+    fn compute_interval_clamp_max_overall() {
+        // With a master of 100_000s, default would be 6250s; cap at MAX_HEARTBEAT_INTERVAL.
+        let interval = compute_heartbeat_interval(Some(Duration::from_secs(100_000)), None);
         assert_eq!(interval, MAX_HEARTBEAT_INTERVAL);
     }
 

--- a/sf_core/src/config/param_registry.rs
+++ b/sf_core/src/config/param_registry.rs
@@ -90,6 +90,8 @@ pub mod param_names {
     pub const LOG_QUERY_PARAMETERS: ParamKey = ParamKey("log_query_parameters");
     pub const CLIENT_TELEMETRY_ENABLED: ParamKey = ParamKey("CLIENT_TELEMETRY_ENABLED");
     pub const CLIENT_SESSION_KEEP_ALIVE: ParamKey = ParamKey("CLIENT_SESSION_KEEP_ALIVE");
+    pub const CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY: ParamKey =
+        ParamKey("CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY");
     // Logout configuration
     pub const SERVER_SESSION_KEEP_ALIVE: ParamKey = ParamKey("server_session_keep_alive");
     pub const ENABLE_SERVER_SESSION_KEEP_ALIVE_AUTO_DETECTION: ParamKey =
@@ -888,6 +890,35 @@ static PARAM_DEFS: &[ParamDef] = &[
         used_at_connect: false,
         mutable_after_connect: true,
     },
+    // ── Session keep-alive ─────────────────────────────────────────────
+    ParamDef {
+        canonical_name: param_names::CLIENT_SESSION_KEEP_ALIVE.as_str(),
+        aliases: &["CLIENT_SESSION_KEEP_ALIVE"],
+        value_type: ValueType::Bool,
+        additional_value_type: None,
+        required: Required::Never,
+        default: Some(|| Setting::Bool(false)),
+        sensitive: false,
+        description: "Keep the session alive with periodic heartbeat requests",
+        deprecated_by: None,
+        scope: ParamScope::Session,
+        used_at_connect: true,
+        mutable_after_connect: false,
+    },
+    ParamDef {
+        canonical_name: param_names::CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY.as_str(),
+        aliases: &["CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY"],
+        value_type: ValueType::Int,
+        additional_value_type: None,
+        required: Required::Never,
+        default: None,
+        sensitive: false,
+        description: "Heartbeat frequency in seconds (clamped to interval master_token_validity/16..master_token_validity/4)",
+        deprecated_by: None,
+        scope: ParamScope::Session,
+        used_at_connect: true,
+        mutable_after_connect: false,
+    },
 ];
 
 impl ParamDef {
@@ -1015,6 +1046,24 @@ mod tests {
                 param.canonical_name
             );
         }
+    }
+
+    #[test]
+    fn client_session_keep_alive_params_registered() {
+        let r = registry();
+        let keep_alive = r
+            .resolve("CLIENT_SESSION_KEEP_ALIVE")
+            .expect("CLIENT_SESSION_KEEP_ALIVE should resolve");
+        assert_eq!(keep_alive.value_type, ValueType::Bool);
+        assert_eq!(keep_alive.scope, ParamScope::Session);
+        assert!(keep_alive.used_at_connect);
+
+        let freq = r
+            .resolve("CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY")
+            .expect("heartbeat frequency param should resolve");
+        assert_eq!(freq.value_type, ValueType::Int);
+        assert_eq!(freq.scope, ParamScope::Session);
+        assert!(freq.used_at_connect);
     }
 
     #[test]

--- a/sf_core/src/rest/snowflake/mod.rs
+++ b/sf_core/src/rest/snowflake/mod.rs
@@ -84,6 +84,10 @@ pub struct SessionTokens {
     pub session_expires_at: Option<std::time::Instant>,
     /// When the master token expires (after this, full re-auth is needed)
     pub master_expires_at: Option<std::time::Instant>,
+    /// Configured master-token TTL as returned by the server (`masterValidityInSeconds`).
+    /// Unlike the remaining time derived from `master_expires_at`, this does not shrink
+    /// as the token ages, so it is the right input for heartbeat-cadence computation.
+    pub master_validity: Option<std::time::Duration>,
 }
 
 /// Result of a successful login to Snowflake
@@ -750,6 +754,7 @@ pub async fn snowflake_login_with_client(
             session_id,
             session_expires_at,
             master_expires_at,
+            master_validity: auth_response.data.master_validity,
         },
         session_parameters: session_params,
         database_name,
@@ -855,6 +860,7 @@ pub async fn refresh_session(
         session_id: data.session_id,
         session_expires_at,
         master_expires_at,
+        master_validity: data.master_validity,
     })
 }
 

--- a/sf_core/src/telemetry/snowflake_exporter.rs
+++ b/sf_core/src/telemetry/snowflake_exporter.rs
@@ -212,6 +212,7 @@ mod tests {
             session_id: 1,
             session_expires_at: None,
             master_expires_at: None,
+            master_validity: None,
         };
 
         Arc::new(ExporterSession {

--- a/sf_core/tests/integration/http/session_refresh.rs
+++ b/sf_core/tests/integration/http/session_refresh.rs
@@ -16,6 +16,7 @@ fn test_tokens() -> SessionTokens {
         session_id: 12345,
         session_expires_at: None,
         master_expires_at: None,
+        master_validity: None,
     }
 }
 

--- a/sf_core/tests/integration/session/heartbeat.rs
+++ b/sf_core/tests/integration/session/heartbeat.rs
@@ -455,5 +455,6 @@ fn test_tokens(session_token: &str) -> SessionTokens {
         session_id: 1,
         session_expires_at: None,
         master_expires_at: Some(std::time::Instant::now() + Duration::from_secs(14400)),
+        master_validity: Some(Duration::from_secs(14400)),
     }
 }

--- a/sf_core/tests/integration/session/session_refresh.rs
+++ b/sf_core/tests/integration/session/session_refresh.rs
@@ -78,6 +78,7 @@ async fn should_only_refresh_once_with_concurrent_401_errors() {
         session_id: 12345,
         session_expires_at: None,
         master_expires_at: None,
+        master_validity: None,
     };
 
     let mut connection = Connection::new();

--- a/sf_core/tests/integration/telemetry/exporter_pipeline.rs
+++ b/sf_core/tests/integration/telemetry/exporter_pipeline.rs
@@ -46,6 +46,7 @@ fn make_active_session(server_url: &str) -> Arc<ExporterSession> {
         session_id: SESSION_ID,
         session_expires_at: None,
         master_expires_at: None,
+        master_validity: None,
     };
     make_session(server_url, Some(tokens))
 }
@@ -158,6 +159,7 @@ async fn span_exporter_handles_token_revoked_between_calls() {
         session_id: SESSION_ID,
         session_expires_at: None,
         master_expires_at: None,
+        master_validity: None,
     };
     let token_store = Arc::new(AsyncRwLock::new(Some(tokens)));
 
@@ -196,6 +198,7 @@ async fn span_exporter_uses_refreshed_token() {
         session_id: SESSION_ID,
         session_expires_at: None,
         master_expires_at: None,
+        master_validity: None,
     };
     let token_store = Arc::new(AsyncRwLock::new(Some(initial_tokens)));
 
@@ -220,6 +223,7 @@ async fn span_exporter_uses_refreshed_token() {
         session_id: SESSION_ID,
         session_expires_at: None,
         master_expires_at: None,
+        master_validity: None,
     };
     *token_store.write().await = Some(new_tokens);
 


### PR DESCRIPTION
## Summary
- Register `CLIENT_SESSION_KEEP_ALIVE` and `CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY` in the sf_core param registry; thread the user-provided heartbeat frequency through `compute_heartbeat_interval` with `[master_validity/16, master_validity/4]` clamping (Python parity, defaults to `master/16` when unspecified, capped at 1h).
- Mirror both values into login session parameters so the server sees them on first contact (matches old Python connector behavior).
- Implement the matching `Connection.client_session_keep_alive[_heartbeat_frequency]` properties on the Python wrapper (previously `NotImplementedError`); regenerate `connection_config.py`.

## Test plan
- [x] `cargo test -p sf_core --lib` (790 pass; 6 new in `heartbeat.rs`, 1 new in `param_registry.rs`)
- [x] `pytest tests/unit/test_connection.py tests/unit/test_connection_config.py` (191 pass; 4 new in `test_connection_config.py`, 3 new in `test_connection.py`)
- [ ] integration test against a live account with `client_session_keep_alive=True` and varying `client_session_keep_alive_heartbeat_frequency` values (in/below/above range)

🤖 Generated with [Claude Code](https://claude.com/claude-code)