### PR TITLE
NO-SNOW: Add Rust flaky test tagging infrastructure

### DIFF
--- a/.github/workflows/test-rust-core.yml
+++ b/.github/workflows/test-rust-core.yml
@@ -280,6 +280,13 @@ jobs:
           export PARAMETER_PATH=$(pwd)/parameters.json
           cargo llvm-cov --no-report --no-fail-fast --package sf_core ${{ matrix.cargo_flags }}
 
+      - name: Run flaky tests (non-blocking)
+        continue-on-error: true
+        run: |
+          export PARAMETER_PATH=$(pwd)/parameters.json
+          cargo llvm-cov --no-report --no-fail-fast --package sf_core ${{ matrix.cargo_flags }} \
+            -- --ignored flaky_
+
       # Report step is best-effort and gated on actually having coverage data. If the
       # build/run step failed at compilation (before any test ran), target/llvm-cov-target/
       # contains no *.profraw files; running `cargo llvm-cov report` then fails with
@@ -445,6 +452,13 @@ jobs:
         run: |
           set PARAMETER_PATH=${{ github.workspace }}\parameters.json
           cargo nextest run --package sf_core --target aarch64-pc-windows-msvc --no-fail-fast
+
+      - name: Run flaky tests (non-blocking)
+        continue-on-error: true
+        shell: cmd
+        run: |
+          set PARAMETER_PATH=${{ github.workspace }}\parameters.json
+          cargo nextest run --package sf_core --target aarch64-pc-windows-msvc --run-ignored ignored-only -E "test(/^flaky_/)"
 
       # Post-mortem diagnostics for Windows ARM64 failures: ARM64-specific build issues
       # (wrong architecture DLLs, missing OpenSSL, MSVC env not targeting ARM64) are
@@ -639,6 +653,13 @@ jobs:
         run: |
           set PARAMETER_PATH=${{ github.workspace }}\parameters.json
           cargo nextest run --package sf_core --no-default-features --features protobuf --target i686-pc-windows-msvc --no-fail-fast
+
+      - name: Run flaky tests (non-blocking)
+        continue-on-error: true
+        shell: cmd
+        run: |
+          set PARAMETER_PATH=${{ github.workspace }}\parameters.json
+          cargo nextest run --package sf_core --no-default-features --features protobuf --target i686-pc-windows-msvc --run-ignored ignored-only -E "test(/^flaky_/)"
 
       - name: Save Rust cache
         if: always()

--- a/sf_core/README.md
+++ b/sf_core/README.md
@@ -46,6 +46,34 @@ cargo test -- --include-ignored
 
 **Note:** VPN tests are skipped in GitHub Actions CI (no VPN access). Run them on Jenkins or locally with VPN.
 
+### Flaky Tests
+
+Tests that fail intermittently (e.g., due to CI runner timing, server-side propagation delays, or OS credential manager races) are marked with the `flaky_` prefix and `#[ignore]` (or platform-conditional `#[cfg_attr(target_os = "...", ignore)]`).
+
+```rust
+// Flaky everywhere
+#[test]
+#[ignore]
+fn flaky_example_test() { ... }
+
+// Flaky only on Windows
+#[test]
+#[cfg_attr(target_os = "windows", ignore)]
+fn flaky_keyring_race_condition() { ... }
+```
+
+CI runs flaky tests in a separate non-blocking step for visibility:
+
+```bash
+# Run only flaky tests (non-blocking in CI)
+cargo test -- --ignored flaky_
+```
+
+**Naming conventions for `#[ignore]` tests:**
+- `flaky_` prefix → Intermittently failing (non-blocking CI step)
+- `vpn_` prefix → Requires VPN access (Jenkins only)
+- No prefix → Manual/slow tests (never run in CI)
+
 ### Requirements
 
 - `PARAMETER_PATH` environment variable pointing to `parameters.json`

--- a/sf_core/src/token_cache/mod.rs
+++ b/sf_core/src/token_cache/mod.rs
@@ -390,7 +390,8 @@ mod tests {
         }
 
         #[test]
-        fn remove_existing_token_succeeds() {
+        #[cfg_attr(target_os = "windows", ignore)]
+        fn flaky_remove_existing_token_succeeds() {
             let cache = KeyringTokenCache::new().expect("Failed to create cache");
             let host = unique_test_key("remove_test_host");
             let username = unique_test_key("remove_test_user");
@@ -436,7 +437,8 @@ mod tests {
         }
 
         #[test]
-        fn overwrite_token_succeeds() {
+        #[cfg_attr(target_os = "windows", ignore)]
+        fn flaky_overwrite_token_succeeds() {
             let cache = KeyringTokenCache::new().expect("Failed to create cache");
             let host = unique_test_key("overwrite_test_host");
             let username = unique_test_key("overwrite_test_user");

--- a/sf_core/tests/e2e/authentication/pat.rs
+++ b/sf_core/tests/e2e/authentication/pat.rs
@@ -16,7 +16,8 @@ fn should_authenticate_using_pat_as_password() {
 }
 
 #[test]
-fn should_authenticate_using_pat_as_token() {
+#[cfg_attr(target_os = "windows", ignore)]
+fn flaky_should_authenticate_using_pat_as_token() {
     //Given Authentication is set to Programmatic Access Token and valid PAT token is provided
     let pat = Pat::acquire();
     let client = SnowflakeTestClient::with_default_params();
@@ -31,7 +32,8 @@ fn should_authenticate_using_pat_as_token() {
 }
 
 #[test]
-fn should_authenticate_using_pat_as_token_with_lowercase_authenticator() {
+#[cfg_attr(target_os = "windows", ignore)]
+fn flaky_should_authenticate_using_pat_as_token_with_lowercase_authenticator() {
     //Given Authentication is set to lowercase programmatic_access_token and valid PAT token is provided
     let pat = Pat::acquire();
     let client = SnowflakeTestClient::with_default_params();

--- a/tests/tests_format_validator/src/utils.rs
+++ b/tests/tests_format_validator/src/utils.rs
@@ -10,10 +10,12 @@ pub fn to_pascal_case(s: &str) -> String {
     s.to_case(Case::Pascal)
 }
 
-/// Strip common test-method prefixes (`test_`, `vpn_`) so the bare name
+/// Strip common test-method prefixes (`test_`, `vpn_`, `flaky_`) so the bare name
 /// can be compared against the Gherkin scenario name.
 pub fn clean_method_name(name: &str) -> &str {
-    name.trim_start_matches("test_").trim_start_matches("vpn_")
+    name.trim_start_matches("test_")
+        .trim_start_matches("vpn_")
+        .trim_start_matches("flaky_")
 }
 
 /// Normalize a string for matching: lowercase, strip whitespace, underscores,


### PR DESCRIPTION
## Summary
- Add `flaky_` prefix + `#[ignore]` convention for intermittently failing Rust tests, mirroring the ODBC `[flaky]` tag
- Add non-blocking CI steps to run flaky tests for visibility without gating the merge queue
- Tag 4 tests as flaky on Windows based on repeated GHA failures:
  - `keyring_token_cache_tests::remove_existing_token_succeeds` (Windows Credential Manager race)
  - `keyring_token_cache_tests::overwrite_token_succeeds` (same root cause)
  - `pat::should_authenticate_using_pat_as_token` (server-side PAT propagation delay)
  - `pat::should_authenticate_using_pat_as_token_with_lowercase_authenticator` (same)
- Teach the tests format validator to strip `flaky_` prefix when matching Gherkin scenarios
- Document the convention in `sf_core/README.md`

## Test plan
- [ ] CI flaky step runs on Linux/macOS via `cargo llvm-cov -- --ignored flaky_`
- [ ] CI flaky step runs on Windows via `cargo nextest --run-ignored ignored-only -E "test(/^flaky_/)"`
- [ ] Main test step no longer fails on the tagged tests (Windows)
- [ ] Tests format validator passes with `flaky_` prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)