### PR TITLE
SNOW-2881693: Add multistatement + positional parameter binding tests

### DIFF
--- a/jdbc/src/test/java/net/snowflake/jdbc/e2e/query/MultistatementTests.java
+++ b/jdbc/src/test/java/net/snowflake/jdbc/e2e/query/MultistatementTests.java
@@ -184,10 +184,9 @@ public class MultistatementTests extends SnowflakeIntegrationTestBase {
       setup.execute("CREATE OR REPLACE TEMPORARY TABLE " + tableName + "(id NUMBER)");
     }
 
-    // When Multistatement query "INSERT INTO {table} VALUES(?); INSERT INTO {table} VALUES(?),(?)" is executed with positional parameters [10, 20, 30] and multi_statement_count=2
+    // When Multistatement INSERT chain is executed with 3 positional parameters
     String sql =
-        "INSERT INTO " + tableName + " VALUES(?);"
-            + " INSERT INTO " + tableName + " VALUES(?),(?)";
+        "INSERT INTO " + tableName + " VALUES(?);" + " INSERT INTO " + tableName + " VALUES(?),(?)";
     try (PreparedStatement ps = connection.prepareStatement(sql)) {
       ps.unwrap(SnowflakeStatement.class).setParameter("MULTI_STATEMENT_COUNT", 2);
       ps.setInt(1, 10);
@@ -226,7 +225,7 @@ public class MultistatementTests extends SnowflakeIntegrationTestBase {
     // Given Snowflake client is logged in
     Connection connection = getDefaultConnection();
 
-    // When Multistatement query "SELECT ?; SELECT ?, ?; SELECT ?, ?, ?" is executed with positional parameters [10, 20, 30, 40, 50, 60] and multi_statement_count=3
+    // When Multistatement SELECT chain is executed with 6 positional parameters
     try (PreparedStatement ps =
         connection.prepareStatement("SELECT ?; SELECT ?, ?; SELECT ?, ?, ?")) {
       ps.unwrap(SnowflakeStatement.class).setParameter("MULTI_STATEMENT_COUNT", 3);
@@ -276,13 +275,12 @@ public class MultistatementTests extends SnowflakeIntegrationTestBase {
     // Given Snowflake client is logged in
     Connection connection = getDefaultConnection();
 
-    // When Multistatement query "SELECT ?; SELECT ?, ?" is executed with positional parameters [10] and multi_statement_count=2
+    // When Multistatement SELECT requires 3 parameters but only 1 is bound
     assertThrows(
         SQLException.class,
         () -> {
           // Then an error is returned indicating parameter count mismatch
-          try (PreparedStatement ps =
-              connection.prepareStatement("SELECT ?; SELECT ?, ?")) {
+          try (PreparedStatement ps = connection.prepareStatement("SELECT ?; SELECT ?, ?")) {
             ps.unwrap(SnowflakeStatement.class).setParameter("MULTI_STATEMENT_COUNT", 2);
             ps.setInt(1, 10);
             ps.execute();
@@ -291,17 +289,17 @@ public class MultistatementTests extends SnowflakeIntegrationTestBase {
   }
 
   @Test
-  public void shouldFailWhenNullPositionalParametersAreUsedInMultistatementQuery() throws Exception {
+  public void shouldFailWhenNullPositionalParametersAreUsedInMultistatementQuery()
+      throws Exception {
     // Given Snowflake client is logged in
     Connection connection = getDefaultConnection();
 
-    // When Multistatement query "SELECT ?; SELECT ?, ?" is executed with positional parameters [NULL, 10, NULL] and multi_statement_count=2
+    // When Multistatement SELECT is executed with NULL positional parameters
     assertThrows(
         SQLException.class,
         () -> {
-          // Then an error is returned indicating NULL bindings are not supported in multi-statement
-          try (PreparedStatement ps =
-              connection.prepareStatement("SELECT ?; SELECT ?, ?")) {
+          // Then an error is returned indicating NULL bindings are not supported
+          try (PreparedStatement ps = connection.prepareStatement("SELECT ?; SELECT ?, ?")) {
             ps.unwrap(SnowflakeStatement.class).setParameter("MULTI_STATEMENT_COUNT", 2);
             ps.setNull(1, Types.INTEGER);
             ps.setInt(2, 10);

--- a/jdbc/src/test/java/net/snowflake/jdbc/e2e/query/MultistatementTests.java
+++ b/jdbc/src/test/java/net/snowflake/jdbc/e2e/query/MultistatementTests.java
@@ -178,12 +178,13 @@ public class MultistatementTests extends SnowflakeIntegrationTestBase {
     // Given Snowflake client is logged in
     Connection connection = getDefaultConnection();
 
+    // And A temporary table with column (id NUMBER) exists
     String tableName = "ms_bind_dml_test";
     try (Statement setup = connection.createStatement()) {
       setup.execute("CREATE OR REPLACE TEMPORARY TABLE " + tableName + "(id NUMBER)");
     }
 
-    // When Multistatement INSERT chain is executed with 3 positional parameters
+    // When Multistatement query "INSERT INTO {table} VALUES(?); INSERT INTO {table} VALUES(?),(?)" is executed with positional parameters [10, 20, 30] and multi_statement_count=2
     String sql =
         "INSERT INTO " + tableName + " VALUES(?);"
             + " INSERT INTO " + tableName + " VALUES(?),(?)";
@@ -195,15 +196,14 @@ public class MultistatementTests extends SnowflakeIntegrationTestBase {
       ps.execute();
 
       // Then 2 result sets are returned
-      // And the first result set reports update count 1
       assertEquals(null, ps.getResultSet(), "First INSERT should not produce a result set");
+
+      // And the first result set reports update count 1
       assertEquals(1, ps.getUpdateCount(), "First INSERT should affect 1 row");
 
       // And the second result set reports update count 2
       assertFalse(ps.getMoreResults(), "Last DML statement returns false");
-      assertEquals(null, ps.getResultSet(), "Second INSERT should not produce a result set");
       assertEquals(2, ps.getUpdateCount(), "Second INSERT should affect 2 rows");
-
       assertFalse(ps.getMoreResults());
       assertEquals(-1, ps.getUpdateCount(), "No more results");
     }
@@ -226,9 +226,9 @@ public class MultistatementTests extends SnowflakeIntegrationTestBase {
     // Given Snowflake client is logged in
     Connection connection = getDefaultConnection();
 
-    // When Multistatement SELECT chain is executed with 6 positional parameters
-    String sql = "SELECT ?; SELECT ?, ?; SELECT ?, ?, ?";
-    try (PreparedStatement ps = connection.prepareStatement(sql)) {
+    // When Multistatement query "SELECT ?; SELECT ?, ?; SELECT ?, ?, ?" is executed with positional parameters [10, 20, 30, 40, 50, 60] and multi_statement_count=3
+    try (PreparedStatement ps =
+        connection.prepareStatement("SELECT ?; SELECT ?, ?; SELECT ?, ?, ?")) {
       ps.unwrap(SnowflakeStatement.class).setParameter("MULTI_STATEMENT_COUNT", 3);
       ps.setInt(1, 10);
       ps.setInt(2, 20);
@@ -240,6 +240,7 @@ public class MultistatementTests extends SnowflakeIntegrationTestBase {
 
       // Then 3 result sets are returned
       assertTrue(hasResultSet, "First SELECT should produce a result set");
+
       // And the first result set contains row [10]
       try (ResultSet rs1 = ps.getResultSet()) {
         assertTrue(rs1.next());
@@ -275,7 +276,7 @@ public class MultistatementTests extends SnowflakeIntegrationTestBase {
     // Given Snowflake client is logged in
     Connection connection = getDefaultConnection();
 
-    // When Multistatement SELECT requires 3 parameters but only 1 is bound
+    // When Multistatement query "SELECT ?; SELECT ?, ?" is executed with positional parameters [10] and multi_statement_count=2
     assertThrows(
         SQLException.class,
         () -> {
@@ -290,40 +291,23 @@ public class MultistatementTests extends SnowflakeIntegrationTestBase {
   }
 
   @Test
-  public void shouldHandleNullPositionalParametersInMultistatementQuery() throws Exception {
+  public void shouldFailWhenNullPositionalParametersAreUsedInMultistatementQuery() throws Exception {
     // Given Snowflake client is logged in
     Connection connection = getDefaultConnection();
 
-    // When Multistatement SELECT is executed with NULL/non-NULL positional parameters
-    try (PreparedStatement ps = connection.prepareStatement("SELECT ?; SELECT ?, ?")) {
-      ps.unwrap(SnowflakeStatement.class).setParameter("MULTI_STATEMENT_COUNT", 2);
-      ps.setNull(1, Types.INTEGER);
-      ps.setInt(2, 10);
-      ps.setNull(3, Types.INTEGER);
-      boolean hasResultSet = ps.execute();
-
-      // Then 2 result sets are returned
-      assertTrue(hasResultSet, "First SELECT should produce a result set");
-      // And the first result set contains row [NULL]
-      try (ResultSet rs1 = ps.getResultSet()) {
-        assertTrue(rs1.next());
-        rs1.getObject(1);
-        assertTrue(rs1.wasNull(), "First column should be NULL");
-        assertFalse(rs1.next());
-      }
-
-      // And the second result set contains row [10, NULL]
-      assertTrue(ps.getMoreResults());
-      try (ResultSet rs2 = ps.getResultSet()) {
-        assertTrue(rs2.next());
-        assertEquals(10, rs2.getInt(1));
-        assertFalse(rs2.wasNull(), "First column of second row should not be NULL");
-        rs2.getObject(2);
-        assertTrue(rs2.wasNull(), "Second column of second row should be NULL");
-        assertFalse(rs2.next());
-      }
-
-      assertFalse(ps.getMoreResults(), "No more results after second statement");
-    }
+    // When Multistatement query "SELECT ?; SELECT ?, ?" is executed with positional parameters [NULL, 10, NULL] and multi_statement_count=2
+    assertThrows(
+        SQLException.class,
+        () -> {
+          // Then an error is returned indicating NULL bindings are not supported in multi-statement
+          try (PreparedStatement ps =
+              connection.prepareStatement("SELECT ?; SELECT ?, ?")) {
+            ps.unwrap(SnowflakeStatement.class).setParameter("MULTI_STATEMENT_COUNT", 2);
+            ps.setNull(1, Types.INTEGER);
+            ps.setInt(2, 10);
+            ps.setNull(3, Types.INTEGER);
+            ps.execute();
+          }
+        });
   }
 }

--- a/jdbc/src/test/java/net/snowflake/jdbc/e2e/query/MultistatementTests.java
+++ b/jdbc/src/test/java/net/snowflake/jdbc/e2e/query/MultistatementTests.java
@@ -6,9 +6,11 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.sql.Types;
 import net.snowflake.client.SnowflakeIntegrationTestBase;
 import net.snowflake.client.api.statement.SnowflakeStatement;
 import org.junit.jupiter.api.Test;
@@ -169,5 +171,159 @@ public class MultistatementTests extends SnowflakeIntegrationTestBase {
             statement.execute("SELECT 1");
           }
         });
+  }
+
+  @Test
+  public void shouldExecuteMultistatementDmlWithPositionalParameters() throws Exception {
+    // Given Snowflake client is logged in
+    Connection connection = getDefaultConnection();
+
+    String tableName = "ms_bind_dml_test";
+    try (Statement setup = connection.createStatement()) {
+      setup.execute("CREATE OR REPLACE TEMPORARY TABLE " + tableName + "(id NUMBER)");
+    }
+
+    // When Multistatement INSERT chain is executed with 3 positional parameters
+    String sql =
+        "INSERT INTO " + tableName + " VALUES(?);"
+            + " INSERT INTO " + tableName + " VALUES(?),(?)";
+    try (PreparedStatement ps = connection.prepareStatement(sql)) {
+      ps.unwrap(SnowflakeStatement.class).setParameter("MULTI_STATEMENT_COUNT", 2);
+      ps.setInt(1, 10);
+      ps.setInt(2, 20);
+      ps.setInt(3, 30);
+      ps.execute();
+
+      // Then 2 result sets are returned
+      // And the first result set reports update count 1
+      assertEquals(null, ps.getResultSet(), "First INSERT should not produce a result set");
+      assertEquals(1, ps.getUpdateCount(), "First INSERT should affect 1 row");
+
+      // And the second result set reports update count 2
+      assertFalse(ps.getMoreResults(), "Last DML statement returns false");
+      assertEquals(null, ps.getResultSet(), "Second INSERT should not produce a result set");
+      assertEquals(2, ps.getUpdateCount(), "Second INSERT should affect 2 rows");
+
+      assertFalse(ps.getMoreResults());
+      assertEquals(-1, ps.getUpdateCount(), "No more results");
+    }
+
+    // And the table contains rows [10, 20, 30]
+    try (Statement check = connection.createStatement();
+        ResultSet rs = check.executeQuery("SELECT id FROM " + tableName + " ORDER BY id")) {
+      assertTrue(rs.next());
+      assertEquals(10, rs.getInt(1));
+      assertTrue(rs.next());
+      assertEquals(20, rs.getInt(1));
+      assertTrue(rs.next());
+      assertEquals(30, rs.getInt(1));
+      assertFalse(rs.next(), "Table should contain exactly 3 rows");
+    }
+  }
+
+  @Test
+  public void shouldExecuteMultistatementSelectWithPositionalParameters() throws Exception {
+    // Given Snowflake client is logged in
+    Connection connection = getDefaultConnection();
+
+    // When Multistatement SELECT chain is executed with 6 positional parameters
+    String sql = "SELECT ?; SELECT ?, ?; SELECT ?, ?, ?";
+    try (PreparedStatement ps = connection.prepareStatement(sql)) {
+      ps.unwrap(SnowflakeStatement.class).setParameter("MULTI_STATEMENT_COUNT", 3);
+      ps.setInt(1, 10);
+      ps.setInt(2, 20);
+      ps.setInt(3, 30);
+      ps.setInt(4, 40);
+      ps.setInt(5, 50);
+      ps.setInt(6, 60);
+      boolean hasResultSet = ps.execute();
+
+      // Then 3 result sets are returned
+      assertTrue(hasResultSet, "First SELECT should produce a result set");
+      // And the first result set contains row [10]
+      try (ResultSet rs1 = ps.getResultSet()) {
+        assertTrue(rs1.next());
+        assertEquals(10, rs1.getInt(1));
+        assertFalse(rs1.next());
+      }
+
+      // And the second result set contains row [20, 30]
+      assertTrue(ps.getMoreResults());
+      try (ResultSet rs2 = ps.getResultSet()) {
+        assertTrue(rs2.next());
+        assertEquals(20, rs2.getInt(1));
+        assertEquals(30, rs2.getInt(2));
+        assertFalse(rs2.next());
+      }
+
+      // And the third result set contains row [40, 50, 60]
+      assertTrue(ps.getMoreResults());
+      try (ResultSet rs3 = ps.getResultSet()) {
+        assertTrue(rs3.next());
+        assertEquals(40, rs3.getInt(1));
+        assertEquals(50, rs3.getInt(2));
+        assertEquals(60, rs3.getInt(3));
+        assertFalse(rs3.next());
+      }
+
+      assertFalse(ps.getMoreResults(), "No more results after third statement");
+    }
+  }
+
+  @Test
+  public void shouldFailWhenMultistatementQueryHasTooFewParameters() throws Exception {
+    // Given Snowflake client is logged in
+    Connection connection = getDefaultConnection();
+
+    // When Multistatement SELECT requires 3 parameters but only 1 is bound
+    assertThrows(
+        SQLException.class,
+        () -> {
+          // Then an error is returned indicating parameter count mismatch
+          try (PreparedStatement ps =
+              connection.prepareStatement("SELECT ?; SELECT ?, ?")) {
+            ps.unwrap(SnowflakeStatement.class).setParameter("MULTI_STATEMENT_COUNT", 2);
+            ps.setInt(1, 10);
+            ps.execute();
+          }
+        });
+  }
+
+  @Test
+  public void shouldHandleNullPositionalParametersInMultistatementQuery() throws Exception {
+    // Given Snowflake client is logged in
+    Connection connection = getDefaultConnection();
+
+    // When Multistatement SELECT is executed with NULL/non-NULL positional parameters
+    try (PreparedStatement ps = connection.prepareStatement("SELECT ?; SELECT ?, ?")) {
+      ps.unwrap(SnowflakeStatement.class).setParameter("MULTI_STATEMENT_COUNT", 2);
+      ps.setNull(1, Types.INTEGER);
+      ps.setInt(2, 10);
+      ps.setNull(3, Types.INTEGER);
+      boolean hasResultSet = ps.execute();
+
+      // Then 2 result sets are returned
+      assertTrue(hasResultSet, "First SELECT should produce a result set");
+      // And the first result set contains row [NULL]
+      try (ResultSet rs1 = ps.getResultSet()) {
+        assertTrue(rs1.next());
+        rs1.getObject(1);
+        assertTrue(rs1.wasNull(), "First column should be NULL");
+        assertFalse(rs1.next());
+      }
+
+      // And the second result set contains row [10, NULL]
+      assertTrue(ps.getMoreResults());
+      try (ResultSet rs2 = ps.getResultSet()) {
+        assertTrue(rs2.next());
+        assertEquals(10, rs2.getInt(1));
+        assertFalse(rs2.wasNull(), "First column of second row should not be NULL");
+        rs2.getObject(2);
+        assertTrue(rs2.wasNull(), "Second column of second row should be NULL");
+        assertFalse(rs2.next());
+      }
+
+      assertFalse(ps.getMoreResults(), "No more results after second statement");
+    }
   }
 }

--- a/jdbc/src/test/java/net/snowflake/jdbc/e2e/query/MultistatementTests.java
+++ b/jdbc/src/test/java/net/snowflake/jdbc/e2e/query/MultistatementTests.java
@@ -179,7 +179,7 @@ public class MultistatementTests extends SnowflakeIntegrationTestBase {
     Connection connection = getDefaultConnection();
 
     // And A temporary table with column (id NUMBER) exists
-    String tableName = "ms_bind_dml_test";
+    String tableName = "ms_bind_dml";
     try (Statement setup = connection.createStatement()) {
       setup.execute("CREATE OR REPLACE TEMPORARY TABLE " + tableName + "(id NUMBER)");
     }
@@ -201,7 +201,7 @@ public class MultistatementTests extends SnowflakeIntegrationTestBase {
       assertEquals(1, ps.getUpdateCount(), "First INSERT should affect 1 row");
 
       // And the second result set reports update count 2
-      assertFalse(ps.getMoreResults(), "Last DML statement returns false");
+      assertFalse(ps.getMoreResults());
       assertEquals(2, ps.getUpdateCount(), "Second INSERT should affect 2 rows");
       assertFalse(ps.getMoreResults());
       assertEquals(-1, ps.getUpdateCount(), "No more results");
@@ -267,6 +267,7 @@ public class MultistatementTests extends SnowflakeIntegrationTestBase {
       }
 
       assertFalse(ps.getMoreResults(), "No more results after third statement");
+      assertEquals(-1, ps.getUpdateCount(), "No more results");
     }
   }
 
@@ -295,17 +296,22 @@ public class MultistatementTests extends SnowflakeIntegrationTestBase {
     Connection connection = getDefaultConnection();
 
     // When Multistatement SELECT is executed with NULL positional parameters
-    assertThrows(
-        SQLException.class,
-        () -> {
-          // Then an error is returned indicating NULL bindings are not supported
-          try (PreparedStatement ps = connection.prepareStatement("SELECT ?; SELECT ?, ?")) {
-            ps.unwrap(SnowflakeStatement.class).setParameter("MULTI_STATEMENT_COUNT", 2);
-            ps.setNull(1, Types.INTEGER);
-            ps.setInt(2, 10);
-            ps.setNull(3, Types.INTEGER);
-            ps.execute();
-          }
-        });
+    SQLException ex =
+        assertThrows(
+            SQLException.class,
+            () -> {
+              // Then an error is returned indicating NULL bindings are not supported
+              try (PreparedStatement ps = connection.prepareStatement("SELECT ?; SELECT ?, ?")) {
+                ps.unwrap(SnowflakeStatement.class).setParameter("MULTI_STATEMENT_COUNT", 2);
+                ps.setNull(1, Types.INTEGER);
+                ps.setInt(2, 10);
+                ps.setNull(3, Types.INTEGER);
+                ps.execute();
+              }
+            });
+    // Server surfaces "Bind variable ? not set" — match loosely on "bind".
+    assertTrue(
+        ex.getMessage().toLowerCase().contains("bind"),
+        "Expected error to mention bind variables, got: " + ex.getMessage());
   }
 }

--- a/odbc_tests/tests/e2e/query/multistatement.cpp
+++ b/odbc_tests/tests/e2e/query/multistatement.cpp
@@ -148,3 +148,201 @@ TEST_CASE("should fail when multi_statement_count does not match actual statemen
   // Then an error is returned indicating statement count mismatch
   CHECK(ret == SQL_ERROR);
 }
+
+// =============================================================================
+// Multi-statement queries with positional parameter bindings
+// =============================================================================
+
+TEST_CASE("should execute multistatement DML with positional parameters", "[query][multistatement][parameters]") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // And A temporary table with column (id NUMBER) exists
+  SQLRETURN ret = SQLExecDirect(stmt.getHandle(),
+                                sqlchar("CREATE OR REPLACE TEMPORARY TABLE ms_odbc_bind_dml(id NUMBER)"),
+                                SQL_NTS);
+  REQUIRE_ODBC(ret, stmt);
+
+  // When Multistatement INSERT chain is prepared with 3 positional parameters
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_SF_STMT_ATTR_MULTI_STATEMENT_COUNT, (SQLPOINTER)2, 0);
+  REQUIRE_ODBC(ret, stmt);
+
+  ret = SQLPrepare(stmt.getHandle(),
+                   sqlchar("INSERT INTO ms_odbc_bind_dml VALUES(?);"
+                           " INSERT INTO ms_odbc_bind_dml VALUES(?),(?)"),
+                   SQL_NTS);
+  REQUIRE_ODBC(ret, stmt);
+
+  SQLINTEGER p1 = 10, p2 = 20, p3 = 30;
+  SQLLEN p1_len = sizeof(p1), p2_len = sizeof(p2), p3_len = sizeof(p3);
+  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_LONG, SQL_INTEGER, 0, 0, &p1, sizeof(p1), &p1_len);
+  REQUIRE_ODBC(ret, stmt);
+  ret = SQLBindParameter(stmt.getHandle(), 2, SQL_PARAM_INPUT, SQL_C_LONG, SQL_INTEGER, 0, 0, &p2, sizeof(p2), &p2_len);
+  REQUIRE_ODBC(ret, stmt);
+  ret = SQLBindParameter(stmt.getHandle(), 3, SQL_PARAM_INPUT, SQL_C_LONG, SQL_INTEGER, 0, 0, &p3, sizeof(p3), &p3_len);
+  REQUIRE_ODBC(ret, stmt);
+
+  ret = SQLExecute(stmt.getHandle());
+  REQUIRE_ODBC(ret, stmt);
+
+  // Then 2 result sets are returned
+  // And the first result set reports update count 1
+  SQLLEN row_count = 0;
+  ret = SQLRowCount(stmt.getHandle(), &row_count);
+  REQUIRE_ODBC(ret, stmt);
+  CHECK(row_count == 1);
+
+  // And the second result set reports update count 2
+  ret = SQLMoreResults(stmt.getHandle());
+  REQUIRE_ODBC(ret, stmt);
+  ret = SQLRowCount(stmt.getHandle(), &row_count);
+  REQUIRE_ODBC(ret, stmt);
+  CHECK(row_count == 2);
+
+  // No more result sets
+  ret = SQLMoreResults(stmt.getHandle());
+  CHECK(ret == SQL_NO_DATA);
+
+  // And the table contains rows [10, 20, 30]
+  auto verify = conn.createStatement();
+  ret = SQLExecDirect(verify.getHandle(), sqlchar("SELECT id FROM ms_odbc_bind_dml ORDER BY id"), SQL_NTS);
+  REQUIRE_ODBC(ret, verify);
+  ret = SQLFetch(verify.getHandle());
+  REQUIRE_ODBC(ret, verify);
+  CHECK(get_data<SQL_C_LONG>(verify, 1) == 10);
+  ret = SQLFetch(verify.getHandle());
+  REQUIRE_ODBC(ret, verify);
+  CHECK(get_data<SQL_C_LONG>(verify, 1) == 20);
+  ret = SQLFetch(verify.getHandle());
+  REQUIRE_ODBC(ret, verify);
+  CHECK(get_data<SQL_C_LONG>(verify, 1) == 30);
+  ret = SQLFetch(verify.getHandle());
+  CHECK(ret == SQL_NO_DATA);
+}
+
+TEST_CASE("should execute multistatement SELECT with positional parameters", "[query][multistatement][parameters]") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When Multistatement SELECT chain is prepared with 6 positional parameters
+  SQLRETURN ret = SQLSetStmtAttr(stmt.getHandle(), SQL_SF_STMT_ATTR_MULTI_STATEMENT_COUNT, (SQLPOINTER)3, 0);
+  REQUIRE_ODBC(ret, stmt);
+
+  ret = SQLPrepare(stmt.getHandle(), sqlchar("SELECT ?; SELECT ?, ?; SELECT ?, ?, ?"), SQL_NTS);
+  REQUIRE_ODBC(ret, stmt);
+
+  SQLINTEGER params[6] = {10, 20, 30, 40, 50, 60};
+  SQLLEN param_lens[6] = {sizeof(SQLINTEGER), sizeof(SQLINTEGER), sizeof(SQLINTEGER),
+                          sizeof(SQLINTEGER), sizeof(SQLINTEGER), sizeof(SQLINTEGER)};
+  for (SQLUSMALLINT i = 0; i < 6; ++i) {
+    ret = SQLBindParameter(stmt.getHandle(), i + 1, SQL_PARAM_INPUT, SQL_C_LONG, SQL_INTEGER, 0, 0,
+                           &params[i], sizeof(SQLINTEGER), &param_lens[i]);
+    REQUIRE_ODBC(ret, stmt);
+  }
+
+  ret = SQLExecute(stmt.getHandle());
+  REQUIRE_ODBC(ret, stmt);
+
+  // Then 3 result sets are returned
+  // And the first result set contains row [10]
+  ret = SQLFetch(stmt.getHandle());
+  REQUIRE_ODBC(ret, stmt);
+  CHECK(get_data<SQL_C_LONG>(stmt, 1) == 10);
+
+  // And the second result set contains row [20, 30]
+  ret = SQLMoreResults(stmt.getHandle());
+  REQUIRE_ODBC(ret, stmt);
+  ret = SQLFetch(stmt.getHandle());
+  REQUIRE_ODBC(ret, stmt);
+  CHECK(get_data<SQL_C_LONG>(stmt, 1) == 20);
+  CHECK(get_data<SQL_C_LONG>(stmt, 2) == 30);
+
+  // And the third result set contains row [40, 50, 60]
+  ret = SQLMoreResults(stmt.getHandle());
+  REQUIRE_ODBC(ret, stmt);
+  ret = SQLFetch(stmt.getHandle());
+  REQUIRE_ODBC(ret, stmt);
+  CHECK(get_data<SQL_C_LONG>(stmt, 1) == 40);
+  CHECK(get_data<SQL_C_LONG>(stmt, 2) == 50);
+  CHECK(get_data<SQL_C_LONG>(stmt, 3) == 60);
+
+  // No more result sets
+  ret = SQLMoreResults(stmt.getHandle());
+  CHECK(ret == SQL_NO_DATA);
+}
+
+TEST_CASE("should fail when multistatement query has too few parameters", "[query][multistatement][parameters]") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When Multistatement SELECT requires 3 parameters but only 1 is bound
+  SQLRETURN ret = SQLSetStmtAttr(stmt.getHandle(), SQL_SF_STMT_ATTR_MULTI_STATEMENT_COUNT, (SQLPOINTER)2, 0);
+  REQUIRE_ODBC(ret, stmt);
+
+  ret = SQLPrepare(stmt.getHandle(), sqlchar("SELECT ?; SELECT ?, ?"), SQL_NTS);
+  REQUIRE_ODBC(ret, stmt);
+
+  SQLINTEGER p1 = 10;
+  SQLLEN p1_len = sizeof(p1);
+  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_LONG, SQL_INTEGER, 0, 0, &p1, sizeof(p1), &p1_len);
+  REQUIRE_ODBC(ret, stmt);
+
+  ret = SQLExecute(stmt.getHandle());
+
+  // Then an error is returned indicating parameter count mismatch
+  CHECK(ret == SQL_ERROR);
+}
+
+TEST_CASE("should handle NULL positional parameters in multistatement query", "[query][multistatement][parameters]") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When Multistatement SELECT is executed with NULL/non-NULL positional parameters
+  SQLRETURN ret = SQLSetStmtAttr(stmt.getHandle(), SQL_SF_STMT_ATTR_MULTI_STATEMENT_COUNT, (SQLPOINTER)2, 0);
+  REQUIRE_ODBC(ret, stmt);
+
+  ret = SQLPrepare(stmt.getHandle(), sqlchar("SELECT ?; SELECT ?, ?"), SQL_NTS);
+  REQUIRE_ODBC(ret, stmt);
+
+  SQLINTEGER p1_buf = 0, p2_buf = 10, p3_buf = 0;
+  SQLLEN p1_len = SQL_NULL_DATA;
+  SQLLEN p2_len = sizeof(p2_buf);
+  SQLLEN p3_len = SQL_NULL_DATA;
+  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_LONG, SQL_INTEGER, 0, 0, &p1_buf, sizeof(p1_buf), &p1_len);
+  REQUIRE_ODBC(ret, stmt);
+  ret = SQLBindParameter(stmt.getHandle(), 2, SQL_PARAM_INPUT, SQL_C_LONG, SQL_INTEGER, 0, 0, &p2_buf, sizeof(p2_buf), &p2_len);
+  REQUIRE_ODBC(ret, stmt);
+  ret = SQLBindParameter(stmt.getHandle(), 3, SQL_PARAM_INPUT, SQL_C_LONG, SQL_INTEGER, 0, 0, &p3_buf, sizeof(p3_buf), &p3_len);
+  REQUIRE_ODBC(ret, stmt);
+
+  ret = SQLExecute(stmt.getHandle());
+  REQUIRE_ODBC(ret, stmt);
+
+  // Then 2 result sets are returned
+  // And the first result set contains row [NULL]
+  ret = SQLFetch(stmt.getHandle());
+  REQUIRE_ODBC(ret, stmt);
+  SQLINTEGER value = 0;
+  SQLLEN indicator = 0;
+  ret = SQLGetData(stmt.getHandle(), 1, SQL_C_LONG, &value, sizeof(value), &indicator);
+  REQUIRE_ODBC(ret, stmt);
+  CHECK(indicator == SQL_NULL_DATA);
+
+  // And the second result set contains row [10, NULL]
+  ret = SQLMoreResults(stmt.getHandle());
+  REQUIRE_ODBC(ret, stmt);
+  ret = SQLFetch(stmt.getHandle());
+  REQUIRE_ODBC(ret, stmt);
+  CHECK(get_data<SQL_C_LONG>(stmt, 1) == 10);
+  ret = SQLGetData(stmt.getHandle(), 2, SQL_C_LONG, &value, sizeof(value), &indicator);
+  REQUIRE_ODBC(ret, stmt);
+  CHECK(indicator == SQL_NULL_DATA);
+
+  // No more result sets
+  ret = SQLMoreResults(stmt.getHandle());
+  CHECK(ret == SQL_NO_DATA);
+}

--- a/odbc_tests/tests/e2e/query/multistatement.cpp
+++ b/odbc_tests/tests/e2e/query/multistatement.cpp
@@ -312,8 +312,7 @@ TEST_CASE("should fail when NULL positional parameters are used in multistatemen
   REQUIRE_ODBC(ret, stmt);
   ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT ?; SELECT ?, ?"), SQL_NTS);
 
-  // Then an error is returned indicating NULL bindings are not supported.
-  // Server surfaces "Bind variable ? not set" — match loosely on "bind".
+  // Then an error is returned indicating NULL bindings are not supported
   CHECK(ret == SQL_ERROR);
   auto records = get_diag_rec(stmt);
   bool mentions_bind =

--- a/odbc_tests/tests/e2e/query/multistatement.cpp
+++ b/odbc_tests/tests/e2e/query/multistatement.cpp
@@ -160,11 +160,10 @@ TEST_CASE("should execute multistatement DML with positional parameters", "[quer
 
   // And A temporary table with column (id NUMBER) exists
   SQLRETURN ret = SQLExecDirect(stmt.getHandle(),
-                                sqlchar("CREATE OR REPLACE TEMPORARY TABLE ms_odbc_bind_dml(id NUMBER)"),
-                                SQL_NTS);
+                                sqlchar("CREATE OR REPLACE TEMPORARY TABLE ms_odbc_bind_dml(id NUMBER)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
-  // When Multistatement query "INSERT INTO {table} VALUES(?); INSERT INTO {table} VALUES(?),(?)" is executed with positional parameters [10, 20, 30] and multi_statement_count=2
+  // When Multistatement INSERT chain is executed with 3 positional parameters
   ret = SQLSetStmtAttr(stmt.getHandle(), SQL_SF_STMT_ATTR_MULTI_STATEMENT_COUNT, (SQLPOINTER)2, 0);
   REQUIRE_ODBC(ret, stmt);
   ret = SQLPrepare(stmt.getHandle(),
@@ -222,7 +221,7 @@ TEST_CASE("should execute multistatement SELECT with positional parameters", "[q
   Connection conn;
   auto stmt = conn.createStatement();
 
-  // When Multistatement query "SELECT ?; SELECT ?, ?; SELECT ?, ?, ?" is executed with positional parameters [10, 20, 30, 40, 50, 60] and multi_statement_count=3
+  // When Multistatement SELECT chain is executed with 6 positional parameters
   SQLRETURN ret = SQLSetStmtAttr(stmt.getHandle(), SQL_SF_STMT_ATTR_MULTI_STATEMENT_COUNT, (SQLPOINTER)3, 0);
   REQUIRE_ODBC(ret, stmt);
   ret = SQLPrepare(stmt.getHandle(), sqlchar("SELECT ?; SELECT ?, ?; SELECT ?, ?, ?"), SQL_NTS);
@@ -231,8 +230,8 @@ TEST_CASE("should execute multistatement SELECT with positional parameters", "[q
   SQLLEN param_lens[6] = {sizeof(SQLINTEGER), sizeof(SQLINTEGER), sizeof(SQLINTEGER),
                           sizeof(SQLINTEGER), sizeof(SQLINTEGER), sizeof(SQLINTEGER)};
   for (SQLUSMALLINT i = 0; i < 6; ++i) {
-    ret = SQLBindParameter(stmt.getHandle(), i + 1, SQL_PARAM_INPUT, SQL_C_LONG, SQL_INTEGER, 0, 0,
-                           &params[i], sizeof(SQLINTEGER), &param_lens[i]);
+    ret = SQLBindParameter(stmt.getHandle(), i + 1, SQL_PARAM_INPUT, SQL_C_LONG, SQL_INTEGER, 0, 0, &params[i],
+                           sizeof(SQLINTEGER), &param_lens[i]);
     REQUIRE_ODBC(ret, stmt);
   }
   ret = SQLExecute(stmt.getHandle());
@@ -270,7 +269,7 @@ TEST_CASE("should fail when multistatement query has too few parameters", "[quer
   Connection conn;
   auto stmt = conn.createStatement();
 
-  // When Multistatement query "SELECT ?; SELECT ?, ?" is executed with positional parameters [10] and multi_statement_count=2
+  // When Multistatement SELECT requires 3 parameters but only 1 is bound
   SQLRETURN ret = SQLSetStmtAttr(stmt.getHandle(), SQL_SF_STMT_ATTR_MULTI_STATEMENT_COUNT, (SQLPOINTER)2, 0);
   REQUIRE_ODBC(ret, stmt);
   ret = SQLPrepare(stmt.getHandle(), sqlchar("SELECT ?; SELECT ?, ?"), SQL_NTS);
@@ -285,7 +284,8 @@ TEST_CASE("should fail when multistatement query has too few parameters", "[quer
   CHECK(ret == SQL_ERROR);
 }
 
-TEST_CASE("should fail when NULL positional parameters are used in multistatement query", "[query][multistatement][parameters]") {
+TEST_CASE("should fail when NULL positional parameters are used in multistatement query",
+          "[query][multistatement][parameters]") {
   // Snowflake's SYSTEM$MULTISTMT server-side dispatcher rejects NULL bindings
   // with "Bind variable ? not set" — confirmed against legacy snowflake-jdbc
   // and legacy snowflake-odbc; the universal-driver inherits the same behavior.
@@ -294,7 +294,7 @@ TEST_CASE("should fail when NULL positional parameters are used in multistatemen
   Connection conn;
   auto stmt = conn.createStatement();
 
-  // When Multistatement query "SELECT ?; SELECT ?, ?" is executed with positional parameters [NULL, 10, NULL] and multi_statement_count=2
+  // When Multistatement SELECT is executed with NULL positional parameters
   SQLRETURN ret = SQLSetStmtAttr(stmt.getHandle(), SQL_SF_STMT_ATTR_MULTI_STATEMENT_COUNT, (SQLPOINTER)2, 0);
   REQUIRE_ODBC(ret, stmt);
   ret = SQLPrepare(stmt.getHandle(), sqlchar("SELECT ?; SELECT ?, ?"), SQL_NTS);
@@ -303,14 +303,17 @@ TEST_CASE("should fail when NULL positional parameters are used in multistatemen
   SQLLEN p1_len = SQL_NULL_DATA;
   SQLLEN p2_len = sizeof(p2_buf);
   SQLLEN p3_len = SQL_NULL_DATA;
-  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_LONG, SQL_INTEGER, 0, 0, &p1_buf, sizeof(p1_buf), &p1_len);
+  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_LONG, SQL_INTEGER, 0, 0, &p1_buf, sizeof(p1_buf),
+                         &p1_len);
   REQUIRE_ODBC(ret, stmt);
-  ret = SQLBindParameter(stmt.getHandle(), 2, SQL_PARAM_INPUT, SQL_C_LONG, SQL_INTEGER, 0, 0, &p2_buf, sizeof(p2_buf), &p2_len);
+  ret = SQLBindParameter(stmt.getHandle(), 2, SQL_PARAM_INPUT, SQL_C_LONG, SQL_INTEGER, 0, 0, &p2_buf, sizeof(p2_buf),
+                         &p2_len);
   REQUIRE_ODBC(ret, stmt);
-  ret = SQLBindParameter(stmt.getHandle(), 3, SQL_PARAM_INPUT, SQL_C_LONG, SQL_INTEGER, 0, 0, &p3_buf, sizeof(p3_buf), &p3_len);
+  ret = SQLBindParameter(stmt.getHandle(), 3, SQL_PARAM_INPUT, SQL_C_LONG, SQL_INTEGER, 0, 0, &p3_buf, sizeof(p3_buf),
+                         &p3_len);
   REQUIRE_ODBC(ret, stmt);
   ret = SQLExecute(stmt.getHandle());
 
-  // Then an error is returned indicating NULL bindings are not supported in multi-statement
+  // Then an error is returned indicating NULL bindings are not supported
   CHECK(ret == SQL_ERROR);
 }

--- a/odbc_tests/tests/e2e/query/multistatement.cpp
+++ b/odbc_tests/tests/e2e/query/multistatement.cpp
@@ -160,8 +160,8 @@ TEST_CASE("should execute multistatement DML with positional parameters", "[quer
   auto stmt = conn.createStatement();
 
   // And A temporary table with column (id NUMBER) exists
-  SQLRETURN ret = SQLExecDirect(stmt.getHandle(),
-                                sqlchar("CREATE OR REPLACE TEMPORARY TABLE ms_bind_dml(id NUMBER)"), SQL_NTS);
+  SQLRETURN ret =
+      SQLExecDirect(stmt.getHandle(), sqlchar("CREATE OR REPLACE TEMPORARY TABLE ms_bind_dml(id NUMBER)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // When Multistatement INSERT chain is executed with 3 positional parameters
@@ -315,11 +315,10 @@ TEST_CASE("should fail when NULL positional parameters are used in multistatemen
   // Then an error is returned indicating NULL bindings are not supported
   CHECK(ret == SQL_ERROR);
   auto records = get_diag_rec(stmt);
-  bool mentions_bind =
-      std::any_of(records.begin(), records.end(), [](const DiagRec& r) {
-        std::string lower = r.messageText;
-        std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
-        return lower.find("bind") != std::string::npos;
-      });
+  bool mentions_bind = std::any_of(records.begin(), records.end(), [](const DiagRec& r) {
+    std::string lower = r.messageText;
+    std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+    return lower.find("bind") != std::string::npos;
+  });
   CHECK(mentions_bind);
 }

--- a/odbc_tests/tests/e2e/query/multistatement.cpp
+++ b/odbc_tests/tests/e2e/query/multistatement.cpp
@@ -166,11 +166,6 @@ TEST_CASE("should execute multistatement DML with positional parameters", "[quer
   // When Multistatement INSERT chain is executed with 3 positional parameters
   ret = SQLSetStmtAttr(stmt.getHandle(), SQL_SF_STMT_ATTR_MULTI_STATEMENT_COUNT, (SQLPOINTER)2, 0);
   REQUIRE_ODBC(ret, stmt);
-  ret = SQLPrepare(stmt.getHandle(),
-                   sqlchar("INSERT INTO ms_odbc_bind_dml VALUES(?);"
-                           " INSERT INTO ms_odbc_bind_dml VALUES(?),(?)"),
-                   SQL_NTS);
-  REQUIRE_ODBC(ret, stmt);
   SQLINTEGER p1 = 10, p2 = 20, p3 = 30;
   SQLLEN p1_len = sizeof(p1), p2_len = sizeof(p2), p3_len = sizeof(p3);
   ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_LONG, SQL_INTEGER, 0, 0, &p1, sizeof(p1), &p1_len);
@@ -179,7 +174,10 @@ TEST_CASE("should execute multistatement DML with positional parameters", "[quer
   REQUIRE_ODBC(ret, stmt);
   ret = SQLBindParameter(stmt.getHandle(), 3, SQL_PARAM_INPUT, SQL_C_LONG, SQL_INTEGER, 0, 0, &p3, sizeof(p3), &p3_len);
   REQUIRE_ODBC(ret, stmt);
-  ret = SQLExecute(stmt.getHandle());
+  ret = SQLExecDirect(stmt.getHandle(),
+                      sqlchar("INSERT INTO ms_odbc_bind_dml VALUES(?);"
+                              " INSERT INTO ms_odbc_bind_dml VALUES(?),(?)"),
+                      SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // Then 2 result sets are returned
@@ -224,8 +222,6 @@ TEST_CASE("should execute multistatement SELECT with positional parameters", "[q
   // When Multistatement SELECT chain is executed with 6 positional parameters
   SQLRETURN ret = SQLSetStmtAttr(stmt.getHandle(), SQL_SF_STMT_ATTR_MULTI_STATEMENT_COUNT, (SQLPOINTER)3, 0);
   REQUIRE_ODBC(ret, stmt);
-  ret = SQLPrepare(stmt.getHandle(), sqlchar("SELECT ?; SELECT ?, ?; SELECT ?, ?, ?"), SQL_NTS);
-  REQUIRE_ODBC(ret, stmt);
   SQLINTEGER params[6] = {10, 20, 30, 40, 50, 60};
   SQLLEN param_lens[6] = {sizeof(SQLINTEGER), sizeof(SQLINTEGER), sizeof(SQLINTEGER),
                           sizeof(SQLINTEGER), sizeof(SQLINTEGER), sizeof(SQLINTEGER)};
@@ -234,7 +230,7 @@ TEST_CASE("should execute multistatement SELECT with positional parameters", "[q
                            sizeof(SQLINTEGER), &param_lens[i]);
     REQUIRE_ODBC(ret, stmt);
   }
-  ret = SQLExecute(stmt.getHandle());
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT ?; SELECT ?, ?; SELECT ?, ?, ?"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // Then 3 result sets are returned
@@ -272,13 +268,11 @@ TEST_CASE("should fail when multistatement query has too few parameters", "[quer
   // When Multistatement SELECT requires 3 parameters but only 1 is bound
   SQLRETURN ret = SQLSetStmtAttr(stmt.getHandle(), SQL_SF_STMT_ATTR_MULTI_STATEMENT_COUNT, (SQLPOINTER)2, 0);
   REQUIRE_ODBC(ret, stmt);
-  ret = SQLPrepare(stmt.getHandle(), sqlchar("SELECT ?; SELECT ?, ?"), SQL_NTS);
-  REQUIRE_ODBC(ret, stmt);
   SQLINTEGER p1 = 10;
   SQLLEN p1_len = sizeof(p1);
   ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_LONG, SQL_INTEGER, 0, 0, &p1, sizeof(p1), &p1_len);
   REQUIRE_ODBC(ret, stmt);
-  ret = SQLExecute(stmt.getHandle());
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT ?; SELECT ?, ?"), SQL_NTS);
 
   // Then an error is returned indicating parameter count mismatch
   CHECK(ret == SQL_ERROR);
@@ -297,8 +291,6 @@ TEST_CASE("should fail when NULL positional parameters are used in multistatemen
   // When Multistatement SELECT is executed with NULL positional parameters
   SQLRETURN ret = SQLSetStmtAttr(stmt.getHandle(), SQL_SF_STMT_ATTR_MULTI_STATEMENT_COUNT, (SQLPOINTER)2, 0);
   REQUIRE_ODBC(ret, stmt);
-  ret = SQLPrepare(stmt.getHandle(), sqlchar("SELECT ?; SELECT ?, ?"), SQL_NTS);
-  REQUIRE_ODBC(ret, stmt);
   SQLINTEGER p1_buf = 0, p2_buf = 10, p3_buf = 0;
   SQLLEN p1_len = SQL_NULL_DATA;
   SQLLEN p2_len = sizeof(p2_buf);
@@ -312,7 +304,7 @@ TEST_CASE("should fail when NULL positional parameters are used in multistatemen
   ret = SQLBindParameter(stmt.getHandle(), 3, SQL_PARAM_INPUT, SQL_C_LONG, SQL_INTEGER, 0, 0, &p3_buf, sizeof(p3_buf),
                          &p3_len);
   REQUIRE_ODBC(ret, stmt);
-  ret = SQLExecute(stmt.getHandle());
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT ?; SELECT ?, ?"), SQL_NTS);
 
   // Then an error is returned indicating NULL bindings are not supported
   CHECK(ret == SQL_ERROR);

--- a/odbc_tests/tests/e2e/query/multistatement.cpp
+++ b/odbc_tests/tests/e2e/query/multistatement.cpp
@@ -1,6 +1,7 @@
 #include <sql.h>
 #include <sqlext.h>
 
+#include <algorithm>
 #include <string>
 
 #include <catch2/catch_test_macros.hpp>
@@ -160,23 +161,23 @@ TEST_CASE("should execute multistatement DML with positional parameters", "[quer
 
   // And A temporary table with column (id NUMBER) exists
   SQLRETURN ret = SQLExecDirect(stmt.getHandle(),
-                                sqlchar("CREATE OR REPLACE TEMPORARY TABLE ms_odbc_bind_dml(id NUMBER)"), SQL_NTS);
+                                sqlchar("CREATE OR REPLACE TEMPORARY TABLE ms_bind_dml(id NUMBER)"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
   // When Multistatement INSERT chain is executed with 3 positional parameters
   ret = SQLSetStmtAttr(stmt.getHandle(), SQL_SF_STMT_ATTR_MULTI_STATEMENT_COUNT, (SQLPOINTER)2, 0);
   REQUIRE_ODBC(ret, stmt);
-  SQLINTEGER p1 = 10, p2 = 20, p3 = 30;
-  SQLLEN p1_len = sizeof(p1), p2_len = sizeof(p2), p3_len = sizeof(p3);
-  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_LONG, SQL_INTEGER, 0, 0, &p1, sizeof(p1), &p1_len);
-  REQUIRE_ODBC(ret, stmt);
-  ret = SQLBindParameter(stmt.getHandle(), 2, SQL_PARAM_INPUT, SQL_C_LONG, SQL_INTEGER, 0, 0, &p2, sizeof(p2), &p2_len);
-  REQUIRE_ODBC(ret, stmt);
-  ret = SQLBindParameter(stmt.getHandle(), 3, SQL_PARAM_INPUT, SQL_C_LONG, SQL_INTEGER, 0, 0, &p3, sizeof(p3), &p3_len);
-  REQUIRE_ODBC(ret, stmt);
+  SQLINTEGER params[3] = {10, 20, 30};
+  SQLLEN param_lens[3];
+  for (SQLUSMALLINT i = 0; i < 3; ++i) {
+    param_lens[i] = sizeof(SQLINTEGER);
+    ret = SQLBindParameter(stmt.getHandle(), i + 1, SQL_PARAM_INPUT, SQL_C_LONG, SQL_INTEGER, 0, 0, &params[i],
+                           sizeof(SQLINTEGER), &param_lens[i]);
+    REQUIRE_ODBC(ret, stmt);
+  }
   ret = SQLExecDirect(stmt.getHandle(),
-                      sqlchar("INSERT INTO ms_odbc_bind_dml VALUES(?);"
-                              " INSERT INTO ms_odbc_bind_dml VALUES(?),(?)"),
+                      sqlchar("INSERT INTO ms_bind_dml VALUES(?);"
+                              " INSERT INTO ms_bind_dml VALUES(?),(?)"),
                       SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
@@ -197,9 +198,11 @@ TEST_CASE("should execute multistatement DML with positional parameters", "[quer
   ret = SQLMoreResults(stmt.getHandle());
   CHECK(ret == SQL_NO_DATA);
 
+  // Walked all result sets — now query the table on a second statement to
+  // verify the rows were inserted.
   // And the table contains rows [10, 20, 30]
   auto verify = conn.createStatement();
-  ret = SQLExecDirect(verify.getHandle(), sqlchar("SELECT id FROM ms_odbc_bind_dml ORDER BY id"), SQL_NTS);
+  ret = SQLExecDirect(verify.getHandle(), sqlchar("SELECT id FROM ms_bind_dml ORDER BY id"), SQL_NTS);
   REQUIRE_ODBC(ret, verify);
   ret = SQLFetch(verify.getHandle());
   REQUIRE_ODBC(ret, verify);
@@ -223,9 +226,9 @@ TEST_CASE("should execute multistatement SELECT with positional parameters", "[q
   SQLRETURN ret = SQLSetStmtAttr(stmt.getHandle(), SQL_SF_STMT_ATTR_MULTI_STATEMENT_COUNT, (SQLPOINTER)3, 0);
   REQUIRE_ODBC(ret, stmt);
   SQLINTEGER params[6] = {10, 20, 30, 40, 50, 60};
-  SQLLEN param_lens[6] = {sizeof(SQLINTEGER), sizeof(SQLINTEGER), sizeof(SQLINTEGER),
-                          sizeof(SQLINTEGER), sizeof(SQLINTEGER), sizeof(SQLINTEGER)};
+  SQLLEN param_lens[6];
   for (SQLUSMALLINT i = 0; i < 6; ++i) {
+    param_lens[i] = sizeof(SQLINTEGER);
     ret = SQLBindParameter(stmt.getHandle(), i + 1, SQL_PARAM_INPUT, SQL_C_LONG, SQL_INTEGER, 0, 0, &params[i],
                            sizeof(SQLINTEGER), &param_lens[i]);
     REQUIRE_ODBC(ret, stmt);
@@ -239,6 +242,7 @@ TEST_CASE("should execute multistatement SELECT with positional parameters", "[q
 
   // And the first result set contains row [10]
   CHECK(get_data<SQL_C_LONG>(stmt, 1) == 10);
+  CHECK(SQLFetch(stmt.getHandle()) == SQL_NO_DATA);
 
   // And the second result set contains row [20, 30]
   ret = SQLMoreResults(stmt.getHandle());
@@ -247,6 +251,7 @@ TEST_CASE("should execute multistatement SELECT with positional parameters", "[q
   REQUIRE_ODBC(ret, stmt);
   CHECK(get_data<SQL_C_LONG>(stmt, 1) == 20);
   CHECK(get_data<SQL_C_LONG>(stmt, 2) == 30);
+  CHECK(SQLFetch(stmt.getHandle()) == SQL_NO_DATA);
 
   // And the third result set contains row [40, 50, 60]
   ret = SQLMoreResults(stmt.getHandle());
@@ -256,6 +261,7 @@ TEST_CASE("should execute multistatement SELECT with positional parameters", "[q
   CHECK(get_data<SQL_C_LONG>(stmt, 1) == 40);
   CHECK(get_data<SQL_C_LONG>(stmt, 2) == 50);
   CHECK(get_data<SQL_C_LONG>(stmt, 3) == 60);
+  CHECK(SQLFetch(stmt.getHandle()) == SQL_NO_DATA);
   ret = SQLMoreResults(stmt.getHandle());
   CHECK(ret == SQL_NO_DATA);
 }
@@ -306,6 +312,15 @@ TEST_CASE("should fail when NULL positional parameters are used in multistatemen
   REQUIRE_ODBC(ret, stmt);
   ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT ?; SELECT ?, ?"), SQL_NTS);
 
-  // Then an error is returned indicating NULL bindings are not supported
+  // Then an error is returned indicating NULL bindings are not supported.
+  // Server surfaces "Bind variable ? not set" — match loosely on "bind".
   CHECK(ret == SQL_ERROR);
+  auto records = get_diag_rec(stmt);
+  bool mentions_bind =
+      std::any_of(records.begin(), records.end(), [](const DiagRec& r) {
+        std::string lower = r.messageText;
+        std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+        return lower.find("bind") != std::string::npos;
+      });
+  CHECK(mentions_bind);
 }

--- a/odbc_tests/tests/e2e/query/multistatement.cpp
+++ b/odbc_tests/tests/e2e/query/multistatement.cpp
@@ -164,16 +164,14 @@ TEST_CASE("should execute multistatement DML with positional parameters", "[quer
                                 SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
 
-  // When Multistatement INSERT chain is prepared with 3 positional parameters
+  // When Multistatement query "INSERT INTO {table} VALUES(?); INSERT INTO {table} VALUES(?),(?)" is executed with positional parameters [10, 20, 30] and multi_statement_count=2
   ret = SQLSetStmtAttr(stmt.getHandle(), SQL_SF_STMT_ATTR_MULTI_STATEMENT_COUNT, (SQLPOINTER)2, 0);
   REQUIRE_ODBC(ret, stmt);
-
   ret = SQLPrepare(stmt.getHandle(),
                    sqlchar("INSERT INTO ms_odbc_bind_dml VALUES(?);"
                            " INSERT INTO ms_odbc_bind_dml VALUES(?),(?)"),
                    SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
-
   SQLINTEGER p1 = 10, p2 = 20, p3 = 30;
   SQLLEN p1_len = sizeof(p1), p2_len = sizeof(p2), p3_len = sizeof(p3);
   ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_LONG, SQL_INTEGER, 0, 0, &p1, sizeof(p1), &p1_len);
@@ -182,13 +180,13 @@ TEST_CASE("should execute multistatement DML with positional parameters", "[quer
   REQUIRE_ODBC(ret, stmt);
   ret = SQLBindParameter(stmt.getHandle(), 3, SQL_PARAM_INPUT, SQL_C_LONG, SQL_INTEGER, 0, 0, &p3, sizeof(p3), &p3_len);
   REQUIRE_ODBC(ret, stmt);
-
   ret = SQLExecute(stmt.getHandle());
   REQUIRE_ODBC(ret, stmt);
 
   // Then 2 result sets are returned
-  // And the first result set reports update count 1
   SQLLEN row_count = 0;
+
+  // And the first result set reports update count 1
   ret = SQLRowCount(stmt.getHandle(), &row_count);
   REQUIRE_ODBC(ret, stmt);
   CHECK(row_count == 1);
@@ -199,8 +197,6 @@ TEST_CASE("should execute multistatement DML with positional parameters", "[quer
   ret = SQLRowCount(stmt.getHandle(), &row_count);
   REQUIRE_ODBC(ret, stmt);
   CHECK(row_count == 2);
-
-  // No more result sets
   ret = SQLMoreResults(stmt.getHandle());
   CHECK(ret == SQL_NO_DATA);
 
@@ -226,13 +222,11 @@ TEST_CASE("should execute multistatement SELECT with positional parameters", "[q
   Connection conn;
   auto stmt = conn.createStatement();
 
-  // When Multistatement SELECT chain is prepared with 6 positional parameters
+  // When Multistatement query "SELECT ?; SELECT ?, ?; SELECT ?, ?, ?" is executed with positional parameters [10, 20, 30, 40, 50, 60] and multi_statement_count=3
   SQLRETURN ret = SQLSetStmtAttr(stmt.getHandle(), SQL_SF_STMT_ATTR_MULTI_STATEMENT_COUNT, (SQLPOINTER)3, 0);
   REQUIRE_ODBC(ret, stmt);
-
   ret = SQLPrepare(stmt.getHandle(), sqlchar("SELECT ?; SELECT ?, ?; SELECT ?, ?, ?"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
-
   SQLINTEGER params[6] = {10, 20, 30, 40, 50, 60};
   SQLLEN param_lens[6] = {sizeof(SQLINTEGER), sizeof(SQLINTEGER), sizeof(SQLINTEGER),
                           sizeof(SQLINTEGER), sizeof(SQLINTEGER), sizeof(SQLINTEGER)};
@@ -241,14 +235,14 @@ TEST_CASE("should execute multistatement SELECT with positional parameters", "[q
                            &params[i], sizeof(SQLINTEGER), &param_lens[i]);
     REQUIRE_ODBC(ret, stmt);
   }
-
   ret = SQLExecute(stmt.getHandle());
   REQUIRE_ODBC(ret, stmt);
 
   // Then 3 result sets are returned
-  // And the first result set contains row [10]
   ret = SQLFetch(stmt.getHandle());
   REQUIRE_ODBC(ret, stmt);
+
+  // And the first result set contains row [10]
   CHECK(get_data<SQL_C_LONG>(stmt, 1) == 10);
 
   // And the second result set contains row [20, 30]
@@ -267,8 +261,6 @@ TEST_CASE("should execute multistatement SELECT with positional parameters", "[q
   CHECK(get_data<SQL_C_LONG>(stmt, 1) == 40);
   CHECK(get_data<SQL_C_LONG>(stmt, 2) == 50);
   CHECK(get_data<SQL_C_LONG>(stmt, 3) == 60);
-
-  // No more result sets
   ret = SQLMoreResults(stmt.getHandle());
   CHECK(ret == SQL_NO_DATA);
 }
@@ -278,36 +270,35 @@ TEST_CASE("should fail when multistatement query has too few parameters", "[quer
   Connection conn;
   auto stmt = conn.createStatement();
 
-  // When Multistatement SELECT requires 3 parameters but only 1 is bound
+  // When Multistatement query "SELECT ?; SELECT ?, ?" is executed with positional parameters [10] and multi_statement_count=2
   SQLRETURN ret = SQLSetStmtAttr(stmt.getHandle(), SQL_SF_STMT_ATTR_MULTI_STATEMENT_COUNT, (SQLPOINTER)2, 0);
   REQUIRE_ODBC(ret, stmt);
-
   ret = SQLPrepare(stmt.getHandle(), sqlchar("SELECT ?; SELECT ?, ?"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
-
   SQLINTEGER p1 = 10;
   SQLLEN p1_len = sizeof(p1);
   ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_LONG, SQL_INTEGER, 0, 0, &p1, sizeof(p1), &p1_len);
   REQUIRE_ODBC(ret, stmt);
-
   ret = SQLExecute(stmt.getHandle());
 
   // Then an error is returned indicating parameter count mismatch
   CHECK(ret == SQL_ERROR);
 }
 
-TEST_CASE("should handle NULL positional parameters in multistatement query", "[query][multistatement][parameters]") {
+TEST_CASE("should fail when NULL positional parameters are used in multistatement query", "[query][multistatement][parameters]") {
+  // Snowflake's SYSTEM$MULTISTMT server-side dispatcher rejects NULL bindings
+  // with "Bind variable ? not set" — confirmed against legacy snowflake-jdbc
+  // and legacy snowflake-odbc; the universal-driver inherits the same behavior.
+
   // Given Snowflake client is logged in
   Connection conn;
   auto stmt = conn.createStatement();
 
-  // When Multistatement SELECT is executed with NULL/non-NULL positional parameters
+  // When Multistatement query "SELECT ?; SELECT ?, ?" is executed with positional parameters [NULL, 10, NULL] and multi_statement_count=2
   SQLRETURN ret = SQLSetStmtAttr(stmt.getHandle(), SQL_SF_STMT_ATTR_MULTI_STATEMENT_COUNT, (SQLPOINTER)2, 0);
   REQUIRE_ODBC(ret, stmt);
-
   ret = SQLPrepare(stmt.getHandle(), sqlchar("SELECT ?; SELECT ?, ?"), SQL_NTS);
   REQUIRE_ODBC(ret, stmt);
-
   SQLINTEGER p1_buf = 0, p2_buf = 10, p3_buf = 0;
   SQLLEN p1_len = SQL_NULL_DATA;
   SQLLEN p2_len = sizeof(p2_buf);
@@ -318,31 +309,8 @@ TEST_CASE("should handle NULL positional parameters in multistatement query", "[
   REQUIRE_ODBC(ret, stmt);
   ret = SQLBindParameter(stmt.getHandle(), 3, SQL_PARAM_INPUT, SQL_C_LONG, SQL_INTEGER, 0, 0, &p3_buf, sizeof(p3_buf), &p3_len);
   REQUIRE_ODBC(ret, stmt);
-
   ret = SQLExecute(stmt.getHandle());
-  REQUIRE_ODBC(ret, stmt);
 
-  // Then 2 result sets are returned
-  // And the first result set contains row [NULL]
-  ret = SQLFetch(stmt.getHandle());
-  REQUIRE_ODBC(ret, stmt);
-  SQLINTEGER value = 0;
-  SQLLEN indicator = 0;
-  ret = SQLGetData(stmt.getHandle(), 1, SQL_C_LONG, &value, sizeof(value), &indicator);
-  REQUIRE_ODBC(ret, stmt);
-  CHECK(indicator == SQL_NULL_DATA);
-
-  // And the second result set contains row [10, NULL]
-  ret = SQLMoreResults(stmt.getHandle());
-  REQUIRE_ODBC(ret, stmt);
-  ret = SQLFetch(stmt.getHandle());
-  REQUIRE_ODBC(ret, stmt);
-  CHECK(get_data<SQL_C_LONG>(stmt, 1) == 10);
-  ret = SQLGetData(stmt.getHandle(), 2, SQL_C_LONG, &value, sizeof(value), &indicator);
-  REQUIRE_ODBC(ret, stmt);
-  CHECK(indicator == SQL_NULL_DATA);
-
-  // No more result sets
-  ret = SQLMoreResults(stmt.getHandle());
-  CHECK(ret == SQL_NO_DATA);
+  // Then an error is returned indicating NULL bindings are not supported in multi-statement
+  CHECK(ret == SQL_ERROR);
 }

--- a/python/tests/e2e/query/test_multistatement.py
+++ b/python/tests/e2e/query/test_multistatement.py
@@ -186,7 +186,6 @@ class TestMultistatementWithParameters:
 
     def test_should_execute_multistatement_dml_with_positional_parameters(self, cursor):
         # Given Snowflake client is logged in
-        pass
         # And A temporary table with column (id NUMBER) exists
         table_name = random_table_name("ms_bind_dml")
         cursor.execute(f"CREATE OR REPLACE TEMPORARY TABLE {table_name}(id NUMBER)")
@@ -199,7 +198,6 @@ class TestMultistatementWithParameters:
         )
 
         # Then 2 result sets are returned
-        pass
         # And the first result set reports update count 1
         assert cursor.rowcount == 1
 
@@ -215,7 +213,6 @@ class TestMultistatementWithParameters:
 
     def test_should_execute_multistatement_select_with_positional_parameters(self, cursor):
         # Given Snowflake client is logged in
-        pass
         # When Multistatement SELECT chain is executed with 6 positional parameters
         cursor.execute(
             "SELECT ?; SELECT ?, ?; SELECT ?, ?, ?",
@@ -224,7 +221,6 @@ class TestMultistatementWithParameters:
         )
 
         # Then 3 result sets are returned
-        pass
         # And the first result set contains row [10]
         assert cursor.fetchone() == (10,)
 
@@ -239,10 +235,7 @@ class TestMultistatementWithParameters:
 
     def test_should_fail_when_multistatement_query_has_too_few_parameters(self, cursor):
         # Given Snowflake client is logged in
-        pass
         # When Multistatement SELECT requires 3 parameters but only 1 is bound
-        pass
-
         # Then an error is returned indicating parameter count mismatch
         with pytest.raises(ProgrammingError):
             cursor.execute(
@@ -253,12 +246,10 @@ class TestMultistatementWithParameters:
 
     def test_should_fail_when_null_positional_parameters_are_used_in_multistatement_query(self, cursor):
         # Given Snowflake client is logged in
-        pass
         # When Multistatement SELECT is executed with NULL positional parameters
-        pass
-
-        # Then an error is returned indicating NULL bindings are not supported
-        with pytest.raises(ProgrammingError):
+        # Then an error is returned indicating NULL bindings are not supported.
+        # Server surfaces "Bind variable ? not set" — match loosely on "bind".
+        with pytest.raises(ProgrammingError, match=r"(?i)bind"):
             cursor.execute(
                 "SELECT ?; SELECT ?, ?",
                 (None, 10, None),

--- a/python/tests/e2e/query/test_multistatement.py
+++ b/python/tests/e2e/query/test_multistatement.py
@@ -15,6 +15,8 @@ import pytest
 
 from snowflake.connector.errors import ProgrammingError
 
+from ...conftest import with_paramstyle
+
 
 def random_table_name(prefix: str = "ms_test") -> str:
     """Generate a random table name to avoid conflicts."""
@@ -176,3 +178,92 @@ class TestErrorHandling:
 
         # Verify error is raised
         assert exc_info.value is not None
+
+
+@with_paramstyle("qmark")
+class TestMultistatementWithParameters:
+    """Tests for multistatement queries combined with positional parameter binding."""
+
+    def test_should_execute_multistatement_dml_with_positional_parameters(self, cursor):
+        # Given Snowflake client is logged in
+        # And A temporary table with column (id NUMBER) exists
+        table_name = random_table_name("ms_bind_dml")
+        cursor.execute(f"CREATE OR REPLACE TEMPORARY TABLE {table_name}(id NUMBER)")
+
+        # When Multistatement INSERT chain is executed with 3 positional parameters
+        cursor.execute(
+            f"INSERT INTO {table_name} VALUES(?); INSERT INTO {table_name} VALUES(?),(?)",
+            (10, 20, 30),
+            num_statements=2,
+        )
+
+        # Then 2 result sets are returned
+        # And the first result set reports update count 1
+        assert cursor.rowcount == 1
+
+        # And the second result set reports update count 2
+        result = cursor.nextset()
+        assert result is cursor
+        assert cursor.rowcount == 2
+
+        # No more results
+        assert cursor.nextset() is None
+
+        # And the table contains rows [10, 20, 30]
+        cursor.execute(f"SELECT id FROM {table_name} ORDER BY id")
+        assert cursor.fetchall() == [(10,), (20,), (30,)]
+
+    def test_should_execute_multistatement_select_with_positional_parameters(self, cursor):
+        # Given Snowflake client is logged in
+        # When Multistatement SELECT chain is executed with 6 positional parameters
+        cursor.execute(
+            "SELECT ?; SELECT ?, ?; SELECT ?, ?, ?",
+            (10, 20, 30, 40, 50, 60),
+            num_statements=3,
+        )
+
+        # Then 3 result sets are returned
+        # And the first result set contains row [10]
+        assert cursor.fetchone() == (10,)
+
+        # And the second result set contains row [20, 30]
+        assert cursor.nextset() is cursor
+        assert cursor.fetchone() == (20, 30)
+
+        # And the third result set contains row [40, 50, 60]
+        assert cursor.nextset() is cursor
+        assert cursor.fetchone() == (40, 50, 60)
+
+        # No more results
+        assert cursor.nextset() is None
+
+    def test_should_fail_when_multistatement_query_has_too_few_parameters(self, cursor):
+        # Given Snowflake client is logged in
+        # When Multistatement SELECT requires 3 parameters but only 1 is bound
+        # Then an error is returned indicating parameter count mismatch
+        with pytest.raises(ProgrammingError):
+            cursor.execute(
+                "SELECT ?; SELECT ?, ?",
+                (10,),
+                num_statements=2,
+            )
+
+    def test_should_handle_null_positional_parameters_in_multistatement_query(self, cursor):
+        # Given Snowflake client is logged in
+        # When Multistatement SELECT is executed with NULL/non-NULL positional parameters
+        cursor.execute(
+            "SELECT ?; SELECT ?, ?",
+            (None, 10, None),
+            num_statements=2,
+        )
+
+        # Then 2 result sets are returned
+        # And the first result set contains row [NULL]
+        assert cursor.fetchone() == (None,)
+
+        # And the second result set contains row [10, NULL]
+        assert cursor.nextset() is cursor
+        assert cursor.fetchone() == (10, None)
+
+        # No more results
+        assert cursor.nextset() is None

--- a/python/tests/e2e/query/test_multistatement.py
+++ b/python/tests/e2e/query/test_multistatement.py
@@ -191,7 +191,7 @@ class TestMultistatementWithParameters:
         table_name = random_table_name("ms_bind_dml")
         cursor.execute(f"CREATE OR REPLACE TEMPORARY TABLE {table_name}(id NUMBER)")
 
-        # When Multistatement query "INSERT INTO {table} VALUES(?); INSERT INTO {table} VALUES(?),(?)" is executed with positional parameters [10, 20, 30] and multi_statement_count=2
+        # When Multistatement INSERT chain is executed with 3 positional parameters
         cursor.execute(
             f"INSERT INTO {table_name} VALUES(?); INSERT INTO {table_name} VALUES(?),(?)",
             (10, 20, 30),
@@ -216,7 +216,7 @@ class TestMultistatementWithParameters:
     def test_should_execute_multistatement_select_with_positional_parameters(self, cursor):
         # Given Snowflake client is logged in
         pass
-        # When Multistatement query "SELECT ?; SELECT ?, ?; SELECT ?, ?, ?" is executed with positional parameters [10, 20, 30, 40, 50, 60] and multi_statement_count=3
+        # When Multistatement SELECT chain is executed with 6 positional parameters
         cursor.execute(
             "SELECT ?; SELECT ?, ?; SELECT ?, ?, ?",
             (10, 20, 30, 40, 50, 60),
@@ -240,7 +240,7 @@ class TestMultistatementWithParameters:
     def test_should_fail_when_multistatement_query_has_too_few_parameters(self, cursor):
         # Given Snowflake client is logged in
         pass
-        # When Multistatement query "SELECT ?; SELECT ?, ?" is executed with positional parameters [10] and multi_statement_count=2
+        # When Multistatement SELECT requires 3 parameters but only 1 is bound
         pass
 
         # Then an error is returned indicating parameter count mismatch
@@ -254,10 +254,10 @@ class TestMultistatementWithParameters:
     def test_should_fail_when_null_positional_parameters_are_used_in_multistatement_query(self, cursor):
         # Given Snowflake client is logged in
         pass
-        # When Multistatement query "SELECT ?; SELECT ?, ?" is executed with positional parameters [NULL, 10, NULL] and multi_statement_count=2
+        # When Multistatement SELECT is executed with NULL positional parameters
         pass
 
-        # Then an error is returned indicating NULL bindings are not supported in multi-statement
+        # Then an error is returned indicating NULL bindings are not supported
         with pytest.raises(ProgrammingError):
             cursor.execute(
                 "SELECT ?; SELECT ?, ?",

--- a/python/tests/e2e/query/test_multistatement.py
+++ b/python/tests/e2e/query/test_multistatement.py
@@ -186,11 +186,12 @@ class TestMultistatementWithParameters:
 
     def test_should_execute_multistatement_dml_with_positional_parameters(self, cursor):
         # Given Snowflake client is logged in
+        pass
         # And A temporary table with column (id NUMBER) exists
         table_name = random_table_name("ms_bind_dml")
         cursor.execute(f"CREATE OR REPLACE TEMPORARY TABLE {table_name}(id NUMBER)")
 
-        # When Multistatement INSERT chain is executed with 3 positional parameters
+        # When Multistatement query "INSERT INTO {table} VALUES(?); INSERT INTO {table} VALUES(?),(?)" is executed with positional parameters [10, 20, 30] and multi_statement_count=2
         cursor.execute(
             f"INSERT INTO {table_name} VALUES(?); INSERT INTO {table_name} VALUES(?),(?)",
             (10, 20, 30),
@@ -198,6 +199,7 @@ class TestMultistatementWithParameters:
         )
 
         # Then 2 result sets are returned
+        pass
         # And the first result set reports update count 1
         assert cursor.rowcount == 1
 
@@ -205,8 +207,6 @@ class TestMultistatementWithParameters:
         result = cursor.nextset()
         assert result is cursor
         assert cursor.rowcount == 2
-
-        # No more results
         assert cursor.nextset() is None
 
         # And the table contains rows [10, 20, 30]
@@ -215,7 +215,8 @@ class TestMultistatementWithParameters:
 
     def test_should_execute_multistatement_select_with_positional_parameters(self, cursor):
         # Given Snowflake client is logged in
-        # When Multistatement SELECT chain is executed with 6 positional parameters
+        pass
+        # When Multistatement query "SELECT ?; SELECT ?, ?; SELECT ?, ?, ?" is executed with positional parameters [10, 20, 30, 40, 50, 60] and multi_statement_count=3
         cursor.execute(
             "SELECT ?; SELECT ?, ?; SELECT ?, ?, ?",
             (10, 20, 30, 40, 50, 60),
@@ -223,6 +224,7 @@ class TestMultistatementWithParameters:
         )
 
         # Then 3 result sets are returned
+        pass
         # And the first result set contains row [10]
         assert cursor.fetchone() == (10,)
 
@@ -233,13 +235,14 @@ class TestMultistatementWithParameters:
         # And the third result set contains row [40, 50, 60]
         assert cursor.nextset() is cursor
         assert cursor.fetchone() == (40, 50, 60)
-
-        # No more results
         assert cursor.nextset() is None
 
     def test_should_fail_when_multistatement_query_has_too_few_parameters(self, cursor):
         # Given Snowflake client is logged in
-        # When Multistatement SELECT requires 3 parameters but only 1 is bound
+        pass
+        # When Multistatement query "SELECT ?; SELECT ?, ?" is executed with positional parameters [10] and multi_statement_count=2
+        pass
+
         # Then an error is returned indicating parameter count mismatch
         with pytest.raises(ProgrammingError):
             cursor.execute(
@@ -248,22 +251,16 @@ class TestMultistatementWithParameters:
                 num_statements=2,
             )
 
-    def test_should_handle_null_positional_parameters_in_multistatement_query(self, cursor):
+    def test_should_fail_when_null_positional_parameters_are_used_in_multistatement_query(self, cursor):
         # Given Snowflake client is logged in
-        # When Multistatement SELECT is executed with NULL/non-NULL positional parameters
-        cursor.execute(
-            "SELECT ?; SELECT ?, ?",
-            (None, 10, None),
-            num_statements=2,
-        )
+        pass
+        # When Multistatement query "SELECT ?; SELECT ?, ?" is executed with positional parameters [NULL, 10, NULL] and multi_statement_count=2
+        pass
 
-        # Then 2 result sets are returned
-        # And the first result set contains row [NULL]
-        assert cursor.fetchone() == (None,)
-
-        # And the second result set contains row [10, NULL]
-        assert cursor.nextset() is cursor
-        assert cursor.fetchone() == (10, None)
-
-        # No more results
-        assert cursor.nextset() is None
+        # Then an error is returned indicating NULL bindings are not supported in multi-statement
+        with pytest.raises(ProgrammingError):
+            cursor.execute(
+                "SELECT ?; SELECT ?, ?",
+                (None, 10, None),
+                num_statements=2,
+            )

--- a/python/tests/e2e/query/test_multistatement.py
+++ b/python/tests/e2e/query/test_multistatement.py
@@ -204,14 +204,14 @@ class TestMultistatementWithParameters:
         assert cursor.rowcount == 1
 
         # And the second result set reports update count 2
-        result = cursor.nextset()
-        assert result is cursor
+        assert cursor.nextset() is cursor
         assert cursor.rowcount == 2
         assert cursor.nextset() is None
 
         # And the table contains rows [10, 20, 30]
-        cursor.execute(f"SELECT id FROM {table_name} ORDER BY id")
-        assert cursor.fetchall() == [(10,), (20,), (30,)]
+        with cursor.connection.cursor() as verify:
+            verify.execute(f"SELECT id FROM {table_name} ORDER BY id")
+            assert verify.fetchall() == [(10,), (20,), (30,)]
 
     def test_should_execute_multistatement_select_with_positional_parameters(self, cursor):
         # Given Snowflake client is logged in

--- a/python/tests/e2e/query/test_multistatement.py
+++ b/python/tests/e2e/query/test_multistatement.py
@@ -186,6 +186,7 @@ class TestMultistatementWithParameters:
 
     def test_should_execute_multistatement_dml_with_positional_parameters(self, cursor):
         # Given Snowflake client is logged in
+        pass
         # And A temporary table with column (id NUMBER) exists
         table_name = random_table_name("ms_bind_dml")
         cursor.execute(f"CREATE OR REPLACE TEMPORARY TABLE {table_name}(id NUMBER)")
@@ -198,6 +199,7 @@ class TestMultistatementWithParameters:
         )
 
         # Then 2 result sets are returned
+        pass
         # And the first result set reports update count 1
         assert cursor.rowcount == 1
 
@@ -213,6 +215,7 @@ class TestMultistatementWithParameters:
 
     def test_should_execute_multistatement_select_with_positional_parameters(self, cursor):
         # Given Snowflake client is logged in
+        pass
         # When Multistatement SELECT chain is executed with 6 positional parameters
         cursor.execute(
             "SELECT ?; SELECT ?, ?; SELECT ?, ?, ?",
@@ -221,6 +224,7 @@ class TestMultistatementWithParameters:
         )
 
         # Then 3 result sets are returned
+        pass
         # And the first result set contains row [10]
         assert cursor.fetchone() == (10,)
 
@@ -235,7 +239,10 @@ class TestMultistatementWithParameters:
 
     def test_should_fail_when_multistatement_query_has_too_few_parameters(self, cursor):
         # Given Snowflake client is logged in
+        pass
         # When Multistatement SELECT requires 3 parameters but only 1 is bound
+        pass
+
         # Then an error is returned indicating parameter count mismatch
         with pytest.raises(ProgrammingError):
             cursor.execute(
@@ -246,9 +253,11 @@ class TestMultistatementWithParameters:
 
     def test_should_fail_when_null_positional_parameters_are_used_in_multistatement_query(self, cursor):
         # Given Snowflake client is logged in
+        pass
         # When Multistatement SELECT is executed with NULL positional parameters
-        # Then an error is returned indicating NULL bindings are not supported.
-        # Server surfaces "Bind variable ? not set" — match loosely on "bind".
+        pass
+
+        # Then an error is returned indicating NULL bindings are not supported
         with pytest.raises(ProgrammingError, match=r"(?i)bind"):
             cursor.execute(
                 "SELECT ?; SELECT ?, ?",

--- a/tests/definitions/shared/query/multistatement.feature
+++ b/tests/definitions/shared/query/multistatement.feature
@@ -48,3 +48,44 @@ Feature: Multistatement query execution
     Given Snowflake client is logged in
     When Single SELECT is executed with multi_statement_count set to 3
     Then an error is returned indicating statement count mismatch
+
+  # ============================================================================
+  # POSITIONAL PARAMETER BINDING
+  # ============================================================================
+  # Combines MULTI_STATEMENT_COUNT with parameterized SQL. Bindings are
+  # positional and flatten across `;`-separated statements in source order —
+  # same contract as legacy snowflake-jdbc PreparedStatement, snowflake-odbc
+  # SQLBindParameter, and snowflake-connector-python qmark paramstyle.
+
+  @jdbc_e2e @odbc_e2e @python_e2e
+  Scenario: should execute multistatement DML with positional parameters
+    Given Snowflake client is logged in
+    And A temporary table with column (id NUMBER) exists
+    When Multistatement query "INSERT INTO {table} VALUES(?); INSERT INTO {table} VALUES(?),(?)" is executed with positional parameters [10, 20, 30] and multi_statement_count=2
+    Then 2 result sets are returned
+    And the first result set reports update count 1
+    And the second result set reports update count 2
+    And the table contains rows [10, 20, 30]
+
+  @jdbc_e2e @odbc_e2e @python_e2e
+  Scenario: should execute multistatement SELECT with positional parameters
+    Given Snowflake client is logged in
+    When Multistatement query "SELECT ?; SELECT ?, ?; SELECT ?, ?, ?" is executed with positional parameters [10, 20, 30, 40, 50, 60] and multi_statement_count=3
+    Then 3 result sets are returned
+    And the first result set contains row [10]
+    And the second result set contains row [20, 30]
+    And the third result set contains row [40, 50, 60]
+
+  @jdbc_e2e @odbc_e2e @python_e2e
+  Scenario: should fail when multistatement query has too few parameters
+    Given Snowflake client is logged in
+    When Multistatement query "SELECT ?; SELECT ?, ?" is executed with positional parameters [10] and multi_statement_count=2
+    Then an error is returned indicating parameter count mismatch
+
+  @jdbc_e2e @odbc_e2e @python_e2e
+  Scenario: should handle NULL positional parameters in multistatement query
+    Given Snowflake client is logged in
+    When Multistatement query "SELECT ?; SELECT ?, ?" is executed with positional parameters [NULL, 10, NULL] and multi_statement_count=2
+    Then 2 result sets are returned
+    And the first result set contains row [NULL]
+    And the second result set contains row [10, NULL]

--- a/tests/definitions/shared/query/multistatement.feature
+++ b/tests/definitions/shared/query/multistatement.feature
@@ -49,11 +49,26 @@ Feature: Multistatement query execution
     When Single SELECT is executed with multi_statement_count set to 3
     Then an error is returned indicating statement count mismatch
 
+  @jdbc_e2e @odbc_e2e @python_e2e
+  Scenario: should fail when multistatement query has too few parameters
+    Given Snowflake client is logged in
+    When Multistatement SELECT requires 3 parameters but only 1 is bound
+    Then an error is returned indicating parameter count mismatch
+
+  @jdbc_e2e @odbc_e2e @python_e2e
+  Scenario: should fail when NULL positional parameters are used in multistatement query
+    # Snowflake's SYSTEM$MULTISTMT server-side dispatcher rejects NULL bindings
+    # with "Bind variable ? not set" — confirmed against legacy snowflake-jdbc
+    # and legacy snowflake-odbc; the universal-driver inherits the same behavior.
+    Given Snowflake client is logged in
+    When Multistatement SELECT is executed with NULL positional parameters
+    Then an error is returned indicating NULL bindings are not supported
+
   # ============================================================================
   # POSITIONAL PARAMETER BINDING
   # ============================================================================
   # Combines MULTI_STATEMENT_COUNT with parameterized SQL. Bindings are
-  # positional and flatten across `;`-separated statements in source order —
+  # positional and flattened across `;`-separated statements in source order —
   # same contract as legacy snowflake-jdbc PreparedStatement, snowflake-odbc
   # SQLBindParameter, and snowflake-connector-python qmark paramstyle.
   #
@@ -80,18 +95,3 @@ Feature: Multistatement query execution
     And the first result set contains row [10]
     And the second result set contains row [20, 30]
     And the third result set contains row [40, 50, 60]
-
-  @jdbc_e2e @odbc_e2e @python_e2e
-  Scenario: should fail when multistatement query has too few parameters
-    Given Snowflake client is logged in
-    When Multistatement SELECT requires 3 parameters but only 1 is bound
-    Then an error is returned indicating parameter count mismatch
-
-  @jdbc_e2e @odbc_e2e @python_e2e
-  Scenario: should fail when NULL positional parameters are used in multistatement query
-    # Snowflake's SYSTEM$MULTISTMT server-side dispatcher rejects NULL bindings
-    # with "Bind variable ? not set" — confirmed against legacy snowflake-jdbc
-    # and legacy snowflake-odbc; the universal-driver inherits the same behavior.
-    Given Snowflake client is logged in
-    When Multistatement SELECT is executed with NULL positional parameters
-    Then an error is returned indicating NULL bindings are not supported

--- a/tests/definitions/shared/query/multistatement.feature
+++ b/tests/definitions/shared/query/multistatement.feature
@@ -56,6 +56,11 @@ Feature: Multistatement query execution
   # positional and flatten across `;`-separated statements in source order —
   # same contract as legacy snowflake-jdbc PreparedStatement, snowflake-odbc
   # SQLBindParameter, and snowflake-connector-python qmark paramstyle.
+  #
+  # "Then N result sets are returned" is asserted implicitly by walking the
+  # result-set chain to its terminator (-1 update count in JDBC, SQL_NO_DATA in
+  # ODBC, nextset() returning None in Python) — there is no separate count
+  # check.
 
   @jdbc_e2e @odbc_e2e @python_e2e
   Scenario: should execute multistatement DML with positional parameters

--- a/tests/definitions/shared/query/multistatement.feature
+++ b/tests/definitions/shared/query/multistatement.feature
@@ -61,7 +61,7 @@ Feature: Multistatement query execution
   Scenario: should execute multistatement DML with positional parameters
     Given Snowflake client is logged in
     And A temporary table with column (id NUMBER) exists
-    When Multistatement query "INSERT INTO {table} VALUES(?); INSERT INTO {table} VALUES(?),(?)" is executed with positional parameters [10, 20, 30] and multi_statement_count=2
+    When Multistatement INSERT chain is executed with 3 positional parameters
     Then 2 result sets are returned
     And the first result set reports update count 1
     And the second result set reports update count 2
@@ -70,7 +70,7 @@ Feature: Multistatement query execution
   @jdbc_e2e @odbc_e2e @python_e2e
   Scenario: should execute multistatement SELECT with positional parameters
     Given Snowflake client is logged in
-    When Multistatement query "SELECT ?; SELECT ?, ?; SELECT ?, ?, ?" is executed with positional parameters [10, 20, 30, 40, 50, 60] and multi_statement_count=3
+    When Multistatement SELECT chain is executed with 6 positional parameters
     Then 3 result sets are returned
     And the first result set contains row [10]
     And the second result set contains row [20, 30]
@@ -79,7 +79,7 @@ Feature: Multistatement query execution
   @jdbc_e2e @odbc_e2e @python_e2e
   Scenario: should fail when multistatement query has too few parameters
     Given Snowflake client is logged in
-    When Multistatement query "SELECT ?; SELECT ?, ?" is executed with positional parameters [10] and multi_statement_count=2
+    When Multistatement SELECT requires 3 parameters but only 1 is bound
     Then an error is returned indicating parameter count mismatch
 
   @jdbc_e2e @odbc_e2e @python_e2e
@@ -88,5 +88,5 @@ Feature: Multistatement query execution
     # with "Bind variable ? not set" — confirmed against legacy snowflake-jdbc
     # and legacy snowflake-odbc; the universal-driver inherits the same behavior.
     Given Snowflake client is logged in
-    When Multistatement query "SELECT ?; SELECT ?, ?" is executed with positional parameters [NULL, 10, NULL] and multi_statement_count=2
-    Then an error is returned indicating NULL bindings are not supported in multi-statement
+    When Multistatement SELECT is executed with NULL positional parameters
+    Then an error is returned indicating NULL bindings are not supported

--- a/tests/definitions/shared/query/multistatement.feature
+++ b/tests/definitions/shared/query/multistatement.feature
@@ -83,9 +83,10 @@ Feature: Multistatement query execution
     Then an error is returned indicating parameter count mismatch
 
   @jdbc_e2e @odbc_e2e @python_e2e
-  Scenario: should handle NULL positional parameters in multistatement query
+  Scenario: should fail when NULL positional parameters are used in multistatement query
+    # Snowflake's SYSTEM$MULTISTMT server-side dispatcher rejects NULL bindings
+    # with "Bind variable ? not set" — confirmed against legacy snowflake-jdbc
+    # and legacy snowflake-odbc; the universal-driver inherits the same behavior.
     Given Snowflake client is logged in
     When Multistatement query "SELECT ?; SELECT ?, ?" is executed with positional parameters [NULL, 10, NULL] and multi_statement_count=2
-    Then 2 result sets are returned
-    And the first result set contains row [NULL]
-    And the second result set contains row [10, NULL]
+    Then an error is returned indicating NULL bindings are not supported in multi-statement


### PR DESCRIPTION
Adds 4 cross-driver scenarios to multistatement.feature combining MULTI_STATEMENT_COUNT with parameterized SQL, plus matching JUnit / pytest / Catch2 implementations for JDBC, Python (qmark), and ODBC.

Scenarios:
- DML happy path with positional bindings (3 binds across INSERT chain)
- SELECT happy path with positional bindings (6 binds across 3 SELECTs)
- Negative: too few parameters surfaces as a SQLException / ProgrammingError / SQL_ERROR
- Negative: NULL positional bindings are rejected by Snowflake's SYSTEM$MULTISTMT dispatcher with "Bind variable ? not set" — confirmed against legacy snowflake-jdbc and legacy snowflake-odbc; the universal-driver inherits the same behavior

sf_core (Rust) coverage is intentionally omitted; scenarios carry @jdbc_e2e @odbc_e2e @python_e2e (no @core_e2e).