### PR TITLE
NO-SNOW: python - remove fetch mode guard on cursor

### DIFF
--- a/python/src/snowflake/connector/cursor/__init__.py
+++ b/python/src/snowflake/connector/cursor/__init__.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 from ._base import (
     DictRow,
-    FetchMode,
     Row,
     SnowflakeCursorBase,
 )
@@ -31,7 +30,6 @@ __all__ = [
     "CursorType",
     "DictCursor",
     "DictRow",
-    "FetchMode",
     "QueryResultStats",
     "ResultMetadata",
     "ResultMetadataV2",

--- a/python/src/snowflake/connector/cursor/_base.py
+++ b/python/src/snowflake/connector/cursor/_base.py
@@ -2,15 +2,14 @@
 Base cursor class and supporting decorators.
 
 This module defines the abstract base cursor class (``SnowflakeCursorBase``)
-and its associated helpers: ``FetchMode``, type aliases, and decorator
-functions for precondition checks.
+and its associated helpers: type aliases, and decorator functions for
+precondition checks.
 """
 
 from __future__ import annotations
 
 import abc
 import ctypes
-import enum
 import functools
 import logging
 
@@ -68,17 +67,6 @@ F = TypeVar("F", bound=Callable[..., Any])
 T = TypeVar("T", bound=Sequence[Any])
 
 
-class FetchMode(enum.Enum):
-    """Distinguishes row-by-row fetching from Arrow/Pandas fetching.
-
-    Once a cursor begins consuming results with one mode, switching to
-    the other is disallowed until a new ``execute()`` resets state.
-    """
-
-    ROW = "row"
-    ARROW = "arrow"
-
-
 def _requires_open(func: F) -> F:
     @functools.wraps(func)
     def wrapper(self: SnowflakeCursorBase, *args: Any, **kwargs: Any) -> Any:
@@ -120,28 +108,6 @@ def _with_prefetch_hook(func: F) -> F:
     return cast(F, wrapper)
 
 
-def _requires_fetch_mode(mode: FetchMode) -> Callable[[F], F]:
-    """Validate and lock the cursor's fetch mode before entering the wrapped method."""
-
-    def decorator(func: F) -> F:
-        @functools.wraps(func)
-        def wrapper(self: SnowflakeCursorBase, *args: Any, **kwargs: Any) -> Any:
-            if self._fetch_mode and self._fetch_mode != mode:
-                if mode == FetchMode.ARROW:
-                    raise ProgrammingError(msg="Cannot use arrow/pandas fetch methods after row-by-row fetching")
-                elif mode == FetchMode.ROW:
-                    raise ProgrammingError(msg="Cannot use row-by-row fetch methods after arrow/pandas fetching")
-                else:
-                    raise ProgrammingError(msg=f"Unexpected fetch mode: {mode}")
-            self._fetch_mode = mode
-
-            return func(self, *args, **kwargs)
-
-        return cast(F, wrapper)
-
-    return decorator
-
-
 class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
     """
     Base cursor class for database operations (PEP 249).
@@ -181,7 +147,6 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
 
         # -- Active iteration state (cleared on reset) --
         self._iterator: ArrowStreamIterator | None = None
-        self._fetch_mode: FetchMode | None = None
 
         # -- Statement parameters (persists until explicitly changed) --
         self._statement_parameters: dict[str, Any] = {}
@@ -690,7 +655,6 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
 
     @_requires_open_cursor_not_connection
     @_with_prefetch_hook
-    @_requires_fetch_mode(FetchMode.ROW)
     def _fetchone(self) -> Row | DictRow | None:
         """Fetch the next row internally.
 
@@ -715,7 +679,6 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
     @api_telemetry
     @_requires_open_cursor_not_connection
     @_with_prefetch_hook
-    @_requires_fetch_mode(FetchMode.ROW)
     def fetchmany(self, size: int | None = None) -> list[Any]:
         """
         Fetch the next set of rows of a query result.
@@ -750,7 +713,6 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
     @api_telemetry
     @_requires_open_cursor_not_connection
     @_with_prefetch_hook
-    @_requires_fetch_mode(FetchMode.ROW)
     def fetchall(self) -> list[Any]:
         """
         Fetch all (remaining) rows of a query result.
@@ -925,7 +887,6 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
         self._query_result.reset(closing=closing)
         self._result_set.release()
         self._iterator = None
-        self._fetch_mode = None
         self._binding_data = None
         self._prefetch_hook = None
         # Clear multistatement state
@@ -1033,7 +994,6 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
     @api_telemetry
     @_requires_open
     @_with_prefetch_hook
-    @_requires_fetch_mode(FetchMode.ARROW)
     def fetch_arrow_batches(
         self,
         force_microsecond_precision: bool = False,
@@ -1052,7 +1012,6 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
     @api_telemetry
     @_requires_open
     @_with_prefetch_hook
-    @_requires_fetch_mode(FetchMode.ARROW)
     def fetch_arrow_all(
         self,
         force_return_table: bool = False,

--- a/python/src/snowflake/connector/cursor/_result_set_wrapper.py
+++ b/python/src/snowflake/connector/cursor/_result_set_wrapper.py
@@ -22,18 +22,14 @@ class _ResultSetWrapper:
     new one; ``release()`` frees the current handle.  ``__del__`` acts as a
     safety net for handles that were never explicitly released.
 
-    The wrapper tracks whether the Arrow stream has already been consumed.
-    A second call to :meth:`get_arrow_stream_ptr` raises instead of
-    silently re-fetching.  (The core layer *does* support re-fetching via a
-    slow path, but the Python wrapper prevents it to catch accidental
-    double-consumption.)
+    The core layer supports repeated ``result_set_get_stream`` calls — each
+    invocation builds a fresh Arrow stream from the stored ``RowsetData``.
     """
 
-    __slots__ = ("_handle", "_stream_consumed")
+    __slots__ = ("_handle",)
 
     def __init__(self, handle: ResultSetHandle | None = None) -> None:
         self._handle: ResultSetHandle | None = handle
-        self._stream_consumed: bool = False
 
     # -- handle management --------------------------------------------------
 
@@ -41,7 +37,6 @@ class _ResultSetWrapper:
         """Release the current handle (if any) and adopt *new_handle*."""
         self._do_release()
         self._handle = new_handle
-        self._stream_consumed = False
 
     def release(self) -> None:
         """Explicitly release the handle."""
@@ -65,24 +60,17 @@ class _ResultSetWrapper:
     def get_arrow_stream_ptr(self) -> int:
         """Fetch the Arrow stream and return the raw C pointer.
 
-        The stream can only be consumed once per result set.  A second call
-        raises ``ProgrammingError`` instead of silently hitting Snowflake.
+        Each call builds a fresh stream from the stored result set data.
 
         Raises:
-            ProgrammingError: If no handle is held or the stream was already consumed.
+            ProgrammingError: If no handle is held.
         """
         if self._handle is None:
             raise ProgrammingError(
                 msg="No results available (not produced by this query)",
                 errno=ER_NO_DATA_FOUND,
             )
-        if self._stream_consumed:
-            raise ProgrammingError(
-                msg="No results available (arrow stream already consumed)",
-                errno=ER_NO_DATA_FOUND,
-            )
         response = core_driver.result_set_get_stream(result_set_handle=self._handle)
-        self._stream_consumed = True
         return get_stream_ptr(response)
 
     def get_chunks(self) -> ResultSetGetChunksResponse | None:

--- a/python/tests/e2e/pandas/test_fetch_arrow.py
+++ b/python/tests/e2e/pandas/test_fetch_arrow.py
@@ -201,6 +201,75 @@ class TestFetchArrowBatches:
         assert total_rows == LARGE_RESULT_SET_ROW_COUNT
 
 
+class TestMixedFetchModes:
+    """Test that mixing row-by-row and arrow fetch modes works on same cursor.
+
+    After the ResultSet concept, each arrow stream is built on-demand from stored
+    RowsetData — there is no reason to prevent switching between fetch modes.
+    """
+
+    def test_fetch_arrow_batches_after_fetchone(self, cursor):
+        """fetch_arrow_batches works after partial row-by-row consumption."""
+        # When a query is executed and partially consumed via fetchone
+        cursor.execute(
+            """
+            SELECT ROW_NUMBER() OVER (ORDER BY seq4()) - 1 AS n
+            FROM TABLE(GENERATOR(ROWCOUNT => 10))
+            ORDER BY 1
+            """
+        )
+        row1 = cursor.fetchone()
+        row2 = cursor.fetchone()
+        assert row1 == (0,)
+        assert row2 == (1,)
+
+        # Then fetch_arrow_batches returns a fresh full result set
+        batches = list(cursor.fetch_arrow_batches())
+        assert len(batches) > 0
+        combined = pa.concat_tables(batches)
+        assert combined.num_rows == 10
+        assert combined.column("N").to_pylist() == list(range(10))
+
+    def test_fetch_arrow_all_after_fetchmany(self, cursor):
+        """fetch_arrow_all works after partial fetchmany consumption."""
+        # When a query is executed and partially consumed via fetchmany
+        cursor.execute(
+            """
+            SELECT ROW_NUMBER() OVER (ORDER BY seq4()) - 1 AS n
+            FROM TABLE(GENERATOR(ROWCOUNT => 5))
+            ORDER BY 1
+            """
+        )
+        batch = cursor.fetchmany(2)
+        assert batch == [(0,), (1,)]
+
+        # Then fetch_arrow_all returns a fresh full result set
+        table = cursor.fetch_arrow_all()
+        assert table is not None
+        assert table.num_rows == 5
+        assert table.column("N").to_pylist() == list(range(5))
+
+    def test_fetchone_after_fetch_arrow_batches(self, cursor):
+        """Row-by-row fetching works after arrow fetching on same result set."""
+        # When a query is executed and consumed via fetch_arrow_batches
+        cursor.execute(
+            """
+            SELECT ROW_NUMBER() OVER (ORDER BY seq4()) - 1 AS n
+            FROM TABLE(GENERATOR(ROWCOUNT => 5))
+            ORDER BY 1
+            """
+        )
+        batches = list(cursor.fetch_arrow_batches())
+        combined = pa.concat_tables(batches)
+        assert combined.num_rows == 5
+
+        # Then fetchone returns rows from a fresh full result set
+        row = cursor.fetchone()
+        assert row == (0,)
+        remaining = cursor.fetchall()
+        assert remaining == [(1,), (2,), (3,), (4,)]
+
+
 class TestResultBatchPickleArrow:
     """Tests for result batch pickle round-trip with to_arrow conversion."""
 

--- a/python/tests/unit/test_api_usage_telemetry.py
+++ b/python/tests/unit/test_api_usage_telemetry.py
@@ -182,7 +182,6 @@ class TestCursorApiTelemetry:
         # fetchone requires a prior execute — mock the iterator
         cursor._execute_result = MagicMock()
         cursor._iterator = iter([])
-        cursor._fetch_mode = None
         cursor.fetchone()
 
         methods = _get_api_methods(mock_db_api)
@@ -194,7 +193,6 @@ class TestCursorApiTelemetry:
         mock_iterator.fetch_many.return_value = [(1,), (2,)]
         cursor._execute_result = MagicMock()
         cursor._iterator = mock_iterator
-        cursor._fetch_mode = None
         cursor.fetchmany(2)
 
         methods = _get_api_methods(mock_db_api)
@@ -209,7 +207,6 @@ class TestCursorApiTelemetry:
 
         cur._execute_result = MagicMock()
         cur._iterator = iter([])
-        cur._fetch_mode = None
         cur.fetchone()
 
         methods = _get_api_methods(mock_db_api)

--- a/python/tests/unit/test_cursor.py
+++ b/python/tests/unit/test_cursor.py
@@ -22,7 +22,7 @@ from snowflake.connector._internal.protobuf_gen.database_driver_v1_pb2 import (
     StatementHandle,
 )
 from snowflake.connector.constants import QueryStatus
-from snowflake.connector.cursor import FetchMode, QueryResultStats, SnowflakeCursor, SnowflakeCursorBase
+from snowflake.connector.cursor import QueryResultStats, SnowflakeCursor, SnowflakeCursorBase
 from snowflake.connector.cursor._query_result import _QueryResult
 from snowflake.connector.cursor._query_result_waiter import QueryResultWaiter
 from snowflake.connector.errors import DatabaseError, InterfaceError, ProgrammingError
@@ -1405,108 +1405,6 @@ class TestFetchPandasAll:
         mock_fetch.assert_called_once_with(force_return_table=True, force_microsecond_precision=True)
 
 
-class TestFetchModeValidation:
-    """Unit tests for fetch mode validation (preventing mixed row/arrow fetching)."""
-
-    @pytest.fixture
-    def mock_connection(self):
-        mock_connection = MagicMock()
-        mock_connection.is_closed.return_value = False
-        return mock_connection
-
-    @pytest.fixture
-    def cursor(self, mock_connection):
-        return SnowflakeCursor(mock_connection)
-
-    @pytest.fixture(autouse=True)
-    def _patch_deps(self):
-        with (
-            patch("snowflake.connector._internal.extras.check_dependency"),
-            patch("snowflake.connector.cursor._base.pyarrow", new=MagicMock()),
-            patch("snowflake.connector.cursor._base.pandas", new=MagicMock()),
-        ):
-            yield
-
-    def test_row_then_arrow_raises(self, cursor):
-        cursor._iterator = iter([(1,)])
-
-        with patch.object(cursor, "_create_row_iterator"):
-            cursor.fetchone()
-
-        with pytest.raises(ProgrammingError, match="Cannot use arrow/pandas fetch methods"):
-            list(cursor.fetch_arrow_batches())
-
-    def test_arrow_then_row_raises(self, cursor):
-        cursor._result_set = MagicMock(get_arrow_stream_ptr=MagicMock(return_value=42))
-
-        with patch("snowflake.connector.cursor._base.create_table_iterator", return_value=iter([])):
-            cursor.fetch_arrow_all()
-
-        with pytest.raises(ProgrammingError, match="Cannot use row-by-row fetch methods"):
-            cursor.fetchone()
-
-    def test_row_then_pandas_raises(self, cursor):
-        cursor._iterator = iter([(1,)])
-
-        with patch.object(cursor, "_create_row_iterator"):
-            cursor.fetchone()
-
-        with pytest.raises(ProgrammingError, match="Cannot use arrow/pandas fetch methods"):
-            list(cursor.fetch_pandas_batches())
-
-    def test_pandas_then_row_raises(self, cursor):
-        cursor._fetch_mode = FetchMode.ARROW
-
-        with pytest.raises(ProgrammingError, match="Cannot use row-by-row fetch methods"):
-            cursor.fetchall()
-
-    def test_fetchall_then_arrow_raises(self, cursor):
-        cursor._iterator = MockRowIterator([(1,)])
-
-        with patch.object(cursor, "_create_row_iterator"):
-            cursor.fetchall()
-
-        with pytest.raises(ProgrammingError, match="Cannot use arrow/pandas fetch methods"):
-            cursor.fetch_arrow_all()
-
-    def test_arrow_then_fetchmany_raises(self, cursor):
-        cursor._fetch_mode = FetchMode.ARROW
-
-        with pytest.raises(ProgrammingError, match="Cannot use row-by-row fetch methods"):
-            cursor.fetchmany(5)
-
-    def test_arrow_then_fetchall_raises(self, cursor):
-        cursor._fetch_mode = FetchMode.ARROW
-
-        with pytest.raises(ProgrammingError, match="Cannot use row-by-row fetch methods"):
-            cursor.fetchall()
-
-    def test_fetchmany_then_arrow_raises(self, cursor):
-        cursor._iterator = MockRowIterator([(1,), (2,)])
-
-        with patch.object(cursor, "_create_row_iterator"):
-            cursor.fetchmany(1)
-
-        with pytest.raises(ProgrammingError, match="Cannot use arrow/pandas fetch methods"):
-            cursor.fetch_arrow_all()
-
-    def test_same_mode_is_fine(self, cursor):
-        cursor._iterator = MockRowIterator([(1,), (2,)])
-
-        with patch.object(cursor, "_create_row_iterator"):
-            cursor.fetchone()
-            cursor.fetchone()
-
-    def test_execute_resets_fetch_mode(self, cursor, mock_connection, mock_core_client):
-        mock_connection.conn_handle = ConnectionHandle(id=1)
-        mock_core_client.statement_new.return_value.stmt_handle = StatementHandle(id=1)
-
-        cursor._fetch_mode = FetchMode.ARROW
-        cursor.execute("SELECT 1")
-
-        assert cursor._fetch_mode is None
-
-
 class TestReset:
     """Unit tests for Cursor.reset method."""
 
@@ -1531,14 +1429,12 @@ class TestReset:
         cursor._iterator = iter([(1,)])
         cursor._binding_data = b"data"
         cursor._rownumber = 10
-        cursor._fetch_mode = FetchMode.ROW
 
         cursor.reset()
 
         # Cleared by reset
         assert cursor._iterator is None
         assert cursor._binding_data is None
-        assert cursor._fetch_mode is None
         assert cursor._query_result.rowcount is None
         # Preserved by reset (matches old driver)
         assert cursor._rownumber == 10
@@ -1551,13 +1447,11 @@ class TestReset:
         """Calling reset() twice produces the same state as calling it once."""
         cursor._query_result = _QueryResult(rowcount=42)
         cursor._iterator = iter([(1,)])
-        cursor._fetch_mode = FetchMode.ROW
 
         cursor.reset()
         cursor.reset()
 
         assert cursor._iterator is None
-        assert cursor._fetch_mode is None
         assert cursor._query_result.rowcount is None
         assert cursor._rownumber == -1
 
@@ -1567,7 +1461,6 @@ class TestReset:
 
         assert cursor._iterator is None
         assert cursor.sqlstate is None
-        assert cursor._fetch_mode is None
         assert cursor._binding_data is None
         assert cursor._rownumber == -1
         assert cursor.rowcount is None
@@ -1585,14 +1478,12 @@ class TestReset:
         cursor._iterator = iter([(1,)])
         cursor._binding_data = b"data"
         cursor._rownumber = 10
-        cursor._fetch_mode = FetchMode.ARROW
 
         cursor.reset(closing=True)
 
         # Cleared by reset
         assert cursor._iterator is None
         assert cursor._binding_data is None
-        assert cursor._fetch_mode is None
         # Preserved by reset (always)
         assert cursor._rownumber == 10
         assert cursor._query_result.description is mock_desc
@@ -1658,13 +1549,11 @@ class TestClose:
         mock_desc = [MagicMock()]
         cursor._query_result = _QueryResult(description=mock_desc)
         cursor._iterator = iter([(1,)])
-        cursor._fetch_mode = FetchMode.ROW
 
         cursor.close()
 
         assert cursor._iterator is None
         assert cursor._query_result.description is mock_desc
-        assert cursor._fetch_mode is None
 
     def test_close_returns_none_on_exception(self, cursor):
         """close() returns None when reset() raises an exception."""
@@ -1750,14 +1639,6 @@ class TestResetIntegration:
         # _execute should be called 3 times
         assert mock_execute.call_count == 3
 
-    def test_execute_resets_fetch_mode_allowing_mode_switch(self, cursor, mock_connection):
-        """After execute(), the fetch mode is cleared so a different fetch strategy can be used."""
-        cursor._fetch_mode = FetchMode.ARROW
-
-        cursor.execute("SELECT 1")
-
-        assert cursor._fetch_mode is None
-
     def test_execute_overwrites_sqlstate_with_new_result(self, cursor, mock_connection):
         """execute() overwrites sqlstate from the new query result."""
         cursor._query_result.sqlstate = "42601"
@@ -1778,22 +1659,18 @@ class TestResetIntegration:
     def test_executemany_server_side_binding_delegates_reset_to_execute(self, cursor, mock_connection):
         """executemany() with server-side (qmark) binding delegates to execute(), which performs its own reset."""
         mock_connection.paramstyle = ParamStyle.QMARK
-        cursor._fetch_mode = FetchMode.ARROW
         cursor._query_result.sqlstate = "42601"
 
         cursor.executemany("INSERT INTO t VALUES (?)", [(1,), (2,), (3,)])
 
-        assert cursor._fetch_mode is None
         assert cursor.sqlstate is None
 
     def test_executemany_empty_params_does_not_reset(self, cursor, mock_connection):
         """executemany() with empty seq_of_parameters returns early without calling reset."""
-        cursor._fetch_mode = FetchMode.ARROW
         cursor._query_result = _QueryResult(rowcount=42)
 
         cursor.executemany("INSERT INTO t VALUES (?)", [])
 
-        assert cursor._fetch_mode == FetchMode.ARROW
         assert cursor._query_result.rowcount == 42
 
 
@@ -1856,7 +1733,6 @@ class TestDescribe:
         )
 
         cursor._query_result.rowcount = 42
-        cursor._fetch_mode = FetchMode.ARROW
 
         cursor.describe("SELECT 1")
 
@@ -1864,7 +1740,6 @@ class TestDescribe:
         assert cursor.query == "SELECT 1"
         assert cursor.sqlstate is None  # "00000" is normalized to None
         assert cursor.rowcount == 0
-        assert cursor._fetch_mode is None
 
     def test_describe_forwards_non_success_sqlstate(self, cursor, mock_core_client):
         """describe() forwards sqlstate when it differs from '00000'."""
@@ -1884,14 +1759,12 @@ class TestDescribe:
     def test_describe_side_effects_without_columns(self, cursor, mock_core_client):
         """describe() resets state; sfqid/query/sqlstate are set from result even without columns."""
         cursor._query_result.rowcount = 42
-        cursor._fetch_mode = FetchMode.ARROW
         self._setup_prepare(mock_core_client)
 
         cursor.describe("SELECT 1")
 
         assert cursor.sfqid is None
         assert cursor.rowcount is None
-        assert cursor._fetch_mode is None
 
     def test_describe_releases_handle_and_stream(self, cursor, mock_core_client):
         """describe() allocates/releases statement handle and releases the arrow stream."""
@@ -2006,15 +1879,13 @@ class TestQueryResult:
         assert request.query_id == "01234567-abcd-ef01-0000-000000000001"
 
     def test_query_result_resets_prior_state(self, cursor, mock_core_client):
-        """query_result clears iterator and fetch mode from a previous execute."""
+        """query_result clears iterator from a previous execute."""
         cursor._query_result = _QueryResult(rowcount=99)
         cursor._iterator = iter([(1,)])
-        cursor._fetch_mode = FetchMode.ROW
 
         self._stub_result(mock_core_client)
         cursor.query_result("qid")
 
-        assert cursor._fetch_mode is None
         assert cursor._iterator is None
 
     def test_query_result_raises_on_closed_cursor_or_connection(self, cursor, mock_connection):
@@ -2291,10 +2162,10 @@ class TestExecuteAsync:
 
     def test_resets_cursor_state(self, cursor):
         """execute_async resets cursor state before submission."""
-        cursor._fetch_mode = FetchMode.ROW
+        cursor._iterator = iter([(1,)])
         cursor.execute_async("SELECT 1")
 
-        assert cursor._fetch_mode is None
+        assert cursor._iterator is None
 
     def test_with_parameters_passes_bindings(self, cursor, mock_core_client):
         """execute_async forwards parameter bindings to the RPC request."""


### PR DESCRIPTION
## Summary

- Removes the `FetchMode` guard that prevented mixing row-by-row (`fetchone`/`fetchmany`/`fetchall`) and arrow (`fetch_arrow_batches`/`fetch_arrow_all`) fetch methods on the same cursor
- Removes the `_stream_consumed` single-use guard in `_ResultSetWrapper` — the core layer rebuilds a fresh Arrow stream from stored `RowsetData` on each `result_set_get_stream` call, so repeated calls are valid
- Adds integration tests (`TestMixedFetchModes`) validating mixed fetch mode usage

## Context

After introducing the ResultSet handle concept (afdc894), result sets hold owned `RowsetData` and lazily rebuild Arrow streams on demand. This means there's no technical reason to prevent switching between row-by-row and arrow fetch modes on the same cursor — each arrow fetch builds a fresh full stream independently of the row iterator.

The old (reference) driver already supports this behavior, confirmed by running the new tests against `hatch run reference:test`.

## Test plan

1. Wrote `TestMixedFetchModes` integration tests (3 scenarios: arrow after row, arrow after fetchmany, row after arrow)
2. Ran against reference driver via `hatch run reference:test` — all 3 PASSED
3. Ran against new driver via `hatch run dev.py3.13:integ` — all 444 tests PASSED (including the 3 new ones)
4. Ran unit tests via `hatch run dev.py3.13:unit` — all 995 tests PASSED
5. Pre-commit hooks pass (ruff, mypy, tests format validator)