### PR TITLE
NO-SNOW: Add BaseWiremockTest + WiremockSanityTest end-to-end smoke

### DIFF
--- a/jdbc/src/test/java/net/snowflake/jdbc/wiremock/BaseWiremockTest.java
+++ b/jdbc/src/test/java/net/snowflake/jdbc/wiremock/BaseWiremockTest.java
@@ -1,0 +1,49 @@
+package net.snowflake.jdbc.wiremock;
+
+import java.net.URI;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+
+/**
+ * Base class for JDBC wiremock tests. Manages one WireMock subprocess per test class and exposes
+ * the JDBC URL that targets it.
+ *
+ * <p>Subclasses are skipped on Java 8 because the vendored WireMock 3.x JAR requires JRE 11+.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public abstract class BaseWiremockTest {
+
+  protected WiremockClient wiremock;
+
+  @BeforeAll
+  protected void startWiremock() {
+    Assumptions.assumeTrue(
+        WiremockClient.requiresJava11OrHigher(),
+        "WireMock 3.x requires JRE 11+ to launch; skipping wiremock tests on Java 8");
+    wiremock = new WiremockClient();
+    wiremock.start();
+  }
+
+  @AfterAll
+  protected void stopWiremock() {
+    if (wiremock != null) {
+      wiremock.stop();
+      wiremock = null;
+    }
+  }
+
+  @AfterEach
+  protected void resetWiremock() {
+    if (wiremock != null) {
+      wiremock.reset();
+    }
+  }
+
+  protected String wiremockJdbcUrl() {
+    URI uri = URI.create(wiremock.httpUrl());
+    return "jdbc:snowflake://" + uri.getHost() + ":" + uri.getPort() + "/";
+  }
+}

--- a/jdbc/src/test/java/net/snowflake/jdbc/wiremock/WiremockSanityTest.java
+++ b/jdbc/src/test/java/net/snowflake/jdbc/wiremock/WiremockSanityTest.java
@@ -1,0 +1,38 @@
+package net.snowflake.jdbc.wiremock;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.util.Properties;
+import net.snowflake.client.api.driver.SnowflakeDriver;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end sanity test: proves that a JDBC connection routed at a wiremock-backed URL reaches
+ * sf_core, which then issues the expected {@code /session/v1/login-request} HTTP call. Intended as
+ * a baseline for more elaborate wiremock-driven JDBC tests (session renewal, telemetry, etc.).
+ */
+public class WiremockSanityTest extends BaseWiremockTest {
+
+  @Test
+  public void opensConnectionAndSendsLoginRequest() throws Exception {
+    wiremock.addMapping("auth/login_success_any.json");
+
+    // ConnectionOptionsResolver always derives "protocol" from the JDBC URL scheme. sf_core
+    // rejects setting both "ssl" and "protocol" as conflicting, so we set protocol=http here
+    // and avoid also passing ssl=off.
+    Properties props = new Properties();
+    props.setProperty("account", "test_account");
+    props.setProperty("user", "test_user");
+    props.setProperty("password", "test_password");
+    props.setProperty("protocol", "http");
+
+    Class.forName(SnowflakeDriver.class.getName());
+    try (Connection conn = DriverManager.getConnection(wiremockJdbcUrl(), props)) {
+      assertFalse(conn.isClosed());
+    }
+
+    wiremock.verifyRequestCount(1, "/session/v1/login-request");
+  }
+}


### PR DESCRIPTION
Introduces the JUnit 5 base class for JDBC wiremock tests and a minimal
sanity test that drives a real JDBC connection through the FFI into sf_core
and out to a wiremock-backed login endpoint.

- BaseWiremockTest: PER_CLASS lifecycle, @BeforeAll/@AfterAll lifecycle for
  a per-class WireMock subprocess, @AfterEach reset, Java 8 skip guard.
  Helpers wiremockConnectionProperties() (ssl=off, fake account/user) and
  wiremockJdbcUrl() (jdbc:snowflake://localhost:<port>/).
- WiremockSanityTest extends BaseWiremockTest. Loads auth/login_success_any
  mapping (no body matcher, simpler than the JWT variant Python uses),
  opens a connection via DriverManager, asserts conn.isClosed() == false,
  then verifies wiremock recorded exactly one POST to
  /session/v1/login-request.

Confirms PR1 + PR2 + this stack actually plumb together end-to-end: JDBC
DriverManager.getConnection -> SnowflakeConnectionImpl -> FFI ->
sf_core::connection_init -> HTTP POST to the wiremock instance.

Verified locally on Java 11 (passes, 3.1s) and Java 8 (cleanly skipped).