### PR TITLE
NO-SNOW: drop POM-only org.apache.arrow:arrow-memory dependency

### DIFF
--- a/jdbc/build.gradle
+++ b/jdbc/build.gradle
@@ -46,7 +46,6 @@ dependencies {
     implementation "org.slf4j:slf4j-simple:${slf4jVersion}"
     implementation 'javax.annotation:javax.annotation-api:1.3.2'
     implementation 'org.apache.arrow:arrow-vector:17.0.0'
-    implementation 'org.apache.arrow:arrow-memory:17.0.0'
     implementation 'org.apache.arrow:arrow-memory-core:17.0.0'
     implementation 'org.apache.arrow:arrow-memory-netty:17.0.0'
     implementation 'org.apache.arrow:arrow-c-data:17.0.0'


### PR DESCRIPTION
`org.apache.arrow:arrow-memory:17.0.0` is a POM-only aggregator artifact - no JAR is published to Maven Central with that exact coordinate, only `arrow-memory-core`, `arrow-memory-netty`, and `arrow-memory-unsafe` underneath it.

Gradle silently resolves it (sees no classes contributed and moves on), so the existing build works. But Maven consumers of the published `com.snowflake:jdbc` POM see it listed as a runtime dependency and try to fetch the missing JAR, which breaks downstream Maven builds (e.g. trino's snowflake plugin compat bench at snowflake-eng/universal-driver-jdbc-compat).

The line contributes nothing to the Gradle build either - the arrow-memory-core and arrow-memory-netty entries below it provide the actual memory implementation classes.