### PR TITLE
SNOW-3098562: Preserve fractional seconds in TIME → SQL_C_TYPE_TIMESTAMP

### DIFF
--- a/odbc/src/conversion/time.rs
+++ b/odbc/src/conversion/time.rs
@@ -200,14 +200,10 @@ impl WriteODBCType for SnowflakeTime {
                     hour: snowflake_value.hour() as u16,
                     minute: snowflake_value.minute() as u16,
                     second: snowflake_value.second() as u16,
-                    fraction: 0,
+                    fraction: snowflake_value.nanosecond(),
                 };
                 binding.write_fixed(ts);
-                if snowflake_value.nanosecond() != 0 {
-                    Ok(vec![Warning::NumericValueTruncated])
-                } else {
-                    Ok(vec![])
-                }
+                Ok(vec![])
             }
             _ => UnsupportedOdbcTypeSnafu {
                 target_type: binding.target_type,

--- a/odbc/src/conversion/time_tests.rs
+++ b/odbc/src/conversion/time_tests.rs
@@ -266,6 +266,33 @@ mod tests {
     }
 
     // ========================================================================
+    // WriteODBCType — SQL_C_TYPE_TIMESTAMP struct
+    // ========================================================================
+
+    #[test]
+    fn write_timestamp_struct_preserves_fractional_seconds() {
+        let sn = time(3);
+        let mut value = sql::Timestamp {
+            year: 0,
+            month: 0,
+            day: 0,
+            hour: 0,
+            minute: 0,
+            second: 0,
+            fraction: 0,
+        };
+        let mut str_len: sql::Len = 0;
+        let binding = binding_for_value(CDataType::TypeTimestamp, &mut value, &mut str_len);
+        let input = NaiveTime::from_hms_milli_opt(12, 56, 10, 513).unwrap();
+        let warnings = sn.write_odbc_type(input, &binding, &mut None).unwrap();
+        assert!(warnings.is_empty());
+        assert_eq!(value.hour, 12);
+        assert_eq!(value.minute, 56);
+        assert_eq!(value.second, 10);
+        assert_eq!(value.fraction, 513_000_000);
+    }
+
+    // ========================================================================
     // WriteODBCType — SQL_C_CHAR
     // ========================================================================
 

--- a/odbc_tests/BehaviorDifferences.yaml
+++ b/odbc_tests/BehaviorDifferences.yaml
@@ -444,15 +444,15 @@ behavior_differences:
 
   42:
     name: "TIME to SQL_C_TYPE_TIMESTAMP does not report fractional truncation"
-    status: unknown
+    status: fixed
     type: bug
     reviewed: false
     old_driver_behavior: |
       When TIME with fractional seconds (e.g. '14:30:45.123') is converted to SQL_C_TYPE_TIMESTAMP, the old driver returns SQL_SUCCESS and places the fractional seconds into the timestamp fraction field. It does not report SQLSTATE 01S07 (Fractional truncation).
     new_driver_behavior: |
-      Per the ODBC specification, when SQL_TYPE_TIME is converted to SQL_C_TYPE_TIMESTAMP the fraction field is set to zero. If the original TIME value had fractional seconds, SQL_SUCCESS_WITH_INFO is returned with SQLSTATE 01S07 (Fractional truncation).
+      Aligned with the old driver: the fractional seconds are placed into the timestamp fraction field (in nanoseconds, per SQL_TIMESTAMP_STRUCT) and SQL_SUCCESS is returned with no warning. Preserves precision for downstream consumers (e.g. dtm-server) that depend on this behavior.
     description: |
-      Spec reference: "Converting Data from SQL to C Data Types" — SQL_TIME to SQL_C_TYPE_TIMESTAMP: "The timestamp fraction field is set to zero."
+      Spec reference: "Converting Data from SQL to C Data Types" — SQL_TIME to SQL_C_TYPE_TIMESTAMP: "The timestamp fraction field is set to zero." We deliberately deviate from this clause to preserve sub-second precision, matching the old driver.
 
   43:
     name: "TIME to SQL_C_BINARY conversion not supported"

--- a/odbc_tests/tests/e2e/types/time_conversion_to_c_timestamp.cpp
+++ b/odbc_tests/tests/e2e/types/time_conversion_to_c_timestamp.cpp
@@ -88,36 +88,46 @@ TEST_CASE("TIME to SQL_C_TYPE_TIMESTAMP end of day", "[time][conversion][c_times
   CHECK(ts.fraction == 0);
 }
 
-TEST_CASE("TIME to SQL_C_TYPE_TIMESTAMP with fractional truncation", "[time][conversion][c_timestamp][truncation]") {
-  SKIP_OLD_DRIVER("BD#42", "old driver does not report 01S07 for fractional seconds");
+TEST_CASE("TIME with fractional seconds to SQL_C_TYPE_TIMESTAMP", "[time][conversion][c_timestamp]") {
   // Given Snowflake client is logged in
   Connection conn;
 
   // When A TIME with non-zero fractional seconds is fetched as SQL_C_TYPE_TIMESTAMP
-  auto ts = check_fractional_truncation<SQL_C_TYPE_TIMESTAMP>(conn.execute_fetch("SELECT '14:30:45.123'::TIME"), 1);
+  int before_y, before_m, before_d;
+  get_local_date(before_y, before_m, before_d);
+  auto ts = check_no_truncation<SQL_C_TYPE_TIMESTAMP>(conn.execute_fetch("SELECT '14:30:45.123'::TIME"), 1);
+  int after_y, after_m, after_d;
+  get_local_date(after_y, after_m, after_d);
 
-  // Then Time components are extracted with SQLSTATE 01S07 warning and fraction is zero
+  // Then Time components and fractional seconds are preserved (fraction holds nanoseconds)
+  CHECK((date_matches(ts.year, ts.month, ts.day, before_y, before_m, before_d) ||
+         date_matches(ts.year, ts.month, ts.day, after_y, after_m, after_d)));
   CHECK(ts.hour == 14);
   CHECK(ts.minute == 30);
   CHECK(ts.second == 45);
-  CHECK(ts.fraction == 0);
+  CHECK(ts.fraction == 123'000'000);
 }
 
-TEST_CASE("TIME to SQL_C_TYPE_TIMESTAMP with high-precision fractional truncation",
-          "[time][conversion][c_timestamp][truncation]") {
-  SKIP_OLD_DRIVER("BD#42", "old driver does not report 01S07 for fractional seconds");
+TEST_CASE("TIME with high-precision fractional seconds to SQL_C_TYPE_TIMESTAMP",
+          "[time][conversion][c_timestamp]") {
   // Given Snowflake client is logged in
   Connection conn;
 
-  // When A TIME with high-precision fractional seconds is fetched as SQL_C_TYPE_TIMESTAMP
+  // When A TIME with nanosecond precision is fetched as SQL_C_TYPE_TIMESTAMP
+  int before_y, before_m, before_d;
+  get_local_date(before_y, before_m, before_d);
   auto ts =
-      check_fractional_truncation<SQL_C_TYPE_TIMESTAMP>(conn.execute_fetch("SELECT '10:30:00.123456789'::TIME"), 1);
+      check_no_truncation<SQL_C_TYPE_TIMESTAMP>(conn.execute_fetch("SELECT '10:30:00.123456789'::TIME"), 1);
+  int after_y, after_m, after_d;
+  get_local_date(after_y, after_m, after_d);
 
-  // Then Time components are extracted with SQLSTATE 01S07 warning and fraction is zero
+  // Then Full nanosecond precision is preserved in the fraction field
+  CHECK((date_matches(ts.year, ts.month, ts.day, before_y, before_m, before_d) ||
+         date_matches(ts.year, ts.month, ts.day, after_y, after_m, after_d)));
   CHECK(ts.hour == 10);
   CHECK(ts.minute == 30);
   CHECK(ts.second == 0);
-  CHECK(ts.fraction == 0);
+  CHECK(ts.fraction == 123'456'789);
 }
 
 TEST_CASE("TIME to SQL_C_TYPE_TIMESTAMP with zero fractional seconds", "[time][conversion][c_timestamp]") {


### PR DESCRIPTION
## Summary
- TIME → `SQL_C_TYPE_TIMESTAMP` was hardcoding `fraction: 0` and emitting a `NumericValueTruncated` warning whenever the input had sub-second precision.
- `sql::Timestamp.fraction` is a `UInteger` that holds nanoseconds per the ODBC spec, so no truncation was actually needed — propagate `snowflake_value.nanosecond()` into the struct and drop the warning.
- Surfaced in dtm-server SXS as `[3706] DTM3103: Numeric value truncated. Result type not handled.` for queries like `select time '12:56:10.513'` (expected `12:56:10.513000`).

Introduced in #844; not previously covered by tests — `time_tests.rs` had no `TYPE_TIMESTAMP` write case. Sibling `timestamp.rs::to_sql_timestamp` already does the right thing.

## Test plan
- [x] `cargo test -p odbc --lib conversion::time_tests::` — 32 passed including new regression test
- [x] `cargo test -p odbc --lib conversion::` — 1065 passed, no regressions
- [ ] Re-run dtm-server `tdc-dtm-snowflake azure.sql` SXS to confirm the diff clears