### PR TITLE
NO-SNOW: Run JDBC wiremock tests on Java 21 in CI

### DIFF
--- a/.github/workflows/test-jdbc.yml
+++ b/.github/workflows/test-jdbc.yml
@@ -31,8 +31,14 @@ jobs:
           - os: ubuntu-latest
             java-version: '8'
             result_format: json
+          # Java 21 row exercises wiremock-based tests in net.snowflake.jdbc.wiremock.*
+          # (the vendored WireMock 3.x JAR requires JRE 11+ to launch). Java 8 rows skip
+          # those tests cleanly via assumeTrue(WiremockClient.requiresJava11OrHigher()).
+          - os: ubuntu-latest
+            java-version: '21'
+            result_format: default
     runs-on: ${{ matrix.os }}
-    name: JDBC Tests (${{ matrix.result_format }} format)
+    name: JDBC Tests (Java ${{ matrix.java-version }}, ${{ matrix.result_format }} format)
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -97,7 +103,9 @@ jobs:
         if: always() && matrix.result_format == 'default'
         uses: actions/upload-artifact@v4
         with:
-          name: jdbc-tests-artifacts
+          # Disambiguate per Java version — actions/upload-artifact@v4 requires unique names
+          # within a single workflow run.
+          name: jdbc-tests-artifacts-java${{ matrix.java-version }}
           path: |
             jdbc/build/test-results/test/**/*.xml
             jdbc/build/jacoco/test.exec
@@ -109,7 +117,7 @@ jobs:
         run: |
           python3 jdbc/ci/reference_tests/extract_coverage.py \
             --report jdbc/build/reports/jacoco/test/jacocoTestReport.xml \
-            --label "NEW JDBC" \
+            --label "NEW JDBC (Java ${{ matrix.java-version }})" \
             --summary "$GITHUB_STEP_SUMMARY" \
             --allow-missing
 

--- a/jdbc/src/test/java/net/snowflake/jdbc/wiremock/WiremockClient.java
+++ b/jdbc/src/test/java/net/snowflake/jdbc/wiremock/WiremockClient.java
@@ -1,0 +1,350 @@
+package net.snowflake.jdbc.wiremock;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.ServerSocket;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import net.snowflake.jdbc.testutil.HttpTestClient;
+import net.snowflake.jdbc.testutil.HttpTestClient.Response;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.json.JSONTokener;
+
+/**
+ * Spawns the WireMock standalone JAR vendored at {@code
+ * tests/wiremock/wiremock_standalone/wiremock-standalone-3.13.2.jar} as a subprocess and drives it
+ * through its admin REST API. Counterpart of Python's {@code python/tests/wiremock_client.py};
+ * mapping files at {@code tests/wiremock/mappings/} are shared across language wrappers.
+ *
+ * <p>The class is Java 8 source compatible and deliberately avoids importing {@code
+ * com.github.tomakehurst.wiremock.*}. The WireMock 3.x JAR itself requires JRE 11+ to launch — test
+ * classes must gate themselves with {@link #requiresJava11OrHigher()}.
+ */
+public final class WiremockClient implements AutoCloseable {
+
+  private static final String WIREMOCK_JAR_RELATIVE =
+      "tests/wiremock/wiremock_standalone/wiremock-standalone-3.13.2.jar";
+  private static final Duration DEFAULT_HEALTH_TIMEOUT = Duration.ofSeconds(30);
+  private static final Duration DEFAULT_HEALTH_POLL_INTERVAL = Duration.ofMillis(250);
+
+  private final Path workspaceRoot;
+  private final Path wiremockDir;
+  private final Path wiremockJar;
+  private Process process;
+  private int httpPort = -1;
+  private Thread stdoutDrain;
+  private Thread stderrDrain;
+  private HttpTestClient httpClient;
+
+  public WiremockClient() {
+    this.workspaceRoot = findWorkspaceRoot();
+    this.wiremockDir = workspaceRoot.resolve("tests/wiremock");
+    this.wiremockJar = workspaceRoot.resolve(WIREMOCK_JAR_RELATIVE);
+    if (!Files.isRegularFile(wiremockJar)) {
+      throw new IllegalStateException(
+          "WireMock standalone JAR not found at "
+              + wiremockJar
+              + " (workspace="
+              + workspaceRoot
+              + ")");
+    }
+    if (!Files.isDirectory(wiremockDir.resolve("mappings"))) {
+      throw new IllegalStateException(
+          "WireMock mappings directory not found at " + wiremockDir.resolve("mappings"));
+    }
+  }
+
+  /** {@code true} on JVMs new enough to launch WireMock 3.x (JRE 11+). */
+  public static boolean requiresJava11OrHigher() {
+    String spec = System.getProperty("java.specification.version", "");
+    return !spec.startsWith("1."); // "1.8" → false, "11"/"17"/"21" → true
+  }
+
+  public WiremockClient start() {
+    if (process != null) {
+      return this;
+    }
+    httpPort = findFreePort();
+    List<String> command = new ArrayList<>();
+    command.add(System.getProperty("java.home") + File.separator + "bin" + File.separator + "java");
+    command.add("-jar");
+    command.add(wiremockJar.toString());
+    command.add("--root-dir");
+    command.add(wiremockDir.toString());
+    command.add("--enable-browser-proxying");
+    command.add("--proxy-pass-through");
+    command.add("false");
+    command.add("--port");
+    command.add(Integer.toString(httpPort));
+    command.add("--disable-banner");
+
+    ProcessBuilder pb = new ProcessBuilder(command);
+    pb.redirectErrorStream(false);
+    try {
+      process = pb.start();
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to start WireMock process", e);
+    }
+    // Anything after a successful pb.start() must be guarded so a failure still reaps the child.
+    try {
+      stdoutDrain = drainAsync(process.getInputStream(), "wiremock-stdout");
+      stderrDrain = drainAsync(process.getErrorStream(), "wiremock-stderr");
+      httpClient = new HttpTestClient();
+      waitForHealth(DEFAULT_HEALTH_TIMEOUT, DEFAULT_HEALTH_POLL_INTERVAL);
+    } catch (RuntimeException | Error e) {
+      stop();
+      throw e;
+    }
+    return this;
+  }
+
+  public String httpUrl() {
+    ensureStarted();
+    return "http://localhost:" + httpPort;
+  }
+
+  public void stop() {
+    if (process == null) {
+      return;
+    }
+    process.destroy();
+    try {
+      if (!process.waitFor(5, TimeUnit.SECONDS)) {
+        process.destroyForcibly();
+        process.waitFor(2, TimeUnit.SECONDS);
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      process.destroyForcibly();
+    } finally {
+      process = null;
+      httpPort = -1;
+      if (stdoutDrain != null) {
+        stdoutDrain.interrupt();
+        stdoutDrain = null;
+      }
+      if (stderrDrain != null) {
+        stderrDrain.interrupt();
+        stderrDrain = null;
+      }
+      if (httpClient != null) {
+        try {
+          httpClient.close();
+        } catch (RuntimeException ignored) {
+          // Best-effort cleanup; nothing actionable.
+        }
+        httpClient = null;
+      }
+    }
+  }
+
+  @Override
+  public void close() {
+    stop();
+  }
+
+  public void reset() {
+    Response resp = httpClient().post(adminUrl("/__admin/reset"), null);
+    if (!resp.ok()) {
+      throw new RuntimeException("Failed to reset WireMock: " + resp.status() + " " + resp.body());
+    }
+  }
+
+  /**
+   * Register a mapping file from {@code tests/wiremock/mappings/<relativePath>}. {@code
+   * {{REPO_ROOT}}} is always available as a placeholder; additional placeholders may be supplied.
+   * Files containing a top-level {@code "mappings": [...]} array are registered one element at a
+   * time (matches Python's behaviour).
+   */
+  public void addMapping(String relativePath, Map<String, String> placeholders) {
+    Path mappingFile = wiremockDir.resolve("mappings").resolve(relativePath);
+    if (!Files.isRegularFile(mappingFile)) {
+      throw new IllegalArgumentException("Mapping file not found: " + mappingFile);
+    }
+    String content;
+    try {
+      content = new String(Files.readAllBytes(mappingFile), StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to read mapping " + mappingFile, e);
+    }
+
+    Map<String, String> all = new HashMap<>();
+    // POSIX separators so the substituted path is valid JSON on Windows too.
+    all.put("{{REPO_ROOT}}", workspaceRoot.toString().replace(File.separatorChar, '/'));
+    if (placeholders != null) {
+      all.putAll(placeholders);
+    }
+    for (Map.Entry<String, String> entry : all.entrySet()) {
+      content = content.replace(entry.getKey(), entry.getValue());
+    }
+
+    JSONObject parsed = new JSONObject(new JSONTokener(content));
+    if (parsed.has("mappings") && parsed.get("mappings") instanceof JSONArray) {
+      JSONArray array = parsed.getJSONArray("mappings");
+      for (int i = 0; i < array.length(); i++) {
+        registerSingleMapping(array.getJSONObject(i).toString());
+      }
+    } else {
+      registerSingleMapping(content);
+    }
+  }
+
+  public void addMapping(String relativePath) {
+    addMapping(relativePath, Collections.emptyMap());
+  }
+
+  public void addMappingJson(String mappingJson) {
+    registerSingleMapping(mappingJson);
+  }
+
+  public List<JSONObject> getRequests(String urlPathPattern) {
+    JSONObject body = new JSONObject().put("urlPathPattern", urlPathPattern);
+    Response resp = httpClient().post(adminUrl("/__admin/requests/find"), body.toString());
+    if (!resp.ok()) {
+      throw new RuntimeException("Failed to query requests: " + resp.status() + " " + resp.body());
+    }
+    JSONObject parsed = resp.json();
+    JSONArray requests = parsed.has("requests") ? parsed.getJSONArray("requests") : new JSONArray();
+    List<JSONObject> out = new ArrayList<>(requests.length());
+    for (int i = 0; i < requests.length(); i++) {
+      out.add(requests.getJSONObject(i));
+    }
+    return out;
+  }
+
+  public void verifyRequestCount(int expectedCount, String urlPathPattern) {
+    JSONObject body = new JSONObject().put("method", "ANY").put("urlPathPattern", urlPathPattern);
+    Response resp = httpClient().post(adminUrl("/__admin/requests/count"), body.toString());
+    if (!resp.ok()) {
+      throw new RuntimeException(
+          "Failed to query request count: " + resp.status() + " " + resp.body());
+    }
+    int actual = resp.json().getInt("count");
+    if (actual != expectedCount) {
+      throw new AssertionError(
+          "Expected "
+              + expectedCount
+              + " requests matching '"
+              + urlPathPattern
+              + "', but found "
+              + actual);
+    }
+  }
+
+  private void ensureStarted() {
+    if (process == null || httpPort < 0) {
+      throw new IllegalStateException("WiremockClient is not started");
+    }
+  }
+
+  private HttpTestClient httpClient() {
+    ensureStarted();
+    return httpClient;
+  }
+
+  private String adminUrl(String path) {
+    return "http://localhost:" + httpPort + path;
+  }
+
+  private void registerSingleMapping(String mappingJson) {
+    Response resp = httpClient().post(adminUrl("/__admin/mappings"), mappingJson);
+    if (resp.status() != 200 && resp.status() != 201) {
+      throw new RuntimeException(
+          "Failed to register mapping: "
+              + resp.status()
+              + " "
+              + resp.body()
+              + " (payload="
+              + mappingJson
+              + ")");
+    }
+  }
+
+  private void waitForHealth(Duration timeout, Duration pollInterval) {
+    long deadlineNanos = System.nanoTime() + timeout.toNanos();
+    long sleepMillis = Math.max(1L, pollInterval.toMillis());
+    Exception lastError = null;
+    while (System.nanoTime() < deadlineNanos) {
+      if (!process.isAlive()) {
+        throw new RuntimeException(
+            "WireMock process exited prematurely with code " + process.exitValue());
+      }
+      try {
+        Response resp = httpClient().get(adminUrl("/__admin/health"));
+        if (resp.status() == 200 && resp.body().contains("\"healthy\"")) {
+          return;
+        }
+      } catch (RuntimeException e) {
+        lastError = e;
+      }
+      try {
+        Thread.sleep(sleepMillis);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new RuntimeException("Interrupted while waiting for WireMock health", e);
+      }
+    }
+    throw new RuntimeException(
+        "WireMock did not become healthy within "
+            + timeout
+            + (lastError != null ? " (last error: " + lastError + ")" : ""));
+  }
+
+  private static int findFreePort() {
+    try (ServerSocket socket = new ServerSocket(0)) {
+      return socket.getLocalPort();
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to allocate a free port", e);
+    }
+  }
+
+  private static Path findWorkspaceRoot() {
+    Path candidate = Paths.get(System.getProperty("user.dir")).toAbsolutePath();
+    for (int i = 0; i < 6; i++) {
+      if (Files.isDirectory(candidate.resolve("tests/wiremock/wiremock_standalone"))
+          && Files.isDirectory(candidate.resolve("tests/wiremock/mappings"))) {
+        return candidate;
+      }
+      Path parent = candidate.getParent();
+      if (parent == null) {
+        break;
+      }
+      candidate = parent;
+    }
+    throw new IllegalStateException(
+        "Could not locate workspace root (expected to find tests/wiremock/wiremock_standalone/ "
+            + "ascending from "
+            + System.getProperty("user.dir")
+            + ")");
+  }
+
+  private static Thread drainAsync(InputStream stream, String name) {
+    Thread t =
+        new Thread(
+            () -> {
+              byte[] buf = new byte[4096];
+              try {
+                while (stream.read(buf) != -1) {
+                  // Discard — keep the pipe drained so the child doesn't block on stdout/stderr.
+                }
+              } catch (IOException ignored) {
+                // Process exit closes the stream; nothing to do.
+              }
+            },
+            name);
+    t.setDaemon(true);
+    t.start();
+    return t;
+  }
+}

--- a/jdbc/src/test/java/net/snowflake/jdbc/wiremock/WiremockClientTest.java
+++ b/jdbc/src/test/java/net/snowflake/jdbc/wiremock/WiremockClientTest.java
@@ -1,0 +1,77 @@
+package net.snowflake.jdbc.wiremock;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import net.snowflake.jdbc.testutil.HttpTestClient;
+import net.snowflake.jdbc.testutil.HttpTestClient.Response;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/** Self-tests for {@link WiremockClient}. Skipped on Java 8 (WireMock 3.x requires JRE 11+). */
+public class WiremockClientTest {
+
+  @BeforeAll
+  public static void skipOnJava8() {
+    Assumptions.assumeTrue(
+        WiremockClient.requiresJava11OrHigher(),
+        "WireMock 3.x requires JRE 11+ to launch; skipping wiremock tests on Java 8");
+  }
+
+  @Test
+  public void inlineMappingIsServedAndRecorded() {
+    try (WiremockClient client = new WiremockClient();
+        HttpTestClient http = new HttpTestClient()) {
+      client.start();
+      client.addMappingJson(
+          new JSONObject()
+              .put("request", new JSONObject().put("method", "GET").put("urlPath", "/ping"))
+              .put(
+                  "response",
+                  new JSONObject()
+                      .put("status", 200)
+                      .put("body", "pong")
+                      .put("headers", new JSONObject().put("Content-Type", "text/plain")))
+              .toString());
+
+      Response resp = http.get(client.httpUrl() + "/ping");
+      assertEquals(200, resp.status());
+      assertEquals("pong", resp.body());
+
+      client.verifyRequestCount(1, "/ping");
+      List<JSONObject> recorded = client.getRequests("/ping");
+      assertEquals(1, recorded.size());
+
+      client.reset();
+      assertEquals(0, client.getRequests("/ping").size());
+    }
+  }
+
+  @Test
+  public void fileBackedMappingIsResolvedFromMappingsDir() {
+    // tests/wiremock/mappings/session/logout_success.json stubs POST /session?delete=true → 200.
+    try (WiremockClient client = new WiremockClient();
+        HttpTestClient http = new HttpTestClient()) {
+      client.start();
+      client.addMapping("session/logout_success.json");
+
+      Response resp = http.post(client.httpUrl() + "/session?delete=true", "{}");
+      assertEquals(200, resp.status());
+      assertTrue(resp.body().contains("\"success\""), "Expected JSON body, got: " + resp.body());
+
+      client.verifyRequestCount(1, "/session");
+    }
+  }
+
+  @Test
+  public void verifyRequestCountThrowsAssertionErrorOnMismatch() {
+    try (WiremockClient client = new WiremockClient()) {
+      client.start();
+      assertThrows(AssertionError.class, () -> client.verifyRequestCount(1, "/never-called"));
+    }
+  }
+}


### PR DESCRIPTION
Adds a Java 21 row to the jdbc_tests matrix so the
net.snowflake.jdbc.wiremock.* tests actually execute in CI. The vendored
WireMock 3.x standalone JAR requires JRE 11+ to launch, so on the
existing Java 8 matrix rows the wiremock tests skip cleanly via
assumeTrue(WiremockClient.requiresJava11OrHigher()) — meaning they
provide zero signal in CI today.

As a side benefit the new row also exercises the JDBC driver itself on
modern Java, catching potential forward-compat issues with Arrow 17,
the FFI bridge, and JVM-version-specific behaviour.

- Adds matrix row: java-version=21, result_format=default
- Disambiguates the upload-artifact name per Java version
  (actions/upload-artifact@v4 requires unique names per workflow run)
- Includes the Java version in the per-row coverage label and job
  display name