### PR TITLE
SNOW-3235555 Cursor & Row Information Attributes

### DIFF
--- a/odbc/src/api/data.rs
+++ b/odbc/src/api/data.rs
@@ -284,7 +284,11 @@ pub fn fetch(statement_handle: sql::Handle, warnings: &mut Warnings) -> OdbcResu
         return DisconnectedSnafu.fail();
     }
     let numeric_settings = conn.numeric_settings;
-    fetch_impl(&guard, &numeric_settings, warnings)
+    let result = fetch_impl(&guard, &numeric_settings, warnings);
+    if matches!(result, Err(crate::api::OdbcError::NoMoreData { .. })) {
+        guard.inner.lock().current_row_number = 0;
+    }
+    result
 }
 
 fn fetch_impl(
@@ -341,6 +345,7 @@ fn fetch_impl(
         match outputs.into_iter().next().unwrap_or_else(|| Ok(Vec::new())) {
             Ok(row_warnings) => {
                 inner.rows_returned += 1;
+                inner.current_row_number += 1;
                 let status = if row_warnings.is_empty() {
                     RowStatus::Success
                 } else {
@@ -487,6 +492,7 @@ fn fetch_impl(
     }
 
     inner.rows_returned += rows_fetched as sql::ULen;
+    inner.current_row_number += rows_fetched as sql::ULen;
 
     if !rows_fetched_ptr.is_null() {
         unsafe { *rows_fetched_ptr = rows_fetched as sql::ULen };
@@ -627,7 +633,11 @@ pub fn extended_fetch(
         inner.ird.array_status_ptr = row_status_ptr;
     }
 
-    fetch_impl(&guard, &numeric_settings, warnings)
+    let result = fetch_impl(&guard, &numeric_settings, warnings);
+    if matches!(result, Err(crate::api::OdbcError::NoMoreData { .. })) {
+        guard.inner.lock().current_row_number = 0;
+    }
+    result
 }
 
 fn write_row_status(row_status_ptr: *mut u16, row_idx: usize, status: RowStatus) {

--- a/odbc/src/api/descriptor.rs
+++ b/odbc/src/api/descriptor.rs
@@ -119,6 +119,12 @@ fn get_ard_field(
                 }
                 Ok(())
             }
+            DescField::ArrayStatusPtr => {
+                unsafe {
+                    std::ptr::write_unaligned(value_ptr as *mut *mut u16, desc.array_status_ptr);
+                }
+                Ok(())
+            }
             _ => {
                 tracing::warn!("get_desc_field: unsupported ARD header field {:?}", field);
                 crate::api::error::UnknownAttributeSnafu {
@@ -320,6 +326,12 @@ fn set_ard_field(
                 let ptr = value_ptr as *mut sql::Len;
                 tracing::debug!("set_desc_field: ARD BindOffsetPtr = {:?}", ptr);
                 desc.bind_offset_ptr = ptr;
+                Ok(())
+            }
+            DescField::ArrayStatusPtr => {
+                let ptr = value_ptr as *mut u16;
+                tracing::debug!("set_desc_field: ARD ArrayStatusPtr = {:?}", ptr);
+                desc.array_status_ptr = ptr;
                 Ok(())
             }
             _ => {

--- a/odbc/src/api/statement.rs
+++ b/odbc/src/api/statement.rs
@@ -324,6 +324,7 @@ fn exec_direct_impl(
     }
 
     inner.rows_returned = 0;
+    inner.current_row_number = 0;
     Ok(())
 }
 
@@ -876,6 +877,7 @@ pub fn execute(
     }
 
     inner.rows_returned = 0;
+    inner.current_row_number = 0;
     Ok(())
 }
 
@@ -1513,6 +1515,7 @@ pub fn free_stmt(statement_handle: sql::Handle, option: FreeStmtOption) -> OdbcR
                 inner.ird.desc_count = desc_count;
                 inner.get_data_state = None;
                 inner.used_extended_fetch = false;
+                inner.current_row_number = 0;
             }
         }
         FreeStmtOption::Unbind => {
@@ -1801,6 +1804,12 @@ pub fn set_stmt_attr(
             inner.ard.bind_offset_ptr = ptr;
             Ok(())
         }
+        StmtAttr::RowOperationPtr => {
+            let ptr = value_ptr as *mut u16;
+            tracing::debug!("set_stmt_attr: RowOperationPtr = {:?}", ptr);
+            inner.ard.array_status_ptr = ptr;
+            Ok(())
+        }
         StmtAttr::ParamsetSize => {
             let size = value_ptr as sql::ULen;
             tracing::debug!("set_stmt_attr: ParamsetSize = {}", size);
@@ -1857,7 +1866,10 @@ pub fn set_stmt_attr(
             inner.metadata_id = val != 0;
             Ok(())
         }
-        StmtAttr::SnowflakeLastQueryId | StmtAttr::ImpRowDesc | StmtAttr::ImpParamDesc => {
+        StmtAttr::SnowflakeLastQueryId
+        | StmtAttr::ImpRowDesc
+        | StmtAttr::ImpParamDesc
+        | StmtAttr::RowNumber => {
             tracing::warn!("set_stmt_attr: {:?} is read-only", attr);
             ReadOnlyAttributeSnafu { attribute }.fail()
         }
@@ -2125,6 +2137,19 @@ pub fn get_stmt_attr<E: OdbcEncoding>(
             }
             Ok(())
         }
+        StmtAttr::RowNumber => {
+            if !value_ptr.is_null() {
+                unsafe {
+                    *(value_ptr as *mut sql::ULen) = inner.current_row_number;
+                }
+            }
+            if !string_length_ptr.is_null() {
+                unsafe {
+                    *string_length_ptr = size_of::<sql::ULen>() as sql::Integer;
+                }
+            }
+            Ok(())
+        }
         StmtAttr::RowArraySize => {
             unsafe {
                 *(value_ptr as *mut sql::ULen) = inner.ard.array_size as sql::ULen;
@@ -2158,6 +2183,14 @@ pub fn get_stmt_attr<E: OdbcEncoding>(
         StmtAttr::RowBindOffsetPtr => {
             unsafe {
                 *(value_ptr as *mut *mut sql::Len) = inner.ard.bind_offset_ptr;
+            }
+            Ok(())
+        }
+        StmtAttr::RowOperationPtr => {
+            if !value_ptr.is_null() {
+                unsafe {
+                    *(value_ptr as *mut *mut u16) = inner.ard.array_status_ptr;
+                }
             }
             Ok(())
         }

--- a/odbc/src/api/types/odbc_types.rs
+++ b/odbc/src/api/types/odbc_types.rs
@@ -327,6 +327,8 @@ pub enum StmtAttr {
     RetrieveData = 11,
     /// `SQL_ATTR_USE_BOOKMARKS` (12) — whether bookmarks are used.
     UseBookmarks = 12,
+    /// `SQL_ATTR_ROW_NUMBER` (14) — read-only: 1-based number of the current row (0 = not positioned).
+    RowNumber = 14,
     /// `SQL_ATTR_ENABLE_AUTO_IPD` (15) — automatic population of the IPD.
     EnableAutoIpd = 15,
     /// `SQL_ATTR_PARAM_BIND_OFFSET_PTR` (17) — maps to `SQL_DESC_BIND_OFFSET_PTR` on the APD.
@@ -343,6 +345,8 @@ pub enum StmtAttr {
     ParamsetSize = 22,
     /// `SQL_ATTR_ROW_BIND_OFFSET_PTR` (23) — binding offset pointer.
     RowBindOffsetPtr = 23,
+    /// `SQL_ATTR_ROW_OPERATION_PTR` (24) — maps to `SQL_DESC_ARRAY_STATUS_PTR` on the ARD.
+    RowOperationPtr = 24,
     /// `SQL_ATTR_ROW_STATUS_PTR` (25) — pointer to per-row status array.
     RowStatusPtr = 25,
     /// `SQL_ATTR_ROWS_FETCHED_PTR` (26) — pointer to count of rows fetched.
@@ -385,6 +389,7 @@ impl TryFrom<i32> for StmtAttr {
             10 => Ok(StmtAttr::SimulateCursor),
             11 => Ok(StmtAttr::RetrieveData),
             12 => Ok(StmtAttr::UseBookmarks),
+            14 => Ok(StmtAttr::RowNumber),
             15 => Ok(StmtAttr::EnableAutoIpd),
             17 => Ok(StmtAttr::ParamBindOffsetPtr),
             18 => Ok(StmtAttr::ParamBindType),
@@ -393,6 +398,7 @@ impl TryFrom<i32> for StmtAttr {
             21 => Ok(StmtAttr::ParamsProcessedPtr),
             22 => Ok(StmtAttr::ParamsetSize),
             23 => Ok(StmtAttr::RowBindOffsetPtr),
+            24 => Ok(StmtAttr::RowOperationPtr),
             25 => Ok(StmtAttr::RowStatusPtr),
             26 => Ok(StmtAttr::RowsFetchedPtr),
             27 => Ok(StmtAttr::RowArraySize),
@@ -791,6 +797,9 @@ pub struct ArdDescriptor {
     pub bind_type: sql::ULen,
     /// `SQL_DESC_BIND_OFFSET_PTR` / `SQL_ATTR_ROW_BIND_OFFSET_PTR` — default null.
     pub bind_offset_ptr: *mut sql::Len,
+    /// `SQL_DESC_ARRAY_STATUS_PTR` / `SQL_ATTR_ROW_OPERATION_PTR` — default null.
+    /// Each element is `SQL_ROW_PROCEED` (0) or `SQL_ROW_IGNORE` (1).
+    pub array_status_ptr: *mut u16,
 }
 
 impl Default for ArdDescriptor {
@@ -809,6 +818,7 @@ impl ArdDescriptor {
             array_size: 1,
             bind_type: 0,
             bind_offset_ptr: std::ptr::null_mut(),
+            array_status_ptr: std::ptr::null_mut(),
         }
     }
 
@@ -1467,6 +1477,10 @@ pub struct StatementInner {
     /// Rows returned to the application so far in the current result set.
     /// Reset to 0 on each execution. Used to enforce `max_rows`.
     pub rows_returned: sql::ULen,
+    /// Current 1-based row number within the result set (`SQL_ATTR_ROW_NUMBER`).
+    /// 0 = not positioned (before first fetch, after end, or on error).
+    /// Reset to 0 on cursor close/re-execute; incremented on each successful fetch.
+    pub current_row_number: sql::ULen,
     /// `SQL_ATTR_CONCURRENCY` — cursor concurrency (default SQL_CONCUR_READ_ONLY = 1).
     pub concurrency: sql::ULen,
     /// `SQL_ATTR_CURSOR_SCROLLABLE` — cursor scrollability (default SQL_NONSCROLLABLE = 0).
@@ -1521,6 +1535,7 @@ impl Statement {
                 noscan: SQL_NOSCAN_OFF,
                 max_rows: 0,
                 rows_returned: 0,
+                current_row_number: 0,
                 concurrency: SQL_CONCUR_READ_ONLY,
                 cursor_scrollable: SQL_NONSCROLLABLE,
                 cursor_sensitivity: SQL_UNSPECIFIED,

--- a/odbc_tests/BehaviorDifferences.yaml
+++ b/odbc_tests/BehaviorDifferences.yaml
@@ -813,6 +813,18 @@ behavior_differences:
     impact: |
       Applications querying these info types to determine driver capabilities for parameter array execution will receive different values. The new driver correctly advertises full parameter array execution support.
 
+  61:
+    name: "SQL_ATTR_ROW_NUMBER returns SQL_SUCCESS with 0 when cursor is not positioned; old driver returns SQL_ERROR"
+    status: unknown
+    type: api_incompatibility
+    reviewed: false
+    old_driver_behavior: |
+      SQLGetStmtAttr(SQL_ATTR_ROW_NUMBER) returns SQL_ERROR when the cursor is not positioned on a row (before first fetch, after SQL_NO_DATA, or on a fresh statement with no result set open).
+    new_driver_behavior: |
+      SQLGetStmtAttr(SQL_ATTR_ROW_NUMBER) returns SQL_SUCCESS with value 0 when the cursor is not positioned on a row, per the ODBC spec which states the attribute returns 0 if there is no current row.
+    impact: |
+      Applications that check the return code of SQLGetStmtAttr(SQL_ATTR_ROW_NUMBER) before a fetch may need to handle SQL_SUCCESS (new) instead of SQL_ERROR (old). Applications that only call it during an active fetch are unaffected.
+
   56:
     name: "SQL_SF_STMT_ATTR_LAST_QUERY_ID (SQLPrepare+SQLExecute path) and SQL_SF_STMT_ATTR_MULTI_STATEMENT_COUNT are only fully supported by the new driver"
     status: unknown

--- a/odbc_tests/tests/e2e/CMakeLists.txt
+++ b/odbc_tests/tests/e2e/CMakeLists.txt
@@ -43,6 +43,7 @@ add_odbc_test(e2e_query_last_query_id query/last_query_id.cpp)
 add_odbc_test(e2e_query_sf_stmt_attrs query/sf_stmt_attrs.cpp)
 add_odbc_test(e2e_query_async_execution query/async_execution.cpp)
 add_odbc_test(e2e_query_param_array_attrs query/param_array_attrs.cpp)
+add_odbc_test(e2e_query_cursor_row_info_attrs query/cursor_row_info_attrs.cpp)
 
 # tls
 add_odbc_test(e2e_tls_crl_enabled tls/crl_enabled.cpp)

--- a/odbc_tests/tests/e2e/query/cursor_row_info_attrs.cpp
+++ b/odbc_tests/tests/e2e/query/cursor_row_info_attrs.cpp
@@ -1,0 +1,227 @@
+#include <sql.h>
+#include <sqlext.h>
+#include <sqltypes.h>
+
+#include <string>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "Connection.hpp"
+#include "compatibility.hpp"
+#include "get_diag_rec.hpp"
+#include "odbc_cast.hpp"
+
+// ============================================================================
+// SQL_ATTR_ROW_NUMBER (14)
+// ============================================================================
+
+TEST_CASE("SQL_ATTR_ROW_NUMBER default value is 0 on a fresh statement.") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_ROW_NUMBER is queried on a fresh statement
+  SQLULEN value = 99;
+  SQLRETURN ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_ROW_NUMBER, &value, 0, nullptr);
+
+  // Then new driver returns SQL_SUCCESS with 0; old driver returns SQL_ERROR (BD#59)
+  NEW_DRIVER_ONLY("BD#59") {
+    REQUIRE(ret == SQL_SUCCESS);
+    CHECK(value == 0);
+  }
+  OLD_DRIVER_ONLY("BD#59") { REQUIRE(ret == SQL_ERROR); }
+}
+
+TEST_CASE("SQL_ATTR_ROW_NUMBER returns 0 before any fetch.") {
+  // Given a prepared and executed query with rows
+  Connection conn;
+  auto stmt = conn.createStatement();
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // When SQL_ATTR_ROW_NUMBER is queried before any SQLFetch
+  SQLULEN value = 99;
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_ROW_NUMBER, &value, 0, nullptr);
+
+  // Then new driver returns SQL_SUCCESS with 0; old driver returns SQL_ERROR (BD#59)
+  NEW_DRIVER_ONLY("BD#59") {
+    REQUIRE(ret == SQL_SUCCESS);
+    CHECK(value == 0);
+  }
+  OLD_DRIVER_ONLY("BD#59") { REQUIRE(ret == SQL_ERROR); }
+}
+
+TEST_CASE("SQL_ATTR_ROW_NUMBER returns 1 after the first SQLFetch.") {
+  // Given an executed query
+  Connection conn;
+  auto stmt = conn.createStatement();
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // When the first row is fetched
+  ret = SQLFetch(stmt.getHandle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Then SQL_ATTR_ROW_NUMBER should be 1
+  SQLULEN value = 0;
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_ROW_NUMBER, &value, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(value == 1);
+}
+
+TEST_CASE("SQL_ATTR_ROW_NUMBER increments with each SQLFetch.") {
+  // Given an executed query
+  Connection conn;
+  auto stmt = conn.createStatement();
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // When three rows are fetched
+  for (SQLULEN expected = 1; expected <= 3; ++expected) {
+    ret = SQLFetch(stmt.getHandle());
+    REQUIRE(ret == SQL_SUCCESS);
+
+    // Then SQL_ATTR_ROW_NUMBER should match the fetch count
+    SQLULEN value = 0;
+    ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_ROW_NUMBER, &value, 0, nullptr);
+    REQUIRE(ret == SQL_SUCCESS);
+    CHECK(value == expected);
+  }
+}
+
+TEST_CASE("SQL_ATTR_ROW_NUMBER returns 0 after SQL_NO_DATA.") {
+  // Given an executed single-row query
+  Connection conn;
+  auto stmt = conn.createStatement();
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT 1"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // When we fetch past the end of the result set
+  ret = SQLFetch(stmt.getHandle());
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLFetch(stmt.getHandle());
+  REQUIRE(ret == SQL_NO_DATA);
+
+  // Then new driver returns SQL_SUCCESS with 0; old driver returns SQL_ERROR (BD#59)
+  SQLULEN value = 99;
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_ROW_NUMBER, &value, 0, nullptr);
+  NEW_DRIVER_ONLY("BD#59") {
+    REQUIRE(ret == SQL_SUCCESS);
+    CHECK(value == 0);
+  }
+  OLD_DRIVER_ONLY("BD#59") { REQUIRE(ret == SQL_ERROR); }
+}
+
+TEST_CASE("SQL_ATTR_ROW_NUMBER set returns SQL_ERROR with state HY092.") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_ROW_NUMBER is set (it is read-only)
+  SQLRETURN ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_ROW_NUMBER, (SQLPOINTER)1, 0);
+
+  // Then it should return SQL_ERROR with SQLSTATE HY092
+  REQUIRE(ret == SQL_ERROR);
+  auto diag = get_diag_rec(SQL_HANDLE_STMT, stmt.getHandle());
+  REQUIRE(!diag.empty());
+  CHECK(diag[0].sqlState == "HY092");
+}
+
+// ============================================================================
+// SQL_ATTR_ROW_OPERATION_PTR (24)
+// ============================================================================
+
+TEST_CASE("SQL_ATTR_ROW_OPERATION_PTR default value is null.") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_ROW_OPERATION_PTR is queried on a fresh statement
+  SQLUSMALLINT* value = reinterpret_cast<SQLUSMALLINT*>(0xdeadbeef);
+  SQLRETURN ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_ROW_OPERATION_PTR, &value, 0, nullptr);
+
+  // Then it should return SQL_SUCCESS and the value nullptr
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(value == nullptr);
+}
+
+TEST_CASE("SQL_ATTR_ROW_OPERATION_PTR can be set and retrieved.") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_ROW_OPERATION_PTR is set to a non-null pointer
+  SQLUSMALLINT ops[4] = {SQL_ROW_PROCEED, SQL_ROW_IGNORE, SQL_ROW_PROCEED, SQL_ROW_PROCEED};
+  SQLRETURN ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_ROW_OPERATION_PTR, ops, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Then get should return the same pointer
+  SQLUSMALLINT* retrieved = nullptr;
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_ROW_OPERATION_PTR, &retrieved, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(retrieved == ops);
+}
+
+// ============================================================================
+// SQL_ATTR_ROW_NUMBER — block cursor (SQL_ATTR_ROW_ARRAY_SIZE > 1)
+// ============================================================================
+
+TEST_CASE("SQL_ATTR_ROW_NUMBER advances by rowset size with block cursor.") {
+  // Given SQL_ATTR_ROW_ARRAY_SIZE is set to 3 and a 6-row result set
+  Connection conn;
+  auto stmt = conn.createStatement();
+  SQLRETURN ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_ROW_ARRAY_SIZE, (SQLPOINTER)3, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  ret = SQLExecDirect(
+      stmt.getHandle(),
+      sqlchar(
+          "SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4 UNION ALL SELECT 5 UNION ALL SELECT 6"),
+      SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // When the first rowset (rows 1-3) is fetched
+  ret = SQLFetch(stmt.getHandle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Then SQL_ATTR_ROW_NUMBER should be 3 (last row of the first rowset)
+  SQLULEN value = 0;
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_ROW_NUMBER, &value, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(value == 3);
+
+  // When the second rowset (rows 4-6) is fetched
+  ret = SQLFetch(stmt.getHandle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Then SQL_ATTR_ROW_NUMBER should be 6 (last row of the second rowset)
+  value = 0;
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_ROW_NUMBER, &value, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(value == 6);
+}
+
+TEST_CASE("SQL_ATTR_ROW_NUMBER resets to 0 after SQLCloseCursor.") {
+  // Given a query has been executed and one row fetched
+  Connection conn;
+  auto stmt = conn.createStatement();
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT 1 UNION ALL SELECT 2"), SQL_NTS);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLFetch(stmt.getHandle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLULEN value = 0;
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_ROW_NUMBER, &value, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  REQUIRE(value == 1);
+
+  // When the cursor is closed
+  ret = SQLCloseCursor(stmt.getHandle());
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // Then SQL_ATTR_ROW_NUMBER should be reset to 0
+  value = 99;
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_ROW_NUMBER, &value, 0, nullptr);
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(value == 0);
+}


### PR DESCRIPTION
- Add SQL_ATTR_ROW_NUMBER (14): read-only attribute returning the
  current 1-based row number during fetch; 0 when not positioned.
  Tracks current_row_number in StatementInner, incremented alongside
  rows_returned in fetch_impl, reset to 0 on cursor close/re-execute
  and after SQL_NO_DATA.
- Add SQL_ATTR_ROW_OPERATION_PTR (24): maps to SQL_DESC_ARRAY_STATUS_PTR
  on the ARD; stored as array_status_ptr field on ArdDescriptor.
- Add ArrayStatusPtr get/set for ARD in descriptor.rs.
- Document BD#59: legacy driver returns SQL_ERROR for
  SQL_ATTR_ROW_NUMBER when cursor is not positioned; new driver returns
  SQL_SUCCESS with 0 per ODBC spec.