### PR TITLE
SNOW-3520403: config: extract `SfOdbcIni` loader and refactor logging config wiring

### DIFF
--- a/odbc/README.md
+++ b/odbc/README.md
@@ -1,5 +1,38 @@
 # ODBC Driver
 
+## Configuration via `sf.odbc.ini`
+
+On startup the driver reads a single `sf.odbc.ini` file. The first existing
+location wins:
+
+1. `$SF_ODBC_INI` (explicit override; useful in tests and CI),
+2. `<config_dir>/snowflake/sf.odbc.ini` (e.g. `~/Library/Application Support/snowflake/sf.odbc.ini` on macOS, `~/.config/snowflake/sf.odbc.ini` on Linux),
+3. `~/.snowflake/sf.odbc.ini`.
+
+On Unix the file must be `chmod 600` (owner read/write only); otherwise the
+driver logs a warning and falls back to defaults. The file is read once,
+during environment allocation, and the snapshot is shared across all
+subsystems.
+
+All keys live in the unnamed top-level section and are matched
+case-insensitively. The logging subsystem recognises:
+
+| Key                  | Type    | Description                                                  |
+|----------------------|---------|--------------------------------------------------------------|
+| `LogLevel`           | enum    | `OFF`, `ERROR`, `WARN`, `INFO` (default), `DEBUG`, `TRACE`.  |
+| `LogPath`            | path    | Directory for the rolling log file.                          |
+| `LogFile`            | string  | Log file name (default `snowflake_odbc.log`).                |
+| `LogMaxSize`         | bytes   | Per-file size cap before rotation.                           |
+| `LogMaxCount`        | integer | Number of rotated files to retain.                           |
+| `LogRotation`        | enum    | `none`, `hourly`, `daily`.                                   |
+| `LogEnabled`         | bool    | Master switch; defaults to `true`.                           |
+| `LogQueryText`       | bool    | Log the SQL text of executed statements.                     |
+| `LogQueryParameters` | bool    | Log bound parameter values.                                  |
+| `ErrorTraceEnabled`  | bool    | Capture error traces alongside the diagnostic record.        |
+
+Unknown keys are silently ignored by the logging subsystem and made
+available to other subsystems through the shared INI snapshot.
+
 ## Testing
 
 ODBC tests are written in C++ using CMake and Catch2 framework.

--- a/sf_core/src/config/mod.rs
+++ b/sf_core/src/config/mod.rs
@@ -12,6 +12,7 @@ pub mod resolver;
 pub mod rest_parameters;
 pub mod retry;
 pub mod settings;
+pub mod sf_odbc_ini;
 pub mod toml_loader;
 
 use error_trace::ErrorTrace;

--- a/sf_core/src/config/sf_odbc_ini.rs
+++ b/sf_core/src/config/sf_odbc_ini.rs
@@ -1,0 +1,278 @@
+//! One-shot reader for `sf.odbc.ini`.
+//!
+//! The instance is created lazily by [`SfOdbcIni::global`] on first
+//! access. The driver's bootstrap calls it during environment allocation
+//! to seed the [`LogManager`]; the ODBC wrappers call it on the first
+//! wide-string operation. Both observers see the same snapshot.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+use crate::logging::LoggingConfig;
+use crate::logging::ini_config;
+
+/// Process-wide snapshot of `sf.odbc.ini`.
+///
+/// Construction is fallible-by-default: any I/O or parse error in the load
+/// path is surfaced via `eprintln!` (the [`LogManager`] is not yet wired up
+/// when the snapshot is first built) and the field defaults are used so
+/// the driver continues to function. The `path` field records which file,
+/// if any, was actually read so diagnostics elsewhere can reference it.
+///
+/// [`LogManager`]: crate::logging::LogManager
+pub struct SfOdbcIni {
+    /// Path that was actually read, if any. Kept so future diagnostics can
+    /// answer "where did this config come from?"; currently surfaced only
+    /// to tests via [`SfOdbcIni::path`].
+    #[allow(dead_code)]
+    path: Option<PathBuf>,
+    logging: LoggingConfig,
+    /// Lowercased keys that are not part of the logging namespace. Other
+    /// subsystems look these up via [`SfOdbcIni::raw_value`].
+    /// Keeping the values untyped lets `sf_core` host the singleton
+    /// without taking a dependency on every consumer's types.
+    raw_values: HashMap<String, String>,
+}
+
+impl SfOdbcIni {
+    /// Returns the process-global snapshot, loading and caching it on
+    /// first access. Subsequent calls return the same instance.
+    pub fn global() -> &'static SfOdbcIni {
+        static INSTANCE: OnceLock<SfOdbcIni> = OnceLock::new();
+        INSTANCE.get_or_init(Self::load)
+    }
+
+    /// Locate, permission-check, and parse `sf.odbc.ini`. Any failure
+    /// falls back to defaults and is reported on `stderr` (we run before
+    /// `LogManager::init`, so the `tracing` subscriber is not yet
+    /// installed).
+    fn load() -> Self {
+        let Some(path) = ini_config::find_odbc_ini() else {
+            return Self::defaults(None);
+        };
+
+        if let Err(e) = crate::config::toml_loader::check_file_permissions(&path) {
+            eprintln!(
+                "sf.odbc.ini at {} has insecure permissions ({e}); using defaults",
+                path.display()
+            );
+            return Self::defaults(Some(path));
+        }
+
+        let ini = match ini::Ini::load_from_file_noescape(&path) {
+            Ok(ini) => ini,
+            Err(e) => {
+                eprintln!(
+                    "Failed to parse sf.odbc.ini at {}: {e}; using defaults",
+                    path.display()
+                );
+                return Self::defaults(Some(path));
+            }
+        };
+
+        let (logging, raw_values) = parse_section(ini.general_section(), Some(&path));
+        Self {
+            path: Some(path),
+            logging,
+            raw_values,
+        }
+    }
+
+    fn defaults(path: Option<PathBuf>) -> Self {
+        Self {
+            path,
+            logging: LoggingConfig::default(),
+            raw_values: HashMap::new(),
+        }
+    }
+
+    /// Path to the INI file that was actually read, if any. Currently
+    /// surfaced only to tests; kept for future diagnostics.
+    #[allow(dead_code)]
+    pub fn path(&self) -> Option<&Path> {
+        self.path.as_deref()
+    }
+
+    /// Logging configuration parsed from the INI. Defaults when the file
+    /// was not found, was unreadable, or contained no logging keys. Used
+    /// by the ODBC bootstrap to seed [`crate::logging::LogManager::init`].
+    pub fn logging(&self) -> &LoggingConfig {
+        &self.logging
+    }
+
+    /// Untyped value for a key outside the logging namespace.
+    /// Returns `None` when the key was absent.
+    /// Lookup is case-insensitive.
+    pub fn raw_value(&self, key: &str) -> Option<&str> {
+        self.raw_values
+            .get(&key.to_ascii_lowercase())
+            .map(String::as_str)
+    }
+}
+
+/// Apply the section's keys to a fresh [`LoggingConfig`], collecting
+/// everything not owned by logging into a `raw_values` map. Used by
+/// [`SfOdbcIni::load`] (where `source` is the on-disk path for diagnostic
+/// messages) and by tests (where `source` is `None`).
+fn parse_section(
+    props: &ini::Properties,
+    source: Option<&Path>,
+) -> (LoggingConfig, HashMap<String, String>) {
+    let mut logging = LoggingConfig::default();
+    let mut raw_values = HashMap::new();
+    for (key, value) in props.iter() {
+        match ini_config::apply_logging_key(key, value, &mut logging) {
+            Ok(true) => {}
+            Ok(false) => {
+                raw_values.insert(key.to_ascii_lowercase(), value.to_string());
+            }
+            Err(e) => match source {
+                Some(path) => eprintln!(
+                    "Invalid value for `{key}` in sf.odbc.ini at {}: {e}; skipping key",
+                    path.display()
+                ),
+                None => eprintln!("Invalid value for `{key}` in sf.odbc.ini: {e}; skipping key"),
+            },
+        }
+    }
+    (logging, raw_values)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build an `SfOdbcIni` directly from in-memory INI content, bypassing
+    /// the global singleton. Mirrors the dispatching logic in [`load`] so
+    /// the per-key behavior can be unit-tested without touching the
+    /// process-global `OnceLock`.
+    fn load_from_content(content: &str) -> SfOdbcIni {
+        let ini = ini::Ini::load_from_str_noescape(content).expect("valid INI");
+        let (logging, raw_values) = parse_section(ini.general_section(), None);
+        SfOdbcIni {
+            path: None,
+            logging,
+            raw_values,
+        }
+    }
+
+    #[test]
+    fn empty_ini_returns_defaults() {
+        let ini = load_from_content("");
+        assert!(ini.raw_value("DriverManagerEncoding").is_none());
+        assert!(ini.logging().enabled);
+        assert!(ini.logging().log_path.is_none());
+    }
+
+    #[test]
+    fn dispatches_logging_keys_to_logging_config() {
+        let ini = load_from_content("LogLevel=DEBUG\nLogFile=driver.log\n");
+        assert_eq!(
+            ini.logging().level,
+            tracing::level_filters::LevelFilter::DEBUG
+        );
+        assert_eq!(ini.logging().log_file_name.as_deref(), Some("driver.log"));
+        assert!(ini.raw_value("DriverManagerEncoding").is_none());
+    }
+
+    #[test]
+    fn non_logging_keys_land_in_raw_values() {
+        let ini = load_from_content("DriverManagerEncoding=UTF-32\n");
+        assert_eq!(ini.raw_value("DriverManagerEncoding"), Some("UTF-32"));
+        // Logging defaults are untouched.
+        assert!(ini.logging().enabled);
+    }
+
+    #[test]
+    fn combined_keys_route_to_their_subsystems() {
+        let ini =
+            load_from_content("LogLevel=WARN\nDriverManagerEncoding=UTF-16\nLogEnabled=false\n");
+        assert_eq!(
+            ini.logging().level,
+            tracing::level_filters::LevelFilter::WARN
+        );
+        assert!(!ini.logging().enabled);
+        assert_eq!(ini.raw_value("DriverManagerEncoding"), Some("UTF-16"));
+    }
+
+    #[test]
+    fn raw_value_lookup_is_case_insensitive() {
+        let ini = load_from_content("DriverManagerEncoding=UTF-32\n");
+        for spelling in [
+            "drivermanagerencoding",
+            "DRIVERMANAGERENCODING",
+            "DriverManagerEncoding",
+            "driverManagerEncoding",
+        ] {
+            assert_eq!(
+                ini.raw_value(spelling),
+                Some("UTF-32"),
+                "spelling `{spelling}` should be recognised"
+            );
+        }
+    }
+
+    #[test]
+    fn raw_value_preserves_original_case_insensitive_storage() {
+        // Keys are stored lowercased so foreign-subsystem lookups don't
+        // depend on the INI author's capitalisation choices.
+        let ini = load_from_content("DRIVERMANAGERENCODING=UTF-16\n");
+        assert_eq!(ini.raw_value("DriverManagerEncoding"), Some("UTF-16"));
+    }
+
+    #[test]
+    fn unknown_logging_value_is_dropped() {
+        // The logging parser rejects the value, so the key is neither
+        // applied to LoggingConfig nor stashed in raw_values.
+        let ini = load_from_content("LogLevel=NOISY\n");
+        assert_eq!(
+            ini.logging().level,
+            tracing::level_filters::LevelFilter::INFO
+        );
+        assert!(ini.raw_value("LogLevel").is_none());
+    }
+
+    #[test]
+    fn load_from_missing_file_returns_defaults() {
+        // Point SF_ODBC_INI at a non-existent file. Use the constructor
+        // directly so we don't race with `global()`'s OnceLock.
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("nope.ini");
+        temp_env::with_var("SF_ODBC_INI", Some(missing.to_str().unwrap()), || {
+            let ini = SfOdbcIni::load();
+            assert!(ini.path().is_none(), "find_odbc_ini should skip missing");
+            assert!(ini.raw_value("DriverManagerEncoding").is_none());
+            assert!(ini.logging().enabled);
+        });
+    }
+
+    #[test]
+    fn load_from_real_file_parses_both_subsystems() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("sf.odbc.ini");
+        std::fs::write(
+            &path,
+            "LogLevel=DEBUG\nLogPath=/var/log/sf\nDriverManagerEncoding=UTF-32\n",
+        )
+        .unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        }
+        temp_env::with_var("SF_ODBC_INI", Some(path.to_str().unwrap()), || {
+            let ini = SfOdbcIni::load();
+            assert_eq!(ini.path(), Some(path.as_path()));
+            assert_eq!(
+                ini.logging().level,
+                tracing::level_filters::LevelFilter::DEBUG
+            );
+            assert_eq!(
+                ini.logging().log_path.as_deref(),
+                Some(std::path::Path::new("/var/log/sf"))
+            );
+            assert_eq!(ini.raw_value("DriverManagerEncoding"), Some("UTF-32"));
+        });
+    }
+}

--- a/sf_core/src/logging/ini_config.rs
+++ b/sf_core/src/logging/ini_config.rs
@@ -47,23 +47,49 @@ pub fn parse_ini_content(content: &str) -> Result<LoggingConfig, LogError> {
     apply_ini_section(ini.general_section())
 }
 
-/// Map INI properties to a [`LoggingConfig`].
+/// Apply a single INI `key=value` pair to `config` if the key belongs to
+/// the logging subsystem.
+///
+/// Returns `Ok(true)` when the key was recognised and applied, `Ok(false)`
+/// when the key is owned by some other subsystem (the caller decides what
+/// to do — typically dispatch elsewhere or log a warning), and `Err` when
+/// the key was recognised but the value failed to parse.
+///
+/// Key matching is case-insensitive. This is the per-key primitive used by
+/// [`crate::config::sf_odbc_ini::SfOdbcIni`] to walk an INI section
+/// exactly once and dispatch each entry to the right subsystem, without
+/// splitting parsing rules across the logging code and the foreign-key
+/// lookup path.
+pub fn apply_logging_key(
+    key: &str,
+    value: &str,
+    config: &mut LoggingConfig,
+) -> Result<bool, LogError> {
+    match key.to_ascii_lowercase().as_str() {
+        "loglevel" => config.level = parse_level(value)?,
+        "logpath" => config.log_path = Some(PathBuf::from(value)),
+        "logfile" => config.log_file_name = Some(value.to_string()),
+        "logmaxsize" => config.max_file_size = Some(parse_u64(value)?),
+        "logmaxcount" => config.max_file_count = Some(parse_u32(value)?),
+        "logrotation" => config.rotation = parse_rotation(value)?,
+        "logenabled" => config.enabled = parse_bool(value)?,
+        "logquerytext" => config.log_query_text = Some(parse_bool(value)?),
+        "logqueryparameters" => config.log_query_parameters = Some(parse_bool(value)?),
+        "errortraceenabled" => config.error_trace_enabled = parse_bool(value)?,
+        _ => return Ok(false),
+    }
+    Ok(true)
+}
+
+/// Map INI properties to a [`LoggingConfig`], silently ignoring keys that
+/// belong to other subsystems. Used by tests and by [`parse_ini_file`] /
+/// [`parse_ini_content`]; production loading of `sf.odbc.ini` goes through
+/// [`crate::config::sf_odbc_ini::SfOdbcIni`], which routes non-logging
+/// keys into a per-section raw-value map for foreign-subsystem lookups.
 fn apply_ini_section(props: &ini::Properties) -> Result<LoggingConfig, LogError> {
     let mut config = LoggingConfig::default();
     for (key, value) in props.iter() {
-        match key.to_ascii_lowercase().as_str() {
-            "loglevel" => config.level = parse_level(value)?,
-            "logpath" => config.log_path = Some(PathBuf::from(value)),
-            "logfile" => config.log_file_name = Some(value.to_string()),
-            "logmaxsize" => config.max_file_size = Some(parse_u64(value)?),
-            "logmaxcount" => config.max_file_count = Some(parse_u32(value)?),
-            "logrotation" => config.rotation = parse_rotation(value)?,
-            "logenabled" => config.enabled = parse_bool(value)?,
-            "logquerytext" => config.log_query_text = Some(parse_bool(value)?),
-            "logqueryparameters" => config.log_query_parameters = Some(parse_bool(value)?),
-            "errortraceenabled" => config.error_trace_enabled = parse_bool(value)?,
-            other => eprintln!("ignoring unknown INI key: {other}"),
-        }
+        apply_logging_key(key, value, &mut config)?;
     }
     Ok(config)
 }

--- a/sf_core/src/logging/log_manager.rs
+++ b/sf_core/src/logging/log_manager.rs
@@ -164,18 +164,18 @@ impl LogManager {
         })
     }
 
-    /// Factory: find and parse `sf.odbc.ini`, falling back to defaults.
+    /// Factory: read `sf.odbc.ini` via [`crate::config::sf_odbc_ini::SfOdbcIni`]
+    /// and initialise logging with the resulting [`LoggingConfig`].
+    ///
+    /// The INI file is the shared source of truth for the ODBC driver: the
+    /// same snapshot also drives the wide-string ABI wrappers. Reading
+    /// goes through [`crate::config::sf_odbc_ini::SfOdbcIni::global`] so
+    /// both subsystems see identical values without opening the file
+    /// twice.
     pub fn for_odbc() -> Option<Self> {
-        let config = match super::ini_config::find_odbc_ini() {
-            Some(path) => super::ini_config::parse_ini_file(&path).unwrap_or_else(|e| {
-                eprintln!(
-                    "Failed to parse sf.odbc.ini at {}: {e:?}, using defaults",
-                    path.display()
-                );
-                LoggingConfig::default()
-            }),
-            None => LoggingConfig::default(),
-        };
+        let config = crate::config::sf_odbc_ini::SfOdbcIni::global()
+            .logging()
+            .clone();
         match Self::init(config) {
             Ok(lm) => Some(lm),
             Err(e) => {

--- a/sf_core/src/logging/mod.rs
+++ b/sf_core/src/logging/mod.rs
@@ -40,7 +40,7 @@ impl LogRotation {
 }
 
 /// Configuration for the logging subsystem.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct LoggingConfig {
     pub enabled: bool,
     pub level: LevelFilter,

--- a/sf_core/tests/integration/logging/for_odbc_factory.rs
+++ b/sf_core/tests/integration/logging/for_odbc_factory.rs
@@ -5,7 +5,9 @@ use sf_core::logging::LogManager;
 
 /// End-to-end: write a temp INI, point `SF_ODBC_INI` at it, call
 /// `LogManager::for_odbc()`, emit an event, and verify it lands in the log
-/// file.
+/// file. `LogManager::for_odbc` reads the INI via the shared
+/// `sf_core::config::sf_odbc_ini::SfOdbcIni` snapshot, so this also
+/// exercises the singleton's load path under a real file.
 #[test]
 fn for_odbc_factory_end_to_end() {
     let dir = tempfile::tempdir().unwrap();
@@ -21,6 +23,11 @@ fn for_odbc_factory_end_to_end() {
         ),
     )
     .unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&ini_path, std::fs::Permissions::from_mode(0o600)).unwrap();
+    }
 
     temp_env::with_var("SF_ODBC_INI", Some(ini_path.to_str().unwrap()), || {
         LogManager::for_odbc();


### PR DESCRIPTION
### TL;DR

Centralise `sf.odbc.ini` parsing in a new `sf_core::config::sf_odbc_ini::SfOdbcIni` snapshot so the logging subsystem and the ODBC wide-string ABI read the file once, from one place, and see identical values. Document the file's location, security requirements, and the supported logging keys in the ODBC driver README.

This is the base of a 3-PR stack:
- **#1238 (this PR)**: config refactor — `SfOdbcIni` loader + README documentation.
- **#1239**: UTF-32 `SQLWCHAR` support consuming `SfOdbcIni::raw_value` for `DriverManagerEncoding`.
- **#1107**: iODBC driver-manager support — CI matrix cell, test infrastructure, `SKIP_IODBC` annotations.

### What changed?

**`sf_core::config::sf_odbc_ini::SfOdbcIni`** (new)
- Process-wide snapshot loaded lazily via `OnceLock` on first call to `SfOdbcIni::global()`.
- Locates the INI file in the documented order (`$SF_ODBC_INI` → `<config_dir>/snowflake/sf.odbc.ini` → `~/.snowflake/sf.odbc.ini`), enforces `chmod 600` on Unix, and falls back to defaults with an `eprintln!` warning on any I/O or parse failure (the `LogManager` is not yet wired up at this point).
- Routes logging keys to `LoggingConfig` and stores everything else in a case-insensitive `raw_values` map so foreign subsystems (e.g. the UTF-32 ABI follow-up) can look up keys without re-parsing the file.

**`sf_core::logging::ini_config`**
- Extract `apply_logging_key(key, value, &mut LoggingConfig) -> Result<bool, LogError>` as the canonical per-key primitive. Returns `Ok(true)` when the key is owned by logging, `Ok(false)` when it belongs to another subsystem.
- `apply_ini_section` (used by `parse_ini_*` helpers and tests) now delegates to `apply_logging_key`, eliminating the duplicate match between the standalone parser and the new snapshot.

**`sf_core::logging::log_manager`**
- `LogManager::for_odbc()` now reads its `LoggingConfig` from `SfOdbcIni::global().logging().clone()` instead of opening the INI file directly. This guarantees the logging subsystem and any future readers see the same snapshot.
- `LoggingConfig` derives `Clone` to support this.

**`odbc/README.md`**
- New `Configuration via sf.odbc.ini` section: file lookup order, Unix `chmod 600` requirement, and a table of the recognised logging keys (`LogLevel`, `LogPath`, `LogFile`, `LogMaxSize`, `LogMaxCount`, `LogRotation`, `LogEnabled`, `LogQueryText`, `LogQueryParameters`, `ErrorTraceEnabled`).
- The next PR in the stack appends a `DriverManagerEncoding` subsection.

### How to test?

- `cargo test -p sf_core --lib config::sf_odbc_ini::` — 9 unit tests covering the dispatch (logging vs. raw), case-insensitive lookups, missing-file/missing-perms fallback, and a real on-disk round-trip with `chmod 600`.
- `cargo test -p sf_core --lib logging::` — existing 50-test suite passes unchanged (the refactor is behaviour-preserving).
- `cargo test -p sf_core --test logging_for_odbc_tests` — end-to-end test that writes a temp INI, sets `$SF_ODBC_INI`, calls `LogManager::for_odbc()`, and verifies an event lands in the log file. Now also exercises the `SfOdbcIni` singleton's load path.

### Why make this change?

The ODBC driver needs `sf.odbc.ini` for two independent subsystems: logging (which has always read it) and the upcoming UTF-32 `SQLWCHAR` ABI (which needs `DriverManagerEncoding`). Reading the file in two places would either drift out of sync or require both subsystems to know about each other's keys. Funnelling everything through a single `SfOdbcIni` snapshot keeps the two consumers loosely coupled while ensuring they observe identical configuration.

The README change makes the file's location, security requirements, and supported keys discoverable without having to read the Rust source.