### PR TITLE
SNOW-2314157: inline analysis_feature_oauth.md references in code comments

### DIFF
--- a/sf_core/src/auth.rs
+++ b/sf_core/src/auth.rs
@@ -41,8 +41,8 @@ pub enum Credentials {
         passcode: Option<SensitiveString>,
     },
     /// Pre-acquired OAuth access token forwarded to Snowflake unchanged
-    /// (analysis §6 — legacy `AUTHENTICATOR=OAUTH` with raw `token=`).
-    /// Consumed by `auth_request_data` to populate the legacy login body.
+    /// (legacy `AUTHENTICATOR=OAUTH` with raw `token=`). Consumed by
+    /// `auth_request_data` to populate the legacy login body.
     OAuth {
         username: String,
         access_token: SensitiveString,
@@ -182,10 +182,10 @@ pub fn create_credentials(login_parameters: &LoginParameters) -> Result<Credenti
             username: username.clone(),
             access_token: token.clone(),
         }),
-        // OAuth Authorization Code and Client Credentials run their own multi-step
-        // flow (PKCE, browser/loopback, token exchange, refresh) outside of
-        // create_credentials — see analysis_feature_oauth.md §3 / §4. Mirror the
-        // NativeOkta arm above and surface a typed error rather than panicking.
+        // OAuth AC and CC run their own multi-step flow (PKCE,
+        // browser/loopback, token exchange, refresh) outside of
+        // create_credentials. Mirror the NativeOkta arm above and surface
+        // a typed error rather than panicking.
         LoginMethod::OAuthAuthorizationCode(_) => UnsupportedLoginMethodSnafu {
             method: "OAuthAuthorizationCode",
         }

--- a/sf_core/src/config/param_registry.rs
+++ b/sf_core/src/config/param_registry.rs
@@ -92,7 +92,7 @@ pub mod param_names {
     pub const CLIENT_SESSION_KEEP_ALIVE: ParamKey = ParamKey("CLIENT_SESSION_KEEP_ALIVE");
     pub const CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY: ParamKey =
         ParamKey("CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY");
-    // ── OAuth (analysis_feature_oauth.md §9) ───────────────────────────────
+    // ── OAuth (cross-driver configuration matrix) ─────────────────────────
     pub const OAUTH_CLIENT_ID: ParamKey = ParamKey("oauth_client_id");
     pub const OAUTH_CLIENT_SECRET: ParamKey = ParamKey("oauth_client_secret");
     pub const OAUTH_AUTHORIZATION_URL: ParamKey = ParamKey("oauth_authorization_url");
@@ -476,9 +476,9 @@ static PARAM_DEFS: &[ParamDef] = &[
         mutable_after_connect: false,
     },
     // ── OAuth ───────────────────────────────────────────────────────────
-    // Cross-driver canonical naming follows JDBC `SFSessionProperty.OAUTH_*`
-    // (analysis_feature_oauth.md §9). All OAuth params are connect-time
-    // and immutable for the life of the connection.
+    // Cross-driver canonical naming follows JDBC `SFSessionProperty.OAUTH_*`.
+    // All OAuth params are connect-time and immutable for the life of the
+    // connection.
     ParamDef {
         canonical_name: param_names::OAUTH_CLIENT_ID.as_str(),
         aliases: &["OAUTH_CLIENT_ID"],

--- a/sf_core/src/config/rest_parameters.rs
+++ b/sf_core/src/config/rest_parameters.rs
@@ -247,44 +247,44 @@ pub struct NativeOktaConfig {
 
 /// OAuth 2.0 Authorization Code (with PKCE) flow configuration.
 ///
-/// Mirrors the cross-driver configuration matrix in `analysis_feature_oauth.md` §9.
-/// All optional URL fields fall back to Snowflake-as-IdP defaults at flow time
-/// (see analysis §9 / §14): `https://{host}/oauth/authorize`,
-/// `https://{host}/oauth/token-request`, and an ephemeral `http://127.0.0.1:<random>`
-/// loopback redirect URI.
+/// Mirrors the cross-driver configuration matrix
+/// (JDBC/ODBC/Python/.NET/Go/Node). All optional URL fields fall back to
+/// Snowflake-as-IdP defaults at flow time: `https://{host}/oauth/authorize`,
+/// `https://{host}/oauth/token-request`, and an ephemeral
+/// `http://127.0.0.1:<random>` loopback redirect URI.
 #[derive(Debug)]
 pub struct OAuthAuthorizationCodeConfig {
     /// Snowflake user name. Sent unchanged in the login-request body
-    /// (analysis §10.1: `LOGIN_NAME` is always set, unlike .NET's `loginName=""` quirk).
+    /// (`LOGIN_NAME` is always set; .NET's `loginName=""` quirk is not replicated).
     pub username: String,
     /// IdP-issued client identifier. For Snowflake-as-IdP the wiring step
-    /// will substitute `LOCAL_APPLICATION` when this is empty (analysis §1, §9).
+    /// will substitute `LOCAL_APPLICATION` when this is empty.
     pub client_id: String,
     /// IdP-issued client secret.
     pub client_secret: SensitiveString,
     /// Optional override for the IdP authorization endpoint.
-    /// `None` ⇒ default `https://{host}/oauth/authorize` (analysis §9).
+    /// `None` ⇒ default `https://{host}/oauth/authorize`.
     pub authorization_url: Option<Url>,
     /// Optional override for the IdP token endpoint.
     /// `None` ⇒ default `https://{host}/oauth/token-request`. Also used to
-    /// derive the OAuth cache-key host (analysis §7.3).
+    /// derive the OAuth cache-key host.
     pub token_url: Option<Url>,
     /// Optional override for the loopback redirect URI advertised to the IdP.
-    /// `None` ⇒ ephemeral `http://127.0.0.1:<random>` (analysis §3.5; bind to
-    /// `127.0.0.1`, never `0.0.0.0` per §14 gotcha #11).
+    /// `None` ⇒ ephemeral `http://127.0.0.1:<random>` (bind to `127.0.0.1`,
+    /// never `0.0.0.0`).
     pub redirect_uri: Option<Url>,
     /// OAuth scope string (space-separated). `None` ⇒ derived from role
-    /// (`session:role:<role>` per analysis §9).
+    /// (`session:role:<role>`).
     pub scope: Option<String>,
     /// Snowflake-as-IdP only: request single-use refresh-token rotation by
-    /// adding `enable_single_use_refresh_tokens=true` to the token body
-    /// (analysis §7.4). Defaults to `false`.
+    /// adding `enable_single_use_refresh_tokens=true` to the token body.
+    /// Defaults to `false`.
     pub enable_single_use_refresh_tokens: bool,
-    /// Python-only escape hatch (analysis §9): disable PKCE S256.
-    /// All other drivers always run PKCE; defaults to `false` here.
+    /// Python-only escape hatch: disable PKCE S256. All other drivers
+    /// always run PKCE; defaults to `false` here.
     pub disable_pkce: bool,
     /// Whether refresh tokens may be persisted to the OS-level token cache
-    /// (analysis §7.1; controls `client_store_temporary_credential`).
+    /// (controls `client_store_temporary_credential`).
     pub client_store_temporary_credential: bool,
     /// Driver-local flow behavior (DPoP, timeout). Not sent to Snowflake.
     pub flow_options: OAuthFlowOptions,
@@ -299,15 +299,15 @@ pub struct OAuthAuthorizationCodeConfig {
 #[derive(Debug)]
 pub struct OAuthFlowOptions {
     /// Enable RFC 9449 DPoP proof-of-possession on token + login requests.
-    /// Currently only JDBC has parity (analysis §5); defaults to `false`.
+    /// Currently only JDBC has DPoP parity; defaults to `false`.
     pub enable_dpop: bool,
     /// End-to-end auth budget for the OAuth flow.
     pub authentication_timeout_secs: u64,
 }
 
 /// OAuth 2.0 Client Credentials flow configuration (external IdP only —
-/// Snowflake's GS does not issue tokens for `grant_type=client_credentials`,
-/// see analysis §4).
+/// Snowflake's GS does not issue tokens for
+/// `grant_type=client_credentials`).
 #[derive(Debug)]
 pub struct OAuthClientCredentialsConfig {
     /// Snowflake user name (sent in the Snowflake login-request body).
@@ -317,7 +317,7 @@ pub struct OAuthClientCredentialsConfig {
     /// IdP-issued client secret (required for CC).
     pub client_secret: SensitiveString,
     /// IdP token endpoint. **Required** for CC: there is no Snowflake default
-    /// because Snowflake-as-IdP does not support CC (analysis §4).
+    /// because Snowflake-as-IdP does not support CC.
     pub token_url: Url,
     /// OAuth scope string (space-separated). `None` ⇒ derived from role.
     pub scope: Option<String>,
@@ -353,16 +353,15 @@ pub enum LoginMethod {
         authentication_timeout_secs: u64,
     },
     /// Pre-acquired OAuth access token (legacy `AUTHENTICATOR=OAUTH` with
-    /// raw `token=`). The driver forwards the token to Snowflake unchanged
-    /// (analysis §6). Production wiring + parsing land in step 2.3.
+    /// raw `token=`). The driver forwards the token to Snowflake unchanged.
     OAuthAccessToken {
         username: String,
         token: SensitiveString,
     },
     /// OAuth 2.0 Authorization Code with PKCE (S256). Multi-step flow
-    /// orchestrated outside of `create_credentials` (analysis §3).
+    /// orchestrated outside of `create_credentials`.
     OAuthAuthorizationCode(OAuthAuthorizationCodeConfig),
-    /// OAuth 2.0 Client Credentials. External IdP only (analysis §4).
+    /// OAuth 2.0 Client Credentials. External IdP only.
     OAuthClientCredentials(OAuthClientCredentialsConfig),
 }
 
@@ -614,9 +613,8 @@ impl LoginMethod {
                 let username = Self::non_empty_string(settings, "user")
                     .context(MissingParameterSnafu { parameter: "user" })?;
                 // Snowflake-as-IdP substitutes `LOCAL_APPLICATION` for
-                // missing client_id/client_secret at flow time
-                // (analysis_feature_oauth.md §1, §9). Keep them empty here
-                // and let the AC provider apply that default.
+                // missing client_id/client_secret at flow time. Keep them
+                // empty here and let the AC provider apply that default.
                 let client_id =
                     Self::non_empty_string(settings, "oauth_client_id").unwrap_or_default();
                 let client_secret =
@@ -655,8 +653,8 @@ impl LoginMethod {
             }
             "OAUTH_CLIENT_CREDENTIALS" => {
                 // CC is external-IdP only: Snowflake's GS does not issue
-                // tokens for `grant_type=client_credentials` (analysis §4),
-                // so client_id, client_secret and token_url are mandatory.
+                // tokens for `grant_type=client_credentials`, so client_id,
+                // client_secret and token_url are mandatory.
                 let username = Self::non_empty_string(settings, "user")
                     .context(MissingParameterSnafu { parameter: "user" })?;
                 let client_id = Self::non_empty_string(settings, "oauth_client_id").context(

--- a/sf_core/src/rest/snowflake/auth.rs
+++ b/sf_core/src/rest/snowflake/auth.rs
@@ -100,8 +100,8 @@ pub struct AuthRequestData {
     /// Transient DPoP JWK JSON carried from the OAuth flow to
     /// `send_login_request` when DPoP is enabled. Never serialized into
     /// the login-request body — it is consumed by `send_login_request`
-    /// to sign the DPoP proof JWT attached as an HTTP header
-    /// (analysis_feature_oauth.md §5 / §14 #5).
+    /// to sign the RFC 9449 DPoP proof JWT attached as an HTTP header
+    /// (matching JDBC's `DPoPUtil` pattern).
     #[serde(skip)]
     pub dpop_jwk_json: Option<String>,
 }

--- a/sf_core/src/rest/snowflake/mod.rs
+++ b/sf_core/src/rest/snowflake/mod.rs
@@ -72,12 +72,12 @@ pub const SESSION_GONE: i32 = 390111;
 /// The caller must use the master token to obtain a fresh session token and retry.
 pub const SESSION_TOKEN_EXPIRED: i32 = 390112;
 /// GS error code returned when the OAuth access token presented at login is
-/// invalid (analysis_feature_oauth.md §8). Treated cross-driver as a signal
-/// to evict the cached access token and replay the OAuth flow.
+/// invalid. Treated cross-driver as a signal to evict the cached access
+/// token and replay the OAuth flow.
 pub const OAUTH_ACCESS_TOKEN_INVALID: i32 = 390303;
 /// GS error code returned when the OAuth access token presented at login has
-/// expired (analysis_feature_oauth.md §8). Same eviction-and-retry behavior
-/// as [`OAUTH_ACCESS_TOKEN_INVALID`].
+/// expired. Same eviction-and-retry behavior as
+/// [`OAUTH_ACCESS_TOKEN_INVALID`].
 pub const OAUTH_ACCESS_TOKEN_EXPIRED: i32 = 390318;
 /// GS error codes that indicate the cached OAuth access token (and any
 /// DPoP-bundled cache entry) must be evicted, after which the login is
@@ -405,12 +405,12 @@ fn remove_mfa_token_from_cache(
 /// present) for an Authorization Code login. Used by the
 /// `390303 / 390318` retry block in [`snowflake_login_with_client`]:
 /// after eviction the next call to `auth_request_data` will run the
-/// refresh-token leg or, if that also fails, the full interactive flow
-/// (analysis_feature_oauth.md §8 + §3.2 state machine).
+/// refresh-token leg or, if that also fails, the full interactive flow.
 ///
-/// The cache key host follows the cross-driver convention from analysis
-/// §7.3: prefer the IdP token URL host, otherwise fall back to the
-/// Snowflake server host. The synthetic `https://{host}` URL string
+/// The cache key host follows the cross-driver convention
+/// (JDBC/Python/.NET/Node): prefer the IdP token URL host, otherwise
+/// fall back to the Snowflake server host. The synthetic `https://{host}`
+/// URL string
 /// passed to the eviction helpers parses cleanly into the same host the
 /// AC flow used when storing the token.
 fn evict_oauth_access_token_for_authorization_code(
@@ -487,11 +487,10 @@ pub async fn auth_request_data(
         // Authorization Code orchestration runs the PKCE/state/loopback flow
         // (and any cache hits / refresh-token exchange) before forwarding the
         // resulting access token to Snowflake under AUTHENTICATOR=OAUTH.
-        // Per analysis §10.1 / §14 #5, the body always uses uppercase
-        // "OAUTH" — never the user-supplied authenticator string verbatim —
-        // and tags the request with OAUTH_TYPE=OAUTH_AUTHORIZATION_CODE so
-        // GS knows which flow produced the token. LOGIN_NAME is always set
-        // (§14 #10).
+        // The body always uses uppercase "OAUTH" — never the user-supplied
+        // authenticator string verbatim — and tags the request with
+        // OAUTH_TYPE=OAUTH_AUTHORIZATION_CODE so GS knows which flow
+        // produced the token. LOGIN_NAME is always set.
         LoginMethod::OAuthAuthorizationCode(cfg) => {
             let server_url = url::Url::parse(&login_parameters.server_url)
                 .context(oauth::EndpointUrlParseSnafu {
@@ -515,8 +514,8 @@ pub async fn auth_request_data(
             // (RFC 9449).
             data.dpop_jwk_json = acquired.dpop_jwk_json;
         }
-        // Client Credentials is external-IdP only (analysis §4) and tokens
-        // are intentionally not cached (§14 #12). On Snowflake error codes
+        // Client Credentials is external-IdP only and tokens are
+        // intentionally not cached. On Snowflake error codes
         // 390303/390318 the retry block in `snowflake_login_with_client`
         // skips the AC eviction step and just replays the flow so the IdP
         // token endpoint is re-hit.
@@ -781,15 +780,14 @@ pub async fn snowflake_login_with_client(
         }
     }
 
-    // OAuth refresh-on-failure (analysis_feature_oauth.md §8 / §14 #9):
-    // when GS rejects the OAuth access token with 390303 / 390318, replay
-    // the login once. For Authorization Code we first evict the cached
-    // access token (and any DPoP-bundled entry) so the replay exercises
-    // the refresh-token leg or, failing that, the interactive flow. For
-    // Client Credentials there is no cache to evict (analysis §4 / §14
-    // #12), so the replay re-hits the IdP token endpoint to fetch a
-    // fresh access token. Cross-driver consensus per analysis §8 (JDBC,
-    // ODBC, .NET, Go all retry both flows). Legacy `OAuthAccessToken`
+    // OAuth refresh-on-failure: when GS rejects the OAuth access token
+    // with 390303 / 390318, replay the login once. For Authorization Code
+    // we first evict the cached access token (and any DPoP-bundled entry)
+    // so the replay exercises the refresh-token leg or, failing that, the
+    // interactive flow. For Client Credentials there is no cache to evict
+    // (CC tokens are not persisted), so the replay re-hits the IdP token
+    // endpoint to fetch a fresh access token. Cross-driver consensus:
+    // JDBC, ODBC, .NET, Go all retry both flows. Legacy `OAuthAccessToken`
     // bubbles the error since the caller supplies the token directly.
     if !auth_response.success {
         let code = auth_response
@@ -814,7 +812,7 @@ pub async fn snowflake_login_with_client(
                     should_retry = true;
                 }
                 LoginMethod::OAuthClientCredentials(_) => {
-                    // No cache to evict for CC (analysis §4 / §14 #12);
+                    // No cache to evict for CC (tokens are not persisted);
                     // the replay re-acquires from the IdP token endpoint.
                     tracing::debug!(
                         code = code,

--- a/sf_core/src/rest/snowflake/oauth/authorization_code.rs
+++ b/sf_core/src/rest/snowflake/oauth/authorization_code.rs
@@ -2,11 +2,10 @@
 //!
 //! Owns the end-to-end orchestration: PKCE verifier/challenge, CSRF state,
 //! browser launch, loopback HTTP redirect handling, token exchange, and
-//! refresh-token rotation. See `analysis_feature_oauth.md` §3 for the
-//! per-driver state machine and gotchas (notably §3.5 on 127.0.0.1
-//! binding and §14 #11 on rejecting Node's `0.0.0.0`).
+//! refresh-token rotation. Loopback binds `127.0.0.1` explicitly (Node's
+//! `0.0.0.0` bind is intentionally not replicated).
 //!
-//! Defaults follow JDBC/Python (analysis §9):
+//! Defaults follow JDBC/Python:
 //! * `authorization_url` ⇒ `https://{server_host}/oauth/authorize`
 //! * `token_url` ⇒ `https://{server_host}/oauth/token-request`
 //! * `redirect_uri` ⇒ ephemeral `http://127.0.0.1:<port>/`
@@ -15,7 +14,7 @@
 //! `client_store_temporary_credential` is enabled and a [`TokenCache`] is
 //! provided, the access token is consulted first, then the refresh token
 //! is exchanged, and only if both fall through do we drive the
-//! interactive flow (analysis §3.2 state machine).
+//! interactive flow.
 //!
 //! HTTP transport, body encoding, CSRF generation, and PKCE generation
 //! are owned by the `oauth2` crate; we only orchestrate the moving parts
@@ -108,8 +107,7 @@ pub(crate) struct AcquiredOAuthToken {
     /// flow itself; the wiring layer does not consume it directly.
     pub(crate) refresh_token: Option<SensitiveString>,
     /// Present iff DPoP was negotiated. Carries the JWK JSON so the
-    /// Snowflake login-request can reuse the same key when signing
-    /// (analysis §5.1).
+    /// Snowflake login-request can reuse the same key when signing.
     pub(crate) dpop_jwk_json: Option<String>,
     /// IdP-reported lifetime of the access token, when present. Snowflake
     /// drives session validity itself, so this is informational only.
@@ -177,7 +175,7 @@ async fn run_authorization_code_flow(
     // wait, the IdP token exchange and any refresh exchange.
     let deadline = FlowDeadline::new(config.flow_options.authentication_timeout_secs);
 
-    // 1. Cache short-circuit (analysis §3.2 + §7).
+    // 1. Cache short-circuit.
     if let Some(cached) = try_cache_short_circuit(
         client,
         &token_url,
@@ -229,7 +227,7 @@ async fn try_cache_short_circuit(
     // Drift B.11: when DPoP is enabled, look up the bundled cache entry
     // first. The bundle carries both the access token and the JWK JSON
     // so the same DPoP key can sign the Snowflake login leg without
-    // re-running the interactive flow (analysis §5.1, §6).
+    // re-running the interactive flow.
     if config.flow_options.enable_dpop
         && let Some((cached_at, jwk_json)) =
             token::try_get_cached_oauth_dpop_bundled(cache_host_url, &config.username, token_cache)
@@ -348,7 +346,7 @@ async fn run_interactive_flow(
         redirect_uri.clone(),
     )?;
 
-    // PKCE S256 is on by default across drivers (analysis §3.3); Python
+    // PKCE S256 is on by default across drivers; Python
     // is the only one with a `oauth_disable_pkce` escape hatch and we
     // mirror it here (drift A.2). When disabled we skip both the
     // `set_pkce_challenge` on the authorize URL and the
@@ -359,8 +357,7 @@ async fn run_interactive_flow(
         Some(PkceCodeChallenge::new_random_sha256())
     };
 
-    // 256-bit CSRF state per `doc/oauth.md` §3 ("Key properties") and
-    // analysis §3.4 (drift A.4). 32 random bytes base64url-encoded.
+    // 256-bit CSRF state (drift A.4). 32 random bytes base64url-encoded.
     let mut request = oauth_client.authorize_url(|| CsrfToken::new_random_len(32));
     if let Some((challenge, _)) = pkce.as_ref() {
         request = request.set_pkce_challenge(challenge.clone());
@@ -498,8 +495,8 @@ async fn refresh_access_token(
 
     // Drift B.12: serialize the DPoP JWK alongside the new access token
     // so `persist_access_token` takes the bundled-cache write path
-    // (analysis §6: "DPoP key + access token JSON" lives under the
-    // bundled entry, not `OAUTH_ACCESS_TOKEN`).
+    // (DPoP key + access token lives under the bundled entry, not
+    // `OAUTH_ACCESS_TOKEN`).
     let dpop_jwk_json = match dpop_key {
         Some(k) => Some(k.to_jwk_json()?),
         None => None,
@@ -523,8 +520,8 @@ fn build_oauth_client(
     OAuthError,
 > {
     // Snowflake-as-IdP substitutes `LOCAL_APPLICATION` for missing
-    // client_id/client_secret (`doc/oauth.md` §2; analysis §1, §9 — drift
-    // B.1). We treat "user did not override the token URL" as the
+    // client_id/client_secret (drift B.1). We treat "user did not override
+    // the token URL" as the
     // Snowflake-as-IdP signal, matching JDBC's `OAuthUtil` heuristic.
     let snowflake_idp = config.token_url.is_none();
     let (client_id, client_secret) = resolve_client_credentials(config, snowflake_idp);
@@ -538,7 +535,7 @@ fn build_oauth_client(
 /// Drift B.1: if no client credentials were provided and Snowflake is
 /// the IdP, substitute the literal `LOCAL_APPLICATION` for both
 /// `client_id` and `client_secret` (matches JDBC, ODBC, Python, .NET,
-/// Go and Node — analysis §1 and §2). External IdPs require explicit
+/// Go and Node). External IdPs require explicit
 /// credentials, so the empty values fall through unchanged.
 fn resolve_client_credentials(
     config: &OAuthAuthorizationCodeConfig,

--- a/sf_core/src/rest/snowflake/oauth/client_credentials.rs
+++ b/sf_core/src/rest/snowflake/oauth/client_credentials.rs
@@ -1,9 +1,9 @@
 //! OAuth 2.0 Client Credentials flow (external IdP only).
 //!
-//! Snowflake-as-IdP does not currently issue tokens for
-//! `grant_type=client_credentials` (analysis_feature_oauth.md §4), so this
-//! module always requires an explicit `token_url`. Tokens obtained here are
-//! intentionally not persisted to the OS token cache (analysis §14 #12).
+//! Snowflake GS does not currently issue tokens for
+//! `grant_type=client_credentials`, so this module always requires an
+//! explicit `token_url`. Tokens obtained here are intentionally not
+//! persisted to the OS token cache (matches JDBC/.NET/Python/Node).
 //!
 //! HTTP authentication uses RFC 6749 §2.3.1 Basic auth, mirroring JDBC,
 //! ODBC, .NET, Python (default), and Go. Node's `ClientSecretPost` shape
@@ -42,8 +42,8 @@ pub(crate) async fn acquire_client_credentials(
     };
 
     // Drift B.1: `LOCAL_APPLICATION` substitution is intentionally NOT
-    // performed for CC. CC is external-IdP only (analysis §4: Snowflake's
-    // GS does not issue tokens for `grant_type=client_credentials`), and
+    // performed for CC. CC is external-IdP only (Snowflake's GS does not
+    // issue tokens for `grant_type=client_credentials`), and
     // `LoginMethod::from_settings` enforces non-empty `client_id` /
     // `client_secret` before the config ever reaches this function — so
     // the Snowflake-IdP substitution path documented for AC has no
@@ -85,8 +85,8 @@ pub(crate) async fn acquire_client_credentials(
     };
 
     tracing::info!("OAuth client credentials flow completed");
-    // CC tokens MUST NOT be persisted (analysis §14 #12); we hand them
-    // straight back to the caller.
+    // CC tokens MUST NOT be persisted (matches JDBC/.NET/Python/Node);
+    // we hand them straight back to the caller.
     Ok(AcquiredOAuthToken {
         access_token,
         refresh_token: None,

--- a/sf_core/src/rest/snowflake/oauth/dpop.rs
+++ b/sf_core/src/rest/snowflake/oauth/dpop.rs
@@ -3,14 +3,14 @@
 //! ES256 P-256 keypair, proof JWT with `jti`/`htm`/`htu`/`iat` (and
 //! optional `nonce` on `use_dpop_nonce` retry), `dpop_jkt` thumbprint on
 //! the `/authorize` request, and a bundled access-token cache row. Only
-//! JDBC has parity today (analysis_feature_oauth.md §5).
+//! JDBC has DPoP parity today among Snowflake drivers.
 //!
 //! Implementation notes:
 //! - JWS signature is hand-built so we can attach the `jwk` header parameter
 //!   (which the `jwt` crate's [`jwt::Header`] does not expose). We still
 //!   share the openssl-backed signing primitive with `sf_core::auth`.
 //! - `htu` deliberately strips the URL query string and fragment per
-//!   RFC 9449 §4.3 (also gotcha #2 in `analysis_feature_oauth.md` §14).
+//!   RFC 9449 §4.3.
 //! - JWK thumbprint is computed over the canonical RFC 7638 form:
 //!   `{"crv":"P-256","kty":"EC","x":"…","y":"…"}` with lex-sorted keys,
 //!   no whitespace.
@@ -106,7 +106,7 @@ impl DPoPKey {
 
     /// Serialize the key as a JWK including the private component, so it
     /// can be reused across the token-acquisition leg and the Snowflake
-    /// login-request leg (analysis §5.1 — the JDBC bundled-cache pattern).
+    /// login-request leg (the JDBC bundled-cache pattern).
     pub(crate) fn to_jwk_json(&self) -> Result<String, OAuthError> {
         let (x_b64, y_b64) = self.public_xy_b64()?;
         let d_b64 = bn_to_b64url(self.key.private_key())?;
@@ -246,7 +246,7 @@ fn json_escape(s: &str) -> String {
 
 /// If the IdP responded with an `error == "use_dpop_nonce"` body and a
 /// `DPoP-Nonce` header, return the nonce so the caller can retry once
-/// with the nonce embedded in the proof (analysis §5.1; mirrors JDBC
+/// with the nonce embedded in the proof (mirrors JDBC
 /// `RestRequest.checkForDPoPNonceError`).
 pub(crate) fn check_use_dpop_nonce(headers: &HeaderMap, body: &str) -> Option<String> {
     let parsed: serde_json::Value = serde_json::from_str(body).ok()?;

--- a/sf_core/src/rest/snowflake/oauth/error.rs
+++ b/sf_core/src/rest/snowflake/oauth/error.rs
@@ -1,11 +1,11 @@
 //! Errors raised by the OAuth flow engine.
 //!
-//! The variant set is derived from the cross-driver error taxonomy in
-//! `analysis_feature_oauth.md` §13. Marked `pub(crate)` because the
-//! wiring layer (step 2.3) translates these into the driver-facing
-//! `RestError` / `AuthError` taxonomy. Crate-internal callers should
-//! match on variants to make eviction / refresh decisions (analysis §8:
-//! e.g. `RefreshTokenExchange` should drop the cached refresh token and
+//! The variant set mirrors the cross-driver error taxonomy (JDBC
+//! `ErrorCode.OAUTH_*`, ODBC `SFOAuthError`, Python `ER_OAUTH_*`).
+//! Marked `pub(crate)` because the wiring layer translates these into
+//! the driver-facing `RestError` / `AuthError` taxonomy. Crate-internal
+//! callers should match on variants to make eviction / refresh decisions
+//! (e.g. `RefreshTokenExchange` should drop the cached refresh token and
 //! replay the full flow).
 
 use crate::token_cache::TokenCacheError;
@@ -14,7 +14,7 @@ use snafu::{Location, Snafu};
 #[derive(Debug, Snafu, error_trace::ErrorTrace)]
 #[snafu(visibility(pub(crate)))]
 pub enum OAuthError {
-    /// `state` mismatch on the loopback redirect — analysis §14 #7.
+    /// `state` mismatch on the loopback redirect (potential XSS attack).
     /// Equality is enforced via `oauth2::CsrfToken`'s timing-safe
     /// `PartialEq` (the `timing-resistant-secret-traits` feature
     /// derives a SHA-256-based comparator).
@@ -46,8 +46,7 @@ pub enum OAuthError {
     },
 
     /// Loopback `accept()` did not see a request before the configured
-    /// browser-response timeout elapsed (cross-driver: JDBC/Python/Go/.NET
-    /// 120s default, analysis §3.5).
+    /// browser-response timeout elapsed (cross-driver default: 120s).
     #[snafu(display("OAuth browser authorization timed out"))]
     BrowserTimeout {
         #[snafu(implicit)]
@@ -106,7 +105,7 @@ pub enum OAuthError {
     },
 
     /// Refresh-token exchange failed. Caller should evict the refresh
-    /// token from cache and replay the full flow (analysis §7.4 / §8).
+    /// token from cache and replay the full flow.
     #[snafu(display("OAuth refresh-token exchange failed"))]
     RefreshTokenExchange {
         #[snafu(implicit)]
@@ -115,7 +114,7 @@ pub enum OAuthError {
 
     /// Token endpoint returned 2xx but no `access_token` field. Treated
     /// as an error to avoid passing an empty Bearer token downstream
-    /// (analysis §13: ODBC's `idp_auth_missing_access_token` fixture).
+    /// (mirrors ODBC's `idp_auth_missing_access_token` fixture).
     #[snafu(display("OAuth token response did not include an access_token"))]
     MissingAccessToken {
         #[snafu(implicit)]
@@ -151,7 +150,7 @@ pub enum OAuthError {
 
     /// Sentinel: token endpoint requested a DPoP nonce. Internal callers
     /// catch this once and retry with the supplied nonce embedded in the
-    /// proof JWT. Never bubbled to user code (analysis §5.1).
+    /// proof JWT. Never bubbled to user code.
     #[snafu(display("OAuth token endpoint requested a DPoP nonce; retrying"))]
     DPoPNonceRequired {
         #[snafu(implicit)]

--- a/sf_core/src/rest/snowflake/oauth/http_client.rs
+++ b/sf_core/src/rest/snowflake/oauth/http_client.rs
@@ -10,7 +10,7 @@
 //! only place a DPoP header needs to be attached during the AC/CC flows
 //! (RFC 9449 §5). On a `400 use_dpop_nonce` response the adapter stashes
 //! the `DPoP-Nonce` header value and performs exactly one retry with
-//! the nonce embedded in the proof JWT (RFC 9449 §8 + analysis §5.1).
+//! the nonce embedded in the proof JWT (RFC 9449 §8).
 
 use std::future::Future;
 use std::pin::Pin;
@@ -133,7 +133,7 @@ impl<'c> AsyncHttpClient<'c> for OAuthHttpClient {
             let first_request = clone_request(&request);
             let response = self.send_once(first_request, nonce.as_deref()).await?;
 
-            // DPoP nonce-retry per RFC 9449 §8 + analysis §5.1.
+            // DPoP nonce-retry per RFC 9449 §8.
             if let Some(dpop) = self.dpop.as_ref()
                 && let Ok(body) = std::str::from_utf8(response.body())
                 && let Some(server_nonce) = dpop::check_use_dpop_nonce(response.headers(), body)

--- a/sf_core/src/rest/snowflake/oauth/loopback_server.rs
+++ b/sf_core/src/rest/snowflake/oauth/loopback_server.rs
@@ -2,7 +2,8 @@
 //!
 //! Must bind explicitly to `127.0.0.1` (and only `::1` when the user
 //! supplies a literal IPv6 redirect URI). Do **not** replicate Node's
-//! `0.0.0.0` bind — see `analysis_feature_oauth.md` §3.5 and §14 #11.
+//! `0.0.0.0` bind — it widens the OAuth-window attack surface to the
+//! local network.
 //!
 //! HTTP parsing and response writing are delegated to `axum`; we keep
 //! ownership of the bind decision and the single-shot semantics

--- a/sf_core/src/rest/snowflake/oauth/mod.rs
+++ b/sf_core/src/rest/snowflake/oauth/mod.rs
@@ -5,14 +5,12 @@
 //! loopback HTTP server, DPoP, token cache I/O, and the OAuth-specific
 //! error type). CSRF state, browser launch, and the token-endpoint HTTP
 //! exchange are handled by the `oauth2`, `webbrowser`, and `axum`
-//! crates respectively. Cross-driver behavior, parameter names,
-//! redaction expectations, and gotchas are catalogued in
-//! `analysis_feature_oauth.md` (especially §2–§9 and §14).
+//! crates respectively.
 //!
 //! The re-exports below pin the surface that `auth_request_data`
-//! consumes when wiring `LoginMethod::OAuth*` (analysis §6 / §10.1)
-//! and that `snowflake_login_with_client` uses for the
-//! refresh-on-failure retry path (analysis §8 / §14 #9).
+//! consumes when wiring `LoginMethod::OAuth*` (login-request payload
+//! mapping) and that `snowflake_login_with_client` uses for the
+//! refresh-on-failure retry path (390303/390318 eviction + replay).
 
 mod authorization_code;
 mod client_credentials;
@@ -21,7 +19,7 @@ mod error;
 mod http_client;
 mod loopback_server;
 // Standalone PKCE helper kept as scaffolding; the active flow uses
-// `oauth2::PkceCodeChallenge` directly (analysis §9: PKCE always-on).
+// `oauth2::PkceCodeChallenge` directly (PKCE always-on).
 #[allow(dead_code)]
 mod pkce;
 mod token;

--- a/sf_core/src/rest/snowflake/oauth/pkce.rs
+++ b/sf_core/src/rest/snowflake/oauth/pkce.rs
@@ -1,7 +1,7 @@
 //! PKCE (RFC 7636) verifier and S256 challenge generation.
 //!
-//! Cross-driver verifier sizes converge on ≥43 URL-safe characters; see
-//! `analysis_feature_oauth.md` §3.3 for the per-driver matrix. We use the
+//! Cross-driver verifier sizes converge on ≥43 URL-safe characters (JDBC
+//! 256-bit Nimbus, ODBC/Go/Node 32-byte, Python 43-byte). We use the
 //! `oauth2` crate's RFC-compliant generator (32 random bytes → 43-char
 //! URL-safe verifier), matching ODBC/Go/Node and well within the
 //! 43..=128 character window required by the RFC.

--- a/sf_core/src/rest/snowflake/oauth/token.rs
+++ b/sf_core/src/rest/snowflake/oauth/token.rs
@@ -1,9 +1,10 @@
 //! OAuth token cache I/O and refresh-token rotation.
 //!
 //! Cache key derivation follows JDBC/Python: host is the IdP token URL
-//! host (or fall back to the Snowflake server URL host) — see analysis
-//! `analysis_feature_oauth.md` §7.3, gotcha §14 #3. Eviction on Snowflake
-//! error codes `390303` / `390318` is required across all drivers (§8).
+//! host (or fall back to the Snowflake server URL host), matching JDBC's
+//! `getHostForOAuthCacheKey` and Python's
+//! `urlparse(token_request_url).hostname`. Eviction on Snowflake error
+//! codes `390303` / `390318` is required across all drivers.
 //!
 //! These helpers mirror the MFA-token helpers in
 //! `sf_core::rest::snowflake::mod` so the call sites in the OAuth flow
@@ -18,8 +19,8 @@ use crate::token_cache::{TokenCache, TokenType};
 
 /// Resolve the cache-key host for OAuth tokens.
 ///
-/// Python convention (`urllib.parse.urlparse(token_request_url).hostname`,
-/// see analysis §7.3): use the IdP token endpoint host when present,
+/// Python convention (`urllib.parse.urlparse(token_request_url).hostname`):
+/// use the IdP token endpoint host when present,
 /// otherwise fall back to the Snowflake server host.
 pub(crate) fn host_from_token_url(
     token_request_url: &str,
@@ -178,8 +179,7 @@ pub(crate) fn pack_dpop_bundle(access_token: &str, jwk_json: &str) -> String {
 
 /// Inverse of [`pack_dpop_bundle`]. Returns `None` if the format is not
 /// recognized so callers can evict the corrupt entry and start over
-/// (mirrors JDBC's "legacy non-base64 encoded cache values" branch —
-/// analysis §14 #9).
+/// (mirrors JDBC's "legacy non-base64 encoded cache values" branch).
 pub(crate) fn unpack_dpop_bundle(packed: &str) -> Option<(String, String)> {
     let (at_b64, jwk_b64) = packed.split_once('.')?;
     let at = BASE64_STD.decode(at_b64.as_bytes()).ok()?;


### PR DESCRIPTION
Replace all references to analysis_feature_oauth.md (and its section
numbers) in sf_core code comments with self-contained inline extracts.
Comment-only change across 14 files; no functional change.