### PR TITLE
feat(s3): support enable_stage_s3_privatelink session parameter

### DIFF
--- a/python/BehaviorDifferences.yaml
+++ b/python/BehaviorDifferences.yaml
@@ -302,3 +302,24 @@ behavior_differences:
       Support for the body-encoded form (`client_secret_post`) is tracked as
       a follow-up; IdPs that *require* `client_secret_post` are not yet
       supported on the universal driver.
+
+  30:
+    name: "enable_stage_s3_privatelink_for_us_east_1 renamed to use_s3_regional_url"
+    status: allowed
+    type: api_incompatibility
+    reviewed: false
+    old_driver_behavior: |
+      `enable_stage_s3_privatelink_for_us_east_1` is the connection kwarg / session
+      parameter that forces PUT/GET to use the S3 regional endpoint
+      (`s3.<region>.amazonaws.com[.cn]`) instead of the global one. Required for
+      accounts using PrivateLink-to-S3 and for Snowpipe Streaming. The misleading
+      `_for_us_east_1` suffix is historical: the feature applies to any S3 region.
+    new_driver_behavior: |
+      `use_s3_regional_url` is the canonical connection kwarg. The name matches
+      the `StageInfo.use_s3_regional_url` field that drives endpoint selection
+      and aligns with libsnowflakeclient's connection-level `use_s3_regional_url`
+      attribute. `enable_stage_s3_privatelink_for_us_east_1` is accepted as a
+      deprecated alias and emits a `DeprecationWarning`. The server-pushed session
+      parameter `ENABLE_STAGE_S3_PRIVATELINK_FOR_US_EAST_1` continues to be honored
+      verbatim (it is the same string all reference drivers — Python, JDBC,
+      libsnowflakeclient — read from the login response).

--- a/python/src/snowflake/connector/_internal/connection_config_mixin.py
+++ b/python/src/snowflake/connector/_internal/connection_config_mixin.py
@@ -130,6 +130,7 @@ class ConnectionConfigMixin:
     _DEPRECATED_REWRITES: ClassVar[dict[str, str]] = {
         "client_fetch_threads": "client_prefetch_threads",
         "client_request_mfa_token": "client_store_temporary_credential",
+        "enable_stage_s3_privatelink_for_us_east_1": "use_s3_regional_url",
         "private_key_file_pwd": "private_key_password",
         "oauth_socket_uri": "oauth_redirect_uri",
     }

--- a/python/src/snowflake/connector/connection_config.py
+++ b/python/src/snowflake/connector/connection_config.py
@@ -220,6 +220,9 @@ class ConnectionConfig(ConnectionConfigMixin):
     schema: str | None = None
     """Default schema to use"""
 
+    use_s3_regional_url: bool | None = False
+    """Force the S3 regional endpoint for PUT/GET (PrivateLink-to-S3). Default: False"""
+
     warehouse: str | None = None
     """Default warehouse to use"""
 
@@ -228,6 +231,7 @@ class ConnectionConfig(ConnectionConfigMixin):
         "clientstoretemporarycredential": "client_store_temporary_credential",
         "crl_enabled": "crl_check_mode",
         "crl_mode": "crl_check_mode",
+        "enable_stage_s3_privatelink_for_us_east_1": "use_s3_regional_url",
         "oauth_token_url": "oauth_token_request_url",
         "passcodeinpassword": "passcode_in_password",
         "priv_key_base64": "private_key",

--- a/python/tests/e2e/put_get/test_put_get_s3_privatelink.py
+++ b/python/tests/e2e/put_get/test_put_get_s3_privatelink.py
@@ -1,0 +1,78 @@
+"""
+End-to-end coverage for the `use_s3_regional_url` kwarg and its
+deprecated alias `enable_stage_s3_privatelink_for_us_east_1`.
+
+We can't assert that the regional S3 endpoint is actually used — that
+would require a PrivateLink-enabled test account — but we can verify
+that:
+  * the kwarg is accepted by the public `connect()` API and a basic PUT
+    round-trips successfully (run against both drivers — the universal
+    driver receives the canonical name, the reference connector receives
+    the legacy name, since each is the only spelling that driver accepts);
+  * the legacy kwarg emits a `DeprecationWarning` at connection time
+    (universal driver only — the reference connector exposes it as a
+    non-deprecated kwarg).
+
+The OR-with-stage-info-flags logic is covered by Rust unit tests in
+`sf_core/src/rest/snowflake/query_response.rs::tests`, and the
+kwarg-rewrite logic by `tests/unit/test_connection_config.py`.
+"""
+
+import pytest
+
+from tests.compatibility import IS_UNIVERSAL_DRIVER
+from tests.e2e.put_get.put_get_helper import (
+    create_temporary_stage_and_upload_file,
+)
+from tests.utils import shared_test_data_dir
+
+
+# The reference connector only accepts `enable_stage_s3_privatelink_for_us_east_1`;
+# the universal driver accepts both but `use_s3_regional_url` is canonical and the
+# legacy name emits a DeprecationWarning. Pick the spelling each driver expects so
+# the round-trip test exercises real reference coverage of the underlying feature.
+_REGIONAL_URL_KWARG = "use_s3_regional_url" if IS_UNIVERSAL_DRIVER else "enable_stage_s3_privatelink_for_us_east_1"
+
+
+def test_s3_regional_url_kwarg_accepts_and_round_trips(connection_factory):
+    # The kwarg is harmless on non-S3 stages (the OR only affects the S3
+    # path), so this test runs on any cloud-backed test account. The
+    # point is to prove the kwarg flows from the public `connect()` API
+    # through the wrapper (and, for universal, the Rust core and
+    # file-transfer agent).
+    file_path = shared_test_data_dir() / "overwrite" / "original" / "test_data.csv"
+
+    # Given a connection opened with the regional-URL kwarg set
+    with connection_factory(**{_REGIONAL_URL_KWARG: True}) as conn:
+        with conn.cursor() as cursor:
+            # When a file is uploaded to a temporary stage
+            stage_name, upload_result = create_temporary_stage_and_upload_file(
+                cursor,
+                "TEST_S3_REGIONAL_URL_KWARG",
+                file_path,
+                auto_compress=False,
+                overwrite=True,
+            )
+
+            # Then the upload succeeds and the round-trip read matches
+            assert upload_result[6] == "UPLOADED"
+            cursor.execute(f"SELECT $1, $2, $3 FROM @{stage_name}")
+            row = cursor.fetchone()
+            assert row == ("original", "test", "data")
+
+
+@pytest.mark.skip_reference(
+    reason="Reference Python connector exposes enable_stage_s3_privatelink_for_us_east_1 "
+    "as a non-deprecated kwarg; the universal driver demotes it to a deprecated alias."
+)
+def test_legacy_kwarg_emits_deprecation_warning_on_connection(connection_factory):
+    # The deprecation rewrite happens inside `from_kwargs`. Catching it
+    # on the connection-construction path proves it is wired through
+    # the public `connect()` API and not just the unit-tested config
+    # layer.
+
+    # When opening a connection with the legacy kwarg
+    # Then a DeprecationWarning naming the legacy kwarg is emitted
+    with pytest.warns(DeprecationWarning, match="enable_stage_s3_privatelink_for_us_east_1"):
+        with connection_factory(enable_stage_s3_privatelink_for_us_east_1=True) as conn:
+            assert conn is not None

--- a/python/tests/unit/test_connection_config.py
+++ b/python/tests/unit/test_connection_config.py
@@ -110,6 +110,31 @@ class TestFromKwargs:
         config = ConnectionConfig.from_kwargs(CLIENT_SESSION_KEEP_ALIVE=True)
         assert config.client_session_keep_alive is True
 
+    def test_enable_stage_s3_privatelink_for_us_east_1_maps_with_warning(self):
+        # The reference Python connector exposes this kwarg as
+        # `enable_stage_s3_privatelink_for_us_east_1`. The universal driver
+        # demotes it to a deprecated alias for the canonical
+        # `use_s3_regional_url` name (which matches the StageInfo field).
+        with pytest.warns(DeprecationWarning, match="enable_stage_s3_privatelink_for_us_east_1"):
+            config = ConnectionConfig.from_kwargs(enable_stage_s3_privatelink_for_us_east_1=True)
+        assert config.use_s3_regional_url is True
+
+    def test_use_s3_regional_url_canonical_kwarg_no_warning(self):
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            config = ConnectionConfig.from_kwargs(use_s3_regional_url=True)
+        assert config.use_s3_regional_url is True
+
+    def test_use_s3_regional_url_legacy_does_not_override_canonical(self):
+        with pytest.warns(DeprecationWarning):
+            config = ConnectionConfig.from_kwargs(
+                enable_stage_s3_privatelink_for_us_east_1=True,
+                use_s3_regional_url=False,
+            )
+        assert config.use_s3_regional_url is False
+
 
 class TestFromConnectionArgs:
     """Test ConnectionConfig.from_connection_args factory method."""

--- a/sf_core/src/apis/database_driver_v1/connection.rs
+++ b/sf_core/src/apis/database_driver_v1/connection.rs
@@ -840,6 +840,15 @@ impl Connection {
         self.http_client.is_some()
     }
 
+    /// Resolves the `ENABLE_STAGE_S3_PRIVATELINK_FOR_US_EAST_1` session
+    /// parameter to a boolean by briefly read-locking the parameter cache.
+    /// Used by the PUT/GET dispatch path to OR into the S3 regional-URL
+    /// decision. See `read_use_s3_regional_url_session_param`.
+    pub(crate) async fn use_s3_regional_url_session_param(&self) -> bool {
+        let params = self.session_parameters.read().await;
+        crate::rest::snowflake::query_response::read_use_s3_regional_url_session_param(&params)
+    }
+
     /// Server URL + client fingerprint for query and refresh calls (transport snapshot).
     pub(crate) fn query_transport_parameters(&self) -> Result<QueryParameters, ApiError> {
         let empty = ParamStore::new();

--- a/sf_core/src/apis/database_driver_v1/query.rs
+++ b/sf_core/src/apis/database_driver_v1/query.rs
@@ -59,11 +59,18 @@ pub struct StageCredsRefreshContext {
 /// When `stage_creds_refresh_context` is `Some`, an S3 `ExpiredToken` during a
 /// file transfer triggers a re-issue of the original PUT/GET SQL to obtain fresh
 /// STS credentials and the operation is retried. Non-PUT/GET callers pass `None`.
+///
+/// `use_s3_regional_url_session_param` is the resolved value of the
+/// `ENABLE_STAGE_S3_PRIVATELINK_FOR_US_EAST_1` session parameter (read at the
+/// dispatch site via `read_use_s3_regional_url_session_param`). When `true`,
+/// it ORs into the S3 regional-URL decision, matching the Python connector,
+/// JDBC, and libsnowflakeclient behavior.
 pub(super) async fn perform_put_get_transfer(
     command: &str,
     data: &query_response::Data,
     wrapper_presets: &WrapperPresets,
     stage_creds_refresh_context: Option<StageCredsRefreshContext>,
+    use_s3_regional_url_session_param: bool,
 ) -> Result<RowsetData, QueryResponseProcessingError> {
     // Seed the refresher's cache with the initial creds.
     let initial_creds = data
@@ -79,7 +86,10 @@ pub(super) async fn perform_put_get_transfer(
     match command {
         "UPLOAD" => {
             let file_upload_data = data
-                .to_file_upload_data(wrapper_presets.put_get_resultset_flavor.clone())
+                .to_file_upload_data(
+                    wrapper_presets.put_get_resultset_flavor.clone(),
+                    use_s3_regional_url_session_param,
+                )
                 .context(FileTransferPreparationSnafu)?;
             let upload_results = upload_files(&file_upload_data, refresher_handle)
                 .await
@@ -88,7 +98,10 @@ pub(super) async fn perform_put_get_transfer(
         }
         "DOWNLOAD" => {
             let file_download_data = data
-                .to_file_download_data(&wrapper_presets.put_get_resultset_flavor)
+                .to_file_download_data(
+                    &wrapper_presets.put_get_resultset_flavor,
+                    use_s3_regional_url_session_param,
+                )
                 .map_err(|e| {
                     if e.to_string().contains("source locations") {
                         RemoteFileNotFoundSnafu.build()

--- a/sf_core/src/apis/database_driver_v1/statement.rs
+++ b/sf_core/src/apis/database_driver_v1/statement.rs
@@ -341,11 +341,17 @@ impl DatabaseDriverV1 {
                     query_parameters: query_parameters.clone(),
                     conn: conn_arc.clone(),
                 };
+                let use_s3_regional_url_session_param = conn_arc
+                    .lock()
+                    .await
+                    .use_s3_regional_url_session_param()
+                    .await;
                 perform_put_get_transfer(
                     command,
                     &data,
                     &self.wrapper_presets,
                     Some(stage_creds_refresh_context),
+                    use_s3_regional_url_session_param,
                 )
                 .await
                 .context(QueryResponseProcessingSnafu)?
@@ -442,9 +448,22 @@ impl DatabaseDriverV1 {
         }
 
         let rowset_data = match data.command.as_deref() {
-            Some(command) => perform_put_get_transfer(command, &data, &self.wrapper_presets, None)
+            Some(command) => {
+                let use_s3_regional_url_session_param = conn_ptr
+                    .lock()
+                    .await
+                    .use_s3_regional_url_session_param()
+                    .await;
+                perform_put_get_transfer(
+                    command,
+                    &data,
+                    &self.wrapper_presets,
+                    None,
+                    use_s3_regional_url_session_param,
+                )
                 .await
-                .context(QueryResponseProcessingSnafu)?,
+                .context(QueryResponseProcessingSnafu)?
+            }
             None => data.into_rowset_data(),
         };
         let reader_ctx = resolve_reader_ctx(&conn_ptr).await?;

--- a/sf_core/src/config/param_registry.rs
+++ b/sf_core/src/config/param_registry.rs
@@ -118,6 +118,11 @@ pub mod param_names {
     // Prefetch configuration
     pub const CLIENT_PREFETCH_THREADS: ParamKey = ParamKey("CLIENT_PREFETCH_THREADS");
     pub const CLIENT_MEMORY_LIMIT: ParamKey = ParamKey("CLIENT_MEMORY_LIMIT");
+    // PUT/GET — S3 regional endpoint override. Server pushes this as the
+    // session parameter `ENABLE_STAGE_S3_PRIVATELINK_FOR_US_EAST_1`; the
+    // canonical name matches the field on `StageInfo` (and libsfclient's
+    // `use_s3_regional_url` connection attribute).
+    pub const USE_S3_REGIONAL_URL: ParamKey = ParamKey("use_s3_regional_url");
 }
 
 /// Which API layer owns writes for a parameter.
@@ -1089,6 +1094,30 @@ static PARAM_DEFS: &[ParamDef] = &[
         scope: ParamScope::Session,
         used_at_connect: true,
         mutable_after_connect: false,
+    },
+    // ── PUT/GET — S3 regional endpoint ─────────────────────────────────
+    //
+    // Forces the regional S3 endpoint (`s3.<region>.amazonaws.com[.cn]`) for
+    // PUT/GET. Mirrors the OR-with-stage-info-flags semantics that the
+    // Python connector, snowflake-jdbc, and libsnowflakeclient all implement.
+    //
+    // `ENABLE_STAGE_S3_PRIVATELINK_FOR_US_EAST_1` is the server-pushed
+    // session-parameter key. `enable_stage_s3_privatelink_for_us_east_1` is
+    // the legacy Python kwarg name (kept as a deprecated alias via the
+    // Python wrapper's `_DEPRECATED_REWRITES`).
+    ParamDef {
+        canonical_name: param_names::USE_S3_REGIONAL_URL.as_str(),
+        aliases: &["ENABLE_STAGE_S3_PRIVATELINK_FOR_US_EAST_1"],
+        value_type: ValueType::Bool,
+        additional_value_type: None,
+        required: Required::Never,
+        default: Some(|| Setting::Bool(false)),
+        sensitive: false,
+        description: "Force the S3 regional endpoint for PUT/GET (PrivateLink-to-S3)",
+        deprecated_by: None,
+        scope: ParamScope::Session,
+        used_at_connect: false,
+        mutable_after_connect: true,
     },
 ];
 

--- a/sf_core/src/rest/snowflake/query_response.rs
+++ b/sf_core/src/rest/snowflake/query_response.rs
@@ -323,6 +323,7 @@ impl Data {
     pub fn to_file_upload_data(
         &self,
         flavor: PutGetResultsetFlavor,
+        use_s3_regional_url_session_param: bool,
     ) -> Result<file_manager::UploadData, QueryResponseError> {
         let src_locations = self.src_locations.as_ref().context(MissingParameterSnafu {
             parameter: "source locations",
@@ -342,13 +343,17 @@ impl Data {
             })?
             .clone();
 
-        let stage_info: file_manager::StageInfo = self
+        let mut stage_info: file_manager::StageInfo = self
             .stage_info
             .as_ref()
             .context(MissingParameterSnafu {
                 parameter: "stage info",
             })?
             .try_into()?;
+
+        if use_s3_regional_url_session_param {
+            stage_info.use_s3_regional_url = true;
+        }
 
         let encryption_material: Option<file_manager::EncryptionMaterial> = match &self
             .encryption_material
@@ -418,6 +423,7 @@ impl Data {
     pub fn to_file_download_data(
         &self,
         flavor: &PutGetResultsetFlavor,
+        use_s3_regional_url_session_param: bool,
     ) -> Result<file_manager::DownloadData, QueryResponseError> {
         let src_locations = self
             .src_locations
@@ -434,13 +440,17 @@ impl Data {
             .fail()?;
         }
 
-        let stage_info: file_manager::StageInfo = self
+        let mut stage_info: file_manager::StageInfo = self
             .stage_info
             .as_ref()
             .context(MissingParameterSnafu {
                 parameter: "stage info",
             })?
             .try_into()?;
+
+        if use_s3_regional_url_session_param {
+            stage_info.use_s3_regional_url = true;
+        }
 
         let encryption_materials: Vec<Option<file_manager::EncryptionMaterial>> =
             match &self.encryption_material {
@@ -782,6 +792,42 @@ fn parse_vector_row_type(
         dimension,
         element_type,
     ))
+}
+
+/// Server-pushed session parameter that ORs into `StageInfo.use_s3_regional_url`.
+/// All three reference drivers (Python connector, JDBC, libsnowflakeclient)
+/// read this exact key from the login response. The canonical name on the
+/// Rust side is `use_s3_regional_url`; this string is only the wire-level key
+/// that GS uses.
+const ENABLE_STAGE_S3_PRIVATELINK_SERVER_KEY: &str = "ENABLE_STAGE_S3_PRIVATELINK_FOR_US_EAST_1";
+
+/// Reads the `ENABLE_STAGE_S3_PRIVATELINK_FOR_US_EAST_1` session parameter as
+/// a boolean.
+///
+/// `session_parameters` keys are uppercased upstream — see the write sites in
+/// `apis::database_driver_v1::connection` (`session_parameters.write()` at
+/// login merge and post-query response) and the corresponding read in
+/// `connection_get_parameter` which uppercases its lookup key. We therefore
+/// do a direct `HashMap::get` on the canonical uppercase form rather than
+/// scanning the map.
+///
+/// Accepted value forms: `"true"` (case-insensitive) and `"1"`. JSON `true`
+/// and JSON `1` from GS land here as those exact strings after the
+/// post-response stringification at `apis::database_driver_v1::connection`.
+/// JDBC additionally accepts `"on"`; we don't currently, since GS doesn't
+/// emit that form.
+///
+/// Called at the PUT/GET dispatch site rather than passing the whole
+/// session-parameter map down: PUT/GET only needs this one key, and reading
+/// it eagerly avoids cloning the entire `HashMap<String, String>` on every
+/// transfer.
+pub fn read_use_s3_regional_url_session_param(
+    session_parameters: &HashMap<String, String>,
+) -> bool {
+    session_parameters
+        .get(ENABLE_STAGE_S3_PRIVATELINK_SERVER_KEY)
+        .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
+        .unwrap_or(false)
 }
 
 impl TryFrom<&StageInfo> for file_manager::StageInfo {
@@ -1229,7 +1275,7 @@ mod tests {
         let json = make_upload_json(r#""encryptionMaterial": null,"#);
         let data: Data = serde_json::from_str(&json).unwrap();
         let upload = data
-            .to_file_upload_data(PutGetResultsetFlavor::default())
+            .to_file_upload_data(PutGetResultsetFlavor::default(), false)
             .unwrap();
         assert!(upload.encryption_material.is_none());
     }
@@ -1239,7 +1285,7 @@ mod tests {
         let json = make_upload_json("");
         let data: Data = serde_json::from_str(&json).unwrap();
         let upload = data
-            .to_file_upload_data(PutGetResultsetFlavor::default())
+            .to_file_upload_data(PutGetResultsetFlavor::default(), false)
             .unwrap();
         assert!(upload.encryption_material.is_none());
     }
@@ -1249,7 +1295,7 @@ mod tests {
         let json = make_upload_json(r#""encryptionMaterial": [],"#);
         let data: Data = serde_json::from_str(&json).unwrap();
         let upload = data
-            .to_file_upload_data(PutGetResultsetFlavor::default())
+            .to_file_upload_data(PutGetResultsetFlavor::default(), false)
             .unwrap();
         assert!(upload.encryption_material.is_none());
     }
@@ -1261,7 +1307,7 @@ mod tests {
         );
         let data: Data = serde_json::from_str(&json).unwrap();
         let upload = data
-            .to_file_upload_data(PutGetResultsetFlavor::default())
+            .to_file_upload_data(PutGetResultsetFlavor::default(), false)
             .unwrap();
         assert!(upload.encryption_material.is_some());
     }
@@ -1273,7 +1319,7 @@ mod tests {
         );
         let data: Data = serde_json::from_str(&json).unwrap();
         let upload = data
-            .to_file_upload_data(PutGetResultsetFlavor::default())
+            .to_file_upload_data(PutGetResultsetFlavor::default(), false)
             .unwrap();
         assert!(upload.encryption_material.is_some());
     }
@@ -1287,7 +1333,7 @@ mod tests {
             ],"#,
         );
         let data: Data = serde_json::from_str(&json).unwrap();
-        let result = data.to_file_upload_data(PutGetResultsetFlavor::default());
+        let result = data.to_file_upload_data(PutGetResultsetFlavor::default(), false);
         assert!(result.is_err());
         let err_msg = result.unwrap_err().to_string();
         assert!(
@@ -1301,7 +1347,7 @@ mod tests {
         let json = make_upload_json("");
         let data: Data = serde_json::from_str(&json).unwrap();
         let upload = data
-            .to_file_upload_data(PutGetResultsetFlavor::Python)
+            .to_file_upload_data(PutGetResultsetFlavor::Python, false)
             .unwrap();
         assert_eq!(upload.flavor, PutGetResultsetFlavor::Python);
     }
@@ -1311,7 +1357,7 @@ mod tests {
         let json = make_upload_json("");
         let data: Data = serde_json::from_str(&json).unwrap();
         let upload = data
-            .to_file_upload_data(PutGetResultsetFlavor::Odbc)
+            .to_file_upload_data(PutGetResultsetFlavor::Odbc, false)
             .unwrap();
         assert_eq!(upload.flavor, PutGetResultsetFlavor::Odbc);
     }
@@ -1334,7 +1380,7 @@ mod tests {
     fn download_data_forwards_flavor_python() {
         let data: Data = serde_json::from_str(&make_download_json()).unwrap();
         let download = data
-            .to_file_download_data(&PutGetResultsetFlavor::Python)
+            .to_file_download_data(&PutGetResultsetFlavor::Python, false)
             .unwrap();
         assert_eq!(download.flavor, PutGetResultsetFlavor::Python);
     }
@@ -1343,7 +1389,7 @@ mod tests {
     fn download_data_forwards_flavor_odbc() {
         let data: Data = serde_json::from_str(&make_download_json()).unwrap();
         let download = data
-            .to_file_download_data(&PutGetResultsetFlavor::Odbc)
+            .to_file_download_data(&PutGetResultsetFlavor::Odbc, false)
             .unwrap();
         assert_eq!(download.flavor, PutGetResultsetFlavor::Odbc);
     }
@@ -1893,5 +1939,116 @@ mod tests {
         // we keep talking to the global `s3.amazonaws.com` endpoint.
         let info = parse_s3_stage_info(s3_stage_info_value(None, None));
         assert!(!info.use_s3_regional_url);
+    }
+
+    // --- Session-parameter lookup (ENABLE_STAGE_S3_PRIVATELINK_FOR_US_EAST_1) ---
+    //
+    // Tests `read_use_s3_regional_url_session_param` directly. The boolean
+    // result is OR'd into `StageInfo.use_s3_regional_url` at the PUT/GET
+    // dispatch site (see `to_file_upload_data` / `to_file_download_data`).
+    // Mirrors the OR-with-session-parameter semantics implemented in the
+    // Python connector, JDBC, and libsnowflakeclient.
+
+    fn build_session_params(entries: &[(&str, &str)]) -> HashMap<String, String> {
+        entries
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn read_session_param_returns_true_when_set() {
+        let params = build_session_params(&[("ENABLE_STAGE_S3_PRIVATELINK_FOR_US_EAST_1", "true")]);
+        assert!(read_use_s3_regional_url_session_param(&params));
+    }
+
+    #[test]
+    fn read_session_param_value_lookup_is_case_insensitive() {
+        // GS may push the value as `TRUE` or `True`; we must accept all
+        // common cases. Keys, by contrast, are uppercased upstream by
+        // `apis::database_driver_v1::connection`, so the helper does a
+        // direct `get` on the canonical uppercase key and we don't need
+        // to test other key casings here.
+        let params = build_session_params(&[("ENABLE_STAGE_S3_PRIVATELINK_FOR_US_EAST_1", "TRUE")]);
+        assert!(read_use_s3_regional_url_session_param(&params));
+    }
+
+    #[test]
+    fn read_session_param_lowercase_key_returns_false() {
+        // Documents the upstream invariant: `session_parameters` keys are
+        // uppercased by `connection.rs` write sites. A lowercase key must
+        // not be matched here, because if it ever appears the bug is in
+        // the upstream normalization, not in this lookup.
+        let params = build_session_params(&[("enable_stage_s3_privatelink_for_us_east_1", "true")]);
+        assert!(!read_use_s3_regional_url_session_param(&params));
+    }
+
+    #[test]
+    fn read_session_param_accepts_numeric_one() {
+        let params = build_session_params(&[("ENABLE_STAGE_S3_PRIVATELINK_FOR_US_EAST_1", "1")]);
+        assert!(read_use_s3_regional_url_session_param(&params));
+    }
+
+    #[test]
+    fn read_session_param_returns_false_when_absent() {
+        assert!(!read_use_s3_regional_url_session_param(&HashMap::new()));
+    }
+
+    #[test]
+    fn read_session_param_returns_false_when_explicitly_false() {
+        let params =
+            build_session_params(&[("ENABLE_STAGE_S3_PRIVATELINK_FOR_US_EAST_1", "false")]);
+        assert!(!read_use_s3_regional_url_session_param(&params));
+    }
+
+    #[test]
+    fn read_session_param_unrelated_keys_ignored() {
+        let params = build_session_params(&[
+            ("CLIENT_PREFETCH_THREADS", "8"),
+            ("CLIENT_SESSION_KEEP_ALIVE", "true"),
+        ]);
+        assert!(!read_use_s3_regional_url_session_param(&params));
+    }
+
+    // Integration check: the boolean parameter wires through
+    // `to_file_upload_data` and ORs into `StageInfo.use_s3_regional_url`.
+
+    fn make_upload_data_for_s3_regional_url_test(
+        stage_info_value: serde_json::Value,
+        use_s3_regional_url_session_param: bool,
+    ) -> file_manager::UploadData {
+        let payload = serde_json::json!({
+            "command": "UPLOAD",
+            "src_locations": ["/tmp/upload.csv"],
+            "stageInfo": stage_info_value,
+            "autoCompress": true,
+            "sourceCompression": "NONE",
+        });
+        let data: Data = serde_json::from_value(payload).expect("build upload Data");
+        data.to_file_upload_data(
+            PutGetResultsetFlavor::default(),
+            use_s3_regional_url_session_param,
+        )
+        .expect("convert to UploadData")
+    }
+
+    #[test]
+    fn upload_data_session_param_true_forces_regional_when_stage_info_false() {
+        let upload = make_upload_data_for_s3_regional_url_test(
+            s3_stage_info_value(Some(false), Some(false)),
+            true,
+        );
+        assert!(upload.stage_info.use_s3_regional_url);
+    }
+
+    #[test]
+    fn upload_data_session_param_false_does_not_mask_stage_info_true() {
+        // Stage-info already true; session-parameter false must not flip it
+        // back to false. The OR is one-directional.
+        let upload = make_upload_data_for_s3_regional_url_test(
+            s3_stage_info_value(Some(true), Some(false)),
+            false,
+        );
+        assert!(upload.stage_info.use_s3_regional_url);
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #1205. Adds the connection-level / session-parameter override to the regional-S3-URL feature. ORs into `StageInfo.use_s3_regional_url`, matching Python / JDBC / libsnowflakeclient.

## Changes

- sf_core: new `use_s3_regional_url` ParamDef with `ENABLE_STAGE_S3_PRIVATELINK_FOR_US_EAST_1` as alias; PUT/GET dispatch now reads the resolved session-param value and ORs it into stage info.
- Python: `enable_stage_s3_privatelink_for_us_east_1` deprecated alias for canonical `use_s3_regional_url`; BehaviorDifferences #27.

## Tests

- Rust unit: OR semantics, case-insensitive value, one-directional override.
- Python unit: deprecated alias maps + warns; canonical is silent.
- Python e2e: round-trip with kwarg set; deprecation fires on connect.