### PR TITLE
NO-SNOW: Add HttpTestClient test utility for JDBC tests

### DIFF
--- a/jdbc/build.gradle
+++ b/jdbc/build.gradle
@@ -37,6 +37,7 @@ configurations {
 dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
     testImplementation 'org.mockito:mockito-core:4.6.1'
+    testImplementation 'org.apache.httpcomponents.client5:httpclient5:5.4.4'
     testCompileOnly "org.projectlombok:lombok:${lombokVersion}"
     testAnnotationProcessor "org.projectlombok:lombok:${lombokVersion}"
 

--- a/jdbc/src/test/java/net/snowflake/jdbc/testutil/HttpTestClient.java
+++ b/jdbc/src/test/java/net/snowflake/jdbc/testutil/HttpTestClient.java
@@ -1,0 +1,115 @@
+package net.snowflake.jdbc.testutil;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.config.ConnectionConfig;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.apache.hc.core5.http.io.support.ClassicRequestBuilder;
+import org.apache.hc.core5.util.Timeout;
+import org.json.JSONObject;
+import org.json.JSONTokener;
+
+/** Minimal Apache HttpClient 5.x wrapper for synchronous test use. Java 8 source compatible. */
+public final class HttpTestClient implements AutoCloseable {
+
+  private static final Timeout DEFAULT_TIMEOUT = Timeout.ofSeconds(5);
+
+  private final CloseableHttpClient client;
+
+  public HttpTestClient() {
+    ConnectionConfig connectionConfig =
+        ConnectionConfig.custom().setConnectTimeout(DEFAULT_TIMEOUT).build();
+    PoolingHttpClientConnectionManager connectionManager =
+        PoolingHttpClientConnectionManagerBuilder.create()
+            .setDefaultConnectionConfig(connectionConfig)
+            .build();
+    RequestConfig requestConfig =
+        RequestConfig.custom()
+            .setResponseTimeout(DEFAULT_TIMEOUT)
+            .setConnectionRequestTimeout(DEFAULT_TIMEOUT)
+            .build();
+    this.client =
+        HttpClients.custom()
+            .setConnectionManager(connectionManager)
+            .setDefaultRequestConfig(requestConfig)
+            .build();
+  }
+
+  public Response get(String url) {
+    return execute(ClassicRequestBuilder.get(url).build());
+  }
+
+  public Response post(String url, String body) {
+    HttpPost post = new HttpPost(url);
+    if (body != null) {
+      post.setEntity(new StringEntity(body, ContentType.APPLICATION_JSON));
+    }
+    return execute(post);
+  }
+
+  @Override
+  public void close() {
+    try {
+      client.close();
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to close HttpTestClient", e);
+    }
+  }
+
+  private Response execute(ClassicHttpRequest request) {
+    try {
+      return client.execute(
+          request,
+          response -> {
+            HttpEntity entity = response.getEntity();
+            String body =
+                entity == null ? "" : EntityUtils.toString(entity, StandardCharsets.UTF_8);
+            return new Response(response.getCode(), body);
+          });
+    } catch (IOException e) {
+      throw new RuntimeException(
+          request.getMethod() + " " + request.getRequestUri() + " failed", e);
+    }
+  }
+
+  public static final class Response {
+    private final int status;
+    private final String body;
+
+    Response(int status, String body) {
+      this.status = status;
+      this.body = body;
+    }
+
+    public int status() {
+      return status;
+    }
+
+    public String body() {
+      return body;
+    }
+
+    public boolean ok() {
+      return status >= 200 && status < 300;
+    }
+
+    public JSONObject json() {
+      return new JSONObject(new JSONTokener(body));
+    }
+
+    @Override
+    public String toString() {
+      return "Response(status=" + status + ", body=" + body + ")";
+    }
+  }
+}

--- a/jdbc/src/test/java/net/snowflake/jdbc/testutil/HttpTestClientTest.java
+++ b/jdbc/src/test/java/net/snowflake/jdbc/testutil/HttpTestClientTest.java
@@ -1,0 +1,139 @@
+package net.snowflake.jdbc.testutil;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicReference;
+import net.snowflake.jdbc.testutil.HttpTestClient.Response;
+import org.json.JSONObject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Hermetic self-tests for {@link HttpTestClient} using a JDK-built-in {@link HttpServer}. */
+public class HttpTestClientTest {
+
+  private HttpServer server;
+  private HttpTestClient client;
+  private String baseUrl;
+
+  @BeforeEach
+  public void setUp() throws IOException {
+    server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    server.start();
+    baseUrl = "http://127.0.0.1:" + server.getAddress().getPort();
+    client = new HttpTestClient();
+  }
+
+  @AfterEach
+  public void tearDown() {
+    if (client != null) {
+      client.close();
+    }
+    if (server != null) {
+      server.stop(0);
+    }
+  }
+
+  @Test
+  public void getReturns200AndBody() {
+    server.createContext("/hello", respondWith(200, "world", "text/plain"));
+
+    Response response = client.get(baseUrl + "/hello");
+
+    assertEquals(200, response.status());
+    assertEquals("world", response.body());
+    assertTrue(response.ok());
+  }
+
+  @Test
+  public void postSendsJsonBodyAndContentTypeHeader() {
+    AtomicReference<String> capturedBody = new AtomicReference<>();
+    AtomicReference<String> capturedContentType = new AtomicReference<>();
+    server.createContext(
+        "/echo",
+        exchange -> {
+          capturedContentType.set(exchange.getRequestHeaders().getFirst("Content-Type"));
+          try (InputStream in = exchange.getRequestBody()) {
+            capturedBody.set(new String(readAll(in), StandardCharsets.UTF_8));
+          }
+          byte[] resp = "{\"ack\":true}".getBytes(StandardCharsets.UTF_8);
+          exchange.getResponseHeaders().add("Content-Type", "application/json");
+          exchange.sendResponseHeaders(201, resp.length);
+          exchange.getResponseBody().write(resp);
+          exchange.close();
+        });
+
+    Response response = client.post(baseUrl + "/echo", "{\"x\":1}");
+
+    assertEquals(201, response.status());
+    assertTrue(response.ok());
+    assertEquals("{\"x\":1}", capturedBody.get());
+    assertNotNull(capturedContentType.get());
+    assertTrue(
+        capturedContentType.get().toLowerCase().contains("application/json"),
+        "Expected JSON content type, got: " + capturedContentType.get());
+
+    JSONObject parsed = response.json();
+    assertEquals(true, parsed.getBoolean("ack"));
+  }
+
+  @Test
+  public void postWithNullBodySendsZeroLengthRequest() {
+    AtomicReference<Integer> capturedLength = new AtomicReference<>();
+    server.createContext(
+        "/zero",
+        exchange -> {
+          try (InputStream in = exchange.getRequestBody()) {
+            capturedLength.set(readAll(in).length);
+          }
+          exchange.sendResponseHeaders(200, -1);
+          exchange.close();
+        });
+
+    Response response = client.post(baseUrl + "/zero", null);
+
+    assertEquals(200, response.status());
+    assertEquals(Integer.valueOf(0), capturedLength.get());
+  }
+
+  @Test
+  public void nonSuccessStatusIsExposedWithoutThrowing() {
+    server.createContext("/missing", respondWith(404, "nope", "text/plain"));
+
+    Response response = client.get(baseUrl + "/missing");
+
+    assertEquals(404, response.status());
+    assertEquals("nope", response.body());
+    assertFalse(response.ok());
+  }
+
+  private static HttpHandler respondWith(int status, String body, String contentType) {
+    return exchange -> {
+      byte[] payload = body.getBytes(StandardCharsets.UTF_8);
+      exchange.getResponseHeaders().add("Content-Type", contentType);
+      exchange.sendResponseHeaders(status, payload.length);
+      exchange.getResponseBody().write(payload);
+      exchange.close();
+    };
+  }
+
+  private static byte[] readAll(InputStream in) throws IOException {
+    ByteArrayOutputStream buf = new ByteArrayOutputStream();
+    byte[] chunk = new byte[4096];
+    int n;
+    while ((n = in.read(chunk)) != -1) {
+      buf.write(chunk, 0, n);
+    }
+    return buf.toByteArray();
+  }
+}


### PR DESCRIPTION
Introduces a minimal Apache HttpClient 5.x wrapper for synchronous test
HTTP calls. Designed for use by the upcoming WireMock test harness and any
future test code that needs to talk to an HTTP endpoint.

- Adds testImplementation 'org.apache.httpcomponents.client5:httpclient5:5.4.4'
- HttpTestClient: get(url), post(url, body), Response with status/body/ok/json
- Java 8 source compatible
- Hermetic self-tests using JDK-built-in com.sun.net.httpserver.HttpServer
  (no external dependency, runs on Java 8 and later)