### PR TITLE
NO-SNOW: Add WiremockClient test harness for JDBC tests

### DIFF
--- a/jdbc/build.gradle
+++ b/jdbc/build.gradle
@@ -37,6 +37,7 @@ configurations {
 dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
     testImplementation 'org.mockito:mockito-core:4.6.1'
+    testImplementation 'org.apache.httpcomponents.client5:httpclient5:5.4.4'
     testCompileOnly "org.projectlombok:lombok:${lombokVersion}"
     testAnnotationProcessor "org.projectlombok:lombok:${lombokVersion}"
 

--- a/jdbc/src/test/java/net/snowflake/jdbc/testutil/HttpTestClient.java
+++ b/jdbc/src/test/java/net/snowflake/jdbc/testutil/HttpTestClient.java
@@ -1,0 +1,115 @@
+package net.snowflake.jdbc.testutil;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.config.ConnectionConfig;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.apache.hc.core5.http.io.support.ClassicRequestBuilder;
+import org.apache.hc.core5.util.Timeout;
+import org.json.JSONObject;
+import org.json.JSONTokener;
+
+/** Minimal Apache HttpClient 5.x wrapper for synchronous test use. Java 8 source compatible. */
+public final class HttpTestClient implements AutoCloseable {
+
+  private static final Timeout DEFAULT_TIMEOUT = Timeout.ofSeconds(5);
+
+  private final CloseableHttpClient client;
+
+  public HttpTestClient() {
+    ConnectionConfig connectionConfig =
+        ConnectionConfig.custom().setConnectTimeout(DEFAULT_TIMEOUT).build();
+    PoolingHttpClientConnectionManager connectionManager =
+        PoolingHttpClientConnectionManagerBuilder.create()
+            .setDefaultConnectionConfig(connectionConfig)
+            .build();
+    RequestConfig requestConfig =
+        RequestConfig.custom()
+            .setResponseTimeout(DEFAULT_TIMEOUT)
+            .setConnectionRequestTimeout(DEFAULT_TIMEOUT)
+            .build();
+    this.client =
+        HttpClients.custom()
+            .setConnectionManager(connectionManager)
+            .setDefaultRequestConfig(requestConfig)
+            .build();
+  }
+
+  public Response get(String url) {
+    return execute(ClassicRequestBuilder.get(url).build());
+  }
+
+  public Response post(String url, String body) {
+    HttpPost post = new HttpPost(url);
+    if (body != null) {
+      post.setEntity(new StringEntity(body, ContentType.APPLICATION_JSON));
+    }
+    return execute(post);
+  }
+
+  @Override
+  public void close() {
+    try {
+      client.close();
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to close HttpTestClient", e);
+    }
+  }
+
+  private Response execute(ClassicHttpRequest request) {
+    try {
+      return client.execute(
+          request,
+          response -> {
+            HttpEntity entity = response.getEntity();
+            String body =
+                entity == null ? "" : EntityUtils.toString(entity, StandardCharsets.UTF_8);
+            return new Response(response.getCode(), body);
+          });
+    } catch (IOException e) {
+      throw new RuntimeException(
+          request.getMethod() + " " + request.getRequestUri() + " failed", e);
+    }
+  }
+
+  public static final class Response {
+    private final int status;
+    private final String body;
+
+    Response(int status, String body) {
+      this.status = status;
+      this.body = body;
+    }
+
+    public int status() {
+      return status;
+    }
+
+    public String body() {
+      return body;
+    }
+
+    public boolean ok() {
+      return status >= 200 && status < 300;
+    }
+
+    public JSONObject json() {
+      return new JSONObject(new JSONTokener(body));
+    }
+
+    @Override
+    public String toString() {
+      return "Response(status=" + status + ", body=" + body + ")";
+    }
+  }
+}

--- a/jdbc/src/test/java/net/snowflake/jdbc/testutil/HttpTestClientTest.java
+++ b/jdbc/src/test/java/net/snowflake/jdbc/testutil/HttpTestClientTest.java
@@ -1,0 +1,139 @@
+package net.snowflake.jdbc.testutil;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicReference;
+import net.snowflake.jdbc.testutil.HttpTestClient.Response;
+import org.json.JSONObject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Hermetic self-tests for {@link HttpTestClient} using a JDK-built-in {@link HttpServer}. */
+public class HttpTestClientTest {
+
+  private HttpServer server;
+  private HttpTestClient client;
+  private String baseUrl;
+
+  @BeforeEach
+  public void setUp() throws IOException {
+    server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    server.start();
+    baseUrl = "http://127.0.0.1:" + server.getAddress().getPort();
+    client = new HttpTestClient();
+  }
+
+  @AfterEach
+  public void tearDown() {
+    if (client != null) {
+      client.close();
+    }
+    if (server != null) {
+      server.stop(0);
+    }
+  }
+
+  @Test
+  public void getReturns200AndBody() {
+    server.createContext("/hello", respondWith(200, "world", "text/plain"));
+
+    Response response = client.get(baseUrl + "/hello");
+
+    assertEquals(200, response.status());
+    assertEquals("world", response.body());
+    assertTrue(response.ok());
+  }
+
+  @Test
+  public void postSendsJsonBodyAndContentTypeHeader() {
+    AtomicReference<String> capturedBody = new AtomicReference<>();
+    AtomicReference<String> capturedContentType = new AtomicReference<>();
+    server.createContext(
+        "/echo",
+        exchange -> {
+          capturedContentType.set(exchange.getRequestHeaders().getFirst("Content-Type"));
+          try (InputStream in = exchange.getRequestBody()) {
+            capturedBody.set(new String(readAll(in), StandardCharsets.UTF_8));
+          }
+          byte[] resp = "{\"ack\":true}".getBytes(StandardCharsets.UTF_8);
+          exchange.getResponseHeaders().add("Content-Type", "application/json");
+          exchange.sendResponseHeaders(201, resp.length);
+          exchange.getResponseBody().write(resp);
+          exchange.close();
+        });
+
+    Response response = client.post(baseUrl + "/echo", "{\"x\":1}");
+
+    assertEquals(201, response.status());
+    assertTrue(response.ok());
+    assertEquals("{\"x\":1}", capturedBody.get());
+    assertNotNull(capturedContentType.get());
+    assertTrue(
+        capturedContentType.get().toLowerCase().contains("application/json"),
+        "Expected JSON content type, got: " + capturedContentType.get());
+
+    JSONObject parsed = response.json();
+    assertEquals(true, parsed.getBoolean("ack"));
+  }
+
+  @Test
+  public void postWithNullBodySendsZeroLengthRequest() {
+    AtomicReference<Integer> capturedLength = new AtomicReference<>();
+    server.createContext(
+        "/zero",
+        exchange -> {
+          try (InputStream in = exchange.getRequestBody()) {
+            capturedLength.set(readAll(in).length);
+          }
+          exchange.sendResponseHeaders(200, -1);
+          exchange.close();
+        });
+
+    Response response = client.post(baseUrl + "/zero", null);
+
+    assertEquals(200, response.status());
+    assertEquals(Integer.valueOf(0), capturedLength.get());
+  }
+
+  @Test
+  public void nonSuccessStatusIsExposedWithoutThrowing() {
+    server.createContext("/missing", respondWith(404, "nope", "text/plain"));
+
+    Response response = client.get(baseUrl + "/missing");
+
+    assertEquals(404, response.status());
+    assertEquals("nope", response.body());
+    assertFalse(response.ok());
+  }
+
+  private static HttpHandler respondWith(int status, String body, String contentType) {
+    return exchange -> {
+      byte[] payload = body.getBytes(StandardCharsets.UTF_8);
+      exchange.getResponseHeaders().add("Content-Type", contentType);
+      exchange.sendResponseHeaders(status, payload.length);
+      exchange.getResponseBody().write(payload);
+      exchange.close();
+    };
+  }
+
+  private static byte[] readAll(InputStream in) throws IOException {
+    ByteArrayOutputStream buf = new ByteArrayOutputStream();
+    byte[] chunk = new byte[4096];
+    int n;
+    while ((n = in.read(chunk)) != -1) {
+      buf.write(chunk, 0, n);
+    }
+    return buf.toByteArray();
+  }
+}

--- a/jdbc/src/test/java/net/snowflake/jdbc/wiremock/WiremockClient.java
+++ b/jdbc/src/test/java/net/snowflake/jdbc/wiremock/WiremockClient.java
@@ -1,0 +1,350 @@
+package net.snowflake.jdbc.wiremock;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.ServerSocket;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import net.snowflake.jdbc.testutil.HttpTestClient;
+import net.snowflake.jdbc.testutil.HttpTestClient.Response;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.json.JSONTokener;
+
+/**
+ * Spawns the WireMock standalone JAR vendored at {@code
+ * tests/wiremock/wiremock_standalone/wiremock-standalone-3.13.2.jar} as a subprocess and drives it
+ * through its admin REST API. Counterpart of Python's {@code python/tests/wiremock_client.py};
+ * mapping files at {@code tests/wiremock/mappings/} are shared across language wrappers.
+ *
+ * <p>The class is Java 8 source compatible and deliberately avoids importing {@code
+ * com.github.tomakehurst.wiremock.*}. The WireMock 3.x JAR itself requires JRE 11+ to launch — test
+ * classes must gate themselves with {@link #requiresJava11OrHigher()}.
+ */
+public final class WiremockClient implements AutoCloseable {
+
+  private static final String WIREMOCK_JAR_RELATIVE =
+      "tests/wiremock/wiremock_standalone/wiremock-standalone-3.13.2.jar";
+  private static final Duration DEFAULT_HEALTH_TIMEOUT = Duration.ofSeconds(30);
+  private static final Duration DEFAULT_HEALTH_POLL_INTERVAL = Duration.ofMillis(250);
+
+  private final Path workspaceRoot;
+  private final Path wiremockDir;
+  private final Path wiremockJar;
+  private Process process;
+  private int httpPort = -1;
+  private Thread stdoutDrain;
+  private Thread stderrDrain;
+  private HttpTestClient httpClient;
+
+  public WiremockClient() {
+    this.workspaceRoot = findWorkspaceRoot();
+    this.wiremockDir = workspaceRoot.resolve("tests/wiremock");
+    this.wiremockJar = workspaceRoot.resolve(WIREMOCK_JAR_RELATIVE);
+    if (!Files.isRegularFile(wiremockJar)) {
+      throw new IllegalStateException(
+          "WireMock standalone JAR not found at "
+              + wiremockJar
+              + " (workspace="
+              + workspaceRoot
+              + ")");
+    }
+    if (!Files.isDirectory(wiremockDir.resolve("mappings"))) {
+      throw new IllegalStateException(
+          "WireMock mappings directory not found at " + wiremockDir.resolve("mappings"));
+    }
+  }
+
+  /** {@code true} on JVMs new enough to launch WireMock 3.x (JRE 11+). */
+  public static boolean requiresJava11OrHigher() {
+    String spec = System.getProperty("java.specification.version", "");
+    return !spec.startsWith("1."); // "1.8" → false, "11"/"17"/"21" → true
+  }
+
+  public WiremockClient start() {
+    if (process != null) {
+      return this;
+    }
+    httpPort = findFreePort();
+    List<String> command = new ArrayList<>();
+    command.add(System.getProperty("java.home") + File.separator + "bin" + File.separator + "java");
+    command.add("-jar");
+    command.add(wiremockJar.toString());
+    command.add("--root-dir");
+    command.add(wiremockDir.toString());
+    command.add("--enable-browser-proxying");
+    command.add("--proxy-pass-through");
+    command.add("false");
+    command.add("--port");
+    command.add(Integer.toString(httpPort));
+    command.add("--disable-banner");
+
+    ProcessBuilder pb = new ProcessBuilder(command);
+    pb.redirectErrorStream(false);
+    try {
+      process = pb.start();
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to start WireMock process", e);
+    }
+    // Anything after a successful pb.start() must be guarded so a failure still reaps the child.
+    try {
+      stdoutDrain = drainAsync(process.getInputStream(), "wiremock-stdout");
+      stderrDrain = drainAsync(process.getErrorStream(), "wiremock-stderr");
+      httpClient = new HttpTestClient();
+      waitForHealth(DEFAULT_HEALTH_TIMEOUT, DEFAULT_HEALTH_POLL_INTERVAL);
+    } catch (RuntimeException | Error e) {
+      stop();
+      throw e;
+    }
+    return this;
+  }
+
+  public String httpUrl() {
+    ensureStarted();
+    return "http://localhost:" + httpPort;
+  }
+
+  public void stop() {
+    if (process == null) {
+      return;
+    }
+    process.destroy();
+    try {
+      if (!process.waitFor(5, TimeUnit.SECONDS)) {
+        process.destroyForcibly();
+        process.waitFor(2, TimeUnit.SECONDS);
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      process.destroyForcibly();
+    } finally {
+      process = null;
+      httpPort = -1;
+      if (stdoutDrain != null) {
+        stdoutDrain.interrupt();
+        stdoutDrain = null;
+      }
+      if (stderrDrain != null) {
+        stderrDrain.interrupt();
+        stderrDrain = null;
+      }
+      if (httpClient != null) {
+        try {
+          httpClient.close();
+        } catch (RuntimeException ignored) {
+          // Best-effort cleanup; nothing actionable.
+        }
+        httpClient = null;
+      }
+    }
+  }
+
+  @Override
+  public void close() {
+    stop();
+  }
+
+  public void reset() {
+    Response resp = httpClient().post(adminUrl("/__admin/reset"), null);
+    if (!resp.ok()) {
+      throw new RuntimeException("Failed to reset WireMock: " + resp.status() + " " + resp.body());
+    }
+  }
+
+  /**
+   * Register a mapping file from {@code tests/wiremock/mappings/<relativePath>}. {@code
+   * {{REPO_ROOT}}} is always available as a placeholder; additional placeholders may be supplied.
+   * Files containing a top-level {@code "mappings": [...]} array are registered one element at a
+   * time (matches Python's behaviour).
+   */
+  public void addMapping(String relativePath, Map<String, String> placeholders) {
+    Path mappingFile = wiremockDir.resolve("mappings").resolve(relativePath);
+    if (!Files.isRegularFile(mappingFile)) {
+      throw new IllegalArgumentException("Mapping file not found: " + mappingFile);
+    }
+    String content;
+    try {
+      content = new String(Files.readAllBytes(mappingFile), StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to read mapping " + mappingFile, e);
+    }
+
+    Map<String, String> all = new HashMap<>();
+    // POSIX separators so the substituted path is valid JSON on Windows too.
+    all.put("{{REPO_ROOT}}", workspaceRoot.toString().replace(File.separatorChar, '/'));
+    if (placeholders != null) {
+      all.putAll(placeholders);
+    }
+    for (Map.Entry<String, String> entry : all.entrySet()) {
+      content = content.replace(entry.getKey(), entry.getValue());
+    }
+
+    JSONObject parsed = new JSONObject(new JSONTokener(content));
+    if (parsed.has("mappings") && parsed.get("mappings") instanceof JSONArray) {
+      JSONArray array = parsed.getJSONArray("mappings");
+      for (int i = 0; i < array.length(); i++) {
+        registerSingleMapping(array.getJSONObject(i).toString());
+      }
+    } else {
+      registerSingleMapping(content);
+    }
+  }
+
+  public void addMapping(String relativePath) {
+    addMapping(relativePath, Collections.emptyMap());
+  }
+
+  public void addMappingJson(String mappingJson) {
+    registerSingleMapping(mappingJson);
+  }
+
+  public List<JSONObject> getRequests(String urlPathPattern) {
+    JSONObject body = new JSONObject().put("urlPathPattern", urlPathPattern);
+    Response resp = httpClient().post(adminUrl("/__admin/requests/find"), body.toString());
+    if (!resp.ok()) {
+      throw new RuntimeException("Failed to query requests: " + resp.status() + " " + resp.body());
+    }
+    JSONObject parsed = resp.json();
+    JSONArray requests = parsed.has("requests") ? parsed.getJSONArray("requests") : new JSONArray();
+    List<JSONObject> out = new ArrayList<>(requests.length());
+    for (int i = 0; i < requests.length(); i++) {
+      out.add(requests.getJSONObject(i));
+    }
+    return out;
+  }
+
+  public void verifyRequestCount(int expectedCount, String urlPathPattern) {
+    JSONObject body = new JSONObject().put("method", "ANY").put("urlPathPattern", urlPathPattern);
+    Response resp = httpClient().post(adminUrl("/__admin/requests/count"), body.toString());
+    if (!resp.ok()) {
+      throw new RuntimeException(
+          "Failed to query request count: " + resp.status() + " " + resp.body());
+    }
+    int actual = resp.json().getInt("count");
+    if (actual != expectedCount) {
+      throw new AssertionError(
+          "Expected "
+              + expectedCount
+              + " requests matching '"
+              + urlPathPattern
+              + "', but found "
+              + actual);
+    }
+  }
+
+  private void ensureStarted() {
+    if (process == null || httpPort < 0) {
+      throw new IllegalStateException("WiremockClient is not started");
+    }
+  }
+
+  private HttpTestClient httpClient() {
+    ensureStarted();
+    return httpClient;
+  }
+
+  private String adminUrl(String path) {
+    return "http://localhost:" + httpPort + path;
+  }
+
+  private void registerSingleMapping(String mappingJson) {
+    Response resp = httpClient().post(adminUrl("/__admin/mappings"), mappingJson);
+    if (resp.status() != 200 && resp.status() != 201) {
+      throw new RuntimeException(
+          "Failed to register mapping: "
+              + resp.status()
+              + " "
+              + resp.body()
+              + " (payload="
+              + mappingJson
+              + ")");
+    }
+  }
+
+  private void waitForHealth(Duration timeout, Duration pollInterval) {
+    long deadlineNanos = System.nanoTime() + timeout.toNanos();
+    long sleepMillis = Math.max(1L, pollInterval.toMillis());
+    Exception lastError = null;
+    while (System.nanoTime() < deadlineNanos) {
+      if (!process.isAlive()) {
+        throw new RuntimeException(
+            "WireMock process exited prematurely with code " + process.exitValue());
+      }
+      try {
+        Response resp = httpClient().get(adminUrl("/__admin/health"));
+        if (resp.status() == 200 && resp.body().contains("\"healthy\"")) {
+          return;
+        }
+      } catch (RuntimeException e) {
+        lastError = e;
+      }
+      try {
+        Thread.sleep(sleepMillis);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new RuntimeException("Interrupted while waiting for WireMock health", e);
+      }
+    }
+    throw new RuntimeException(
+        "WireMock did not become healthy within "
+            + timeout
+            + (lastError != null ? " (last error: " + lastError + ")" : ""));
+  }
+
+  private static int findFreePort() {
+    try (ServerSocket socket = new ServerSocket(0)) {
+      return socket.getLocalPort();
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to allocate a free port", e);
+    }
+  }
+
+  private static Path findWorkspaceRoot() {
+    Path candidate = Paths.get(System.getProperty("user.dir")).toAbsolutePath();
+    for (int i = 0; i < 6; i++) {
+      if (Files.isDirectory(candidate.resolve("tests/wiremock/wiremock_standalone"))
+          && Files.isDirectory(candidate.resolve("tests/wiremock/mappings"))) {
+        return candidate;
+      }
+      Path parent = candidate.getParent();
+      if (parent == null) {
+        break;
+      }
+      candidate = parent;
+    }
+    throw new IllegalStateException(
+        "Could not locate workspace root (expected to find tests/wiremock/wiremock_standalone/ "
+            + "ascending from "
+            + System.getProperty("user.dir")
+            + ")");
+  }
+
+  private static Thread drainAsync(InputStream stream, String name) {
+    Thread t =
+        new Thread(
+            () -> {
+              byte[] buf = new byte[4096];
+              try {
+                while (stream.read(buf) != -1) {
+                  // Discard — keep the pipe drained so the child doesn't block on stdout/stderr.
+                }
+              } catch (IOException ignored) {
+                // Process exit closes the stream; nothing to do.
+              }
+            },
+            name);
+    t.setDaemon(true);
+    t.start();
+    return t;
+  }
+}

--- a/jdbc/src/test/java/net/snowflake/jdbc/wiremock/WiremockClientTest.java
+++ b/jdbc/src/test/java/net/snowflake/jdbc/wiremock/WiremockClientTest.java
@@ -1,0 +1,77 @@
+package net.snowflake.jdbc.wiremock;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import net.snowflake.jdbc.testutil.HttpTestClient;
+import net.snowflake.jdbc.testutil.HttpTestClient.Response;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/** Self-tests for {@link WiremockClient}. Skipped on Java 8 (WireMock 3.x requires JRE 11+). */
+public class WiremockClientTest {
+
+  @BeforeAll
+  public static void skipOnJava8() {
+    Assumptions.assumeTrue(
+        WiremockClient.requiresJava11OrHigher(),
+        "WireMock 3.x requires JRE 11+ to launch; skipping wiremock tests on Java 8");
+  }
+
+  @Test
+  public void inlineMappingIsServedAndRecorded() {
+    try (WiremockClient client = new WiremockClient();
+        HttpTestClient http = new HttpTestClient()) {
+      client.start();
+      client.addMappingJson(
+          new JSONObject()
+              .put("request", new JSONObject().put("method", "GET").put("urlPath", "/ping"))
+              .put(
+                  "response",
+                  new JSONObject()
+                      .put("status", 200)
+                      .put("body", "pong")
+                      .put("headers", new JSONObject().put("Content-Type", "text/plain")))
+              .toString());
+
+      Response resp = http.get(client.httpUrl() + "/ping");
+      assertEquals(200, resp.status());
+      assertEquals("pong", resp.body());
+
+      client.verifyRequestCount(1, "/ping");
+      List<JSONObject> recorded = client.getRequests("/ping");
+      assertEquals(1, recorded.size());
+
+      client.reset();
+      assertEquals(0, client.getRequests("/ping").size());
+    }
+  }
+
+  @Test
+  public void fileBackedMappingIsResolvedFromMappingsDir() {
+    // tests/wiremock/mappings/session/logout_success.json stubs POST /session?delete=true → 200.
+    try (WiremockClient client = new WiremockClient();
+        HttpTestClient http = new HttpTestClient()) {
+      client.start();
+      client.addMapping("session/logout_success.json");
+
+      Response resp = http.post(client.httpUrl() + "/session?delete=true", "{}");
+      assertEquals(200, resp.status());
+      assertTrue(resp.body().contains("\"success\""), "Expected JSON body, got: " + resp.body());
+
+      client.verifyRequestCount(1, "/session");
+    }
+  }
+
+  @Test
+  public void verifyRequestCountThrowsAssertionErrorOnMismatch() {
+    try (WiremockClient client = new WiremockClient()) {
+      client.start();
+      assertThrows(AssertionError.class, () -> client.verifyRequestCount(1, "/never-called"));
+    }
+  }
+}


### PR DESCRIPTION
Adds a Java 8-compatible harness that spawns the vendored WireMock
standalone JAR (tests/wiremock/wiremock_standalone/wiremock-standalone-3.13.2.jar)
as a subprocess and drives it through the admin REST API. Built on top of
HttpTestClient (introduced in the previous PR); no com.github.tomakehurst.*
imports — keeps the test source Java 8 compilable.

- WiremockClient: start/stop/reset, addMapping(relPath[, placeholders]),
  addMappingJson(json), getRequests(pattern), verifyRequestCount(n, pattern)
- Mapping files are read from the repo-shared tests/wiremock/mappings/ tree;
  {{REPO_ROOT}} placeholder auto-injected. Files containing a top-level
  "mappings": [...] array are split and registered one at a time, matching
  Python's wiremock_client.py behaviour.
- requiresJava11OrHigher() static helper for test classes to gate themselves
  (WireMock 3.x requires JRE 11+ to launch; tests skip cleanly on Java 8).
- WiremockClientTest: 3 self-tests covering inline mapping, file-backed
  mapping (uses existing session/logout_success.json), and the verify-count
  assertion path. All HTTP calls go through HttpTestClient.