### PR TITLE
SNOW-3406388, gap 9: honor useS3RegionalUrl / useRegionalUrl from stage info

### DIFF
--- a/sf_core/src/file_manager/azure_transfer.rs
+++ b/sf_core/src/file_manager/azure_transfer.rs
@@ -562,6 +562,7 @@ mod tests {
             presigned_url: None,
             use_virtual_url: false,
             use_regional_url: false,
+            use_s3_regional_url: false,
             storage_account: overrides
                 .storage_account
                 .or(Some("mystorageaccount".to_string())),

--- a/sf_core/src/file_manager/azure_transfer.rs
+++ b/sf_core/src/file_manager/azure_transfer.rs
@@ -269,7 +269,7 @@ fn resolve_url_and_token<'a>(
 
 /// Builds the Azure Blob Storage URL for a given object key.
 ///
-/// When `end_point` contains a URL scheme (`http://` or `https://`), it is used directly
+/// When `endpoint` contains a URL scheme (`http://` or `https://`), it is used directly
 /// as the base URL. This supports Azure-compatible local emulators (e.g. Azurite) and
 /// testing with mock servers. Otherwise, the standard Azure URL pattern
 /// `https://{storageAccount}.blob.{endpoint}/{container}/{key}` is used.
@@ -277,7 +277,7 @@ fn build_azure_url(stage_info: &StageInfo, key: &str) -> Result<String, AzureReq
     let encoded_key = percent_encode_path(key);
 
     // If endpoint contains a scheme, use it directly (e.g. Azurite or test servers).
-    if let Some(ref ep) = stage_info.end_point
+    if let Some(ref ep) = stage_info.endpoint
         && (ep.starts_with("http://") || ep.starts_with("https://"))
     {
         return Ok(format!("{ep}/{}/{encoded_key}", stage_info.bucket));
@@ -293,7 +293,7 @@ fn build_azure_url(stage_info: &StageInfo, key: &str) -> Result<String, AzureReq
         })?;
 
     let raw_endpoint = stage_info
-        .end_point
+        .endpoint
         .as_deref()
         .unwrap_or("blob.core.windows.net");
 
@@ -558,7 +558,7 @@ mod tests {
             creds: overrides.creds.unwrap_or(CloudCredentials::Azure {
                 sas_token: SensitiveString::from("fake-sas-token"),
             }),
-            end_point: overrides.end_point,
+            endpoint: overrides.endpoint,
             presigned_url: None,
             use_virtual_url: false,
             use_regional_url: false,
@@ -575,7 +575,7 @@ mod tests {
         key_prefix: Option<String>,
         region: Option<String>,
         creds: Option<CloudCredentials>,
-        end_point: Option<String>,
+        endpoint: Option<String>,
         storage_account: Option<String>,
     }
 
@@ -596,7 +596,7 @@ mod tests {
     #[test]
     fn url_custom_endpoint_with_blob_prefix() {
         let stage = make_stage_info(StageInfoOverrides {
-            end_point: Some("blob.core.usgovcloudapi.net".to_string()),
+            endpoint: Some("blob.core.usgovcloudapi.net".to_string()),
             ..Default::default()
         });
         let url = build_azure_url(&stage, "prefix/file.csv.gz").unwrap();
@@ -609,7 +609,7 @@ mod tests {
     #[test]
     fn url_custom_endpoint_without_blob_prefix() {
         let stage = make_stage_info(StageInfoOverrides {
-            end_point: Some("core.chinacloudapi.cn".to_string()),
+            endpoint: Some("core.chinacloudapi.cn".to_string()),
             ..Default::default()
         });
         let url = build_azure_url(&stage, "prefix/file.csv.gz").unwrap();
@@ -622,7 +622,7 @@ mod tests {
     #[test]
     fn url_endpoint_without_trailing_slash() {
         let stage = make_stage_info(StageInfoOverrides {
-            end_point: Some("core.windows.net".to_string()),
+            endpoint: Some("core.windows.net".to_string()),
             ..Default::default()
         });
         let url = build_azure_url(&stage, "prefix/file.csv.gz").unwrap();
@@ -777,7 +777,7 @@ mod tests {
     #[test]
     fn url_endpoint_with_scheme_is_used_directly() {
         let stage = make_stage_info(StageInfoOverrides {
-            end_point: Some("http://127.0.0.1:10000".to_string()),
+            endpoint: Some("http://127.0.0.1:10000".to_string()),
             ..Default::default()
         });
         let url = build_azure_url(&stage, "prefix/file.csv.gz").unwrap();
@@ -790,7 +790,7 @@ mod tests {
     #[test]
     fn url_endpoint_with_https_scheme_is_used_directly() {
         let stage = make_stage_info(StageInfoOverrides {
-            end_point: Some("https://azurite.local:10000".to_string()),
+            endpoint: Some("https://azurite.local:10000".to_string()),
             ..Default::default()
         });
         let url = build_azure_url(&stage, "prefix/file.csv.gz").unwrap();

--- a/sf_core/src/file_manager/gcs_transfer.rs
+++ b/sf_core/src/file_manager/gcs_transfer.rs
@@ -556,6 +556,7 @@ mod tests {
             presigned_url: overrides.presigned_url,
             use_virtual_url: overrides.use_virtual_url,
             use_regional_url: overrides.use_regional_url,
+            use_s3_regional_url: false,
             storage_account: None,
         }
     }

--- a/sf_core/src/file_manager/gcs_transfer.rs
+++ b/sf_core/src/file_manager/gcs_transfer.rs
@@ -280,7 +280,7 @@ fn create_gcs_client() -> Result<reqwest::Client, GcsRequestError> {
 ///
 /// URL strategy priority (matching JDBC/ODBC/Python):
 /// 1. Presigned URL — use directly, no token
-/// 2. Custom endpoint — `https://{end_point}/{bucket}/{key}`
+/// 2. Custom endpoint — `https://{endpoint}/{bucket}/{key}`
 /// 3. Virtual host — `https://{bucket}.storage.googleapis.com/{key}`
 /// 4. Regional — `https://storage.{region}.rep.googleapis.com/{bucket}/{key}`
 /// 5. Default — `https://storage.googleapis.com/{bucket}/{key}`
@@ -314,7 +314,7 @@ fn build_gcs_url(stage_info: &StageInfo, key: &str) -> String {
     let encoded_key = percent_encode_path(key);
 
     // Strategy 2: custom endpoint
-    if let Some(ref ep) = stage_info.end_point
+    if let Some(ref ep) = stage_info.endpoint
         && !ep.is_empty()
     {
         let base = if ep.starts_with("https://") || ep.starts_with("http://") {
@@ -552,7 +552,7 @@ mod tests {
             creds: overrides.creds.unwrap_or(CloudCredentials::Gcs {
                 gcs_access_token: Some(SensitiveString::from("fake-token")),
             }),
-            end_point: overrides.end_point,
+            endpoint: overrides.endpoint,
             presigned_url: overrides.presigned_url,
             use_virtual_url: overrides.use_virtual_url,
             use_regional_url: overrides.use_regional_url,
@@ -567,7 +567,7 @@ mod tests {
         key_prefix: Option<String>,
         region: Option<String>,
         creds: Option<CloudCredentials>,
-        end_point: Option<String>,
+        endpoint: Option<String>,
         presigned_url: Option<String>,
         use_virtual_url: bool,
         use_regional_url: bool,
@@ -588,7 +588,7 @@ mod tests {
     fn url_custom_endpoint() {
         // Matches ODBC test_gcs_override_endpoint
         let stage = make_stage_info(StageInfoOverrides {
-            end_point: Some("testendpoint.googleapis.com".to_string()),
+            endpoint: Some("testendpoint.googleapis.com".to_string()),
             ..Default::default()
         });
         let url = build_gcs_url(&stage, "file.csv.gz");
@@ -601,7 +601,7 @@ mod tests {
     #[test]
     fn url_custom_endpoint_with_scheme() {
         let stage = make_stage_info(StageInfoOverrides {
-            end_point: Some("https://custom.example.com".to_string()),
+            endpoint: Some("https://custom.example.com".to_string()),
             ..Default::default()
         });
         let url = build_gcs_url(&stage, "file.csv.gz");
@@ -655,7 +655,7 @@ mod tests {
     fn url_custom_endpoint_takes_precedence() {
         // Matches ODBC test_gcs_all_endpoint_fields_enabled
         let stage = make_stage_info(StageInfoOverrides {
-            end_point: Some("testendpoint.googleapis.com".to_string()),
+            endpoint: Some("testendpoint.googleapis.com".to_string()),
             region: Some("testregion".to_string()),
             use_virtual_url: true,
             use_regional_url: true,
@@ -671,7 +671,7 @@ mod tests {
     #[test]
     fn url_empty_endpoint_falls_through() {
         let stage = make_stage_info(StageInfoOverrides {
-            end_point: Some("".to_string()),
+            endpoint: Some("".to_string()),
             ..Default::default()
         });
         let url = build_gcs_url(&stage, "file.csv.gz");
@@ -906,7 +906,7 @@ mod tests {
     #[test]
     fn url_custom_endpoint_encodes_key() {
         let stage = make_stage_info(StageInfoOverrides {
-            end_point: Some("custom.example.com".to_string()),
+            endpoint: Some("custom.example.com".to_string()),
             ..Default::default()
         });
         let url = build_gcs_url(&stage, "dir/file name.csv");

--- a/sf_core/src/file_manager/s3_transfer.rs
+++ b/sf_core/src/file_manager/s3_transfer.rs
@@ -266,9 +266,28 @@ async fn create_s3_client(
         };
         tracing::debug!("Using Snowflake-provided S3 endpoint: {endpoint_url}");
         s3_config = s3_config.endpoint_url(endpoint_url);
+    } else if stage_info.use_s3_regional_url {
+        // PrivateLink-to-S3 / Snowpipe Streaming: the global endpoint is
+        // unreachable, only `s3.<region>.amazonaws.com[.cn]` resolves.
+        let endpoint_url = regional_s3_endpoint(&stage_info.region);
+        tracing::debug!("Using S3 regional endpoint: {endpoint_url}");
+        s3_config = s3_config.endpoint_url(endpoint_url);
     }
 
     Ok(S3Client::from_conf(s3_config.build()))
+}
+
+/// Builds the S3 regional endpoint URL for a given region. China regions
+/// (`cn-*`) use the `amazonaws.com.cn` suffix; everything else uses
+/// `amazonaws.com`. Mirrors `getDomainSuffixForRegionalUrl` in
+/// snowflake-jdbc's `SnowflakeS3Client.java:248-250`.
+fn regional_s3_endpoint(region: &str) -> String {
+    let suffix = if region.to_ascii_lowercase().starts_with("cn-") {
+        "amazonaws.com.cn"
+    } else {
+        "amazonaws.com"
+    };
+    format!("https://s3.{region}.{suffix}")
 }
 
 /// Error returned when `create_s3_client` is called with non-S3 credentials.
@@ -411,5 +430,43 @@ mod tests {
         let cfg = to_aws_timeout_config(&policy);
         assert_eq!(cfg.operation_timeout(), Some(policy.max_elapsed));
         assert_eq!(cfg.operation_attempt_timeout(), policy.per_request_timeout);
+    }
+
+    // --- Regional endpoint construction ---
+
+    #[test]
+    fn regional_s3_endpoint_default_suffix() {
+        assert_eq!(
+            regional_s3_endpoint("us-east-1"),
+            "https://s3.us-east-1.amazonaws.com"
+        );
+    }
+
+    #[test]
+    fn regional_s3_endpoint_china_suffix() {
+        assert_eq!(
+            regional_s3_endpoint("cn-north-1"),
+            "https://s3.cn-north-1.amazonaws.com.cn"
+        );
+    }
+
+    #[test]
+    fn regional_s3_endpoint_china_match_is_case_insensitive() {
+        // GS could conceivably send the region in upper case; the suffix
+        // detection must not depend on case.
+        assert_eq!(
+            regional_s3_endpoint("CN-NORTH-1"),
+            "https://s3.CN-NORTH-1.amazonaws.com.cn"
+        );
+    }
+
+    #[test]
+    fn regional_s3_endpoint_govcloud_uses_default_suffix() {
+        // GovCloud regions are still under amazonaws.com (e.g.
+        // s3.us-gov-west-1.amazonaws.com); only `cn-*` gets the .cn TLD.
+        assert_eq!(
+            regional_s3_endpoint("us-gov-west-1"),
+            "https://s3.us-gov-west-1.amazonaws.com"
+        );
     }
 }

--- a/sf_core/src/file_manager/s3_transfer.rs
+++ b/sf_core/src/file_manager/s3_transfer.rs
@@ -257,30 +257,47 @@ async fn create_s3_client(
         .await;
 
     let mut s3_config = aws_sdk_s3::config::Builder::from(&config);
-    if let Some(end_point) = &stage_info.end_point {
-        let endpoint_url = if end_point.starts_with("https://") || end_point.starts_with("http://")
-        {
-            end_point.clone()
-        } else {
-            format!("https://{end_point}")
-        };
-        tracing::debug!("Using Snowflake-provided S3 endpoint: {endpoint_url}");
-        s3_config = s3_config.endpoint_url(endpoint_url);
-    } else if stage_info.use_s3_regional_url {
-        // PrivateLink-to-S3 / Snowpipe Streaming: the global endpoint is
-        // unreachable, only `s3.<region>.amazonaws.com[.cn]` resolves.
-        let endpoint_url = regional_s3_endpoint(&stage_info.region);
-        tracing::debug!("Using S3 regional endpoint: {endpoint_url}");
+    if let Some(endpoint_url) = resolve_s3_endpoint(stage_info) {
+        tracing::debug!("Using S3 endpoint: {endpoint_url}");
         s3_config = s3_config.endpoint_url(endpoint_url);
     }
 
     Ok(S3Client::from_conf(s3_config.build()))
 }
 
+/// Resolves the explicit S3 endpoint URL to hand to the AWS SDK builder, or
+/// `None` to let the SDK derive the endpoint from the region.
+///
+/// Precedence (matches `snowflake-jdbc` and `libsnowflakeclient`):
+/// 1. `stage_info.endpoint` set (FIPS / VPCE / custom): used verbatim, with
+///    `https://` prepended if no scheme is present.
+/// 2. `stage_info.use_s3_regional_url` set: route to
+///    `s3.<region>.amazonaws.com[.cn]`.
+/// 3. Neither: `None` — the SDK uses its default endpoint resolver, which
+///    handles standard regions, GovCloud, and `cn-*` correctly on its own.
+///
+/// Extracted as a pure function so callers (and tests) can verify the chosen
+/// endpoint without going through `aws_sdk_s3::Config`, which doesn't expose
+/// the configured URL.
+fn resolve_s3_endpoint(stage_info: &StageInfo) -> Option<String> {
+    if let Some(ep) = stage_info.endpoint.as_deref() {
+        let endpoint_url = if ep.starts_with("https://") || ep.starts_with("http://") {
+            ep.to_string()
+        } else {
+            format!("https://{ep}")
+        };
+        return Some(endpoint_url);
+    }
+    if stage_info.use_s3_regional_url {
+        return Some(regional_s3_endpoint(&stage_info.region));
+    }
+    None
+}
+
 /// Builds the S3 regional endpoint URL for a given region. China regions
 /// (`cn-*`) use the `amazonaws.com.cn` suffix; everything else uses
 /// `amazonaws.com`. Mirrors `getDomainSuffixForRegionalUrl` in
-/// snowflake-jdbc's `SnowflakeS3Client.java:248-250`.
+/// snowflake-jdbc's `SnowflakeS3Client`.
 fn regional_s3_endpoint(region: &str) -> String {
     let suffix = if region.to_ascii_lowercase().starts_with("cn-") {
         "amazonaws.com.cn"
@@ -467,6 +484,86 @@ mod tests {
         assert_eq!(
             regional_s3_endpoint("us-gov-west-1"),
             "https://s3.us-gov-west-1.amazonaws.com"
+        );
+    }
+
+    // --- Endpoint resolution ---
+    //
+    // Exercises the four cases the AWS SDK can't surface for us because
+    // `aws_sdk_s3::Config` does not expose the resolved URL: explicit
+    // endpoint, regional flag, neither, and scheme-less endpoint.
+
+    use crate::file_manager::types::{CloudCredentials, LocationType};
+    use crate::sensitive::SensitiveString;
+
+    fn s3_stage(endpoint: Option<&str>, use_s3_regional_url: bool) -> StageInfo {
+        StageInfo {
+            location_type: LocationType::S3,
+            bucket: "my-bucket".to_string(),
+            key_prefix: "prefix/".to_string(),
+            region: "us-east-1".to_string(),
+            creds: CloudCredentials::S3 {
+                aws_key_id: "k".to_string(),
+                aws_secret_key: SensitiveString::from("s"),
+                aws_token: SensitiveString::from("t"),
+            },
+            endpoint: endpoint.map(str::to_string),
+            presigned_url: None,
+            use_virtual_url: false,
+            use_regional_url: false,
+            use_s3_regional_url,
+            storage_account: None,
+        }
+    }
+
+    #[test]
+    fn resolve_endpoint_explicit_endpoint_wins_over_regional_flag() {
+        // GS-supplied endpoint always wins — FIPS / VPCE / custom must not
+        // be silently overridden by the regional flag.
+        let stage = s3_stage(Some("https://my-fips.us-east-1.amazonaws.com"), true);
+        assert_eq!(
+            resolve_s3_endpoint(&stage).as_deref(),
+            Some("https://my-fips.us-east-1.amazonaws.com")
+        );
+    }
+
+    #[test]
+    fn resolve_endpoint_uses_regional_when_only_flag_set() {
+        let stage = s3_stage(None, true);
+        assert_eq!(
+            resolve_s3_endpoint(&stage).as_deref(),
+            Some("https://s3.us-east-1.amazonaws.com")
+        );
+    }
+
+    #[test]
+    fn resolve_endpoint_returns_none_when_neither_set() {
+        // Falls through to the AWS SDK's default endpoint resolver — we
+        // must NOT pre-pin an endpoint, otherwise the SDK can't apply its
+        // own `cn-*` / GovCloud handling.
+        let stage = s3_stage(None, false);
+        assert_eq!(resolve_s3_endpoint(&stage), None);
+    }
+
+    #[test]
+    fn resolve_endpoint_prepends_https_when_scheme_missing() {
+        // GS sometimes sends `endPoint` without a scheme (host only).
+        // The SDK's `endpoint_url` requires a scheme, so we add `https://`.
+        let stage = s3_stage(Some("my-fips.us-east-1.amazonaws.com"), false);
+        assert_eq!(
+            resolve_s3_endpoint(&stage).as_deref(),
+            Some("https://my-fips.us-east-1.amazonaws.com")
+        );
+    }
+
+    #[test]
+    fn resolve_endpoint_preserves_http_scheme() {
+        // If GS or a test fixture supplies `http://`, we must not double-
+        // prefix or upgrade the scheme.
+        let stage = s3_stage(Some("http://localhost:9000"), false);
+        assert_eq!(
+            resolve_s3_endpoint(&stage).as_deref(),
+            Some("http://localhost:9000")
         );
     }
 }

--- a/sf_core/src/file_manager/types.rs
+++ b/sf_core/src/file_manager/types.rs
@@ -122,7 +122,7 @@ pub struct StageInfo {
     pub creds: CloudCredentials,
     /// Cloud endpoint provided by Snowflake (e.g. for FIPS or regional routing).
     /// When present, the storage client uses this instead of the default.
-    pub end_point: Option<String>,
+    pub endpoint: Option<String>,
     /// Presigned URL for GCS operations (when access tokens are not available).
     pub presigned_url: Option<String>,
     /// Whether to use virtual-hosted-style URLs for GCS.
@@ -132,7 +132,7 @@ pub struct StageInfo {
     /// Whether to use the S3 regional endpoint (`s3.<region>.amazonaws.com`)
     /// instead of the global one. Set by GS for PrivateLink-to-S3 accounts
     /// and Snowpipe Streaming. Computed as `useS3RegionalUrl || useRegionalUrl`
-    /// from the response. Ignored when `end_point` is set — FIPS / VPCE /
+    /// from the response. Ignored when `endpoint` is set — FIPS / VPCE /
     /// custom endpoint takes precedence.
     pub use_s3_regional_url: bool,
     /// Azure storage account name (required for Azure Blob Storage).

--- a/sf_core/src/file_manager/types.rs
+++ b/sf_core/src/file_manager/types.rs
@@ -129,6 +129,12 @@ pub struct StageInfo {
     pub use_virtual_url: bool,
     /// Whether to use regional GCS endpoints.
     pub use_regional_url: bool,
+    /// Whether to use the S3 regional endpoint (`s3.<region>.amazonaws.com`)
+    /// instead of the global one. Set by GS for PrivateLink-to-S3 accounts
+    /// and Snowpipe Streaming. Computed as `useS3RegionalUrl || useRegionalUrl`
+    /// from the response. Ignored when `end_point` is set — FIPS / VPCE /
+    /// custom endpoint takes precedence.
+    pub use_s3_regional_url: bool,
     /// Azure storage account name (required for Azure Blob Storage).
     pub storage_account: Option<String>,
 }

--- a/sf_core/src/rest/snowflake/query_response.rs
+++ b/sf_core/src/rest/snowflake/query_response.rs
@@ -243,7 +243,7 @@ pub struct StageInfo {
     location: Option<String>,
 
     #[serde(rename = "endPoint")]
-    end_point: Option<String>,
+    endpoint: Option<String>,
 
     #[serde(rename = "locationType")]
     location_type: Option<String>,
@@ -852,11 +852,7 @@ impl TryFrom<&StageInfo> for file_manager::StageInfo {
             },
         };
 
-        let end_point = value
-            .end_point
-            .as_ref()
-            .filter(|ep| !ep.is_empty())
-            .cloned();
+        let endpoint = value.endpoint.as_ref().filter(|ep| !ep.is_empty()).cloned();
 
         let presigned_url = value
             .presigned_url
@@ -900,7 +896,7 @@ impl TryFrom<&StageInfo> for file_manager::StageInfo {
             key_prefix,
             region,
             creds,
-            end_point,
+            endpoint,
             presigned_url,
             use_virtual_url,
             use_regional_url,
@@ -1785,52 +1781,52 @@ mod tests {
     // `useS3RegionalUrl` / `useRegionalUrl` mirror the reference Python /
     // JDBC / libsnowflakeclient S3 paths.
 
-    fn s3_stage_info_json(use_s3_regional: Option<bool>, use_regional: Option<bool>) -> String {
-        let s3_regional = match use_s3_regional {
-            Some(b) => format!(", \"useS3RegionalUrl\": {b}"),
-            None => String::new(),
-        };
-        let regional = match use_regional {
-            Some(b) => format!(", \"useRegionalUrl\": {b}"),
-            None => String::new(),
-        };
-        format!(
-            r#"{{
-                "locationType": "S3",
-                "location": "my-bucket/some/prefix/",
-                "region": "us-east-1",
-                "endPoint": null,
-                "creds": {{
-                    "AWS_KEY_ID": "k",
-                    "AWS_SECRET_KEY": "s",
-                    "AWS_TOKEN": "t"
-                }}{s3_regional}{regional}
-            }}"#
-        )
+    fn s3_stage_info_value(
+        use_s3_regional: Option<bool>,
+        use_regional: Option<bool>,
+    ) -> serde_json::Value {
+        let mut value = serde_json::json!({
+            "locationType": "S3",
+            "location": "my-bucket/some/prefix/",
+            "region": "us-east-1",
+            "endPoint": null,
+            "creds": {
+                "AWS_KEY_ID": "k",
+                "AWS_SECRET_KEY": "s",
+                "AWS_TOKEN": "t",
+            },
+        });
+        let obj = value.as_object_mut().expect("stage-info JSON is an object");
+        if let Some(b) = use_s3_regional {
+            obj.insert("useS3RegionalUrl".to_string(), serde_json::Value::Bool(b));
+        }
+        if let Some(b) = use_regional {
+            obj.insert("useRegionalUrl".to_string(), serde_json::Value::Bool(b));
+        }
+        value
     }
 
-    fn parse_s3_stage_info(json: &str) -> file_manager::StageInfo {
-        let raw: super::StageInfo = serde_json::from_str(json).expect("parse stage info json");
+    fn parse_s3_stage_info(value: serde_json::Value) -> file_manager::StageInfo {
+        let raw: super::StageInfo = serde_json::from_value(value).expect("parse stage info json");
         (&raw).try_into().expect("convert stage info")
     }
 
     #[test]
     fn use_s3_regional_url_propagates_when_only_s3_flag_set() {
-        let info = parse_s3_stage_info(&s3_stage_info_json(Some(true), Some(false)));
+        let info = parse_s3_stage_info(s3_stage_info_value(Some(true), Some(false)));
         assert!(info.use_s3_regional_url);
     }
 
     #[test]
     fn use_s3_regional_url_propagates_when_only_generic_regional_flag_set() {
-        // Mirrors Python's `useS3RegionalUrl OR useRegionalUrl` at
-        // s3_storage_client.py:85-91.
-        let info = parse_s3_stage_info(&s3_stage_info_json(Some(false), Some(true)));
+        // Mirrors Python's `useS3RegionalUrl OR useRegionalUrl` semantics.
+        let info = parse_s3_stage_info(s3_stage_info_value(Some(false), Some(true)));
         assert!(info.use_s3_regional_url);
     }
 
     #[test]
     fn use_s3_regional_url_false_when_neither_flag_set() {
-        let info = parse_s3_stage_info(&s3_stage_info_json(Some(false), Some(false)));
+        let info = parse_s3_stage_info(s3_stage_info_value(Some(false), Some(false)));
         assert!(!info.use_s3_regional_url);
     }
 
@@ -1838,7 +1834,7 @@ mod tests {
     fn use_s3_regional_url_false_when_both_flags_absent() {
         // Older GS responses may omit both fields. Default must be false so
         // we keep talking to the global `s3.amazonaws.com` endpoint.
-        let info = parse_s3_stage_info(&s3_stage_info_json(None, None));
+        let info = parse_s3_stage_info(s3_stage_info_value(None, None));
         assert!(!info.use_s3_regional_url);
     }
 }

--- a/sf_core/src/rest/snowflake/query_response.rs
+++ b/sf_core/src/rest/snowflake/query_response.rs
@@ -259,7 +259,7 @@ pub struct StageInfo {
     #[serde(rename = "isClientSideEncrypted")]
     _is_client_side_encrypted: Option<bool>,
     #[serde(rename = "useS3RegionalUrl")]
-    _use_s3_regional_url: Option<bool>,
+    use_s3_regional_url: Option<bool>,
     #[serde(rename = "useRegionalUrl")]
     use_regional_url: Option<bool>,
     #[serde(rename = "useVirtualUrl")]
@@ -868,6 +868,13 @@ impl TryFrom<&StageInfo> for file_manager::StageInfo {
         let use_regional_url =
             value.use_regional_url.unwrap_or(false) || region.eq_ignore_ascii_case("me-central2");
         let use_virtual_url = value.use_virtual_url.unwrap_or(false);
+        // S3 PrivateLink / Snowpipe Streaming: either useS3RegionalUrl or
+        // useRegionalUrl forces the regional endpoint. Mirrors the OR
+        // semantics in the reference Python (s3_storage_client.py:85-91),
+        // JDBC (StorageClientFactory.java:55-58), and libsnowflakeclient
+        // (SnowflakeS3Client.cpp:106-113) S3 paths.
+        let use_s3_regional_url =
+            value.use_s3_regional_url.unwrap_or(false) || value.use_regional_url.unwrap_or(false);
 
         let storage_account = match location_type {
             file_manager::LocationType::Azure => Some(
@@ -897,6 +904,7 @@ impl TryFrom<&StageInfo> for file_manager::StageInfo {
             presigned_url,
             use_virtual_url,
             use_regional_url,
+            use_s3_regional_url,
             storage_account,
         })
     }
@@ -1768,5 +1776,69 @@ mod tests {
             }
             _ => panic!("Expected RowType::Text"),
         }
+    }
+
+    // --- StageInfo regional URL plumbing ---
+    //
+    // Build a minimal S3 stage-info JSON, deserialize, and convert to the
+    // public `file_manager::StageInfo`. Asserts the OR semantics for
+    // `useS3RegionalUrl` / `useRegionalUrl` mirror the reference Python /
+    // JDBC / libsnowflakeclient S3 paths.
+
+    fn s3_stage_info_json(use_s3_regional: Option<bool>, use_regional: Option<bool>) -> String {
+        let s3_regional = match use_s3_regional {
+            Some(b) => format!(", \"useS3RegionalUrl\": {b}"),
+            None => String::new(),
+        };
+        let regional = match use_regional {
+            Some(b) => format!(", \"useRegionalUrl\": {b}"),
+            None => String::new(),
+        };
+        format!(
+            r#"{{
+                "locationType": "S3",
+                "location": "my-bucket/some/prefix/",
+                "region": "us-east-1",
+                "endPoint": null,
+                "creds": {{
+                    "AWS_KEY_ID": "k",
+                    "AWS_SECRET_KEY": "s",
+                    "AWS_TOKEN": "t"
+                }}{s3_regional}{regional}
+            }}"#
+        )
+    }
+
+    fn parse_s3_stage_info(json: &str) -> file_manager::StageInfo {
+        let raw: super::StageInfo = serde_json::from_str(json).expect("parse stage info json");
+        (&raw).try_into().expect("convert stage info")
+    }
+
+    #[test]
+    fn use_s3_regional_url_propagates_when_only_s3_flag_set() {
+        let info = parse_s3_stage_info(&s3_stage_info_json(Some(true), Some(false)));
+        assert!(info.use_s3_regional_url);
+    }
+
+    #[test]
+    fn use_s3_regional_url_propagates_when_only_generic_regional_flag_set() {
+        // Mirrors Python's `useS3RegionalUrl OR useRegionalUrl` at
+        // s3_storage_client.py:85-91.
+        let info = parse_s3_stage_info(&s3_stage_info_json(Some(false), Some(true)));
+        assert!(info.use_s3_regional_url);
+    }
+
+    #[test]
+    fn use_s3_regional_url_false_when_neither_flag_set() {
+        let info = parse_s3_stage_info(&s3_stage_info_json(Some(false), Some(false)));
+        assert!(!info.use_s3_regional_url);
+    }
+
+    #[test]
+    fn use_s3_regional_url_false_when_both_flags_absent() {
+        // Older GS responses may omit both fields. Default must be false so
+        // we keep talking to the global `s3.amazonaws.com` endpoint.
+        let info = parse_s3_stage_info(&s3_stage_info_json(None, None));
+        assert!(!info.use_s3_regional_url);
     }
 }

--- a/sf_core/tests/integration/http/azure_retry.rs
+++ b/sf_core/tests/integration/http/azure_retry.rs
@@ -19,7 +19,7 @@ fn azure_stage(mock_uri: &str) -> StageInfo {
         creds: CloudCredentials::Azure {
             sas_token: SensitiveString::from("sv=2021-08-06&sig=test-secret-sig&se=2099-01-01"),
         },
-        end_point: Some(mock_uri.to_string()),
+        endpoint: Some(mock_uri.to_string()),
         presigned_url: None,
         use_virtual_url: false,
         use_regional_url: false,
@@ -223,7 +223,7 @@ async fn azure_transport_error_does_not_leak_sas_token() {
         creds: CloudCredentials::Azure {
             sas_token: SensitiveString::from("sv=2021-08-06&sig=test-secret-sig&se=2099-01-01"),
         },
-        end_point: Some(format!("http://{addr}")),
+        endpoint: Some(format!("http://{addr}")),
         presigned_url: None,
         use_virtual_url: false,
         use_regional_url: false,
@@ -275,7 +275,7 @@ async fn azure_download_with_missing_storage_account_fails() {
     let mut stage = azure_stage(&server.uri());
     stage.storage_account = None;
     // Remove scheme so it falls through to the standard URL path
-    stage.end_point = Some("blob.core.windows.net".to_string());
+    stage.endpoint = Some("blob.core.windows.net".to_string());
 
     let result = sf_core::file_manager::download_from_azure(&stage, "file.csv").await;
 

--- a/sf_core/tests/integration/http/azure_retry.rs
+++ b/sf_core/tests/integration/http/azure_retry.rs
@@ -23,6 +23,7 @@ fn azure_stage(mock_uri: &str) -> StageInfo {
         presigned_url: None,
         use_virtual_url: false,
         use_regional_url: false,
+        use_s3_regional_url: false,
         storage_account: Some("test".to_string()),
     }
 }
@@ -226,6 +227,7 @@ async fn azure_transport_error_does_not_leak_sas_token() {
         presigned_url: None,
         use_virtual_url: false,
         use_regional_url: false,
+        use_s3_regional_url: false,
         storage_account: Some("test".to_string()),
     };
 

--- a/sf_core/tests/integration/http/gcs_retry.rs
+++ b/sf_core/tests/integration/http/gcs_retry.rs
@@ -19,6 +19,7 @@ fn gcs_stage_with_presigned_url(presigned_url: &str) -> StageInfo {
         presigned_url: Some(presigned_url.to_string()),
         use_virtual_url: false,
         use_regional_url: false,
+        use_s3_regional_url: false,
         storage_account: None,
     }
 }
@@ -37,6 +38,7 @@ fn gcs_stage_with_token(endpoint: &str) -> StageInfo {
         presigned_url: None,
         use_virtual_url: false,
         use_regional_url: false,
+        use_s3_regional_url: false,
         storage_account: None,
     }
 }

--- a/sf_core/tests/integration/http/gcs_retry.rs
+++ b/sf_core/tests/integration/http/gcs_retry.rs
@@ -15,7 +15,7 @@ fn gcs_stage_with_presigned_url(presigned_url: &str) -> StageInfo {
         creds: CloudCredentials::Gcs {
             gcs_access_token: None,
         },
-        end_point: None,
+        endpoint: None,
         presigned_url: Some(presigned_url.to_string()),
         use_virtual_url: false,
         use_regional_url: false,
@@ -34,7 +34,7 @@ fn gcs_stage_with_token(endpoint: &str) -> StageInfo {
         creds: CloudCredentials::Gcs {
             gcs_access_token: Some(SensitiveString::from("test-bearer-token")),
         },
-        end_point: Some(endpoint.to_string()),
+        endpoint: Some(endpoint.to_string()),
         presigned_url: None,
         use_virtual_url: false,
         use_regional_url: false,


### PR DESCRIPTION
## Summary

Plumbs the GS \`useS3RegionalUrl\` and \`useRegionalUrl\` flags into the universal driver's S3 client builder so PrivateLink-to-S3 accounts and Snowpipe Streaming work — they previously silently failed because the universal driver was building an aws-sdk-s3 client pointed at the global endpoint while the stage required the regional one.

- Adds \`use_s3_regional_url: bool\` to \`file_manager::StageInfo\`.
- \`stage_info_from_response\` populates it as \`useS3RegionalUrl OR useRegionalUrl\` — mirroring Python (\`s3_storage_client.py:85-91\`), JDBC (\`StorageClientFactory.java:55-58\`), and libsnowflakeclient (\`SnowflakeS3Client.cpp:106-113\`).
- \`create_s3_client\` overrides the SDK endpoint to \`https://s3.<region>.amazonaws.com[.cn]\` when the flag is set and GS hasn't supplied an explicit \`endPoint\` (FIPS / VPCE / custom endpoint takes precedence).
- The existing \`use_regional_url\` field stays GCS-conceptual (it carries the \`me-central2\` special case which is irrelevant for S3).

The \`cn-*\` suffix logic matches \`getDomainSuffixForRegionalUrl\` in \`snowflake-jdbc\` (\`SnowflakeS3Client.java:248-250\`).

## Tests

- 4 unit tests in \`s3_transfer.rs::tests\` covering \`regional_s3_endpoint\` for default / china / case-insensitive / GovCloud regions.
- 4 round-trip tests in \`query_response.rs::tests\` covering OR semantics (only \`useS3RegionalUrl\`, only \`useRegionalUrl\`, neither, both absent).
- Updated existing \`make_stage_info\` test fixtures in \`gcs_transfer.rs\` and \`azure_transfer.rs\`, and the wiremock-based integration tests in \`tests/integration/http/{azure,gcs}_retry.rs\`.

Not asserting the AWS SDK actually uses the resolved endpoint — aws-sdk-s3 doesn't expose that on its config in a stable way; reference drivers also test at the unit level by string-equality on the constructed URL.

## Test plan

- [x] \`cargo check -p sf_core\`
- [x] \`cargo clippy -p sf_core --all-targets -- -D warnings\`
- [x] \`cargo test -p sf_core --lib\` (815 passed)
- [x] Pre-commit hooks pass (formatting, clippy, cargo check)
- [ ] Validate on a PrivateLink-backed account that \`useS3RegionalUrl: true\` actually flips PUT/GET to the regional endpoint (requires server-side fixture; out of band)

## Out of scope

This addresses Gap 9 from the S3 feature-gap analysis. Other gaps (multipart upload, parallel transfer, streaming, SSE-S3, transfer acceleration, progress callbacks, GCM encryption, etc.) are left for follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)