### PR TITLE
SNOW-3487102: python - callback-based async FFI boundary

### DIFF
--- a/python/src/snowflake/connector/_internal/api_client/c_api.py
+++ b/python/src/snowflake/connector/_internal/api_client/c_api.py
@@ -63,6 +63,7 @@ LOGGER_CALLBACK = ctypes.CFUNCTYPE(
 core.sf_core_init.argtypes = [LOGGER_CALLBACK]
 core.sf_core_init.restype = ctypes.c_uint32
 
+# Sync proto API (blocks until complete)
 core.sf_core_api_call_proto.restype = ctypes.c_uint32
 core.sf_core_api_call_proto.argtypes = [
     ctypes.c_char_p,  # const char* api
@@ -78,6 +79,68 @@ core.sf_core_free_buffer.argtypes = [
     ctypes.POINTER(ctypes.c_ubyte),  # uint8_t* buffer
     ctypes.c_size_t,  # size_t len
 ]
+
+# Async proto API (callback-based, returns immediately).
+#
+# Signature: uint64_t sf_core_api_call_proto_async(
+#     api, method, request, request_len,
+#     callback,    // ResponseCallback fn pointer
+#     user_data,   // opaque void*
+# )
+#
+# Returns a non-zero request ID. Pass it to ``sf_core_cancel_request`` to ask
+# Rust to abort the in-flight task. The callback is invoked exactly once from
+# a tokio worker thread when the request completes (unless the task was
+# aborted before it reached its last await point). Callers must:
+#   1. Keep both ``callback`` and any object referenced by ``user_data`` alive
+#      until the callback fires.
+#   2. Copy the response buffer inside the callback — Rust frees it on return.
+RESPONSE_CALLBACK = ctypes.CFUNCTYPE(
+    None,  # return type (must not raise/unwind)
+    ctypes.c_void_p,  # user_data
+    ctypes.c_size_t,  # status (0=ok, 1=app error, 2=transport error)
+    ctypes.POINTER(ctypes.c_ubyte),  # response_ptr
+    ctypes.c_size_t,  # response_len
+)
+core.sf_core_api_call_proto_async.restype = ctypes.c_uint64
+core.sf_core_api_call_proto_async.argtypes = [
+    ctypes.c_char_p,  # const char* api
+    ctypes.c_char_p,  # const char* method
+    ctypes.POINTER(ctypes.c_ubyte),  # const uint8_t* request
+    ctypes.c_size_t,  # size_t request_len
+    RESPONSE_CALLBACK,  # callback
+    ctypes.c_void_p,  # user_data
+]
+
+# Cancel a previously submitted async request by ID. Best-effort: aborts the
+# tokio task at its next await point. Idempotent on unknown IDs.
+core.sf_core_cancel_request.restype = None
+core.sf_core_cancel_request.argtypes = [ctypes.c_uint64]
+
+
+def sf_core_api_call_proto_async(
+    api: bytes,
+    method: bytes,
+    request: Any,
+    request_len: int,
+    callback: Any,
+    user_data: Any,
+) -> int:
+    """Submit an async proto request. Returns immediately with a request ID.
+
+    The returned ID may be passed to :func:`sf_core_cancel_request` to ask
+    Rust to abort the task. ``callback`` is invoked exactly once unless the
+    task is aborted before it reaches its last await point.
+    """
+    return int(core.sf_core_api_call_proto_async(api, method, request, request_len, callback, user_data))
+
+
+def sf_core_cancel_request(request_id: int) -> None:
+    """Best-effort cancellation of an in-flight async request.
+
+    A no-op if the request has already completed or never existed.
+    """
+    core.sf_core_cancel_request(ctypes.c_uint64(request_id))
 
 
 # Performance instrumentation FFI bindings (see sf_core/src/c_api.rs).

--- a/python/src/snowflake/connector/_internal/api_client/client_api.py
+++ b/python/src/snowflake/connector/_internal/api_client/client_api.py
@@ -4,7 +4,6 @@ import asyncio
 import ctypes
 import threading
 
-from ctypes import c_char_p
 from typing import Any
 
 from snowflake.connector._internal.status_codes import (
@@ -117,7 +116,7 @@ from ..protobuf_gen.proto_exception import (
     ProtoApplicationException,
     ProtoTransportException,
 )
-from .c_api import sf_core_api_call_proto, sf_core_free_buffer
+from .c_api import RESPONSE_CALLBACK, sf_core_api_call_proto_async, sf_core_cancel_request
 
 
 # ---------------------------------------------------------------------------
@@ -274,30 +273,87 @@ def _derive_sqlstate(driver_exception: Any) -> str | None:
 
 
 class ProtoTransport:
+    """Async, callback-based bridge to the Rust core RPC layer.
+
+    Each call:
+      1. Creates an :class:`asyncio.Future` bound to the running event loop.
+      2. Builds a C callback that resolves the Future when Rust completes.
+      3. Submits the request to ``sf_core_api_call_proto_async`` (returns
+         immediately — Rust spawns the work on its tokio runtime).
+      4. Awaits the Future.
+
+    Lifetime correctness is critical: the C callback object **must** outlive
+    the Rust task that may invoke it. We pin it to the Future so it stays alive
+    until the Future is resolved (and thus garbage-collected only after the
+    awaiting coroutine resumes). Stack-locals are not safe — if the awaiting
+    coroutine is cancelled, its frame is collected before Rust may have fired
+    the callback.
+    """
+
     async def handle_message(self, api: str, method: str, message: bytes) -> tuple[int, bytes]:
-        return await asyncio.to_thread(self._handle_message_sync, api, method, message)
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future[tuple[int, bytes]] = loop.create_future()
 
-    def _handle_message_sync(self, api: str, method: str, message: bytes) -> tuple[int, bytes]:
-        response = ctypes.POINTER(ctypes.c_ubyte)()
-        response_len = ctypes.c_size_t()
-        api_bytes: c_char_p = ctypes.c_char_p(api.encode("utf-8"))
-        method_bytes: c_char_p = ctypes.c_char_p(method.encode("utf-8"))
-        message_buf = (ctypes.c_ubyte * len(message))()
-        message_buf[:] = message  # type: ignore
-        code = sf_core_api_call_proto(
-            api_bytes,
-            method_bytes,
-            ctypes.cast(message_buf, ctypes.POINTER(ctypes.c_ubyte)),
+        # Closure captures `loop` and `future` only — no `self`.
+        def on_response(
+            user_data_ptr: int,
+            status: int,
+            response_ptr: Any,
+            response_len: int,
+        ) -> None:
+            # Copy response bytes BEFORE returning — Rust frees the buffer next.
+            # `string_at` is a single memcpy; avoids the O(n) Python __getitem__
+            # loop you get from `bytes(ptr[:n])`.
+            response_bytes = ctypes.string_at(response_ptr, response_len)
+
+            def _set() -> None:
+                # The Future may have been cancelled while Rust was working;
+                # `set_result` would raise InvalidStateError. Guard explicitly.
+                if not future.done():
+                    future.set_result((status, response_bytes))
+
+            loop.call_soon_threadsafe(_set)
+
+        callback_ref = RESPONSE_CALLBACK(on_response)
+        # Pin the callback to the Future so it cannot be garbage-collected
+        # before Rust invokes it. Without this, an awaiting coroutine that
+        # gets cancelled could free the callback object while Rust still
+        # holds the function pointer — use-after-free / segfault.
+        #
+        # Note: this creates a deliberate reference cycle
+        # (future -> callback_ref -> on_response closure -> future). It is
+        # broken by the cycle GC after the Future resolves and the awaiting
+        # coroutine drops its reference. Do not optimise this pin away
+        # thinking it is redundant — the lifetime invariant matters precisely
+        # in the cancellation path.
+        future._proto_transport_callback_ref = callback_ref  # type: ignore[attr-defined]
+
+        # Build a C-compatible buffer from the message bytes. (c_ubyte * n) is
+        # contiguous and ctypes can pass its address directly — no extra copy
+        # versus the prior `message_buf[:] = message` approach, but cleaner.
+        request_buf = (ctypes.c_ubyte * len(message)).from_buffer_copy(message)
+
+        request_id = sf_core_api_call_proto_async(
+            api.encode("utf-8"),
+            method.encode("utf-8"),
+            ctypes.cast(request_buf, ctypes.POINTER(ctypes.c_ubyte)),
             len(message),
-            ctypes.byref(response),
-            ctypes.byref(response_len),
+            callback_ref,
+            None,  # user_data — unused; we capture future in the closure
         )
-        if code == 0 or code == 1 or code == 2:
-            result = bytes(response[: response_len.value])
-            sf_core_free_buffer(response, response_len.value)
-            return (code, result)
 
-        raise ProtoTransportException(f"Unknown error code: {code}")
+        try:
+            status, response_bytes = await future
+        except asyncio.CancelledError:
+            # Tell Rust to abort the in-flight task at its next await point.
+            # The callback may still fire if Rust is past that point — the
+            # `future.done()` guard above makes that case a safe no-op.
+            sf_core_cancel_request(request_id)
+            raise
+
+        if status in (0, 1, 2):
+            return (status, response_bytes)
+        raise ProtoTransportException(f"Unknown error code: {status}")
 
 
 _background_loop: asyncio.AbstractEventLoop | None = None
@@ -383,7 +439,7 @@ class CoreDriver:
     The held client is a :class:`DatabaseDriverBlockingClient` that wraps the
     async-first :class:`DatabaseDriverClient`. This keeps every CoreDriver
     method synchronous for existing callers while the underlying transport
-    runs the FFI call off-loop via ``asyncio.to_thread``.
+    runs the FFI call asynchronously via a callback-based bridge to tokio.
     """
 
     def __init__(self) -> None:

--- a/python/tests/unit/conftest.py
+++ b/python/tests/unit/conftest.py
@@ -1,0 +1,24 @@
+"""Unit-test conftest.
+
+Overrides fixtures from ``tests/conftest.py`` that would otherwise reach a
+real Snowflake backend. Unit tests must remain hermetic — no network, no
+``parameters.json`` requirement.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def connection(mock_db_api):
+    """Mocked, function-scoped Connection for unit tests.
+
+    Overrides ``tests/conftest.py``'s module-scoped real-connection fixture so
+    unit tests don't attempt to talk to a real Snowflake account. ``mock_db_api``
+    patches ``core_driver.client`` with a ``MagicMock`` that stubs every RPC
+    Connection.__init__ touches.
+    """
+    from snowflake.connector.connection import Connection
+
+    return Connection(user="test_user", account="test_account")

--- a/python/tests/unit/test_callback_ffi.py
+++ b/python/tests/unit/test_callback_ffi.py
@@ -1,0 +1,352 @@
+"""Unit tests for the callback-based async FFI in ProtoTransport.
+
+These tests mock at the FFI boundary (sf_core_api_call_proto_async) so they
+run without the Rust dylib loaded. They cover:
+
+* successful single-call path (status 0)
+* application-error path (status 1)
+* transport-error path (status 2)
+* unknown status -> ProtoTransportException
+* cancellation safety -- callback firing into a cancelled Future must not crash
+* lifetime safety -- callback ref is pinned to the Future
+* concurrency -- many in-flight calls resolve independently
+"""
+
+from __future__ import annotations
+
+import asyncio
+import ctypes
+
+from typing import Any
+
+import pytest
+
+from snowflake.connector._internal.api_client import client_api
+from snowflake.connector._internal.api_client.client_api import ProtoTransport
+from snowflake.connector._internal.protobuf_gen.proto_exception import (
+    ProtoTransportException,
+)
+
+
+class _FakeFFI:
+    """Records FFI calls and lets the test fire the callback at will."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.cancelled_ids: list[int] = []
+        self._next_id = 1
+
+    def __call__(
+        self,
+        api_bytes: bytes,
+        method_bytes: bytes,
+        request_ptr: Any,
+        request_len: int,
+        callback: Any,
+        user_data: Any,
+    ) -> int:
+        request_id = self._next_id
+        self._next_id += 1
+        self.calls.append(
+            {
+                "id": request_id,
+                "api": api_bytes,
+                "method": method_bytes,
+                "request_len": request_len,
+                "callback": callback,
+                "user_data": user_data,
+            }
+        )
+        return request_id
+
+    def cancel(self, request_id: int) -> None:
+        self.cancelled_ids.append(request_id)
+
+    def complete(self, index: int, status: int, payload: bytes) -> None:
+        """Simulate Rust firing the callback for the index-th call."""
+        call = self.calls[index]
+        buf = (ctypes.c_ubyte * len(payload)).from_buffer_copy(payload)
+        ptr = ctypes.cast(buf, ctypes.POINTER(ctypes.c_ubyte))
+        call["callback"](call["user_data"], status, ptr, len(payload))
+
+
+@pytest.fixture
+def fake_ffi(monkeypatch: pytest.MonkeyPatch) -> _FakeFFI:
+    """Patch sf_core_api_call_proto_async + sf_core_cancel_request with a recording fake."""
+    fake = _FakeFFI()
+    monkeypatch.setattr(client_api, "sf_core_api_call_proto_async", fake)
+    monkeypatch.setattr(client_api, "sf_core_cancel_request", fake.cancel)
+    return fake
+
+
+class TestSingleCall:
+    """Verify the basic request-response flow."""
+
+    def test_status_0_returns_response(self, fake_ffi: _FakeFFI) -> None:
+        async def run() -> tuple[int, bytes]:
+            transport = ProtoTransport()
+            task = asyncio.create_task(transport.handle_message("DatabaseDriver", "database_new", b"req"))
+            # Yield once so the FFI call is submitted.
+            await asyncio.sleep(0)
+            assert len(fake_ffi.calls) == 1
+            fake_ffi.complete(0, 0, b"response-bytes")
+            return await task
+
+        status, response = asyncio.run(run())
+        assert status == 0
+        assert response == b"response-bytes"
+
+    def test_status_1_returned_unchanged(self, fake_ffi: _FakeFFI) -> None:
+        """Application errors flow through; the transport never raises on status 1."""
+
+        async def run() -> tuple[int, bytes]:
+            transport = ProtoTransport()
+            task = asyncio.create_task(transport.handle_message("DatabaseDriver", "database_new", b"req"))
+            await asyncio.sleep(0)
+            fake_ffi.complete(0, 1, b"app-error-bytes")
+            return await task
+
+        status, response = asyncio.run(run())
+        assert status == 1
+        assert response == b"app-error-bytes"
+
+    def test_status_2_returned_unchanged(self, fake_ffi: _FakeFFI) -> None:
+        async def run() -> tuple[int, bytes]:
+            transport = ProtoTransport()
+            task = asyncio.create_task(transport.handle_message("DatabaseDriver", "database_new", b"req"))
+            await asyncio.sleep(0)
+            fake_ffi.complete(0, 2, b"transport-error-msg")
+            return await task
+
+        status, response = asyncio.run(run())
+        assert status == 2
+        assert response == b"transport-error-msg"
+
+    def test_unknown_status_raises(self, fake_ffi: _FakeFFI) -> None:
+        async def run() -> None:
+            transport = ProtoTransport()
+            task = asyncio.create_task(transport.handle_message("DatabaseDriver", "database_new", b"req"))
+            await asyncio.sleep(0)
+            fake_ffi.complete(0, 99, b"")
+            await task
+
+        with pytest.raises(ProtoTransportException, match="Unknown error code: 99"):
+            asyncio.run(run())
+
+    def test_request_passed_through(self, fake_ffi: _FakeFFI) -> None:
+        """Verify api / method / request bytes reach the FFI correctly."""
+
+        async def run() -> None:
+            transport = ProtoTransport()
+            task = asyncio.create_task(transport.handle_message("DatabaseDriver", "connection_init", b"\x01\x02\x03"))
+            await asyncio.sleep(0)
+            fake_ffi.complete(0, 0, b"")
+            await task
+
+        asyncio.run(run())
+        call = fake_ffi.calls[0]
+        assert call["api"] == b"DatabaseDriver"
+        assert call["method"] == b"connection_init"
+        assert call["request_len"] == 3
+
+
+class TestCancellationSafety:
+    """Cancellation must not crash. Two scenarios matter:
+
+    1. Future cancelled BEFORE callback fires -> callback must not raise
+       InvalidStateError when it tries to set_result on a cancelled Future.
+    2. Future cancelled AFTER callback already fired -> normal cancellation,
+       no special behaviour needed.
+    """
+
+    def test_callback_after_cancel_does_not_crash(self, fake_ffi: _FakeFFI) -> None:
+        async def run() -> None:
+            transport = ProtoTransport()
+            task = asyncio.create_task(transport.handle_message("DatabaseDriver", "database_new", b"req"))
+            # Let the FFI submit the request.
+            await asyncio.sleep(0)
+            assert len(fake_ffi.calls) == 1
+
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+            # Now Rust fires the callback (race we're testing).
+            # Must not raise InvalidStateError.
+            fake_ffi.complete(0, 0, b"too-late-response")
+            # Yield to let any scheduled call_soon_threadsafe run.
+            await asyncio.sleep(0)
+
+        asyncio.run(run())
+
+    def test_cancel_before_submit_works(self, fake_ffi: _FakeFFI) -> None:
+        """Sanity: a coroutine can be cancelled before reaching the FFI."""
+
+        async def run() -> None:
+            transport = ProtoTransport()
+            coro = transport.handle_message("DatabaseDriver", "database_new", b"req")
+            task = asyncio.create_task(coro)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        asyncio.run(run())
+
+
+class TestLifetimeSafety:
+    """The C callback object must outlive the Rust task that may call it.
+
+    We verify by stashing a weak reference and checking it survives a GC pass
+    while the Future is still pending.
+    """
+
+    def test_callback_pinned_to_future(self, fake_ffi: _FakeFFI) -> None:
+        """The handle_message coroutine pins the C callback to the Future.
+
+        We verify this with a direct attribute check rather than a weakref/GC
+        test: the awaiting coroutine's local frame already keeps the callback
+        alive in the happy path, so a GC-based test cannot distinguish "pinned
+        to future" from "kept alive by the awaiting frame". The direct check
+        proves the implementation actually attaches the pin — which is what
+        protects against use-after-free when the awaiting frame is dropped on
+        cancellation.
+        """
+
+        async def run() -> None:
+            # Spy on Future creation so we can grab the Future that
+            # handle_message creates internally.
+            loop = asyncio.get_running_loop()
+            original = loop.create_future
+            captured: list[asyncio.Future] = []
+
+            def spy() -> asyncio.Future:
+                f = original()
+                captured.append(f)
+                return f
+
+            loop.create_future = spy  # type: ignore[method-assign]
+            try:
+                transport = ProtoTransport()
+                task = asyncio.create_task(transport.handle_message("DatabaseDriver", "database_new", b"req"))
+                await asyncio.sleep(0)
+            finally:
+                loop.create_future = original  # type: ignore[method-assign]
+
+            assert len(captured) == 1, "handle_message should create exactly one Future"
+            future = captured[0]
+            cb = fake_ffi.calls[0]["callback"]
+
+            # The pin attaches the exact CFUNCTYPE object passed to FFI.
+            pinned = getattr(future, "_proto_transport_callback_ref", None)
+            assert pinned is cb, (
+                "callback not pinned to Future — without this, a cancelled coroutine "
+                "could drop the only Python-side reference to the C callback while "
+                "Rust still holds the function pointer (use-after-free)"
+            )
+
+            fake_ffi.complete(0, 0, b"done")
+            await task
+
+        asyncio.run(run())
+
+
+class TestConcurrency:
+    """Multiple in-flight calls must each resolve to their own response."""
+
+    def test_many_concurrent_calls(self, fake_ffi: _FakeFFI) -> None:
+        async def run() -> list[tuple[int, bytes]]:
+            transport = ProtoTransport()
+            n = 25
+            tasks = [
+                asyncio.create_task(transport.handle_message("DatabaseDriver", "database_new", f"req-{i}".encode()))
+                for i in range(n)
+            ]
+            await asyncio.sleep(0)
+            assert len(fake_ffi.calls) == n
+            # Complete in reverse order to verify each Future tracks its own callback.
+            for i in reversed(range(n)):
+                fake_ffi.complete(i, 0, f"resp-{i}".encode())
+            return await asyncio.gather(*tasks)
+
+        results = asyncio.run(run())
+        assert len(results) == 25
+        for i, (status, response) in enumerate(results):
+            assert status == 0
+            assert response == f"resp-{i}".encode()
+
+
+class TestCancellationPropagation:
+    """Cancelling the awaiting task must propagate to Rust via sf_core_cancel_request."""
+
+    def test_cancel_calls_rust_cancel(self, fake_ffi: _FakeFFI) -> None:
+        async def run() -> None:
+            transport = ProtoTransport()
+            task = asyncio.create_task(transport.handle_message("DatabaseDriver", "database_new", b"req"))
+            await asyncio.sleep(0)
+            assert len(fake_ffi.calls) == 1
+            request_id = fake_ffi.calls[0]["id"]
+
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+            assert fake_ffi.cancelled_ids == [request_id], (
+                f"expected exactly one cancel for id={request_id}, got {fake_ffi.cancelled_ids}"
+            )
+
+        asyncio.run(run())
+
+    def test_normal_completion_does_not_cancel(self, fake_ffi: _FakeFFI) -> None:
+        """Successful path must not call sf_core_cancel_request."""
+
+        async def run() -> None:
+            transport = ProtoTransport()
+            task = asyncio.create_task(transport.handle_message("DatabaseDriver", "database_new", b"req"))
+            await asyncio.sleep(0)
+            fake_ffi.complete(0, 0, b"ok")
+            await task
+
+        asyncio.run(run())
+        assert fake_ffi.cancelled_ids == []
+
+    def test_late_callback_after_cancel_is_noop(self, fake_ffi: _FakeFFI) -> None:
+        """If Rust fires the callback after cancellation (race past the abort
+        point), the Python side must not crash and must not double-cancel.
+        """
+
+        async def run() -> None:
+            transport = ProtoTransport()
+            task = asyncio.create_task(transport.handle_message("DatabaseDriver", "database_new", b"req"))
+            await asyncio.sleep(0)
+            request_id = fake_ffi.calls[0]["id"]
+
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+            # Now Rust fires the callback anyway (race past the abort point).
+            fake_ffi.complete(0, 0, b"too-late")
+            await asyncio.sleep(0)
+
+            assert fake_ffi.cancelled_ids == [request_id]
+
+        asyncio.run(run())
+
+
+class TestEmptyMessage:
+    """Regression: empty proto messages (e.g. ``DatabaseNewRequest()`` which
+    serializes to ``b""``) must not produce a null/dangling pointer that the
+    Rust side then dereferences.
+    """
+
+    def test_empty_message_passes_through(self, fake_ffi: _FakeFFI) -> None:
+        async def run() -> None:
+            transport = ProtoTransport()
+            task = asyncio.create_task(transport.handle_message("DatabaseDriver", "database_new", b""))
+            await asyncio.sleep(0)
+            assert len(fake_ffi.calls) == 1
+            assert fake_ffi.calls[0]["request_len"] == 0
+            fake_ffi.complete(0, 0, b"resp")
+            await task
+
+        asyncio.run(run())

--- a/sf_core/src/protobuf/c_api.rs
+++ b/sf_core/src/protobuf/c_api.rs
@@ -1,10 +1,35 @@
-use std::ffi::c_char;
+use std::collections::BTreeMap;
+use std::ffi::{c_char, c_void};
+use std::sync::Arc;
 use std::sync::OnceLock;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::apis::database_driver_v1::{DriverProviders, WrapperPresets};
 use crate::logging::LogManager;
 use crate::protobuf::apis::RustTransport;
+use futures::FutureExt;
 use proto_utils::{ProtoError, Transport};
+use tokio::sync::Notify;
+use tokio::task::AbortHandle;
+
+/// C callback type invoked when an async proto API call completes.
+///
+/// Parameters: `(user_data, status, response_ptr, response_len)`.
+/// Status codes: `0`=success, `1`=application error, `2`=transport error.
+///
+/// # Safety
+/// - Must not unwind across the FFI boundary.
+/// - The `response_ptr`/`response_len` buffer is owned by Rust and is freed
+///   immediately after the callback returns; the callback must copy any data
+///   it needs before returning.
+type ResponseCallback = unsafe extern "C" fn(*mut c_void, usize, *const u8, usize);
+
+/// Wrapper that promises a raw pointer is safe to send across threads.
+/// We never dereference it on the Rust side — it is opaque user data passed
+/// straight back to the callback.
+#[derive(Copy, Clone)]
+struct UserData(*mut c_void);
+unsafe impl Send for UserData {}
 
 struct CApiState {
     runtime: tokio::runtime::Runtime,
@@ -12,6 +37,18 @@ struct CApiState {
 }
 
 static STATE: OnceLock<CApiState> = OnceLock::new();
+
+/// Monotonic source for request IDs returned by [`sf_core_api_call_proto_async`].
+/// Wraps after `2^64` requests, which we treat as never.
+static NEXT_REQUEST_ID: AtomicU64 = AtomicU64::new(1);
+
+/// Registry of in-flight async requests, keyed by request ID. Holding the
+/// `AbortHandle` lets [`sf_core_cancel_request`] tell tokio to drop the task at
+/// its next await point. Entries are removed either when the task self-completes
+/// (success path) or when the caller cancels (cancel path) — whichever happens
+/// first wins; the loser is a no-op.
+static REQUEST_REGISTRY: std::sync::Mutex<BTreeMap<u64, AbortHandle>> =
+    std::sync::Mutex::new(BTreeMap::new());
 
 /// Eagerly build the entire core state (tokio runtime + transport) using the
 /// given `LogManager`.  Called once from `sf_core_init`.
@@ -107,5 +144,164 @@ pub unsafe extern "C" fn sf_core_api_call_proto(
             write_buffer(msg, response, response_len);
             2
         }
+    }
+}
+
+/// Invoke `callback` with the result of an FFI async dispatch, then free the
+/// response buffer. Splitting this out of the FFI function keeps the unsafe
+/// pointer arithmetic in one place.
+///
+/// # Safety
+/// `callback` must satisfy the contract documented on [`ResponseCallback`].
+unsafe fn fire_callback(
+    callback: ResponseCallback,
+    user_data: UserData,
+    status: usize,
+    response_vec: Vec<u8>,
+) {
+    // `boxed` must outlive the callback invocation: the callback receives a
+    // raw pointer into this allocation and reads it before returning.
+    // Binding it here keeps it alive for the whole scope; the explicit `drop`
+    // after the callback makes the lifetime extension intent unambiguous to
+    // future readers (and is a no-op the optimiser will elide anyway).
+    let boxed = response_vec.into_boxed_slice();
+    let ptr = boxed.as_ptr();
+    let len = boxed.len();
+    // SAFETY: caller-supplied callback contract; pointer/len pair is valid
+    // for the duration of the call (`boxed` is held below) and freed
+    // immediately after via `drop(boxed)`.
+    unsafe { callback(user_data.0, status, ptr, len) };
+    drop(boxed);
+}
+
+/// Async variant of [`sf_core_api_call_proto`] that returns immediately and
+/// invokes `callback` from a tokio worker thread when the request completes.
+///
+/// Returns a non-zero **request ID**. The caller may pass this ID to
+/// [`sf_core_cancel_request`] to ask Rust to abort the in-flight task. The ID
+/// is valid until either (a) the callback fires or (b) the caller cancels —
+/// whichever comes first; after that it is reused for a future request.
+///
+/// Unlike the sync variant, this does **not** block the caller — multiple
+/// outstanding requests run concurrently on the shared tokio runtime.
+///
+/// # Safety
+/// - `api`, `method`, `request` must point to valid data of the specified
+///   lengths for the duration of this call. They are copied immediately;
+///   the caller may free them after this returns.
+/// - `callback` is invoked exactly once and must be `Send`-safe (it will
+///   fire from a tokio worker thread, not the calling thread). It may still
+///   be invoked after [`sf_core_cancel_request`] if the task happened to be
+///   past its last await point — callers must guard against that on their side.
+/// - `user_data` is opaque and is forwarded to the callback unchanged.
+///   The caller is responsible for keeping any referent alive until the
+///   callback fires.
+/// - The response buffer passed to the callback is owned by Rust and freed
+///   immediately after the callback returns; copy before returning.
+#[unsafe(no_mangle)]
+#[cfg(feature = "protobuf")]
+pub unsafe extern "C" fn sf_core_api_call_proto_async(
+    api: *const c_char,
+    method: *const c_char,
+    request: *const u8,
+    request_len: usize,
+    callback: ResponseCallback,
+    user_data: *mut c_void,
+) -> u64 {
+    // Copy inputs eagerly — the caller may free these after we return.
+    let api_str = unsafe { std::ffi::CStr::from_ptr(api).to_string_lossy().into_owned() };
+    let method_str = unsafe {
+        std::ffi::CStr::from_ptr(method)
+            .to_string_lossy()
+            .into_owned()
+    };
+    let request_vec = if request_len == 0 {
+        // Avoid `slice::from_raw_parts` with len=0 — that requires a non-null
+        // aligned pointer, but ctypes may pass null for a zero-length buffer.
+        Vec::new()
+    } else {
+        unsafe { std::slice::from_raw_parts(request, request_len).to_vec() }
+    };
+    let user_data = UserData(user_data);
+
+    let state = STATE.get().expect("sf_core_init was not called");
+    let request_id = NEXT_REQUEST_ID.fetch_add(1, Ordering::Relaxed);
+
+    // Gate the spawned task on registration completing. Without this, the task
+    // can run to completion (fast path / no real I/O) BEFORE the calling thread
+    // inserts the AbortHandle, which would leak the handle in the registry.
+    // `Notify` has permit semantics: `notify_one` before `notified().await` is
+    // delivered when the task first awaits, so there is no missed-wakeup race.
+    let registered = Arc::new(Notify::new());
+    let registered_in_task = registered.clone();
+
+    let join = state.runtime.spawn(async move {
+        // Wait until the calling thread has inserted our AbortHandle into
+        // REQUEST_REGISTRY. After this await, cancellation can find us.
+        registered_in_task.notified().await;
+
+        // Re-fetch state from the static — avoids capturing a borrow across
+        // the await point (which would bound the future's lifetime to 'static).
+        let state = STATE.get().expect("sf_core_init was not called");
+
+        // Drive the transport future directly — no `block_on`. This yields
+        // properly to the tokio scheduler so concurrent calls actually run
+        // concurrently. `catch_unwind` ensures a panic in transport code is
+        // surfaced as a transport error rather than aborting the runtime.
+        let result = std::panic::AssertUnwindSafe(state.transport.handle_message(
+            &api_str,
+            &method_str,
+            request_vec,
+        ))
+        .catch_unwind()
+        .await;
+
+        let (status, response_vec): (usize, Vec<u8>) = match result {
+            Ok(Ok(r)) => (0, r),
+            Ok(Err(ProtoError::Application(e))) => (1, e),
+            Ok(Err(ProtoError::Transport(e))) => (2, e.as_bytes().to_vec()),
+            Err(_) => (2, b"sf_core panic in async task".to_vec()),
+        };
+
+        // Self-deregister BEFORE firing the callback. Whichever side
+        // (completion vs cancel) wins the lock first owns the cleanup; the
+        // loser's `remove` is a no-op. Doing this before the callback also
+        // means a concurrent cancel can't race with the callback firing.
+        let _ = REQUEST_REGISTRY.lock().unwrap().remove(&request_id);
+
+        // SAFETY: callback contract documented on this function.
+        unsafe { fire_callback(callback, user_data, status, response_vec) };
+    });
+
+    // Register the abort handle, then release the task. The task is gated on
+    // `notified().await` above, so it cannot reach `REQUEST_REGISTRY.remove`
+    // before this insert lands.
+    REQUEST_REGISTRY
+        .lock()
+        .unwrap()
+        .insert(request_id, join.abort_handle());
+    registered.notify_one();
+
+    request_id
+}
+
+/// Request that an in-flight async call submitted via
+/// [`sf_core_api_call_proto_async`] be cancelled.
+///
+/// This is **best-effort**: tokio aborts the task at its next await point.
+/// If the task is past its last await (e.g. about to fire the callback) the
+/// callback may still be invoked. Python is responsible for guarding the
+/// downstream Future against late callbacks (e.g. checking `done()` before
+/// `set_result`). After this call the `request_id` is invalid; passing the
+/// same ID twice is safe but a no-op.
+///
+/// # Safety
+/// `request_id` must come from a prior [`sf_core_api_call_proto_async`]; any
+/// other value is a no-op.
+#[unsafe(no_mangle)]
+#[cfg(feature = "protobuf")]
+pub unsafe extern "C" fn sf_core_cancel_request(request_id: u64) {
+    if let Some(handle) = REQUEST_REGISTRY.lock().unwrap().remove(&request_id) {
+        handle.abort();
     }
 }


### PR DESCRIPTION
## Summary

- Add `sf_core_api_call_proto_async` in Rust (`sf_core/src/protobuf/c_api.rs`).
  Spawns the work on the existing tokio runtime and drives it with a real
  `.await` (no `block_on`, no thread-per-call). When the request finishes a C
  callback is invoked from a tokio worker thread with
  `(user_data, status, response_ptr, response_len)`. Panics in the underlying
  transport are caught via `futures::FutureExt::catch_unwind` and surfaced as
  status-2 transport errors instead of aborting the runtime.
- Add `sf_core_cancel_request(request_id: u64)` for cooperative cancellation:
  every async request gets a monotonic ID and registers an `AbortHandle` in a
  `Mutex<BTreeMap>` registry; cancel removes + aborts. The spawned task waits
  on a `tokio::sync::Notify` until the AbortHandle is registered, so a
  fast-completing task can never deregister itself before the caller registers
  it (avoids a stale-handle leak in the registry).
- Replace the `asyncio.to_thread` bridge in `ProtoTransport.handle_message`
  with a true callback-based dispatch: create an `asyncio.Future`, build a C
  callback that resolves the Future via `loop.call_soon_threadsafe`, submit
  via `sf_core_api_call_proto_async`, await the Future. On
  `asyncio.CancelledError`, call `sf_core_cancel_request(request_id)` before
  re-raising — cancellation now genuinely propagates to Rust.
- Lifetime safety: pin the `RESPONSE_CALLBACK` ctypes object to the Future
  via `future._proto_transport_callback_ref`. Without this, an awaiting
  coroutine that gets cancelled would drop the only Python-side reference
  while Rust still holds the function pointer (use-after-free / segfault).
  The closure also `future.done()`-guards `set_result`, so a callback that
  fires after the Future is cancelled is a safe no-op.
- Use `ctypes.string_at` for the response copy (single memcpy) instead of
  the O(n) Python `__getitem__` slice path.
- Empty-message safety: `sf_core_api_call_proto_async` skips
  `slice::from_raw_parts(ptr, 0)` when `request_len == 0`, since ctypes may
  pass a null pointer for a zero-length buffer and `from_raw_parts` requires
  non-null even at length 0. `DatabaseNewRequest()` serializes to `b""`, so
  this code path runs in production.

## Tests

`python/tests/unit/test_callback_ffi.py` — 13 unit tests that mock at the
FFI boundary so they run without the dylib loaded:

- `TestSingleCall` — status 0/1/2 paths, unknown status raises, request
  bytes / api / method are passed through unchanged.
- `TestCancellationSafety` — callback firing into a cancelled Future is a
  no-op; cancel-before-submit works.
- `TestCancellationPropagation` — cancelling the awaiting task calls
  `sf_core_cancel_request` exactly once; normal completion does not call
  cancel; a late callback racing past the abort point does not double-cancel.
- `TestLifetimeSafety` — directly asserts
  `future._proto_transport_callback_ref is callback` (mutation-tested:
  forcing the pin to `None` causes the test to fail).
- `TestConcurrency` — 25 in-flight requests, completed in reverse order,
  each resolves to its own response.
- `TestEmptyMessage` — regression for the `b""` case.

`python/tests/unit/conftest.py` (new) — hermetic `connection` fixture for
unit tests. Overrides `tests/conftest.py`'s module-scoped fixture that
attempts a real Snowflake connection (and hangs forever in unit-test mode
without `parameters.json`). This was the **actual** root cause of the
`test_connect_returns_connection` timeout from the previous PR; the
`@pytest.mark.skip` was a cover-up. The skip is removed and the test now
passes via the mocked Connection.

## Why callback-based instead of `asyncio.to_thread`

The `asyncio.to_thread` bridge from SNOW-3487070 had three real costs:

- Concurrency capped at the loop's default `ThreadPoolExecutor`
  (`min(32, os.cpu_count() + 4)` workers); above that, calls queue silently
  and contend with anything else in the process using `to_thread`.
- A pointless three-thread hop on every sync call: caller → loop thread →
  executor thread → ctypes.
- Hidden coupling to the default executor's shutdown lifecycle.

With this PR the transport is genuinely non-blocking up to whatever
concurrency the tokio runtime provides; no Python thread is spawned per call.

## What this PR is **not**

- Cancellation is now propagated to Rust, but it is still **best-effort**:
  tokio aborts the task at its next await point. If the task is past its
  last await (mid-callback dispatch) the callback can still fire — Python's
  `future.done()` guard makes that case a safe no-op.
- The tokio runtime still has `worker_threads(1)`. That's fine for true
  async I/O but limits concurrency for any sync work the transport might do
  internally; tunable separately.

## Test plan

- [x] `cargo build -p sf_core`
- [x] `hatch build` regenerates `database_driver_v1_services.py` cleanly
- [x] `pytest tests/unit/test_callback_ffi.py` → **13 passed**
- [x] `hatch run dev.py3.13:unit` → **1027 passed, 1 skipped, 0 errors, ~12 s**
      (was 1013 passed / 2 skipped / 1 timeout under the previous bridge)
- [x] Smoke test against real `libsf_core`: 1 single call + 50 concurrent
      + 1 cancellation — all green; `threading.active_count()` stays at 2
      throughout
- [x] Mutation test: forcing `future._proto_transport_callback_ref = None`
      makes `TestLifetimeSafety` fail with the expected message
- [x] `ruff format` and `ruff check` clean
- [ ] CI green

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>