### PR TITLE
NO-SNOW: tag concurrent close test as flaky

### DIFF
--- a/odbc_tests/tests/e2e/session/logout.cpp
+++ b/odbc_tests/tests/e2e/session/logout.cpp
@@ -54,7 +54,7 @@ TEST_CASE("should be idempotent when close called multiple times", "[session][lo
   CHECK(first_ret == SQL_SUCCESS);
 }
 
-TEST_CASE("should handle concurrent close calls safely", "[session][logout]") {
+TEST_CASE("should handle concurrent close calls safely", "[session][logout][flaky]") {
 #ifdef _WIN32
   SKIP("WireMock tests not yet validated on Windows");
 #endif


### PR DESCRIPTION
## Summary
- Tag `e2e_session_logout:should handle concurrent close calls safely` with `[flaky]` so it runs in the non-blocking flaky job instead of gating CI.

## Test plan
- [ ] CI flaky job picks up the test via `ctest -L flaky`
- [ ] Main CI excludes it via `-LE flaky`

🤖 Generated with [Claude Code](https://claude.com/claude-code)