### PR TITLE
NO-SNOW: python - bump version to 5.0.0b2

### DIFF
--- a/python/src/snowflake/connector/version.py
+++ b/python/src/snowflake/connector/version.py
@@ -1,5 +1,5 @@
 # PEP 440 compliant version string (used by hatch for packaging)
-__version__ = "5.0.0b1"
+__version__ = "5.0.0b2"
 
 
 def _release_components(version: str) -> tuple[int, ...]:


### PR DESCRIPTION
## Summary
- Bump Python wrapper version from `5.0.0b1` to `5.0.0b2` in `python/src/snowflake/connector/version.py`.
- Generalize the example version mentioned in a comment in `tests/integ/telemetry/test_client_identity.py` so the comment stays valid across future bumps.

The version-related unit tests (`tests/unit/test_version.py`, `tests/unit/test_internal_telemetry.py`, version assertions in `tests/unit/test_connection.py`) all pass — they read `__version__` dynamically rather than hardcoding it, so no test code changes are required for the bump.

## Test plan
- [ ] `hatch run dev.py3.13:python -m pytest tests/unit/test_version.py tests/unit/test_internal_telemetry.py tests/unit/test_connection.py`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)