### PR TITLE
SNOW-2881745: cache external browser SSO ID tokens for re-authentication

### DIFF
--- a/sf_core/src/apis/database_driver_v1/connection.rs
+++ b/sf_core/src/apis/database_driver_v1/connection.rs
@@ -247,9 +247,12 @@ impl DatabaseDriverV1 {
                     read_spcs_token(self.fs_adapter().as_ref()),
                 );
 
-                let mfa_caching_requested = matches!(
+                let token_caching_requested = matches!(
                     &login_parameters.login_method,
                     LoginMethod::UserPasswordMfa {
+                        client_store_temporary_credential: true,
+                        ..
+                    } | LoginMethod::ExternalBrowser {
                         client_store_temporary_credential: true,
                         ..
                     }
@@ -270,7 +273,7 @@ impl DatabaseDriverV1 {
                         if cfg.client_store_temporary_credential
                 );
 
-                let token_cache = if mfa_caching_requested || oauth_caching_requested {
+                let token_cache = if token_caching_requested || oauth_caching_requested {
                     Some(self.token_cache().context(TokenCacheInitializationSnafu)?)
                 } else {
                     None

--- a/sf_core/src/config/connection_config.rs
+++ b/sf_core/src/config/connection_config.rs
@@ -69,6 +69,7 @@ pub enum AuthConfig {
     ExternalBrowser {
         user: String,
         authentication_timeout_secs: u64,
+        client_store_temporary_credential: bool,
     },
     /// Legacy pre-acquired OAuth access token (`AUTHENTICATOR=OAUTH` +
     /// raw `token=`). Forwarded unchanged to Snowflake
@@ -460,6 +461,9 @@ fn build_auth_config(settings: &ParamStore) -> Result<AuthConfig, ConfigError> {
                 parameter: String::from(USER),
             })?,
             authentication_timeout_secs: parse_authentication_timeout(settings),
+            client_store_temporary_credential: settings
+                .get_bool(CLIENT_STORE_TEMPORARY_CREDENTIAL)
+                .unwrap_or(false),
         }),
         _ => InvalidParameterValueSnafu {
             parameter: String::from(AUTHENTICATOR),
@@ -563,9 +567,11 @@ fn login_method_from_auth_config(auth: &AuthConfig) -> LoginMethod {
         AuthConfig::ExternalBrowser {
             user,
             authentication_timeout_secs,
+            client_store_temporary_credential,
         } => LoginMethod::ExternalBrowser {
             username: user.clone(),
             authentication_timeout_secs: *authentication_timeout_secs,
+            client_store_temporary_credential: *client_store_temporary_credential,
         },
         AuthConfig::OAuthAccessToken { user, token } => LoginMethod::OAuthAccessToken {
             username: user.clone(),

--- a/sf_core/src/config/rest_parameters.rs
+++ b/sf_core/src/config/rest_parameters.rs
@@ -409,6 +409,7 @@ pub enum LoginMethod {
     ExternalBrowser {
         username: String,
         authentication_timeout_secs: u64,
+        client_store_temporary_credential: bool,
     },
     /// Pre-acquired OAuth access token (legacy `AUTHENTICATOR=OAUTH` with
     /// raw `token=`). The driver forwards the token to Snowflake unchanged.
@@ -794,19 +795,10 @@ impl LoginMethod {
                     .or_else(|| settings.get_int("passcodeInPassword").map(|v| v != 0))
                     .unwrap_or(false),
                 passcode: settings.get_string("passcode").map(SensitiveString::from),
-                client_store_temporary_credential: settings
-                    .get_bool("client_store_temporary_credential")
-                    .or_else(|| {
-                        settings
-                            .get_string("client_store_temporary_credential")
-                            .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
-                    })
-                    .or_else(|| {
-                        settings
-                            .get_int("client_store_temporary_credential")
-                            .map(|v| v != 0)
-                    })
-                    .unwrap_or(false),
+                client_store_temporary_credential: get_flexible_bool(
+                    settings,
+                    "client_store_temporary_credential",
+                ),
             }),
             "EXTERNALBROWSER" => {
                 let authentication_timeout_secs = settings
@@ -817,6 +809,10 @@ impl LoginMethod {
                     username: non_empty_string(settings, "user")
                         .context(MissingParameterSnafu { parameter: "user" })?,
                     authentication_timeout_secs,
+                    client_store_temporary_credential: get_flexible_bool(
+                        settings,
+                        "client_store_temporary_credential",
+                    ),
                 })
             }
             _ => InvalidParameterValueSnafu {
@@ -1524,7 +1520,7 @@ mod tests {
 
     // ─── External Browser config tests ───────────────────────────────────
 
-    fn external_browser_config(extras: Vec<(&str, Setting)>) -> (String, u64) {
+    fn external_browser_config(extras: Vec<(&str, Setting)>) -> (String, u64, bool) {
         let mut base = vec![
             ("user", Setting::String("browser_user".to_string())),
             (
@@ -1543,21 +1539,27 @@ mod tests {
             LoginMethod::ExternalBrowser {
                 username,
                 authentication_timeout_secs,
-            } => (username, authentication_timeout_secs),
+                client_store_temporary_credential,
+            } => (
+                username,
+                authentication_timeout_secs,
+                client_store_temporary_credential,
+            ),
             other => panic!("Expected ExternalBrowser, got {other:?}"),
         }
     }
 
     #[test]
     fn test_external_browser_happy_path() {
-        let (user, timeout) = external_browser_config(vec![]);
+        let (user, timeout, store_cred) = external_browser_config(vec![]);
         assert_eq!(user, "browser_user");
         assert_eq!(timeout, DEFAULT_AUTHENTICATION_TIMEOUT_SECS);
+        assert!(!store_cred);
     }
 
     #[test]
     fn test_external_browser_custom_timeout() {
-        let (_, timeout) = external_browser_config(vec![(
+        let (_, timeout, _) = external_browser_config(vec![(
             "authentication_timeout",
             Setting::String("30".to_string()),
         )]);
@@ -1566,11 +1568,20 @@ mod tests {
 
     #[test]
     fn test_external_browser_invalid_timeout_uses_default() {
-        let (_, timeout) = external_browser_config(vec![(
+        let (_, timeout, _) = external_browser_config(vec![(
             "authentication_timeout",
             Setting::String("abc".to_string()),
         )]);
         assert_eq!(timeout, DEFAULT_AUTHENTICATION_TIMEOUT_SECS);
+    }
+
+    #[test]
+    fn test_external_browser_with_credential_caching_enabled() {
+        let (_, _, store_cred) = external_browser_config(vec![(
+            "client_store_temporary_credential",
+            Setting::String("true".to_string()),
+        )]);
+        assert!(store_cred);
     }
 
     #[test]

--- a/sf_core/src/rest/snowflake/auth.rs
+++ b/sf_core/src/rest/snowflake/auth.rs
@@ -14,6 +14,16 @@ where
     Ok(secs.map(Duration::from_secs))
 }
 
+/// Wire-format authenticator values sent in the `AUTHENTICATOR` field of the login-request body.
+pub mod authenticator {
+    pub const EXTERNAL_BROWSER: &str = "EXTERNALBROWSER";
+    pub const ID_TOKEN: &str = "ID_TOKEN";
+    pub const OAUTH: &str = "OAUTH";
+    pub const SNOWFLAKE_JWT: &str = "SNOWFLAKE_JWT";
+    pub const PROGRAMMATIC_ACCESS_TOKEN: &str = "PROGRAMMATIC_ACCESS_TOKEN";
+    pub const USERNAME_PASSWORD_MFA: &str = "USERNAME_PASSWORD_MFA";
+}
+
 // TODO: Delete all unused fields when we are sure they are not needed
 
 #[derive(Debug, Serialize, Default)]
@@ -104,6 +114,16 @@ pub struct AuthRequestData {
     /// (matching JDBC's `DPoPUtil` pattern).
     #[serde(skip)]
     pub dpop_jwk_json: Option<String>,
+    /// Whether this request uses a cached token (ID token or MFA token).
+    /// Guards the evict-and-retry path so we don't retry pointlessly when
+    /// the original login didn't use a cached token.
+    #[serde(skip)]
+    pub token_from_cache_used: bool,
+    /// Transient flag (not serialized): whether the IdP consented to ID
+    /// token caching. `None` when the browser flow was skipped (cache hit)
+    /// or when the callback was a plain GET redirect without consent info.
+    #[serde(skip)]
+    pub consent_cache_id_token: Option<bool>,
 }
 
 #[derive(Debug, Serialize)]
@@ -155,7 +175,7 @@ pub struct AuthResponseMain {
     #[serde(rename = "mfaToken")]
     pub mfa_token: Option<SensitiveString>,
     #[serde(rename = "idToken")]
-    pub _id_token: Option<SensitiveString>,
+    pub id_token: Option<SensitiveString>,
     #[serde(rename = "idTokenValidityInSeconds")]
     pub _id_token_validity: Option<u64>,
     #[serde(rename = "displayUserName")]

--- a/sf_core/src/rest/snowflake/mod.rs
+++ b/sf_core/src/rest/snowflake/mod.rs
@@ -32,7 +32,7 @@ use crate::config::retry::RetryPolicy;
 use crate::http::retry::{HttpContext, HttpError, execute_with_retry};
 use crate::rest::snowflake::auth::{
     AuthRequest, AuthRequestClientCapabilities, AuthRequestClientEnvironment, AuthRequestData,
-    AuthResponse,
+    AuthResponse, authenticator,
 };
 use crate::rest::snowflake::error::SfError;
 use crate::rest::snowflake::external_browser::{
@@ -336,12 +336,15 @@ fn base_auth_request_data(login_parameters: &LoginParameters) -> AuthRequestData
     }
 }
 
-const EXT_AUTHN_ERROR_CODES: [i32; 5] = [
+const EXT_AUTHN_ERROR_CODES: [i32; 8] = [
     390120, // EXT_AUTHN_DENIED
+    390122, // EXT_AUTHN_NOT_ENROLLED
     390123, // EXT_AUTHN_LOCKED
     390126, // EXT_AUTHN_TIMEOUT
     390127, // EXT_AUTHN_INVALID
     390129, // EXT_AUTHN_EXCEPTION
+    390132, // EXT_AUTHN_DUO_PUSH_DISABLED
+    390195, // ID_TOKEN_INVALID
 ];
 
 fn extract_host_from_url(server_url: &str) -> Option<String> {
@@ -351,64 +354,66 @@ fn extract_host_from_url(server_url: &str) -> Option<String> {
         .map(|h| h.to_string())
 }
 
-fn try_get_cached_mfa_token(
+fn try_get_cached_token(
     server_url: &str,
     username: &str,
+    token_type: TokenType,
     token_cache: Option<&dyn TokenCache>,
 ) -> Option<SensitiveString> {
     let host = extract_host_from_url(server_url)?;
     let cache = token_cache?;
-    match cache.get_token(&host, username, TokenType::MfaToken) {
+    match cache.get_token(&host, username, token_type) {
         Ok(Some(token)) if !token.is_empty() => {
-            tracing::info!("Found cached MFA token");
+            tracing::info!(%token_type, "Found cached token");
             Some(token.into())
         }
         Ok(_) => None,
         Err(e) => {
-            tracing::warn!(error = %e, "Failed to retrieve cached MFA token");
+            tracing::warn!(%token_type, error = %e, "Failed to retrieve cached token");
             None
         }
     }
 }
 
-fn store_mfa_token_in_cache(
+fn store_token_in_cache(
     server_url: &str,
     username: &str,
-    mfa_token: &str,
+    token_type: TokenType,
+    token_value: &str,
     token_cache: Option<&dyn TokenCache>,
 ) {
     let Some(host) = extract_host_from_url(server_url) else {
-        tracing::warn!("Cannot cache MFA token: unable to extract host from server URL");
+        tracing::warn!(%token_type, "Cannot cache token: unable to extract host from server URL");
         return;
     };
     let Some(cache) = token_cache else {
-        tracing::debug!("No token cache available for MFA token storage");
+        tracing::debug!(%token_type, "No token cache available");
         return;
     };
-    if let Err(e) = cache.add_token(&host, username, TokenType::MfaToken, mfa_token) {
-        tracing::warn!(error = %e, "Failed to cache MFA token");
+    if let Err(e) = cache.add_token(&host, username, token_type, token_value) {
+        tracing::warn!(%token_type, error = %e, "Failed to cache token");
     } else {
-        tracing::info!("Cached MFA token for future use");
+        tracing::info!(%token_type, "Cached token for future use");
     }
 }
 
-fn remove_mfa_token_from_cache(
+fn remove_token_from_cache(
     server_url: &str,
     username: &str,
+    token_type: TokenType,
     token_cache: Option<&dyn TokenCache>,
 ) {
     let Some(host) = extract_host_from_url(server_url) else {
-        tracing::warn!("Cannot remove cached MFA token: unable to extract host from server URL");
+        tracing::warn!(%token_type, "Cannot remove cached token: unable to extract host");
         return;
     };
     let Some(cache) = token_cache else {
-        tracing::debug!("No token cache available for MFA token removal");
         return;
     };
-    if let Err(e) = cache.remove_token(&host, username, TokenType::MfaToken) {
-        tracing::warn!(error = %e, "Failed to remove cached MFA token");
+    if let Err(e) = cache.remove_token(&host, username, token_type) {
+        tracing::warn!(%token_type, error = %e, "Failed to remove cached token");
     } else {
-        tracing::info!("Removed cached MFA token due to authentication error");
+        tracing::info!(%token_type, "Removed cached token");
     }
 }
 
@@ -478,27 +483,56 @@ pub async fn auth_request_data(
         LoginMethod::ExternalBrowser {
             username,
             authentication_timeout_secs,
+            client_store_temporary_credential,
         } => {
-            // TODO: cache SSO tokens (same approach as MFA tokens)
-            let result = external_browser_authenticate(
-                client,
-                login_parameters,
-                username,
-                *authentication_timeout_secs,
-                &DefaultBrowserOpener,
-            )
-            .await
-            .context(ExternalBrowserSnafu)?;
-
             data.login_name = Some(username.clone());
-            data.authenticator = Some("EXTERNALBROWSER".to_string());
-            data.token = Some(result.token);
-            data.proof_key = Some(result.proof_key);
+            data.authenticator = Some(authenticator::EXTERNAL_BROWSER.to_string());
+
+            if *client_store_temporary_credential {
+                data.session_parameters
+                    .get_or_insert_with(HashMap::new)
+                    .insert(
+                        "CLIENT_STORE_TEMPORARY_CREDENTIAL".to_string(),
+                        serde_json::Value::Bool(true),
+                    );
+            }
+
+            let cached_id_token = if *client_store_temporary_credential {
+                try_get_cached_token(
+                    &login_parameters.server_url,
+                    username,
+                    TokenType::IdToken,
+                    token_cache,
+                )
+            } else {
+                None
+            };
+
+            if let Some(cached_token) = cached_id_token {
+                tracing::info!("Using cached SSO ID token for external browser login");
+                data.authenticator = Some(authenticator::ID_TOKEN.to_string());
+                data.token = Some(cached_token);
+                data.token_from_cache_used = true;
+            } else {
+                let result = external_browser_authenticate(
+                    client,
+                    login_parameters,
+                    username,
+                    *authentication_timeout_secs,
+                    &DefaultBrowserOpener,
+                )
+                .await
+                .context(ExternalBrowserSnafu)?;
+
+                data.token = Some(result.token);
+                data.proof_key = Some(result.proof_key);
+                data.consent_cache_id_token = result.consent_cache_id_token;
+            }
         }
         // Authorization Code orchestration runs the PKCE/state/loopback flow
         // (and any cache hits / refresh-token exchange) before forwarding the
         // resulting access token to Snowflake under AUTHENTICATOR=OAUTH.
-        // The body always uses uppercase "OAUTH" — never the user-supplied
+        // The body always uses uppercase OAUTH — never the user-supplied
         // authenticator string verbatim — and tags the request with
         // OAUTH_TYPE=OAUTH_AUTHORIZATION_CODE so GS knows which flow
         // produced the token. LOGIN_NAME is always set.
@@ -514,7 +548,7 @@ pub async fn auth_request_data(
                     .context(OAuthFlowSnafu)?;
             data.login_name = Some(cfg.username.clone());
             data.token = Some(acquired.access_token);
-            data.authenticator = Some("OAUTH".to_string());
+            data.authenticator = Some(authenticator::OAUTH.to_string());
             data.oauth_type = Some("OAUTH_AUTHORIZATION_CODE".to_string());
             // `dpop_jwk_json` is `Option<String>`: `Some` when DPoP was
             // enabled, `None` otherwise, so the assignment is implicitly
@@ -536,7 +570,7 @@ pub async fn auth_request_data(
                 .context(OAuthFlowSnafu)?;
             data.login_name = Some(cfg.username.clone());
             data.token = Some(acquired.access_token);
-            data.authenticator = Some("OAUTH".to_string());
+            data.authenticator = Some(authenticator::OAUTH.to_string());
             data.oauth_type = Some("OAUTH_CLIENT_CREDENTIALS".to_string());
             // See AC branch above for why dpop_jwk_json is carried here.
             data.dpop_jwk_json = acquired.dpop_jwk_json;
@@ -549,12 +583,12 @@ pub async fn auth_request_data(
             Credentials::Jwt { username, token } => {
                 data.login_name = Some(username);
                 data.token = Some(token);
-                data.authenticator = Some("SNOWFLAKE_JWT".to_string());
+                data.authenticator = Some(authenticator::SNOWFLAKE_JWT.to_string());
             }
             Credentials::Pat { username, token } => {
                 data.login_name = Some(username);
                 data.token = Some(token);
-                data.authenticator = Some("PROGRAMMATIC_ACCESS_TOKEN".to_string());
+                data.authenticator = Some(authenticator::PROGRAMMATIC_ACCESS_TOKEN.to_string());
             }
             // Legacy pre-acquired access token: forward unchanged (analysis
             // §6 / §10.1). LOGIN_NAME is always set (§14 #10) — never the
@@ -566,7 +600,7 @@ pub async fn auth_request_data(
             } => {
                 data.login_name = Some(username);
                 data.token = Some(access_token);
-                data.authenticator = Some("OAUTH".to_string());
+                data.authenticator = Some(authenticator::OAUTH.to_string());
             }
             Credentials::UserPasswordMfa {
                 username,
@@ -583,17 +617,23 @@ pub async fn auth_request_data(
                 );
 
                 let cached_mfa_token = if store_temp_cred {
-                    try_get_cached_mfa_token(&login_parameters.server_url, &username, token_cache)
+                    try_get_cached_token(
+                        &login_parameters.server_url,
+                        &username,
+                        TokenType::MfaToken,
+                        token_cache,
+                    )
                 } else {
                     None
                 };
 
                 data.login_name = Some(username);
                 data.password = Some(password);
-                data.authenticator = Some("USERNAME_PASSWORD_MFA".to_string());
+                data.authenticator = Some(authenticator::USERNAME_PASSWORD_MFA.to_string());
 
                 if let Some(cached_token) = cached_mfa_token {
                     data.token = Some(cached_token);
+                    data.token_from_cache_used = true;
                 } else {
                     data.ext_authn_duo_method =
                         Some(if passcode.is_some() || passcode_in_password {
@@ -749,10 +789,6 @@ pub async fn snowflake_login_with_client(
     let login_request_data =
         auth_request_data(client, login_parameters, session_parameters, token_cache).await?;
     tracing::Span::current().record("login_name", &login_request_data.login_name);
-    let used_cached_mfa_token = matches!(
-        &login_parameters.login_method,
-        LoginMethod::UserPasswordMfa { .. }
-    ) && login_request_data.token.is_some();
     let login_request = AuthRequest {
         data: login_request_data,
     };
@@ -763,50 +799,58 @@ pub async fn snowflake_login_with_client(
         "Login request prepared (secrets redacted)"
     );
 
+    // Send the actual login request
     let mut auth_response = send_login_request(client, login_parameters, &login_request).await?;
 
-    // TODO: cache SSO tokens (same approach as MFA tokens)
-    // When a cached MFA token caused an EXT_AUTHN error, evict it and retry
-    // via the normal DUO push/passcode flow.
-    if !auth_response.success && used_cached_mfa_token {
-        let code = auth_response
-            .code
-            .as_deref()
-            .and_then(|c| c.parse::<i32>().ok())
-            .unwrap_or(-1);
-        if EXT_AUTHN_ERROR_CODES.contains(&code)
-            && let LoginMethod::UserPasswordMfa { username, .. } = &login_parameters.login_method
-        {
-            tracing::warn!(
-                code = code,
-                "MFA authentication error detected, removing cached MFA token"
-            );
-            remove_mfa_token_from_cache(&login_parameters.server_url, username, token_cache);
-            tracing::info!("Retrying login without cached MFA token");
-            let retry_data =
-                auth_request_data(client, login_parameters, session_parameters, token_cache)
-                    .await?;
-            let retry_request = AuthRequest { data: retry_data };
-            auth_response = send_login_request(client, login_parameters, &retry_request).await?;
-        }
-    }
-
-    // OAuth refresh-on-failure: when GS rejects the OAuth access token
-    // with 390303 / 390318, replay the login once. For Authorization Code
-    // we first evict the cached access token (and any DPoP-bundled entry)
-    // so the replay exercises the refresh-token leg or, failing that, the
-    // interactive flow. For Client Credentials there is no cache to evict
-    // (CC tokens are not persisted), so the replay re-hits the IdP token
-    // endpoint to fetch a fresh access token. Cross-driver consensus:
-    // JDBC, ODBC, .NET, Go all retry both flows. Legacy `OAuthAccessToken`
-    // bubbles the error since the caller supplies the token directly.
+    // Revoke cached token and retry if cached token caused failure
     if !auth_response.success {
         let code = auth_response
             .code
             .as_deref()
             .and_then(|c| c.parse::<i32>().ok())
             .unwrap_or(-1);
-        if OAUTH_REFRESH_ERROR_CODES.contains(&code) {
+
+        // Cached token (ID token or MFA) rejected with an EXT_AUTHN error:
+        // evict it and retry via the normal interactive flow.
+        if login_request.data.token_from_cache_used && EXT_AUTHN_ERROR_CODES.contains(&code) {
+            if let Some((username, token_type)) = match &login_parameters.login_method {
+                LoginMethod::ExternalBrowser { username, .. } => {
+                    Some((username.as_str(), TokenType::IdToken))
+                }
+                LoginMethod::UserPasswordMfa { username, .. } => {
+                    Some((username.as_str(), TokenType::MfaToken))
+                }
+                _ => None,
+            } {
+                tracing::warn!(
+                    code,
+                    %token_type,
+                    "Cached token rejected, evicting and retrying"
+                );
+                remove_token_from_cache(
+                    &login_parameters.server_url,
+                    username,
+                    token_type,
+                    token_cache,
+                );
+                let retry_data =
+                    auth_request_data(client, login_parameters, session_parameters, token_cache)
+                        .await?;
+                let retry_request = AuthRequest { data: retry_data };
+                auth_response =
+                    send_login_request(client, login_parameters, &retry_request).await?;
+            }
+        }
+        // OAuth refresh-on-failure: when GS rejects the OAuth access token
+        // with 390303 / 390318, replay the login once. For Authorization Code
+        // we first evict the cached access token (and any DPoP-bundled entry)
+        // so the replay exercises the refresh-token leg or, failing that, the
+        // interactive flow. For Client Credentials there is no cache to evict
+        // (CC tokens are not persisted), so the replay re-hits the IdP token
+        // endpoint to fetch a fresh access token. Cross-driver consensus:
+        // JDBC, ODBC, .NET, Go all retry both flows. Legacy `OAuthAccessToken`
+        // bubbles the error since the caller supplies the token directly.
+        else if OAUTH_REFRESH_ERROR_CODES.contains(&code) {
             let mut should_retry = false;
             match &login_parameters.login_method {
                 LoginMethod::OAuthAuthorizationCode(cfg) => {
@@ -846,6 +890,7 @@ pub async fn snowflake_login_with_client(
         }
     }
 
+    // If retry failed or unrecoverable, evict tokens from cache and fail
     if !auth_response.success {
         let message = auth_response
             .message
@@ -856,37 +901,66 @@ pub async fn snowflake_login_with_client(
             .as_deref()
             .and_then(|c| c.parse::<i32>().ok())
             .unwrap_or(-1);
-        if EXT_AUTHN_ERROR_CODES.contains(&code)
-            && let LoginMethod::UserPasswordMfa { username, .. } = &login_parameters.login_method
-        {
-            tracing::warn!(
-                code = code,
-                "MFA authentication error detected, removing cached MFA token"
-            );
-            remove_mfa_token_from_cache(&login_parameters.server_url, username, token_cache);
+        if EXT_AUTHN_ERROR_CODES.contains(&code) {
+            let evictable = match &login_parameters.login_method {
+                LoginMethod::UserPasswordMfa { username, .. } => {
+                    Some((username.as_str(), TokenType::MfaToken))
+                }
+                LoginMethod::ExternalBrowser { username, .. } => {
+                    Some((username.as_str(), TokenType::IdToken))
+                }
+                _ => None,
+            };
+            if let Some((username, token_type)) = evictable {
+                tracing::warn!(code, %token_type, "Evicting cached token after terminal login failure");
+                remove_token_from_cache(
+                    &login_parameters.server_url,
+                    username,
+                    token_type,
+                    token_cache,
+                );
+            }
         }
         LoginSnafu { message, code }.fail()?;
     }
 
     tracing::debug!("Login successful, extracting session tokens");
 
-    // TODO: cache SSO tokens (same approach as MFA tokens)
-    // Cache MFA token from response if caching is enabled
-    if let LoginMethod::UserPasswordMfa {
-        username,
-        client_store_temporary_credential: true,
-        ..
-    } = &login_parameters.login_method
-        && let Some(mfa_token) = &auth_response.data.mfa_token
-    {
-        store_mfa_token_in_cache(
+    // If success - cache response tokens (MFA or ID token) when caching is enabled.
+    // Also, for IdToken, respect IdP consent: skip caching when explicitly denied.
+    let cacheable_token: Option<(&str, TokenType, &SensitiveString)> =
+        match &login_parameters.login_method {
+            LoginMethod::UserPasswordMfa {
+                username,
+                client_store_temporary_credential: true,
+                ..
+            } => auth_response
+                .data
+                .mfa_token
+                .as_ref()
+                .map(|t| (username.as_str(), TokenType::MfaToken, t)),
+            LoginMethod::ExternalBrowser {
+                username,
+                client_store_temporary_credential: true,
+                ..
+            } if login_request.data.consent_cache_id_token != Some(false) => auth_response
+                .data
+                .id_token
+                .as_ref()
+                .map(|t| (username.as_str(), TokenType::IdToken, t)),
+            _ => None,
+        };
+    if let Some((username, token_type, token)) = cacheable_token {
+        store_token_in_cache(
             &login_parameters.server_url,
             username,
-            mfa_token.reveal(),
+            token_type,
+            token.reveal(),
             token_cache,
         );
     }
 
+    // Extract tokens and session id from response
     let session_token = auth_response
         .data
         .token
@@ -2121,105 +2195,116 @@ mod tests {
         }
     }
 
-    mod try_get_cached_mfa_token_tests {
+    mod token_cache_helpers_tests {
         use super::*;
 
-        #[test]
-        fn returns_cached_token_on_hit() {
-            let cache = StubTokenCache::with_token(
-                "host.example.com",
-                "alice",
-                TokenType::MfaToken,
-                "tok123",
-            );
-            let result =
-                try_get_cached_mfa_token("https://host.example.com", "alice", Some(&cache));
-            assert_eq!(result.unwrap().reveal(), "tok123");
-        }
-
-        #[test]
-        fn returns_none_on_cache_miss() {
-            let cache = StubTokenCache::new();
-            let result =
-                try_get_cached_mfa_token("https://host.example.com", "alice", Some(&cache));
-            assert!(result.is_none());
-        }
-
-        #[test]
-        fn returns_none_when_no_cache_provided() {
-            let result = try_get_cached_mfa_token("https://host.example.com", "alice", None);
-            assert!(result.is_none());
-        }
-
-        #[test]
-        fn returns_none_for_invalid_url() {
-            let cache = StubTokenCache::new();
-            let result = try_get_cached_mfa_token("not-a-url", "alice", Some(&cache));
-            assert!(result.is_none());
-        }
-
-        #[test]
-        fn returns_none_for_empty_cached_token() {
+        fn assert_get_store_remove_for(token_type: TokenType) {
+            // try_get: returns cached token on hit
             let cache =
-                StubTokenCache::with_token("host.example.com", "alice", TokenType::MfaToken, "");
-            let result =
-                try_get_cached_mfa_token("https://host.example.com", "alice", Some(&cache));
-            assert!(result.is_none());
-        }
-    }
+                StubTokenCache::with_token("host.example.com", "alice", token_type, "tok_val");
+            let result = try_get_cached_token(
+                "https://host.example.com",
+                "alice",
+                token_type,
+                Some(&cache),
+            );
+            assert_eq!(result.unwrap().reveal(), "tok_val");
 
-    mod store_mfa_token_in_cache_tests {
-        use super::*;
+            // try_get: returns None on cache miss
+            let empty = StubTokenCache::new();
+            assert!(
+                try_get_cached_token(
+                    "https://host.example.com",
+                    "alice",
+                    token_type,
+                    Some(&empty),
+                )
+                .is_none()
+            );
 
-        #[test]
-        fn stores_token_successfully() {
+            // try_get: returns None when no cache provided
+            assert!(
+                try_get_cached_token("https://host.example.com", "alice", token_type, None)
+                    .is_none()
+            );
+
+            // try_get: returns None for invalid URL
+            assert!(try_get_cached_token("not-a-url", "alice", token_type, Some(&empty)).is_none());
+
+            // try_get: returns None for empty cached value
+            let empty_val = StubTokenCache::with_token("host.example.com", "alice", token_type, "");
+            assert!(
+                try_get_cached_token(
+                    "https://host.example.com",
+                    "alice",
+                    token_type,
+                    Some(&empty_val),
+                )
+                .is_none()
+            );
+
+            // store + get round-trip
             let cache = StubTokenCache::new();
-            store_mfa_token_in_cache("https://host.example.com", "alice", "new_tok", Some(&cache));
+            store_token_in_cache(
+                "https://host.example.com",
+                "alice",
+                token_type,
+                "new_tok",
+                Some(&cache),
+            );
             let stored = cache
-                .get_token("host.example.com", "alice", TokenType::MfaToken)
+                .get_token("host.example.com", "alice", token_type)
                 .unwrap();
             assert_eq!(stored.as_deref(), Some("new_tok"));
-        }
 
-        #[test]
-        fn no_panic_when_no_cache() {
-            store_mfa_token_in_cache("https://host.example.com", "alice", "tok", None);
-        }
+            // store: no panic when no cache
+            store_token_in_cache("https://host.example.com", "alice", token_type, "tok", None);
 
-        #[test]
-        fn no_panic_for_invalid_url() {
-            let cache = StubTokenCache::new();
-            store_mfa_token_in_cache("not-a-url", "alice", "tok", Some(&cache));
-        }
-    }
-
-    mod remove_mfa_token_from_cache_tests {
-        use super::*;
-
-        #[test]
-        fn removes_existing_token() {
-            let cache = StubTokenCache::with_token(
-                "host.example.com",
+            // store: no panic for invalid URL
+            store_token_in_cache(
+                "not-a-url",
                 "alice",
-                TokenType::MfaToken,
-                "tok_to_remove",
+                token_type,
+                "tok",
+                Some(&StubTokenCache::new()),
             );
-            remove_mfa_token_from_cache("https://host.example.com", "alice", Some(&cache));
-            let stored = cache
-                .get_token("host.example.com", "alice", TokenType::MfaToken)
-                .unwrap();
-            assert!(stored.is_none());
+
+            // remove evicts token
+            let cache =
+                StubTokenCache::with_token("host.example.com", "alice", token_type, "to_remove");
+            remove_token_from_cache(
+                "https://host.example.com",
+                "alice",
+                token_type,
+                Some(&cache),
+            );
+            assert!(
+                cache
+                    .get_token("host.example.com", "alice", token_type)
+                    .unwrap()
+                    .is_none()
+            );
+
+            // remove: no panic when no cache
+            remove_token_from_cache("https://host.example.com", "alice", token_type, None);
+
+            // remove: no panic for invalid URL
+            remove_token_from_cache(
+                "not-a-url",
+                "alice",
+                token_type,
+                Some(&StubTokenCache::new()),
+            );
         }
 
         #[test]
-        fn no_panic_when_no_cache() {
-            remove_mfa_token_from_cache("https://host.example.com", "alice", None);
+        fn mfa_token_cache_operations() {
+            assert_get_store_remove_for(TokenType::MfaToken);
         }
 
         #[test]
-        fn no_panic_for_invalid_url() {
-            let cache = StubTokenCache::new();
-            remove_mfa_token_from_cache("not-a-url", "alice", Some(&cache));
+        fn id_token_cache_operations() {
+            assert_get_store_remove_for(TokenType::IdToken);
         }
     }
 

--- a/sf_core/tests/common/mocks/external_browser.rs
+++ b/sf_core/tests/common/mocks/external_browser.rs
@@ -107,3 +107,108 @@ pub fn login_failure() -> Mock {
             "message": "Invalid credentials"
         })))
 }
+
+// ─── Cached ID Token Login ──────────────────────────────────────────────────
+
+/// Successful login using a cached SSO ID token (no PROOF_KEY in request).
+pub fn login_success_with_cached_id_token() -> Mock {
+    Mock::given(method("POST"))
+        .and(path_regex(r"/session/v1/login-request"))
+        .and(body_partial_json(json!({
+            "data": {
+                "AUTHENTICATOR": "ID_TOKEN",
+                "TOKEN": "cached_id_token"
+            }
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "success": true,
+            "data": {
+                "token": "mock_session_token",
+                "masterToken": "mock_master_token",
+                "sessionId": 12345,
+                "validityInSeconds": 3600,
+                "masterValidityInSeconds": 14400,
+                "parameters": [],
+                "sessionInfo": {
+                    "databaseName": "test_database",
+                    "schemaName": "test_schema",
+                    "warehouseName": "test_warehouse",
+                    "roleName": "test_role"
+                }
+            }
+        })))
+}
+
+/// Successful login that returns an idToken (for caching after browser flow).
+pub fn login_success_with_id_token_in_response() -> Mock {
+    Mock::given(method("POST"))
+        .and(path_regex(r"/session/v1/login-request"))
+        .and(body_partial_json(json!({
+            "data": {
+                "AUTHENTICATOR": "EXTERNALBROWSER"
+            }
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "success": true,
+            "data": {
+                "token": "mock_session_token",
+                "masterToken": "mock_master_token",
+                "sessionId": 12345,
+                "idToken": "server_issued_id_token",
+                "idTokenValidityInSeconds": 3600,
+                "validityInSeconds": 3600,
+                "masterValidityInSeconds": 14400,
+                "parameters": [],
+                "sessionInfo": {
+                    "databaseName": "test_database",
+                    "schemaName": "test_schema",
+                    "warehouseName": "test_warehouse",
+                    "roleName": "test_role"
+                }
+            }
+        })))
+}
+
+// ─── EXT_AUTHN Failure with Cached ID Token ─────────────────────────────────
+
+fn login_failure_ext_authn_with_cached_id_token(code: &str, message: &str) -> Mock {
+    Mock::given(method("POST"))
+        .and(path_regex(r"/session/v1/login-request"))
+        .and(body_partial_json(json!({
+            "data": {
+                "AUTHENTICATOR": "ID_TOKEN",
+                "TOKEN": "cached_id_token"
+            }
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "success": false,
+            "code": code,
+            "message": message
+        })))
+}
+
+pub fn login_failure_ext_authn_denied_cached_id() -> Mock {
+    login_failure_ext_authn_with_cached_id_token(
+        "390120",
+        "Authentication denied by external provider",
+    )
+}
+
+pub fn login_failure_ext_authn_locked_cached_id() -> Mock {
+    login_failure_ext_authn_with_cached_id_token("390123", "Account locked by external provider")
+}
+
+pub fn login_failure_ext_authn_timeout_cached_id() -> Mock {
+    login_failure_ext_authn_with_cached_id_token("390126", "External authentication timed out")
+}
+
+pub fn login_failure_ext_authn_invalid_cached_id() -> Mock {
+    login_failure_ext_authn_with_cached_id_token(
+        "390127",
+        "External authentication token is invalid",
+    )
+}
+
+pub fn login_failure_ext_authn_exception_cached_id() -> Mock {
+    login_failure_ext_authn_with_cached_id_token("390129", "External authentication exception")
+}

--- a/sf_core/tests/integration/authentication/external_browser_id_token_cache.rs
+++ b/sf_core/tests/integration/authentication/external_browser_id_token_cache.rs
@@ -1,0 +1,402 @@
+use std::io::{Read, Write};
+
+use crate::common::mocks::external_browser;
+use crate::common::snowflake_test_client::SnowflakeTestClient;
+use crate::common::tls_proxy::MockServerWithTls;
+use sf_core::token_cache::{KeyringTokenCache, TokenCache, TokenType};
+
+// =============================================================================
+// Test Fixture
+// =============================================================================
+
+struct IdTokenCacheFixture {
+    mock: MockServerWithTls,
+    client: SnowflakeTestClient,
+    cache: KeyringTokenCache,
+    host: String,
+    user: String,
+}
+
+impl IdTokenCacheFixture {
+    fn new(user: &str) -> Self {
+        unsafe { std::env::set_var("SF_TEST_BROWSER_OPENER", "noop") };
+
+        let mock = MockServerWithTls::start();
+        let client = SnowflakeTestClient::with_int_tests_params(Some(&mock.http_url()));
+        client.set_connection_option("authenticator", "EXTERNALBROWSER");
+        client.set_connection_option("user", user);
+        client.set_connection_option("authentication_timeout", "10");
+        client.set_connection_option("client_store_temporary_credential", "true");
+
+        let cache = KeyringTokenCache::new().expect("token cache should be available");
+        let host = url::Url::parse(&mock.http_url())
+            .expect("mock URL should be valid")
+            .host_str()
+            .expect("mock URL should have a host")
+            .to_string();
+
+        Self {
+            mock,
+            client,
+            cache,
+            host,
+            user: user.to_string(),
+        }
+    }
+
+    fn seed_cached_id_token(&self) {
+        self.cache
+            .add_token(
+                &self.host,
+                &self.user,
+                TokenType::IdToken,
+                "cached_id_token",
+            )
+            .expect("failed to seed ID token in cache");
+    }
+
+    fn connect(&self) -> Result<(), String> {
+        self.client.connect()
+    }
+
+    fn cached_id_token(&self) -> Option<String> {
+        self.cache
+            .get_token(&self.host, &self.user, TokenType::IdToken)
+            .expect("get_token should not fail")
+    }
+}
+
+impl Drop for IdTokenCacheFixture {
+    fn drop(&mut self) {
+        let _ = self
+            .cache
+            .remove_token(&self.host, &self.user, TokenType::IdToken);
+    }
+}
+
+fn assert_success(result: Result<(), String>, context: &str) {
+    assert!(result.is_ok(), "Expected {context}, got: {result:?}");
+}
+
+fn assert_error(result: Result<(), String>, patterns: &[&str], context: &str) {
+    let error = result.expect_err(&format!("Expected {context} to fail"));
+    let matches = patterns.iter().any(|p| error.contains(p));
+    assert!(matches, "Expected {context}, got: {error}");
+}
+
+/// Simulate a browser callback delivering a token to the loopback server.
+fn simulate_browser_callback(mock: &MockServerWithTls, token: &str) {
+    let requests = mock.received_requests();
+    let authn_req = requests
+        .iter()
+        .find(|r| r.url.path().contains("authenticator-request"))
+        .expect("No authenticator-request was captured");
+
+    let body: serde_json::Value =
+        serde_json::from_slice(&authn_req.body).expect("Request body is not valid JSON");
+    let port_str = body["data"]["BROWSER_MODE_REDIRECT_PORT"]
+        .as_str()
+        .expect("BROWSER_MODE_REDIRECT_PORT not found in request body");
+    let port: u16 = port_str
+        .parse()
+        .expect("BROWSER_MODE_REDIRECT_PORT is not a valid port number");
+
+    let mut stream = std::net::TcpStream::connect(format!("127.0.0.1:{port}"))
+        .expect("Failed to connect to callback listener");
+    let request = format!("GET /?token={token} HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    stream
+        .write_all(request.as_bytes())
+        .expect("Failed to write to callback listener");
+
+    let mut response = Vec::new();
+    stream
+        .read_to_end(&mut response)
+        .expect("Failed to read response from callback listener");
+    let response_str = String::from_utf8_lossy(&response);
+    assert!(
+        response_str.contains("200 OK"),
+        "Expected 200 OK response, got: {response_str}"
+    );
+}
+
+// =============================================================================
+// Cached ID Token - Happy Path
+// =============================================================================
+
+#[test]
+fn should_authenticate_with_cached_id_token() {
+    let fixture = IdTokenCacheFixture::new("eb_cache_hit");
+    fixture.seed_cached_id_token();
+    fixture
+        .mock
+        .mount(external_browser::login_success_with_cached_id_token());
+
+    let result = fixture.connect();
+
+    assert_success(result, "login with cached ID token to succeed");
+
+    let requests = fixture.mock.received_requests();
+    assert!(
+        !requests
+            .iter()
+            .any(|r| r.url.path().contains("authenticator-request")),
+        "Should skip authenticator-request when using cached ID token"
+    );
+    let login_req = requests
+        .iter()
+        .find(|r| r.url.path().contains("login-request"))
+        .expect("No login-request was captured");
+    let body: serde_json::Value = serde_json::from_slice(&login_req.body).unwrap();
+    assert_eq!(body["data"]["AUTHENTICATOR"], "ID_TOKEN");
+    assert_eq!(body["data"]["TOKEN"], "cached_id_token");
+    assert!(
+        body["data"]["PROOF_KEY"].is_null(),
+        "PROOF_KEY should not be sent when using cached ID token"
+    );
+}
+
+// =============================================================================
+// ID Token Stored After Successful Browser Flow
+// =============================================================================
+
+#[test]
+fn should_store_id_token_after_successful_browser_login() {
+    let fixture = IdTokenCacheFixture::new("eb_cache_store");
+    fixture.mock.mount(external_browser::authenticator_request(
+        "https://idp.example.com/sso",
+        "proof_key_store_test",
+    ));
+    fixture
+        .mock
+        .mount(external_browser::login_success_with_id_token_in_response());
+
+    let mock_ref = &fixture.mock;
+    let result = std::thread::scope(|s| {
+        s.spawn(|| {
+            for _ in 0..50 {
+                std::thread::sleep(std::time::Duration::from_millis(100));
+                let requests = mock_ref.received_requests();
+                if requests
+                    .iter()
+                    .any(|r| r.url.path().contains("authenticator-request"))
+                {
+                    simulate_browser_callback(mock_ref, "browser_token_xyz");
+                    return;
+                }
+            }
+            panic!("Timed out waiting for authenticator-request");
+        });
+        fixture.connect()
+    });
+
+    assert_success(result, "browser login to succeed");
+
+    let cached = fixture.cached_id_token();
+    assert_eq!(
+        cached.as_deref(),
+        Some("server_issued_id_token"),
+        "ID token from login response should be stored in cache"
+    );
+}
+
+// =============================================================================
+// EXT_AUTHN Error Evicts Cached ID Token
+// =============================================================================
+
+fn assert_ext_authn_error_evicts_cached_id_token(
+    mount_failure: fn() -> wiremock::Mock,
+    code: &str,
+    user: &str,
+) {
+    let fixture = IdTokenCacheFixture::new(user);
+    fixture.seed_cached_id_token();
+
+    // First request with cached token fails with EXT_AUTHN error.
+    fixture.mock.mount(mount_failure());
+    // Retry goes through browser flow, which also fails (no callback → timeout).
+    // We set a short timeout so the test doesn't hang.
+    fixture
+        .client
+        .set_connection_option("authentication_timeout", "2");
+    fixture.mock.mount(external_browser::authenticator_request(
+        "https://idp.example.com/sso",
+        "retry_proof_key",
+    ));
+
+    let result = fixture.connect();
+
+    assert_error(
+        result,
+        &[
+            "timeout",
+            "Timeout",
+            "browser",
+            "Browser",
+            "ExternalBrowser",
+            "login",
+            "Login",
+        ],
+        &format!("login to fail after evict-and-retry for EXT_AUTHN code {code}"),
+    );
+
+    let cached = fixture.cached_id_token();
+    assert!(
+        cached.is_none(),
+        "Expected cached ID token to be removed after EXT_AUTHN error {code}, but it still exists"
+    );
+}
+
+#[test]
+fn should_evict_cached_id_token_on_ext_authn_denied() {
+    assert_ext_authn_error_evicts_cached_id_token(
+        external_browser::login_failure_ext_authn_denied_cached_id,
+        "390120",
+        "eb_evict_denied",
+    );
+}
+
+#[test]
+fn should_evict_cached_id_token_on_ext_authn_locked() {
+    assert_ext_authn_error_evicts_cached_id_token(
+        external_browser::login_failure_ext_authn_locked_cached_id,
+        "390123",
+        "eb_evict_locked",
+    );
+}
+
+#[test]
+fn should_evict_cached_id_token_on_ext_authn_timeout() {
+    assert_ext_authn_error_evicts_cached_id_token(
+        external_browser::login_failure_ext_authn_timeout_cached_id,
+        "390126",
+        "eb_evict_timeout",
+    );
+}
+
+#[test]
+fn should_evict_cached_id_token_on_ext_authn_invalid() {
+    assert_ext_authn_error_evicts_cached_id_token(
+        external_browser::login_failure_ext_authn_invalid_cached_id,
+        "390127",
+        "eb_evict_invalid",
+    );
+}
+
+#[test]
+fn should_evict_cached_id_token_on_ext_authn_exception() {
+    assert_ext_authn_error_evicts_cached_id_token(
+        external_browser::login_failure_ext_authn_exception_cached_id,
+        "390129",
+        "eb_evict_exception",
+    );
+}
+
+// =============================================================================
+// EXT_AUTHN Retry Succeeds After Eviction
+// =============================================================================
+
+#[test]
+fn should_retry_with_browser_flow_when_cached_id_token_fails() {
+    let fixture = IdTokenCacheFixture::new("eb_retry_ok");
+    fixture.seed_cached_id_token();
+
+    // First request with cached token → EXT_AUTHN denied.
+    fixture
+        .mock
+        .mount(external_browser::login_failure_ext_authn_denied_cached_id());
+    // Retry → browser flow → success with a fresh ID token in response.
+    fixture.mock.mount(external_browser::authenticator_request(
+        "https://idp.example.com/sso",
+        "retry_proof_key",
+    ));
+    fixture
+        .mock
+        .mount(external_browser::login_success_with_id_token_in_response());
+
+    let mock_ref = &fixture.mock;
+    let result = std::thread::scope(|s| {
+        s.spawn(|| {
+            // Wait for the retry's authenticator-request (the second one).
+            // The first login-request uses the cached token (no authenticator-request).
+            for _ in 0..80 {
+                std::thread::sleep(std::time::Duration::from_millis(100));
+                let requests = mock_ref.received_requests();
+                if requests
+                    .iter()
+                    .any(|r| r.url.path().contains("authenticator-request"))
+                {
+                    simulate_browser_callback(mock_ref, "retry_browser_token");
+                    return;
+                }
+            }
+            panic!("Timed out waiting for authenticator-request on retry");
+        });
+        fixture.connect()
+    });
+
+    assert_success(result, "login retry via browser flow to succeed");
+
+    let cached = fixture.cached_id_token();
+    assert_eq!(
+        cached.as_deref(),
+        Some("server_issued_id_token"),
+        "New ID token should be cached after successful retry"
+    );
+}
+
+// =============================================================================
+// Caching Disabled — Token Not Stored
+// =============================================================================
+
+#[test]
+fn should_not_cache_id_token_when_caching_disabled() {
+    unsafe { std::env::set_var("SF_TEST_BROWSER_OPENER", "noop") };
+
+    let mock = MockServerWithTls::start();
+    let client = SnowflakeTestClient::with_int_tests_params(Some(&mock.http_url()));
+    client.set_connection_option("authenticator", "EXTERNALBROWSER");
+    client.set_connection_option("user", "eb_no_cache");
+    client.set_connection_option("authentication_timeout", "10");
+    // client_store_temporary_credential is NOT set (defaults to false)
+
+    mock.mount(external_browser::authenticator_request(
+        "https://idp.example.com/sso",
+        "proof_key_no_cache",
+    ));
+    mock.mount(external_browser::login_success_with_id_token_in_response());
+
+    let mock_ref = &mock;
+    let result = std::thread::scope(|s| {
+        s.spawn(|| {
+            for _ in 0..50 {
+                std::thread::sleep(std::time::Duration::from_millis(100));
+                let requests = mock_ref.received_requests();
+                if requests
+                    .iter()
+                    .any(|r| r.url.path().contains("authenticator-request"))
+                {
+                    simulate_browser_callback(mock_ref, "token_no_cache");
+                    return;
+                }
+            }
+            panic!("Timed out waiting for authenticator-request");
+        });
+        client.connect()
+    });
+
+    assert_success(result, "browser login to succeed without caching");
+
+    let cache = KeyringTokenCache::new().expect("token cache should be available");
+    let host = url::Url::parse(&mock.http_url())
+        .expect("mock URL should be valid")
+        .host_str()
+        .expect("mock URL should have a host")
+        .to_string();
+    let cached = cache
+        .get_token(&host, "eb_no_cache", TokenType::IdToken)
+        .expect("get_token should not fail");
+    assert!(
+        cached.is_none(),
+        "ID token should NOT be cached when client_store_temporary_credential is false"
+    );
+}

--- a/sf_core/tests/integration/authentication/mod.rs
+++ b/sf_core/tests/integration/authentication/mod.rs
@@ -1,4 +1,5 @@
 pub mod external_browser;
+pub mod external_browser_id_token_cache;
 pub mod native_okta;
 pub mod oauth;
 pub mod odbc_client_identity;


### PR DESCRIPTION
## Summary

- Cache the SSO ID token returned by external browser login when `client_store_temporary_credential` is enabled, reusing it on subsequent connections to avoid repeated browser popups
- Implement evict-and-retry: if a cached ID token is rejected with any EXT_AUTHN error code (390120-390132) or ID_TOKEN_INVALID (390195), evict it and fall back to the interactive browser flow
- Honor the IdP's `consent_cache_id_token` signal -- skip caching when the IdP explicitly denies consent
- Refactor 6 near-identical MFA/ID token cache helpers into 3 generic functions parameterized by `TokenType`
- Wire `ExternalBrowser` into the `token_cache` initialization gate in `connection.rs` (was previously MFA-only)

## Context

External browser authentication previously required a browser popup on every connection. This PR brings ID token caching to external browser auth, following the same pattern already established for MFA token caching. The `client_store_temporary_credential` connection parameter controls opt-in, and the cached tokens are stored in the system keyring via `KeyringTokenCache`.

This change also cleans up duplication: the MFA and ID token cache helpers were nearly identical, so they are now unified into generic `try_get_cached_token`, `store_token_in_cache`, and `remove_token_from_cache` functions. A `parse_flexible_bool` helper eliminates duplicated boolean-parsing logic for `client_store_temporary_credential`.