### PR TITLE
NO-SNOW: python - fix GC-timing race in connection unit test fixture

### DIFF
--- a/python/tests/unit/test_connection.py
+++ b/python/tests/unit/test_connection.py
@@ -33,7 +33,11 @@ def connection(mock_db_api):
     from snowflake.connector.connection import Connection
 
     conn = Connection(user="test_user", account="test_account")
-    return conn
+    yield conn
+    # Prevent a late __del__ (deferred GC, especially on Python 3.14+) from
+    # calling close() through the *next* test's mock_db_api and polluting its
+    # call counts.
+    conn.auto_cleanup = False
 
 
 class TestGetConnectionInfo:


### PR DESCRIPTION
## Summary
- Fix a GC-timing race condition in the `connection` unit test fixture that caused `test_close_sends_connection_close_and_releases_handles` to flake on Python 3.14 / Windows
- The fixture now disables `auto_cleanup` on teardown so a late `__del__` (deferred reference counting in 3.14+) cannot call `close()` through the next test's `mock_db_api`

## Context
Python 3.14 introduced deferred reference counting, meaning `__del__` no longer fires immediately when the last reference drops. When `pytest-xdist` runs tests in sequence on a single worker, a stale `Connection` from test N can get GC'd during test N+1. Since `mock_db_api` globally patches `core_driver.client`, the late `__del__` → `_try_close()` → `close()` chain ends up calling `connection_close` on the *wrong* test's mock, inflating its call count and failing `assert_called_once()`.

The production `close()` code is correct — the lock + handle-swap pattern prevents double-release. This is purely a test isolation issue.

## Test plan
1. Verified the fixture teardown only runs *after* each test body completes, so no existing `TestClose` or `TestDel` assertions are affected
2. `test_del_releases_handles_if_not_closed` creates its own `Connection` (doesn't use the fixture) — unaffected
3. CI: the flake was observed on `python_tests test (windows-latest, py3.14, azure)` — this fix prevents the cross-test mock pollution that caused it