### PR TITLE
refactor(refresh): extract generic refresh-and-retry pattern

### DIFF
--- a/sf_core/src/apis/database_driver_v1/connection.rs
+++ b/sf_core/src/apis/database_driver_v1/connection.rs
@@ -1189,9 +1189,9 @@ impl RefreshContext {
     ///
     /// On `SessionExpired`, refreshes the session token via master token and
     /// retries exactly once. Implemented on top of the generic
-    /// [`refresh::execute_with_refresh`] helper — see that module for the
-    /// shared retry-shape that this and the S3 STS refresher both use. Named
-    /// to parallel [`execute_with_retry`](crate::http::retry::execute_with_retry).
+    /// [`refresh::execute_with_refresh`](crate::refresh::execute_with_refresh)
+    /// helper. Named to parallel
+    /// [`execute_with_retry`](crate::http::retry::execute_with_retry).
     pub async fn execute_with_refresh<F, Fut, T>(&mut self, f: F) -> Result<T, ApiError>
     where
         F: Fn(SensitiveString) -> Fut,

--- a/sf_core/src/apis/database_driver_v1/connection.rs
+++ b/sf_core/src/apis/database_driver_v1/connection.rs
@@ -1187,22 +1187,105 @@ impl RefreshContext {
 
     /// Execute an async operation with automatic token refresh on session expiry.
     ///
-    /// Canonical implementation of the refresh-retry loop. On `SessionExpired`,
-    /// refreshes the session token via master token and retries exactly once.
-    /// Named to parallel [`execute_with_retry`](crate::http::retry::execute_with_retry).
+    /// On `SessionExpired`, refreshes the session token via master token and
+    /// retries exactly once. Implemented on top of the generic
+    /// [`refresh::execute_with_refresh`] helper — see that module for the
+    /// shared retry-shape that this and the S3 STS refresher both use. Named
+    /// to parallel [`execute_with_retry`](crate::http::retry::execute_with_retry).
     pub async fn execute_with_refresh<F, Fut, T>(&mut self, f: F) -> Result<T, ApiError>
     where
         F: Fn(SensitiveString) -> Fut,
         Fut: Future<Output = Result<T, RestError>>,
     {
-        let mut last_error: Option<RestError> = None;
-        loop {
-            let token = self.refresh_token(last_error).await?;
-            match f(token).await {
-                Ok(result) => return Ok(result),
-                Err(e) => last_error = Some(e),
+        use snafu::IntoError;
+        crate::refresh::execute_with_refresh(self, |token| {
+            let fut = f(token);
+            async move { fut.await.map_err(|e| QuerySnafu.into_error(e)) }
+        })
+        .await
+    }
+}
+
+impl crate::refresh::Refresher<SensitiveString, ApiError> for RefreshContext {
+    fn current(&mut self) -> crate::refresh::RefreshFuture<'_, Result<SensitiveString, ApiError>> {
+        Box::pin(async move {
+            let tokens_guard = self.tokens_lock.read().await;
+            let token = tokens_guard
+                .as_ref()
+                .map(|t| t.session_token.clone())
+                .context(ConnectionNotInitializedSnafu)?;
+            // Stamp the token into the state machine on first read so that
+            // `refresh()` can detect the "another request already rotated
+            // while we waited" race.
+            if matches!(self.state, RefreshState::Initial) {
+                self.state = RefreshState::FirstToken(token.clone());
             }
-        }
+            Ok(token)
+        })
+    }
+
+    fn should_refresh(&self, err: &ApiError) -> bool {
+        let ApiError::Query { source, .. } = err else {
+            return false;
+        };
+        matches!(
+            source.as_ref(),
+            RestError::InvalidSnowflakeResponse {
+                source: SnowflakeResponseError::SessionExpired { .. },
+                ..
+            },
+        )
+    }
+
+    fn refresh(&mut self) -> crate::refresh::RefreshFuture<'_, Result<bool, ApiError>> {
+        Box::pin(async move {
+            // The existing one-shot state machine: the first refresh call
+            // does the work, subsequent calls return Ok(false) so the
+            // generic helper propagates the original error.
+            let failed_token = match &self.state {
+                RefreshState::FirstToken(t) => t.clone(),
+                RefreshState::Refreshed => return Ok(false),
+                RefreshState::Initial => return Ok(false),
+            };
+            self.state = RefreshState::Refreshed;
+
+            // Acquire the write lock — blocks other readers/writers during
+            // refresh.
+            let mut tokens_guard = self.tokens_lock.write().await;
+            let tokens = tokens_guard
+                .as_ref()
+                .cloned()
+                .context(ConnectionNotInitializedSnafu)?;
+
+            // If another request already refreshed while we waited, the
+            // current token is fresh — treat as a successful rotation
+            // without hitting GS.
+            if tokens.session_token.reveal() != failed_token.reveal() {
+                tracing::debug!("Session already refreshed by another request");
+                return Ok(true);
+            }
+
+            if tokens.is_master_expired() {
+                tracing::error!("Master token expired, full re-authentication required");
+                return MasterTokenExpiredSnafu.fail();
+            }
+
+            tracing::info!("Session expired, attempting refresh");
+            let new_tokens = snowflake::refresh_session(
+                &self.http_client,
+                &self.server_url,
+                &self.client_info,
+                &tokens,
+            )
+            .await
+            .context(SessionRefreshSnafu)?;
+
+            *tokens_guard = Some(new_tokens);
+            drop(tokens_guard);
+
+            tracing::info!("Session refreshed, retrying operation");
+            Ok(true)
+        })
     }
 }
 

--- a/sf_core/src/apis/database_driver_v1/connection.rs
+++ b/sf_core/src/apis/database_driver_v1/connection.rs
@@ -1214,9 +1214,10 @@ impl crate::refresh::Refresher<SensitiveString, ApiError> for RefreshContext {
                 .as_ref()
                 .map(|t| t.session_token.clone())
                 .context(ConnectionNotInitializedSnafu)?;
-            // Stamp the token into the state machine on first read so that
-            // `refresh()` can detect the "another request already rotated
-            // while we waited" race.
+            // Stamp the token into the state machine on first read so
+            // that `refresh()` can detect — by comparing this token
+            // against the cache after acquiring the write lock — whether
+            // another request already rotated while we were waiting.
             if matches!(self.state, RefreshState::Initial) {
                 self.state = RefreshState::FirstToken(token.clone());
             }
@@ -1239,13 +1240,24 @@ impl crate::refresh::Refresher<SensitiveString, ApiError> for RefreshContext {
 
     fn refresh(&mut self) -> crate::refresh::RefreshFuture<'_, Result<bool, ApiError>> {
         Box::pin(async move {
-            // The existing one-shot state machine: the first refresh call
-            // does the work, subsequent calls return Ok(false) so the
-            // generic helper propagates the original error.
+            // One-shot state machine: the first refresh call does the
+            // work, subsequent calls return Ok(false) so the generic
+            // helper propagates the original error. `Initial` is
+            // unreachable in practice — `execute_with_refresh` always
+            // calls `current()` first, which transitions Initial →
+            // FirstToken — but we keep a safe fallback rather than
+            // panicking on a misuse from a future caller.
             let failed_token = match &self.state {
                 RefreshState::FirstToken(t) => t.clone(),
                 RefreshState::Refreshed => return Ok(false),
-                RefreshState::Initial => return Ok(false),
+                RefreshState::Initial => {
+                    debug_assert!(
+                        false,
+                        "RefreshContext::refresh() called before current(); \
+                         execute_with_refresh always calls current() first"
+                    );
+                    return Ok(false);
+                }
             };
             self.state = RefreshState::Refreshed;
 

--- a/sf_core/src/file_manager/s3_transfer.rs
+++ b/sf_core/src/file_manager/s3_transfer.rs
@@ -40,8 +40,8 @@ const REQUEST_TIMEOUT_SECS: u64 = 300;
 /// via the shared cache — no return-value plumbing required.
 ///
 /// When `refresher` is `Some`, the retry loop is driven by
-/// [`crate::refresh::execute_with_refresh`] — see that module for the shared
-/// retry-shape used by both the session-token and STS refresh paths.
+/// [`crate::refresh::execute_with_refresh`] via the [`S3StsRefresher`]
+/// implementation in this module.
 pub async fn upload_to_s3_or_skip(
     prepared: PreparedUpload,
     stage_info: &StageInfo,
@@ -74,23 +74,17 @@ pub async fn upload_to_s3_or_skip(
         }
     };
 
-    let outcome = match refresher.as_deref_mut() {
-        Some(r) => {
-            let mut adapter = StageCredsAdapter::new(r, &stage_info.creds, |e| {
-                upload_file_error::StageCredsRefreshSnafu.into_error(e)
-            });
-            execute_with_refresh(&mut adapter, attempt).await
-        }
-        None => attempt(stage_info.creds.clone()).await,
-    };
-
-    outcome.map_err(|e| match e {
-        S3AttemptError::Other(err) => err,
-        // The refresher declined to rotate (or there was none). Surface the
-        // original AWS error as a normal upload failure — same shape as any
-        // other S3 PUT error.
-        S3AttemptError::StsExpired(aws_err) => upload_file_error::S3UploadSnafu.into_error(aws_err),
-    })
+    run_s3_with_sts_refresh(
+        refresher,
+        &stage_info.creds,
+        |e| upload_file_error::StageCredsRefreshSnafu.into_error(e),
+        // Refresher declined to rotate (or there was none). Surface the
+        // original AWS error as a normal upload failure — same shape as
+        // any other S3 PUT error.
+        |aws_err| upload_file_error::S3UploadSnafu.into_error(aws_err),
+        attempt,
+    )
+    .await
 }
 
 /// Internal error type for one attempt of an S3 operation. The `StsExpired`
@@ -104,24 +98,28 @@ enum S3AttemptError<E> {
     Other(E),
 }
 
-/// Adapter that exposes a `StageCredsRefresher` (file-manager-facing trait)
-/// as a `Refresher<CloudCredentials, S3AttemptError<E>>` so the generic
-/// helper drives the retry loop. `wrap_refresh_err` translates a
-/// `StageCredsRefreshError` from the refresher into the operation's `E` —
-/// this avoids a blanket `From<StageCredsRefreshError>` impl on
-/// `UploadFileError`/`DownloadFileError`, which would skip snafu's
-/// source-location stamping. Tracks the last AWS key id handed out so a
-/// refresh that doesn't actually rotate (refresher inside its coalescing
-/// window) reports `Ok(false)` and the helper propagates the original
-/// error rather than spinning.
-struct StageCredsAdapter<'a, E, W> {
+/// S3 STS implementation of the generic [`Refresher`] trait. Drives the
+/// retry loop in `execute_with_refresh` by reading credentials from a
+/// `StageCredsRefresher`'s shared cache and asking it to rotate when the
+/// AWS SDK reports `ExpiredToken`.
+///
+/// `wrap_refresh_err` translates a `StageCredsRefreshError` from the
+/// refresher into the operation's `E` — this avoids a blanket
+/// `From<StageCredsRefreshError>` impl on `UploadFileError` /
+/// `DownloadFileError`, which would skip snafu's source-location stamping.
+///
+/// Tracks the last AWS key id handed out so a refresh that doesn't
+/// actually rotate (refresher inside its coalescing window) reports
+/// `Ok(false)` and the helper propagates the original error rather than
+/// spinning.
+struct S3StsRefresher<'a, E, W> {
     refresher: &'a mut dyn StageCredsRefresher,
     last_seen_key: Option<String>,
     wrap_refresh_err: W,
     _marker: PhantomData<fn() -> E>,
 }
 
-impl<'a, E, W> StageCredsAdapter<'a, E, W>
+impl<'a, E, W> S3StsRefresher<'a, E, W>
 where
     W: Fn(StageCredsRefreshError) -> E,
 {
@@ -139,7 +137,7 @@ where
     }
 }
 
-impl<'a, E, W> Refresher<CloudCredentials, S3AttemptError<E>> for StageCredsAdapter<'a, E, W>
+impl<'a, E, W> Refresher<CloudCredentials, S3AttemptError<E>> for S3StsRefresher<'a, E, W>
 where
     E: Send,
     W: Fn(StageCredsRefreshError) -> E + Send,
@@ -173,6 +171,42 @@ where
             Ok(true)
         })
     }
+}
+
+/// Runs `attempt` with the supplied credentials, driving STS refresh on
+/// `S3AttemptError::StsExpired` when a `refresher` is provided. With no
+/// refresher, runs the attempt once and folds any `StsExpired` back into
+/// the caller-supplied AWS error path — same shape as any other S3
+/// PUT/GET error.
+///
+/// Owns the refresher-vs-no-refresher branching that was previously
+/// duplicated by both upload and download. `wrap_refresh_err` /
+/// `wrap_sts_err` keep the call sites' snafu instrumentation at the
+/// boundary so source locations land on the operation's own error variants
+/// rather than on this helper.
+async fn run_s3_with_sts_refresh<F, Fut, T, E>(
+    refresher: &mut Option<&mut dyn StageCredsRefresher>,
+    initial_creds: &CloudCredentials,
+    wrap_refresh_err: impl Fn(StageCredsRefreshError) -> E + Send,
+    wrap_sts_err: impl FnOnce(aws_sdk_s3::Error) -> E,
+    attempt: F,
+) -> Result<T, E>
+where
+    F: Fn(CloudCredentials) -> Fut,
+    Fut: Future<Output = Result<T, S3AttemptError<E>>>,
+    E: Send,
+{
+    let outcome = match refresher.as_deref_mut() {
+        Some(r) => {
+            let mut sts = S3StsRefresher::new(r, initial_creds, wrap_refresh_err);
+            execute_with_refresh(&mut sts, attempt).await
+        }
+        None => attempt(initial_creds.clone()).await,
+    };
+    outcome.map_err(|e| match e {
+        S3AttemptError::Other(err) => err,
+        S3AttemptError::StsExpired(aws_err) => wrap_sts_err(aws_err),
+    })
 }
 
 /// Returns the AWS key id from S3 credentials, or None for non-S3 variants.
@@ -303,22 +337,14 @@ pub async fn download_from_s3(
         }
     };
 
-    let outcome = match refresher.as_deref_mut() {
-        Some(r) => {
-            let mut adapter = StageCredsAdapter::new(r, &stage_info.creds, |e| {
-                download_file_error::StageCredsRefreshSnafu.into_error(e)
-            });
-            execute_with_refresh(&mut adapter, attempt).await
-        }
-        None => attempt(stage_info.creds.clone()).await,
-    };
-
-    let response = outcome.map_err(|e| match e {
-        S3AttemptError::Other(err) => err,
-        S3AttemptError::StsExpired(aws_err) => {
-            download_file_error::S3DownloadSnafu.into_error(aws_err)
-        }
-    })?;
+    let response = run_s3_with_sts_refresh(
+        refresher,
+        &stage_info.creds,
+        |e| download_file_error::StageCredsRefreshSnafu.into_error(e),
+        |aws_err| download_file_error::S3DownloadSnafu.into_error(aws_err),
+        attempt,
+    )
+    .await?;
 
     let metadata_map = response.metadata().cloned().unwrap_or_default();
 
@@ -878,9 +904,9 @@ mod tests {
         }
     }
 
-    // --- aws_key_id helper used by the adapter's rotation check ---
+    // --- aws_key_id helper used by S3StsRefresher's rotation check ---
     //
-    // The adapter compares AWS key ids before/after refresh: a different
+    // S3StsRefresher compares AWS key ids before/after refresh: a different
     // key id implies a fresh STS rotation from GS, the same key id means
     // we're inside the refresher's coalescing window and retrying would
     // loop. Non-S3 variants intentionally return None so the comparison
@@ -903,7 +929,7 @@ mod tests {
         assert_eq!(aws_key_id(&azure), None);
     }
 
-    // --- StageCredsAdapter::refresh ---
+    // --- S3StsRefresher::refresh ---
     //
     // A fake StageCredsRefresher records call counts and exposes a mutable
     // cache so tests can simulate "refresh rotated the creds" vs "refresh
@@ -956,13 +982,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn adapter_refresh_returns_true_when_creds_rotate() {
+    async fn s3_sts_refresher_refresh_returns_true_when_creds_rotate() {
         let mut fake = FakeRefresher::new(s3_creds("AKIA1"));
         fake.arm(s3_creds("AKIA2"));
         let initial = s3_creds("AKIA1");
-        let mut adapter = StageCredsAdapter::new(&mut fake, &initial, passthrough_wrap);
+        let mut sts = S3StsRefresher::new(&mut fake, &initial, passthrough_wrap);
 
-        let rotated = adapter.refresh().await.unwrap();
+        let rotated = sts.refresh().await.unwrap();
 
         assert!(rotated);
         assert_eq!(fake.refresh_calls.load(AtomicOrdering::SeqCst), 1);
@@ -974,39 +1000,39 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn adapter_refresh_returns_false_when_creds_unchanged() {
+    async fn s3_sts_refresher_refresh_returns_false_when_creds_unchanged() {
         // FakeRefresher with no `arm()` leaves the cache holding the
         // initial creds — simulating a hit inside the refresher's
-        // coalescing window. The adapter must report Ok(false) so the
-        // generic helper propagates the original error rather than
+        // coalescing window. The S3StsRefresher must report Ok(false) so
+        // the generic helper propagates the original error rather than
         // spinning.
         let mut fake = FakeRefresher::new(s3_creds("AKIA1"));
         let initial = s3_creds("AKIA1");
-        let mut adapter = StageCredsAdapter::new(&mut fake, &initial, passthrough_wrap);
+        let mut sts = S3StsRefresher::new(&mut fake, &initial, passthrough_wrap);
 
-        let rotated = adapter.refresh().await.unwrap();
+        let rotated = sts.refresh().await.unwrap();
 
         assert!(
             !rotated,
-            "unchanged creds → adapter declines further rotations"
+            "unchanged creds → S3StsRefresher declines further rotations"
         );
         assert_eq!(fake.refresh_calls.load(AtomicOrdering::SeqCst), 1);
     }
 
     #[tokio::test]
-    async fn adapter_refresh_tracks_last_seen_key_across_rotations() {
+    async fn s3_sts_refresher_refresh_tracks_last_seen_key_across_rotations() {
         // After a successful rotation, last_seen_key is updated. A
         // subsequent unchanged refresh against the new key should still
         // report Ok(false) — confirming the marker followed the rotation.
         let mut fake = FakeRefresher::new(s3_creds("AKIA1"));
         fake.arm(s3_creds("AKIA2"));
         let initial = s3_creds("AKIA1");
-        let mut adapter = StageCredsAdapter::new(&mut fake, &initial, passthrough_wrap);
+        let mut sts = S3StsRefresher::new(&mut fake, &initial, passthrough_wrap);
 
-        assert!(adapter.refresh().await.unwrap()); // AKIA1 -> AKIA2
+        assert!(sts.refresh().await.unwrap()); // AKIA1 -> AKIA2
         // Cache still holds AKIA2; arming nothing means refresh() leaves
-        // it as-is. Adapter must see "no rotation" against AKIA2 (not
-        // AKIA1).
-        assert!(!adapter.refresh().await.unwrap());
+        // it as-is. S3StsRefresher must see "no rotation" against AKIA2
+        // (not AKIA1).
+        assert!(!sts.refresh().await.unwrap());
     }
 }

--- a/sf_core/src/file_manager/s3_transfer.rs
+++ b/sf_core/src/file_manager/s3_transfer.rs
@@ -3,7 +3,9 @@ use super::types::{
     StageCredsRefreshError, StageCredsRefresher, StageInfo, UploadStatus,
 };
 use crate::config::retry::{BackoffConfig, Jitter, RetryPolicy};
-use snafu::{Location, ResultExt, Snafu};
+use crate::refresh::{Refresher, execute_with_refresh};
+use snafu::{IntoError, Location, ResultExt, Snafu};
+use std::marker::PhantomData;
 use std::time::Duration;
 
 // AWS SDK imports
@@ -36,6 +38,10 @@ const REQUEST_TIMEOUT_SECS: u64 = 300;
 /// successful refresh for 10 minutes, matching ODBC's `m_lastRefreshTokenSec`
 /// gate). The refreshed credentials are visible to other files in the batch
 /// via the shared cache — no return-value plumbing required.
+///
+/// When `refresher` is `Some`, the retry loop is driven by
+/// [`crate::refresh::execute_with_refresh`] — see that module for the shared
+/// retry-shape used by both the session-token and STS refresh paths.
 pub async fn upload_to_s3_or_skip(
     prepared: PreparedUpload,
     stage_info: &StageInfo,
@@ -44,73 +50,147 @@ pub async fn upload_to_s3_or_skip(
     refresher: &mut Option<&mut dyn StageCredsRefresher>,
 ) -> Result<UploadStatus, UploadFileError> {
     let s3_key = format!("{}{filename}", stage_info.key_prefix);
-    // Working copy of stage_info — `creds` may be replaced with refreshed
-    // values pulled from the refresher's cache; bucket/region/key_prefix are
-    // immutable for the lifetime of one PUT/GET command.
-    let mut stage_info = stage_info.clone();
 
-    loop {
-        let s3_client = create_s3_client(&stage_info, SNOWFLAKE_UPLOAD_PROVIDER).await?;
+    let attempt = |creds: CloudCredentials| {
+        let prepared = prepared.clone();
+        let stage_info = with_creds(stage_info, creds);
+        let s3_key = s3_key.clone();
+        async move {
+            let s3_client = create_s3_client(&stage_info, SNOWFLAKE_UPLOAD_PROVIDER)
+                .await
+                .map_err(|e| S3AttemptError::Other(UploadFileError::from(e)))?;
 
-        if !overwrite && check_if_file_exists(&s3_client, &stage_info, &s3_key).await? {
-            tracing::info!("File already exists in S3: {}", s3_key);
-            return Ok(UploadStatus::Skipped);
-        }
-
-        match upload_to_s3(prepared.clone(), &s3_client, &stage_info, &s3_key).await? {
-            S3Outcome::Ok(()) => return Ok(UploadStatus::Uploaded),
-            S3Outcome::StsExpired(aws_err) => {
-                let rotated = try_refresh_creds(refresher, &mut stage_info)
+            if !overwrite
+                && check_if_file_exists(&s3_client, &stage_info, &s3_key)
                     .await
-                    .context(upload_file_error::StageCredsRefreshSnafu)?;
-                if !rotated {
-                    // No refresher, or refresher returned the same creds —
-                    // surface the original AWS error as a normal upload
-                    // failure, the same shape callers see for any other S3
-                    // PUT error.
-                    return Err(aws_err).context(upload_file_error::S3UploadSnafu);
-                }
+                    .map_err(S3AttemptError::Other)?
+            {
+                tracing::info!("File already exists in S3: {}", s3_key);
+                return Ok(UploadStatus::Skipped);
             }
+
+            put_object(prepared, &s3_client, &stage_info, &s3_key).await?;
+            Ok(UploadStatus::Uploaded)
+        }
+    };
+
+    let outcome = match refresher.as_deref_mut() {
+        Some(r) => {
+            let mut adapter = StageCredsAdapter::new(r, &stage_info.creds, |e| {
+                upload_file_error::StageCredsRefreshSnafu.into_error(e)
+            });
+            execute_with_refresh(&mut adapter, attempt).await
+        }
+        None => attempt(stage_info.creds.clone()).await,
+    };
+
+    outcome.map_err(|e| match e {
+        S3AttemptError::Other(err) => err,
+        // The refresher declined to rotate (or there was none). Surface the
+        // original AWS error as a normal upload failure — same shape as any
+        // other S3 PUT error.
+        S3AttemptError::StsExpired(aws_err) => upload_file_error::S3UploadSnafu.into_error(aws_err),
+    })
+}
+
+/// Internal error type for one attempt of an S3 operation. The `StsExpired`
+/// arm is the recoverable signal `should_refresh` matches on; everything
+/// else lives in `Other`. This stays internal — `UploadFileError` /
+/// `DownloadFileError` have no `StsExpiredToken` variant, so callers cannot
+/// observe a refresh-internal state.
+#[derive(Debug)]
+enum S3AttemptError<E> {
+    StsExpired(aws_sdk_s3::Error),
+    Other(E),
+}
+
+/// Adapter that exposes a `StageCredsRefresher` (file-manager-facing trait)
+/// as a `Refresher<CloudCredentials, S3AttemptError<E>>` so the generic
+/// helper drives the retry loop. `wrap_refresh_err` translates a
+/// `StageCredsRefreshError` from the refresher into the operation's `E` —
+/// this avoids a blanket `From<StageCredsRefreshError>` impl on
+/// `UploadFileError`/`DownloadFileError`, which would skip snafu's
+/// source-location stamping. Tracks the last AWS key id handed out so a
+/// refresh that doesn't actually rotate (refresher inside its coalescing
+/// window) reports `Ok(false)` and the helper propagates the original
+/// error rather than spinning.
+struct StageCredsAdapter<'a, E, W> {
+    refresher: &'a mut dyn StageCredsRefresher,
+    last_seen_key: Option<String>,
+    wrap_refresh_err: W,
+    _marker: PhantomData<fn() -> E>,
+}
+
+impl<'a, E, W> StageCredsAdapter<'a, E, W>
+where
+    W: Fn(StageCredsRefreshError) -> E,
+{
+    fn new(
+        refresher: &'a mut dyn StageCredsRefresher,
+        initial: &CloudCredentials,
+        wrap_refresh_err: W,
+    ) -> Self {
+        Self {
+            refresher,
+            last_seen_key: aws_key_id(initial).map(str::to_string),
+            wrap_refresh_err,
+            _marker: PhantomData,
         }
     }
 }
 
-/// Outcome of a single S3 attempt (PUT or GET). `StsExpired` is an
-/// internal-only signal that drives the credential-refresh retry inside this
-/// module — `UploadFileError` / `DownloadFileError` deliberately have no
-/// `StsExpiredToken` variant, so callers cannot observe (or pattern-match on)
-/// a refresh-internal state.
-#[derive(Debug)]
-enum S3Outcome<T> {
-    Ok(T),
-    StsExpired(aws_sdk_s3::Error),
+impl<'a, E, W> Refresher<CloudCredentials, S3AttemptError<E>> for StageCredsAdapter<'a, E, W>
+where
+    E: Send,
+    W: Fn(StageCredsRefreshError) -> E + Send,
+{
+    fn current(
+        &mut self,
+    ) -> crate::refresh::RefreshFuture<'_, Result<CloudCredentials, S3AttemptError<E>>> {
+        let creds = self.refresher.cache().snapshot();
+        Box::pin(async move { Ok(creds) })
+    }
+
+    fn should_refresh(&self, err: &S3AttemptError<E>) -> bool {
+        matches!(err, S3AttemptError::StsExpired(_))
+    }
+
+    fn refresh(&mut self) -> crate::refresh::RefreshFuture<'_, Result<bool, S3AttemptError<E>>> {
+        Box::pin(async move {
+            tracing::info!("S3 hit ExpiredToken; refreshing stage credentials");
+            self.refresher
+                .refresh()
+                .await
+                .map_err(|e| S3AttemptError::Other((self.wrap_refresh_err)(e)))?;
+            let new = self.refresher.cache().snapshot();
+            let new_key = aws_key_id(&new).map(str::to_string);
+            if new_key == self.last_seen_key {
+                // Refresher coalesced or returned the same creds — retrying
+                // would loop, so decline further rotations.
+                return Ok(false);
+            }
+            self.last_seen_key = new_key;
+            Ok(true)
+        })
+    }
 }
 
-/// Asks the refresher (if any) to fetch new stage credentials and updates
-/// `stage_info.creds` from the refresher's cache. Returns:
-/// - `Ok(true)` — credentials rotated; the caller should retry.
-/// - `Ok(false)` — no refresher, or the refresher returned the same creds
-///   (e.g. inside its coalescing window). The caller should propagate the
-///   original AWS error rather than loop.
-/// - `Err(e)` — the refresh itself failed; the caller wraps with
-///   `.context(...)` to attach the upload/download error path's snafu
-///   instrumentation.
-async fn try_refresh_creds(
-    refresher: &mut Option<&mut dyn StageCredsRefresher>,
-    stage_info: &mut StageInfo,
-) -> Result<bool, StageCredsRefreshError> {
-    let Some(r) = refresher.as_deref_mut() else {
-        return Ok(false);
-    };
-    tracing::info!("S3 hit ExpiredToken; refreshing stage credentials");
-    r.refresh().await?;
-    let new_creds = r.cache().snapshot();
-    if creds_unchanged(&stage_info.creds, &new_creds) {
-        Ok(false)
-    } else {
-        stage_info.creds = new_creds;
-        Ok(true)
+/// Returns the AWS key id from S3 credentials, or None for non-S3 variants.
+/// Used as the rotation marker; a different key id implies a fresh STS
+/// rotation from GS.
+fn aws_key_id(creds: &CloudCredentials) -> Option<&str> {
+    match creds {
+        CloudCredentials::S3 { aws_key_id, .. } => Some(aws_key_id.as_str()),
+        _ => None,
     }
+}
+
+/// Returns a copy of `stage_info` with `creds` replaced. Bucket/region/
+/// key_prefix are immutable for the lifetime of one PUT/GET command.
+fn with_creds(stage_info: &StageInfo, creds: CloudCredentials) -> StageInfo {
+    let mut info = stage_info.clone();
+    info.creds = creds;
+    info
 }
 
 /// Returns true if the file exists in S3, false if it does not.
@@ -149,31 +229,14 @@ fn is_expired_token_error(err: &aws_sdk_s3::Error) -> bool {
     err.code() == Some("ExpiredToken")
 }
 
-/// Checks whether a refresh returned the same credentials we already had — for
-/// example because the refresher is inside its coalescing window. Compared on
-/// the non-sensitive `aws_key_id`; `SensitiveString` has no `PartialEq`
-/// (equality on secrets is its own footgun) and a new key id implies a fresh
-/// STS rotation from GS.
-fn creds_unchanged(a: &CloudCredentials, b: &CloudCredentials) -> bool {
-    match (a, b) {
-        (
-            CloudCredentials::S3 {
-                aws_key_id: a_key, ..
-            },
-            CloudCredentials::S3 {
-                aws_key_id: b_key, ..
-            },
-        ) => a_key == b_key,
-        _ => false,
-    }
-}
-
-async fn upload_to_s3(
+/// Issues the S3 `PutObject` call and folds `ExpiredToken` into the
+/// `S3AttemptError::StsExpired` arm so the generic refresh helper can catch it.
+async fn put_object(
     prepared: PreparedUpload,
     s3_client: &S3Client,
     stage_info: &StageInfo,
     s3_key: &str,
-) -> Result<S3Outcome<()>, UploadFileError> {
+) -> Result<(), S3AttemptError<UploadFileError>> {
     let mut put_object_request = s3_client
         .put_object()
         .bucket(stage_info.bucket.clone())
@@ -184,7 +247,8 @@ async fn upload_to_s3(
 
     if let Some(ref enc_meta) = prepared.encryption_metadata {
         let mat_desc = serde_json::to_string(&enc_meta.material_desc)
-            .context(upload_file_error::SerializationSnafu)?;
+            .map_err(|e| upload_file_error::SerializationSnafu.into_error(e))
+            .map_err(S3AttemptError::Other)?;
         put_object_request = put_object_request
             .metadata("x-amz-iv", &enc_meta.iv)
             .metadata("x-amz-key", &enc_meta.encrypted_key)
@@ -196,15 +260,17 @@ async fn upload_to_s3(
     match put_object_request.send().await {
         Ok(res) => {
             tracing::debug!("S3 upload result: {:?}", res);
-            Ok(S3Outcome::Ok(()))
+            Ok(())
         }
         Err(sdk_err) => {
             let aws_err = aws_sdk_s3::Error::from(sdk_err);
             if is_expired_token_error(&aws_err) {
                 tracing::warn!("S3 upload failed with ExpiredToken");
-                Ok(S3Outcome::StsExpired(aws_err))
+                Err(S3AttemptError::StsExpired(aws_err))
             } else {
-                Err(aws_err).context(upload_file_error::S3UploadSnafu)
+                Err(S3AttemptError::Other(
+                    upload_file_error::S3UploadSnafu.into_error(aws_err),
+                ))
             }
         }
     }
@@ -225,22 +291,34 @@ pub async fn download_from_s3(
     refresher: &mut Option<&mut dyn StageCredsRefresher>,
 ) -> Result<DownloadResponse, DownloadFileError> {
     let s3_key = format!("{}{filename}", stage_info.key_prefix);
-    let mut stage_info = stage_info.clone();
 
-    let response = loop {
-        let s3_client = create_s3_client(&stage_info, SNOWFLAKE_DOWNLOAD_PROVIDER).await?;
-        match do_get_object(&s3_client, &stage_info, &s3_key).await? {
-            S3Outcome::Ok(r) => break *r,
-            S3Outcome::StsExpired(aws_err) => {
-                let rotated = try_refresh_creds(refresher, &mut stage_info)
-                    .await
-                    .context(download_file_error::StageCredsRefreshSnafu)?;
-                if !rotated {
-                    return Err(aws_err).context(download_file_error::S3DownloadSnafu);
-                }
-            }
+    let attempt = |creds: CloudCredentials| {
+        let stage_info = with_creds(stage_info, creds);
+        let s3_key = s3_key.clone();
+        async move {
+            let s3_client = create_s3_client(&stage_info, SNOWFLAKE_DOWNLOAD_PROVIDER)
+                .await
+                .map_err(|e| S3AttemptError::Other(DownloadFileError::from(e)))?;
+            get_object(&s3_client, &stage_info, &s3_key).await
         }
     };
+
+    let outcome = match refresher.as_deref_mut() {
+        Some(r) => {
+            let mut adapter = StageCredsAdapter::new(r, &stage_info.creds, |e| {
+                download_file_error::StageCredsRefreshSnafu.into_error(e)
+            });
+            execute_with_refresh(&mut adapter, attempt).await
+        }
+        None => attempt(stage_info.creds.clone()).await,
+    };
+
+    let response = outcome.map_err(|e| match e {
+        S3AttemptError::Other(err) => err,
+        S3AttemptError::StsExpired(aws_err) => {
+            download_file_error::S3DownloadSnafu.into_error(aws_err)
+        }
+    })?;
 
     let metadata_map = response.metadata().cloned().unwrap_or_default();
 
@@ -288,14 +366,12 @@ pub async fn download_from_s3(
 }
 
 /// Issues the S3 `GetObject` call and folds `ExpiredToken` into the
-/// `S3Outcome::StsExpired` arm so the retry loop can catch it. The `Ok`
-/// payload is boxed because `GetObjectOutput` is ~800 bytes — far larger
-/// than the `aws_sdk_s3::Error` in `StsExpired`.
-async fn do_get_object(
+/// `S3AttemptError::StsExpired` arm so the generic refresh helper can catch it.
+async fn get_object(
     s3_client: &S3Client,
     stage_info: &StageInfo,
     s3_key: &str,
-) -> Result<S3Outcome<Box<aws_sdk_s3::operation::get_object::GetObjectOutput>>, DownloadFileError> {
+) -> Result<aws_sdk_s3::operation::get_object::GetObjectOutput, S3AttemptError<DownloadFileError>> {
     match s3_client
         .get_object()
         .bucket(stage_info.bucket.clone())
@@ -303,14 +379,16 @@ async fn do_get_object(
         .send()
         .await
     {
-        Ok(out) => Ok(S3Outcome::Ok(Box::new(out))),
+        Ok(out) => Ok(out),
         Err(sdk_err) => {
             let aws_err = aws_sdk_s3::Error::from(sdk_err);
             if is_expired_token_error(&aws_err) {
                 tracing::warn!("S3 download failed with ExpiredToken");
-                Ok(S3Outcome::StsExpired(aws_err))
+                Err(S3AttemptError::StsExpired(aws_err))
             } else {
-                Err(aws_err).context(download_file_error::S3DownloadSnafu)
+                Err(S3AttemptError::Other(
+                    download_file_error::S3DownloadSnafu.into_error(aws_err),
+                ))
             }
         }
     }
@@ -800,39 +878,39 @@ mod tests {
         }
     }
 
+    // --- aws_key_id helper used by the adapter's rotation check ---
+    //
+    // The adapter compares AWS key ids before/after refresh: a different
+    // key id implies a fresh STS rotation from GS, the same key id means
+    // we're inside the refresher's coalescing window and retrying would
+    // loop. Non-S3 variants intentionally return None so the comparison
+    // never deadlocks the retry on Gcs/Azure stages.
+
     #[test]
-    fn creds_unchanged_returns_true_when_aws_key_id_matches() {
-        assert!(creds_unchanged(&s3_creds("AKIA1"), &s3_creds("AKIA1")));
+    fn aws_key_id_returns_some_for_s3_creds() {
+        assert_eq!(aws_key_id(&s3_creds("AKIA1")), Some("AKIA1"));
     }
 
     #[test]
-    fn creds_unchanged_returns_false_when_aws_key_id_differs() {
-        assert!(!creds_unchanged(&s3_creds("AKIA1"), &s3_creds("AKIA2")));
-    }
-
-    #[test]
-    fn creds_unchanged_returns_false_for_non_s3_variants() {
-        // GCS/Azure can't expire mid-S3-transfer, so the comparison is
-        // S3-only by construction. Other variants always report "changed"
-        // so the retry loop never gets stuck on them.
+    fn aws_key_id_returns_none_for_non_s3_variants() {
         let gcs = CloudCredentials::Gcs {
             gcs_access_token: Some("g".to_string().into()),
         };
         let azure = CloudCredentials::Azure {
             sas_token: "a".to_string().into(),
         };
-        assert!(!creds_unchanged(&gcs, &gcs));
-        assert!(!creds_unchanged(&azure, &azure));
-        assert!(!creds_unchanged(&gcs, &azure));
+        assert_eq!(aws_key_id(&gcs), None);
+        assert_eq!(aws_key_id(&azure), None);
     }
 
-    // --- try_refresh_creds drives the refresher correctly ---
+    // --- StageCredsAdapter::refresh ---
     //
-    // A fake StageCredsRefresher records call counts and exposes a
-    // mutable cache so tests can simulate "refresh rotated the creds"
-    // vs "refresh coalesced and returned the same creds".
+    // A fake StageCredsRefresher records call counts and exposes a mutable
+    // cache so tests can simulate "refresh rotated the creds" vs "refresh
+    // coalesced and returned the same creds".
 
     use super::super::types::{StageCredsCache, StageCredsRefreshError};
+    use crate::refresh::Refresher;
     use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
 
     struct FakeRefresher {
@@ -863,8 +941,6 @@ mod tests {
             if let Some(c) = next {
                 self.cache.store(c);
             }
-            // No-op rotation when not armed: the cache keeps the same creds,
-            // so try_refresh_creds will see "unchanged" and return Ok(false).
             Box::pin(async { Ok::<(), StageCredsRefreshError>(()) })
         }
 
@@ -873,61 +949,64 @@ mod tests {
         }
     }
 
-    fn stage_info_with(creds: CloudCredentials) -> StageInfo {
-        StageInfo {
-            location_type: super::super::types::LocationType::S3,
-            bucket: "bucket".into(),
-            key_prefix: "prefix/".into(),
-            region: "us-east-1".into(),
-            creds,
-            endpoint: None,
-            presigned_url: None,
-            use_virtual_url: false,
-            use_regional_url: false,
-            use_s3_regional_url: false,
-            storage_account: None,
-        }
+    /// Identity wrap_refresh_err keeps the StageCredsRefreshError as-is
+    /// for tests that don't care about translation.
+    fn passthrough_wrap(e: StageCredsRefreshError) -> StageCredsRefreshError {
+        e
     }
 
     #[tokio::test]
-    async fn try_refresh_creds_returns_false_without_refresher() {
-        let mut none: Option<&mut dyn StageCredsRefresher> = None;
-        let mut info = stage_info_with(s3_creds("AKIA1"));
-        let rotated = try_refresh_creds(&mut none, &mut info).await.unwrap();
-        assert!(!rotated, "no refresher → no rotation");
-    }
-
-    #[tokio::test]
-    async fn try_refresh_creds_returns_true_when_creds_rotate() {
+    async fn adapter_refresh_returns_true_when_creds_rotate() {
         let mut fake = FakeRefresher::new(s3_creds("AKIA1"));
         fake.arm(s3_creds("AKIA2"));
-        let mut info = stage_info_with(s3_creds("AKIA1"));
+        let initial = s3_creds("AKIA1");
+        let mut adapter = StageCredsAdapter::new(&mut fake, &initial, passthrough_wrap);
 
-        let mut handle: Option<&mut dyn StageCredsRefresher> = Some(&mut fake);
-        let rotated = try_refresh_creds(&mut handle, &mut info).await.unwrap();
+        let rotated = adapter.refresh().await.unwrap();
 
         assert!(rotated);
         assert_eq!(fake.refresh_calls.load(AtomicOrdering::SeqCst), 1);
-        // The caller's stage_info now holds the rotated key.
-        match &info.creds {
-            CloudCredentials::S3 { aws_key_id, .. } => assert_eq!(aws_key_id, "AKIA2"),
-            _ => panic!("expected S3 creds"),
-        }
+        assert_eq!(
+            aws_key_id(&fake.cache().snapshot()),
+            Some("AKIA2"),
+            "cache holds rotated creds"
+        );
     }
 
     #[tokio::test]
-    async fn try_refresh_creds_returns_false_when_refresher_coalesces() {
-        // Refresher leaves the cache untouched (simulating a hit inside its
-        // coalescing window). try_refresh_creds must report Ok(false) so the
-        // caller propagates the original AWS error rather than spinning.
+    async fn adapter_refresh_returns_false_when_creds_unchanged() {
+        // FakeRefresher with no `arm()` leaves the cache holding the
+        // initial creds — simulating a hit inside the refresher's
+        // coalescing window. The adapter must report Ok(false) so the
+        // generic helper propagates the original error rather than
+        // spinning.
         let mut fake = FakeRefresher::new(s3_creds("AKIA1"));
-        // Not armed → refresh() is a no-op, cache still holds AKIA1.
-        let mut info = stage_info_with(s3_creds("AKIA1"));
+        let initial = s3_creds("AKIA1");
+        let mut adapter = StageCredsAdapter::new(&mut fake, &initial, passthrough_wrap);
 
-        let mut handle: Option<&mut dyn StageCredsRefresher> = Some(&mut fake);
-        let rotated = try_refresh_creds(&mut handle, &mut info).await.unwrap();
+        let rotated = adapter.refresh().await.unwrap();
 
-        assert!(!rotated, "unchanged creds → caller should propagate");
+        assert!(
+            !rotated,
+            "unchanged creds → adapter declines further rotations"
+        );
         assert_eq!(fake.refresh_calls.load(AtomicOrdering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn adapter_refresh_tracks_last_seen_key_across_rotations() {
+        // After a successful rotation, last_seen_key is updated. A
+        // subsequent unchanged refresh against the new key should still
+        // report Ok(false) — confirming the marker followed the rotation.
+        let mut fake = FakeRefresher::new(s3_creds("AKIA1"));
+        fake.arm(s3_creds("AKIA2"));
+        let initial = s3_creds("AKIA1");
+        let mut adapter = StageCredsAdapter::new(&mut fake, &initial, passthrough_wrap);
+
+        assert!(adapter.refresh().await.unwrap()); // AKIA1 -> AKIA2
+        // Cache still holds AKIA2; arming nothing means refresh() leaves
+        // it as-is. Adapter must see "no rotation" against AKIA2 (not
+        // AKIA1).
+        assert!(!adapter.refresh().await.unwrap());
     }
 }

--- a/sf_core/src/file_manager/s3_transfer.rs
+++ b/sf_core/src/file_manager/s3_transfer.rs
@@ -103,10 +103,11 @@ enum S3AttemptError<E> {
 /// `StageCredsRefresher`'s shared cache and asking it to rotate when the
 /// AWS SDK reports `ExpiredToken`.
 ///
-/// `wrap_refresh_err` translates a `StageCredsRefreshError` from the
-/// refresher into the operation's `E` — this avoids a blanket
+/// `map_refresh_err` keeps snafu's source-location stamping at the call
+/// site: each operation translates `StageCredsRefreshError` into its own
+/// error variant locally rather than via a blanket
 /// `From<StageCredsRefreshError>` impl on `UploadFileError` /
-/// `DownloadFileError`, which would skip snafu's source-location stamping.
+/// `DownloadFileError`, which would lose location info.
 ///
 /// Tracks the last AWS key id handed out so a refresh that doesn't
 /// actually rotate (refresher inside its coalescing window) reports
@@ -115,7 +116,7 @@ enum S3AttemptError<E> {
 struct S3StsRefresher<'a, E, W> {
     refresher: &'a mut dyn StageCredsRefresher,
     last_seen_key: Option<String>,
-    wrap_refresh_err: W,
+    map_refresh_err: W,
     _marker: PhantomData<fn() -> E>,
 }
 
@@ -126,12 +127,12 @@ where
     fn new(
         refresher: &'a mut dyn StageCredsRefresher,
         initial: &CloudCredentials,
-        wrap_refresh_err: W,
+        map_refresh_err: W,
     ) -> Self {
         Self {
             refresher,
             last_seen_key: aws_key_id(initial).map(str::to_string),
-            wrap_refresh_err,
+            map_refresh_err,
             _marker: PhantomData,
         }
     }
@@ -159,7 +160,7 @@ where
             self.refresher
                 .refresh()
                 .await
-                .map_err(|e| S3AttemptError::Other((self.wrap_refresh_err)(e)))?;
+                .map_err(|e| S3AttemptError::Other((self.map_refresh_err)(e)))?;
             let new = self.refresher.cache().snapshot();
             let new_key = aws_key_id(&new).map(str::to_string);
             if new_key == self.last_seen_key {
@@ -173,22 +174,20 @@ where
     }
 }
 
-/// Runs `attempt` with the supplied credentials, driving STS refresh on
-/// `S3AttemptError::StsExpired` when a `refresher` is provided. With no
-/// refresher, runs the attempt once and folds any `StsExpired` back into
-/// the caller-supplied AWS error path — same shape as any other S3
-/// PUT/GET error.
+/// Runs `attempt` once (no refresher) or in a refresh-retry loop (with
+/// refresher), folding `S3AttemptError<E>` back to `E` at the boundary so
+/// callers see a uniform error type. With no refresher, an `StsExpired`
+/// outcome surfaces as the caller-supplied AWS error path — same shape as
+/// any other S3 PUT/GET error.
 ///
-/// Owns the refresher-vs-no-refresher branching that was previously
-/// duplicated by both upload and download. `wrap_refresh_err` /
-/// `wrap_sts_err` keep the call sites' snafu instrumentation at the
-/// boundary so source locations land on the operation's own error variants
-/// rather than on this helper.
+/// `map_refresh_err` / `map_sts_err` keep the call sites' snafu
+/// instrumentation at the boundary so source locations land on the
+/// operation's own error variants rather than on this helper.
 async fn run_s3_with_sts_refresh<F, Fut, T, E>(
     refresher: &mut Option<&mut dyn StageCredsRefresher>,
     initial_creds: &CloudCredentials,
-    wrap_refresh_err: impl Fn(StageCredsRefreshError) -> E + Send,
-    wrap_sts_err: impl FnOnce(aws_sdk_s3::Error) -> E,
+    map_refresh_err: impl Fn(StageCredsRefreshError) -> E + Send,
+    map_sts_err: impl FnOnce(aws_sdk_s3::Error) -> E,
     attempt: F,
 ) -> Result<T, E>
 where
@@ -198,14 +197,14 @@ where
 {
     let outcome = match refresher.as_deref_mut() {
         Some(r) => {
-            let mut sts = S3StsRefresher::new(r, initial_creds, wrap_refresh_err);
-            execute_with_refresh(&mut sts, attempt).await
+            let mut sts_refresher = S3StsRefresher::new(r, initial_creds, map_refresh_err);
+            execute_with_refresh(&mut sts_refresher, attempt).await
         }
         None => attempt(initial_creds.clone()).await,
     };
     outcome.map_err(|e| match e {
         S3AttemptError::Other(err) => err,
-        S3AttemptError::StsExpired(aws_err) => wrap_sts_err(aws_err),
+        S3AttemptError::StsExpired(aws_err) => map_sts_err(aws_err),
     })
 }
 
@@ -975,9 +974,9 @@ mod tests {
         }
     }
 
-    /// Identity wrap_refresh_err keeps the StageCredsRefreshError as-is
-    /// for tests that don't care about translation.
-    fn passthrough_wrap(e: StageCredsRefreshError) -> StageCredsRefreshError {
+    /// Identity `map_refresh_err` for tests that don't care about error
+    /// translation — keeps the `StageCredsRefreshError` as-is.
+    fn identity_map(e: StageCredsRefreshError) -> StageCredsRefreshError {
         e
     }
 
@@ -986,9 +985,9 @@ mod tests {
         let mut fake = FakeRefresher::new(s3_creds("AKIA1"));
         fake.arm(s3_creds("AKIA2"));
         let initial = s3_creds("AKIA1");
-        let mut sts = S3StsRefresher::new(&mut fake, &initial, passthrough_wrap);
+        let mut sts_refresher = S3StsRefresher::new(&mut fake, &initial, identity_map);
 
-        let rotated = sts.refresh().await.unwrap();
+        let rotated = sts_refresher.refresh().await.unwrap();
 
         assert!(rotated);
         assert_eq!(fake.refresh_calls.load(AtomicOrdering::SeqCst), 1);
@@ -1008,9 +1007,9 @@ mod tests {
         // spinning.
         let mut fake = FakeRefresher::new(s3_creds("AKIA1"));
         let initial = s3_creds("AKIA1");
-        let mut sts = S3StsRefresher::new(&mut fake, &initial, passthrough_wrap);
+        let mut sts_refresher = S3StsRefresher::new(&mut fake, &initial, identity_map);
 
-        let rotated = sts.refresh().await.unwrap();
+        let rotated = sts_refresher.refresh().await.unwrap();
 
         assert!(
             !rotated,
@@ -1027,12 +1026,12 @@ mod tests {
         let mut fake = FakeRefresher::new(s3_creds("AKIA1"));
         fake.arm(s3_creds("AKIA2"));
         let initial = s3_creds("AKIA1");
-        let mut sts = S3StsRefresher::new(&mut fake, &initial, passthrough_wrap);
+        let mut sts_refresher = S3StsRefresher::new(&mut fake, &initial, identity_map);
 
-        assert!(sts.refresh().await.unwrap()); // AKIA1 -> AKIA2
+        assert!(sts_refresher.refresh().await.unwrap()); // AKIA1 -> AKIA2
         // Cache still holds AKIA2; arming nothing means refresh() leaves
         // it as-is. S3StsRefresher must see "no rotation" against AKIA2
         // (not AKIA1).
-        assert!(!sts.refresh().await.unwrap());
+        assert!(!sts_refresher.refresh().await.unwrap());
     }
 }

--- a/sf_core/src/lib.rs
+++ b/sf_core/src/lib.rs
@@ -19,6 +19,7 @@ pub mod http;
 pub mod logging;
 pub mod perf_timing;
 pub mod query_types;
+pub mod refresh;
 pub mod rest;
 pub mod sensitive;
 pub mod telemetry;

--- a/sf_core/src/refresh.rs
+++ b/sf_core/src/refresh.rs
@@ -1,16 +1,15 @@
-//! Generic refresh-and-retry pattern shared by the session-token and S3 STS
-//! credential paths.
+//! Generic refresh-and-retry pattern for refreshable resources (auth tokens,
+//! cloud-stage credentials, etc.).
 //!
-//! Both paths follow the same shape:
+//! Consumers follow the same shape:
 //!
-//! 1. read the current resource (token / credentials),
+//! 1. read the current resource,
 //! 2. run an operation that consumes it,
 //! 3. on a recoverable error, rotate the resource and retry.
 //!
-//! The differences live entirely in the `Refresher` impl: which error is
-//! recoverable, where the resource lives, whether to coalesce rapid-fire
-//! refreshes (session: one-shot state machine; STS: 10-minute wall-clock
-//! window). The loop itself is shared.
+//! What varies per consumer — which error is recoverable, where the resource
+//! is cached, how rapid-fire refreshes are coalesced — lives entirely in the
+//! `Refresher` impl. The loop itself is shared.
 //!
 //! # Termination
 //!

--- a/sf_core/src/refresh.rs
+++ b/sf_core/src/refresh.rs
@@ -1,0 +1,212 @@
+//! Generic refresh-and-retry pattern shared by the session-token and S3 STS
+//! credential paths.
+//!
+//! Both paths follow the same shape:
+//!
+//! 1. read the current resource (token / credentials),
+//! 2. run an operation that consumes it,
+//! 3. on a recoverable error, rotate the resource and retry.
+//!
+//! The differences live entirely in the `Refresher` impl: which error is
+//! recoverable, where the resource lives, whether to coalesce rapid-fire
+//! refreshes (session: one-shot state machine; STS: 10-minute wall-clock
+//! window). The loop itself is shared.
+//!
+//! # Termination
+//!
+//! `execute_with_refresh` retries at most as many times as the refresher
+//! agrees to rotate. A refresher that returns `Ok(false)` from `refresh`
+//! (meaning "I won't rotate again — recent refresh still considered valid,
+//! or I've exhausted my retries") forces the loop to propagate the original
+//! error. Callers that want a stricter cap can encode it inside `refresh`.
+//!
+//! # Object safety
+//!
+//! The trait carries `Resource` and `Err` as type parameters (rather than
+//! associated types) so that `dyn Refresher<Resource, Err>` works for paths
+//! that need to thread a refresher through a heterogeneous call stack (the
+//! S3 file-transfer path does this).
+
+use std::future::Future;
+use std::pin::Pin;
+
+/// A future returned by `Refresher` methods. Boxed so the trait is dyn-safe.
+pub type RefreshFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+/// Owns a refreshable resource and rotates it on demand.
+///
+/// `Resource` is what the operation consumes per attempt — the implementation
+/// chooses between handing out a clone of a cached value or fetching freshly
+/// each call. `Err` is the error type the operation returns; `should_refresh`
+/// inspects it to decide whether a retry is warranted.
+pub trait Refresher<Resource, Err>: Send
+where
+    Resource: Send,
+    Err: Send,
+{
+    /// Read the current resource for the next attempt. Called once per
+    /// iteration of `execute_with_refresh`.
+    fn current(&mut self) -> RefreshFuture<'_, Result<Resource, Err>>;
+
+    /// Whether `err` is the recoverable kind that warrants a refresh +
+    /// retry. Non-recoverable errors propagate up immediately.
+    fn should_refresh(&self, err: &Err) -> bool;
+
+    /// Rotate the resource. Returns:
+    ///
+    /// - `Ok(true)` — rotation happened; the next `current()` will return a
+    ///   fresh value and the helper will retry.
+    /// - `Ok(false)` — the refresher coalesced or has exhausted its retry
+    ///   budget. The helper propagates the original error.
+    /// - `Err(e)` — the refresh itself failed; this is terminal.
+    fn refresh(&mut self) -> RefreshFuture<'_, Result<bool, Err>>;
+}
+
+/// Run `op` against `refresher`'s resource, refreshing once on recoverable
+/// errors. Loops until either `op` succeeds, the error is non-recoverable,
+/// or the refresher declines to rotate again.
+pub async fn execute_with_refresh<R, Resource, Err, Op, Fut, T>(
+    refresher: &mut R,
+    op: Op,
+) -> Result<T, Err>
+where
+    R: Refresher<Resource, Err> + ?Sized,
+    Resource: Send,
+    Err: Send,
+    Op: Fn(Resource) -> Fut,
+    Fut: Future<Output = Result<T, Err>>,
+{
+    loop {
+        let resource = refresher.current().await?;
+        let err = match op(resource).await {
+            Ok(value) => return Ok(value),
+            Err(e) => e,
+        };
+        if !refresher.should_refresh(&err) {
+            return Err(err);
+        }
+        if !refresher.refresh().await? {
+            // Refresher declined to rotate (coalescing window, exhausted
+            // budget). Retrying without a fresh resource would loop, so
+            // propagate the original error.
+            return Err(err);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    #[derive(Debug, PartialEq)]
+    enum TestErr {
+        Recoverable,
+        Fatal,
+    }
+
+    /// A minimal refresher used by the unit tests below. Holds a single
+    /// integer resource that increments each time `refresh` rotates.
+    struct CountingRefresher {
+        value: i32,
+        refresh_calls: i32,
+        max_refreshes: i32,
+        recoverable_errors: bool,
+    }
+
+    impl CountingRefresher {
+        fn new(max_refreshes: i32) -> Self {
+            Self {
+                value: 0,
+                refresh_calls: 0,
+                max_refreshes,
+                recoverable_errors: true,
+            }
+        }
+    }
+
+    impl Refresher<i32, TestErr> for CountingRefresher {
+        fn current(&mut self) -> RefreshFuture<'_, Result<i32, TestErr>> {
+            let v = self.value;
+            Box::pin(async move { Ok(v) })
+        }
+
+        fn should_refresh(&self, err: &TestErr) -> bool {
+            self.recoverable_errors && matches!(err, TestErr::Recoverable)
+        }
+
+        fn refresh(&mut self) -> RefreshFuture<'_, Result<bool, TestErr>> {
+            Box::pin(async move {
+                if self.refresh_calls >= self.max_refreshes {
+                    return Ok(false);
+                }
+                self.refresh_calls += 1;
+                self.value += 1;
+                Ok(true)
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn returns_first_success_without_refresh() {
+        let mut r = CountingRefresher::new(1);
+        let calls = Mutex::new(0);
+        let result: Result<i32, TestErr> = execute_with_refresh(&mut r, |v| {
+            *calls.lock().unwrap() += 1;
+            async move { Ok(v + 100) }
+        })
+        .await;
+        assert_eq!(result.unwrap(), 100);
+        assert_eq!(*calls.lock().unwrap(), 1);
+        assert_eq!(r.refresh_calls, 0);
+    }
+
+    #[tokio::test]
+    async fn refreshes_once_then_succeeds() {
+        let mut r = CountingRefresher::new(1);
+        let calls = Mutex::new(0);
+        let result: Result<i32, TestErr> = execute_with_refresh(&mut r, |v| {
+            let n = {
+                let mut g = calls.lock().unwrap();
+                *g += 1;
+                *g
+            };
+            async move {
+                if n == 1 {
+                    Err(TestErr::Recoverable)
+                } else {
+                    Ok(v + 100)
+                }
+            }
+        })
+        .await;
+        assert_eq!(result.unwrap(), 101); // resource was rotated to 1
+        assert_eq!(*calls.lock().unwrap(), 2);
+        assert_eq!(r.refresh_calls, 1);
+    }
+
+    #[tokio::test]
+    async fn propagates_when_refresher_declines_second_rotation() {
+        let mut r = CountingRefresher::new(1); // only one refresh allowed
+        let calls = Mutex::new(0);
+        let result: Result<i32, TestErr> = execute_with_refresh(&mut r, |_v| {
+            *calls.lock().unwrap() += 1;
+            async { Err(TestErr::Recoverable) }
+        })
+        .await;
+        assert_eq!(result.unwrap_err(), TestErr::Recoverable);
+        // First op fails → refresh #1 → retry op fails → refresh attempt #2
+        // returns Ok(false) → propagate.
+        assert_eq!(*calls.lock().unwrap(), 2);
+        assert_eq!(r.refresh_calls, 1);
+    }
+
+    #[tokio::test]
+    async fn propagates_non_recoverable_error_without_refresh() {
+        let mut r = CountingRefresher::new(5);
+        let result: Result<i32, TestErr> =
+            execute_with_refresh(&mut r, |_v| async { Err(TestErr::Fatal) }).await;
+        assert_eq!(result.unwrap_err(), TestErr::Fatal);
+        assert_eq!(r.refresh_calls, 0);
+    }
+}

--- a/sf_core/src/refresh.rs
+++ b/sf_core/src/refresh.rs
@@ -8,15 +8,16 @@
 //! 3. on a recoverable error, rotate the resource and retry.
 //!
 //! What varies per consumer — which error is recoverable, where the resource
-//! is cached, how rapid-fire refreshes are coalesced — lives entirely in the
+//! is cached, how rapid-fire refreshes are *coalesced* (collapsed into one
+//! upstream call when they arrive close together) — lives entirely in the
 //! `Refresher` impl. The loop itself is shared.
 //!
 //! # Termination
 //!
 //! `execute_with_refresh` retries at most as many times as the refresher
-//! agrees to rotate. A refresher that returns `Ok(false)` from `refresh`
-//! (meaning "I won't rotate again — recent refresh still considered valid,
-//! or I've exhausted my retries") forces the loop to propagate the original
+//! agrees to rotate. A refresher returns `Ok(false)` from `refresh` when it
+//! declines further rotation (e.g. recent refresh still considered valid, or
+//! retry budget exhausted), and the helper then propagates the original
 //! error. Callers that want a stricter cap can encode it inside `refresh`.
 //!
 //! # Object safety
@@ -61,12 +62,12 @@ where
     fn refresh(&mut self) -> RefreshFuture<'_, Result<bool, Err>>;
 }
 
-/// Run `op` against `refresher`'s resource, refreshing once on recoverable
-/// errors. Loops until either `op` succeeds, the error is non-recoverable,
-/// or the refresher declines to rotate again.
+/// Run `operation` against `refresher`'s resource, refreshing once on
+/// recoverable errors. Loops until either `operation` succeeds, the error
+/// is non-recoverable, or the refresher declines to rotate again.
 pub async fn execute_with_refresh<R, Resource, Err, Op, Fut, T>(
     refresher: &mut R,
-    op: Op,
+    operation: Op,
 ) -> Result<T, Err>
 where
     R: Refresher<Resource, Err> + ?Sized,
@@ -77,7 +78,7 @@ where
 {
     loop {
         let resource = refresher.current().await?;
-        let err = match op(resource).await {
+        let err = match operation(resource).await {
             Ok(value) => return Ok(value),
             Err(e) => e,
         };
@@ -85,9 +86,9 @@ where
             return Err(err);
         }
         if !refresher.refresh().await? {
-            // Refresher declined to rotate (coalescing window, exhausted
-            // budget). Retrying without a fresh resource would loop, so
-            // propagate the original error.
+            // Retrying without a fresh resource would loop, so propagate.
+            // Refresher declined to rotate: coalescing window or exhausted
+            // budget.
             return Err(err);
         }
     }


### PR DESCRIPTION
## Summary

Extract the shared shape of the two refresh-and-retry loops in the codebase
(`RefreshContext::execute_with_refresh` for session tokens; the per-attempt
S3 loops in `s3_transfer.rs` for STS credentials) into a new
`sf_core::refresh` module. Both existing implementations now live behind a
single generic helper.

Stacked on **#1166** because that PR's STS work was the second concrete
data point that motivated this refactor — see boler's review note there.
Doing the abstraction now (with two real implementations to extract from)
rather than before #1166 (with only one) means the API actually fits both
cases.

## Shape

* **`refresh.rs`** — new top-level module:
  * `Refresher<Resource, Err>` trait. `current()` reads the resource for
    the next attempt; `should_refresh(&Err) -> bool` decides which errors
    are recoverable; `refresh() -> Ok(bool)` rotates the resource and
    returns whether anything actually changed.
  * `execute_with_refresh<R, ...>(refresher, op)` — the shared loop. On
    error, calls `should_refresh`; if recoverable, calls `refresh()` —
    `Ok(true)` retries, `Ok(false)` propagates. Termination is
    refresher-driven, so coalescing-window and one-shot state machines
    both fit naturally.
  * Type parameters (not associated types) so `dyn Refresher<R, E>` is
    object-safe. The S3 file-transfer path needs that.

* **`RefreshContext`** (session) — now impls `Refresher<SensitiveString,
  ApiError>`. The existing `RefreshState` state machine maps directly
  onto the `Ok(bool)` return: first refresh returns `Ok(true)` and
  flips to `Refreshed`; second returns `Ok(false)`. Public method
  signatures unchanged; the imperative loop body is replaced with
  a call to `refresh::execute_with_refresh`.

* **STS path** — `s3_transfer` introduces `StageCredsAdapter<'a, E>`,
  a thin bridge from the file-manager-facing `StageCredsRefresher`
  trait (with its shared `StageCredsCache`) to `Refresher<CloudCredentials,
  S3AttemptError<E>>`. The adapter tracks the AWS key id it last handed
  out, so a refresh inside the 10-minute coalescing window reports
  `Ok(false)` and the helper propagates rather than spinning.
  `S3AttemptError<E>` keeps `StsExpired` an internal-only signal —
  `UploadFileError` / `DownloadFileError` still carry no refresh-
  internal variants.

## What didn't fit cleanly

* **No-refresher path.** When the file-transfer caller passes
  `refresher: None`, there's nothing to coalesce or retry on — we just
  do one attempt and propagate. Forcing that through the generic
  helper would require either a no-op refresher impl or an
  `unreachable!` in `current()`. Cleaner to dispatch on the `Option`
  up-front: `Some(_)` goes through the helper, `None` does a single
  call. Two lines on each call site, zero conceptual cost.

* **Session-token error mapping.** `RefreshContext::execute_with_refresh`
  takes a closure that returns `RestError` but the public method
  returns `ApiError` (the existing signature). The wrapper closure
  converts in flight: `f(token).await.map_err(|e| QuerySnafu.into_error(e))`.
  Once that conversion happens up-front, `should_refresh` inspects an
  `ApiError::Query{source: RestError::InvalidSnowflakeResponse{SessionExpired}}`
  pattern. A bit nested but it's matching the existing error shape.

## Test plan

- [x] `cargo fmt && cargo clippy -p sf_core --all-targets -- -D warnings` — clean
- [x] `cargo test -p sf_core --lib` — 804 passed (4 new tests in `refresh::tests`:
      first-success, refresh-then-succeed, refresher-declines, non-recoverable-error)
- [x] `cargo test -p sf_core --test integration_tests put_get` — passes
- [x] No behavior change for existing call sites of either refresh path

## Follow-ups

This PR doesn't touch the lower-level `refresh_token(last_error)` API or
its 5 external call sites (heartbeat, statement, result_set,
connection). They predate `execute_with_refresh` and have their own
loops that need the imperative form. Could be migrated in a future PR
once the generic helper grows a public lower-level entry point if
needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)