### PR TITLE
NO-SNOW: skip weekends for PR review bot reminders

### DIFF
--- a/.github/workflows/pr-review-bot.yml
+++ b/.github/workflows/pr-review-bot.yml
@@ -54,8 +54,8 @@ on:
     types: [opened, ready_for_review, reopened]
   schedule:
     # Every 2h on the hour, but only at UTC times that overlap
-    # working hours (08:00–16:59):
-    - cron: "0 7,12,14 * * *"
+    # working hours (08:00–16:59), Monday-Friday only (skip weekends).
+    - cron: "0 7,12,14 * * 1-5"
   workflow_dispatch:
     inputs:
       mode:


### PR DESCRIPTION
## Summary
- Limit the PR review bot reminder cron to Monday–Friday so it stops posting reminders to `#drivers-review` on weekends.
- Day-of-week field changed from `*` to `1-5`; the working-hour slots (`07:00, 12:00, 14:00` UTC) are unchanged.

## Context
The reminder digest currently fires on weekends too, which is noisy in Slack outside of working days. Only the scheduled `remind-reviewers` job is affected; the PR-event-driven `assign-reviewer` job still runs whenever a PR is opened/marked ready.

## Test plan
- Verified cron expression `0 7,12,14 * * 1-5` parses as Mon–Fri only via standard cron semantics.
- Confirmed no other workflow inputs/jobs were touched: `git diff main...HEAD` shows a single-line schedule change in `.github/workflows/pr-review-bot.yml`.

Made with [Cursor](https://cursor.com)