### PR TITLE
SNOW-2872406: enable CLIENT_SESSION_KEEP_ALIVE in ODBC

### DIFF
--- a/odbc/src/api/connection.rs
+++ b/odbc/src/api/connection.rs
@@ -1383,6 +1383,26 @@ mod tests {
     }
 
     #[test]
+    fn normalize_connection_string_options_forwards_session_keep_alive_params() {
+        let options = normalize_connection_string_options(HashMap::from([
+            ("CLIENT_SESSION_KEEP_ALIVE".to_owned(), "true".to_owned()),
+            (
+                "CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY".to_owned(),
+                "1800".to_owned(),
+            ),
+        ]));
+
+        assert_eq!(
+            config_string(&options, "CLIENT_SESSION_KEEP_ALIVE"),
+            Some("true")
+        );
+        assert_eq!(
+            config_string(&options, "CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY"),
+            Some("1800")
+        );
+    }
+
+    #[test]
     fn apply_pre_connection_overrides_makes_priv_key_base64_authoritative() {
         let mut options = normalize_connection_string_options(HashMap::from([
             ("PRIV_KEY_BASE64".to_owned(), "dsn-key".to_owned()),

--- a/odbc_tests/BehaviorDifferences.yaml
+++ b/odbc_tests/BehaviorDifferences.yaml
@@ -646,3 +646,15 @@ behavior_differences:
       SQL_SF_STMT_ATTR_MULTI_STATEMENT_COUNT: default -1 (auto-detect), supports set/get roundtrip for values -1 to 32767, returns SQL_ERROR with HY024 for values < -1, and forwards the count to the server enabling multi-statement result sets via SQLMoreResults.
     impact: |
       Applications relying on SQL_SF_STMT_ATTR_LAST_QUERY_ID after SQLPrepare+SQLExecute or on SQL_SF_STMT_ATTR_MULTI_STATEMENT_COUNT must target the new driver. Basic last-query-id retrieval after SQLExecDirect works on both drivers.
+
+  57:
+    name: "CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY is sent as a server session parameter"
+    status: unknown
+    type: enhancement
+    reviewed: false
+    old_driver_behavior: |
+      The old driver uses CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY only client-side to configure the background heartbeat thread interval. It is not forwarded to the server as a session parameter, so SHOW PARAMETERS LIKE 'CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY' returns the server default (3600).
+    new_driver_behavior: |
+      The new driver sends CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY to the server as a session parameter during login, making it queryable via SHOW PARAMETERS. The value is also used client-side to configure the heartbeat interval.
+    impact: |
+      Applications that query SHOW PARAMETERS to verify the heartbeat frequency will now see the value they configured in the connection string.

--- a/odbc_tests/tests/e2e/session/session_parameters.cpp
+++ b/odbc_tests/tests/e2e/session/session_parameters.cpp
@@ -19,3 +19,33 @@ TEST_CASE("should forward unrecognized connection option as session parameter", 
   auto value = get_data<SQL_C_CHAR>(stmt, 1);
   CHECK(value == "session_param_e2e_test");
 }
+
+TEST_CASE("should enable session keep-alive via connection string", "[session]") {
+  // Given Snowflake client is logged in with connection option CLIENT_SESSION_KEEP_ALIVE set to "true"
+  auto conn_str = get_connection_string() + "CLIENT_SESSION_KEEP_ALIVE=true;";
+  Connection conn(conn_str);
+
+  // When Query "SHOW PARAMETERS LIKE 'CLIENT_SESSION_KEEP_ALIVE'" is executed
+  auto stmt = conn.execute_fetch("SHOW PARAMETERS LIKE 'CLIENT_SESSION_KEEP_ALIVE'");
+
+  // Then the session parameter value should be "true"
+  auto value = get_data<SQL_C_CHAR>(stmt, 2);
+  CHECK(value == "true");
+}
+
+TEST_CASE("should set heartbeat frequency via connection string", "[session]") {
+  // Given Snowflake client is logged in with CLIENT_SESSION_KEEP_ALIVE=true and
+  // CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY=1800
+  auto conn_str = get_connection_string() +
+                  "CLIENT_SESSION_KEEP_ALIVE=true;"
+                  "CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY=1800;";
+  Connection conn(conn_str);
+
+  // When Query "SHOW PARAMETERS LIKE 'CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY'" is executed
+  auto stmt = conn.execute_fetch("SHOW PARAMETERS LIKE 'CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY'");
+
+  // Then the session parameter value reflects the configured frequency
+  auto value = get_data<SQL_C_CHAR>(stmt, 2);
+  NEW_DRIVER_ONLY("BD#57") { CHECK(value == "1800"); }
+  OLD_DRIVER_ONLY("BD#57") { CHECK(value == "3600"); }
+}

--- a/tests/definitions/shared/session/session_parameters.feature
+++ b/tests/definitions/shared/session/session_parameters.feature
@@ -10,3 +10,15 @@ Feature: Session parameters via connection options
     Given Snowflake client is logged in with connection option QUERY_TAG set to "session_param_e2e_test"
     When Query "SELECT CURRENT_QUERY_TAG()" is executed
     Then the result should contain value "session_param_e2e_test"
+
+  @odbc_e2e
+  Scenario: should enable session keep-alive via connection string
+    Given Snowflake client is logged in with connection option CLIENT_SESSION_KEEP_ALIVE set to "true"
+    When Query "SHOW PARAMETERS LIKE 'CLIENT_SESSION_KEEP_ALIVE'" is executed
+    Then the session parameter value should be "true"
+
+  @odbc_e2e
+  Scenario: should set heartbeat frequency via connection string
+    Given Snowflake client is logged in with CLIENT_SESSION_KEEP_ALIVE=true and CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY=1800
+    When Query "SHOW PARAMETERS LIKE 'CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY'" is executed
+    Then the session parameter value reflects the configured frequency


### PR DESCRIPTION
## Summary
- Unskip existing integration tests for `CLIENT_SESSION_KEEP_ALIVE` connection string param (was blocked by `SKIP_NEW_DRIVER_NOT_IMPLEMENTED()`)
- Add e2e tests verifying `CLIENT_SESSION_KEEP_ALIVE` and `CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY` take effect on the Snowflake session
- Add unit test confirming these params pass through the ODBC normalizer unchanged

No driver code changes needed — PR #1203 registered these params in sf_core's param_registry, and the ODBC layer's default connection string fallback already forwards them correctly with automatic type coercion.

## Test plan
- [x] Rust unit test passes (`normalize_connection_string_options_forwards_session_keep_alive_params`)
- [ ] ODBC CI integration tests pass (unskipped `CLIENT_SESSION_KEEP_ALIVE` test)
- [ ] e2e `session_parameters` tests pass against Snowflake (SHOW PARAMETERS verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)