### PR TITLE
SNOW-3487078: python - extract CursorMixin + AsyncSnowflakeCursorBase

### DIFF
--- a/python/src/snowflake/connector/_internal/decorators.py
+++ b/python/src/snowflake/connector/_internal/decorators.py
@@ -8,6 +8,7 @@ to just the decorator façade.
 
 from __future__ import annotations
 
+import asyncio
 import functools
 import types
 
@@ -80,26 +81,46 @@ def backward_compatibility(obj: T) -> T:
 _TRACKING: ContextVar[bool] = ContextVar("_api_tracking", default=True)
 
 
+def _send_telemetry(self: Any, func_name: str) -> None:
+    """Send api_usage telemetry for either a Connection or a cursor instance."""
+    from snowflake.connector.connection import Connection
+    from snowflake.connector.cursor._cursor_mixin import CursorMixin
+
+    api_name = f"{type(self).__name__}.{func_name}"
+    if isinstance(self, Connection):
+        self._telemetry_client.send_api_usage(api_name)
+    elif isinstance(self, CursorMixin):
+        self._connection._telemetry_client.send_api_usage(api_name)
+
+
 def api_telemetry(func: F) -> F:
     """Record ``{ClassName}.{method_name}`` telemetry for the outermost call.
 
     Suppresses ``_TRACKING`` for the method body so nested decorated calls
     are not recorded.  Generator results are wrapped to suppress only during
     each iteration step (see :func:`_suppress_tracking_generator`).
+
+    Handles both sync and async methods transparently.
     """
+    if asyncio.iscoroutinefunction(func):
+
+        @functools.wraps(func)
+        async def async_wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
+            if _TRACKING.get():
+                _send_telemetry(self, func.__name__)
+                _TRACKING.set(False)
+                try:
+                    return await func(self, *args, **kwargs)
+                finally:
+                    _TRACKING.set(True)
+            return await func(self, *args, **kwargs)
+
+        return cast(F, async_wrapper)
 
     @functools.wraps(func)
     def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
         if _TRACKING.get():
-            from snowflake.connector.connection import Connection
-            from snowflake.connector.cursor._base import SnowflakeCursorBase
-
-            api_name = f"{type(self).__name__}.{func.__name__}"
-            if isinstance(self, Connection):
-                self._telemetry_client.send_api_usage(api_name)
-            elif isinstance(self, SnowflakeCursorBase):
-                self._connection._telemetry_client.send_api_usage(api_name)
-
+            _send_telemetry(self, func.__name__)
             _TRACKING.set(False)
             try:
                 result = func(self, *args, **kwargs)

--- a/python/src/snowflake/connector/_internal/errorhandler.py
+++ b/python/src/snowflake/connector/_internal/errorhandler.py
@@ -22,12 +22,12 @@ from ..errors import Error
 
 if TYPE_CHECKING:
     from ..connection import Connection
-    from ..cursor import SnowflakeCursorBase
+    from ..cursor._cursor_mixin import CursorMixin
 
 
 def route_exception(
     connection: Connection | None,
-    cursor: SnowflakeCursorBase | None,
+    cursor: CursorMixin | None,
     exc: Error,
 ) -> NoReturn:
     """Route an ``Error`` through the PEP 249 errorhandler chain, then re-raise.
@@ -57,7 +57,7 @@ class ErrorHandlerMixin:
         return None
 
     @property
-    def _errorhandler_cursor(self) -> SnowflakeCursorBase | None:
+    def _errorhandler_cursor(self) -> CursorMixin | None:
         return None
 
 
@@ -89,7 +89,30 @@ _errorhandler_active: ContextVar[bool] = ContextVar("_errorhandler_active", defa
 
 
 def _wrap_method(method: Callable) -> Callable:
-    """Wrap a method to route ``Error`` through the errorhandler chain."""
+    """Wrap a method to route ``Error`` through the errorhandler chain.
+
+    Automatically detects coroutine functions and produces an ``async def``
+    wrapper so that ``await`` propagation works correctly.
+    """
+    if inspect.iscoroutinefunction(method):
+
+        @functools.wraps(method)
+        async def async_wrapper(self: ErrorHandlerMixin, *args: Any, **kwargs: Any) -> Any:
+            if _errorhandler_active.get():
+                return await method(self, *args, **kwargs)
+            token = _errorhandler_active.set(True)
+            try:
+                return await method(self, *args, **kwargs)
+            except Error as exc:
+                route_exception(
+                    self._errorhandler_connection,
+                    self._errorhandler_cursor,
+                    exc,
+                )
+            finally:
+                _errorhandler_active.reset(token)
+
+        return async_wrapper
 
     @functools.wraps(method)
     def wrapper(self: ErrorHandlerMixin, *args: Any, **kwargs: Any) -> Any:

--- a/python/src/snowflake/connector/aio/__init__.py
+++ b/python/src/snowflake/connector/aio/__init__.py
@@ -1,0 +1,16 @@
+"""Async-native Snowflake connector interfaces.
+
+This package mirrors the synchronous ``snowflake.connector`` hierarchy
+but uses ``async def`` throughout.
+"""
+
+from __future__ import annotations
+
+from .cursor import AsyncDictCursor, AsyncSnowflakeCursor, AsyncSnowflakeCursorBase
+
+
+__all__ = [
+    "AsyncDictCursor",
+    "AsyncSnowflakeCursor",
+    "AsyncSnowflakeCursorBase",
+]

--- a/python/src/snowflake/connector/aio/cursor.py
+++ b/python/src/snowflake/connector/aio/cursor.py
@@ -1,9 +1,9 @@
-"""
-Synchronous cursor base class.
+"""Async cursor classes.
 
-``SnowflakeCursorBase`` inherits shared state and properties from
-:class:`CursorMixin` and adds every method that performs synchronous I/O
-through :class:`BlockingImmutableCursor`.
+``AsyncSnowflakeCursorBase`` mirrors :class:`SnowflakeCursorBase` but uses
+``async def`` for every method that crosses the FFI boundary, operating
+directly on :class:`ImmutableCursor` (the async primitive) instead of its
+blocking wrapper.
 """
 
 from __future__ import annotations
@@ -11,7 +11,7 @@ from __future__ import annotations
 import abc
 import logging
 
-from collections.abc import Iterator, Sequence
+from collections.abc import AsyncIterator, Sequence
 from typing import TYPE_CHECKING, Any, TypeVar, cast, overload
 
 from .._internal.arrow_stream_utils import (
@@ -22,10 +22,7 @@ from .._internal.decorators import api_telemetry, pep249
 from .._internal.errorcode import ER_INVALID_VALUE
 from .._internal.errorhandler import ErrorHandlerMixin
 from .._internal.extras import pandas, pyarrow, requires_dependency
-from ..errors import InterfaceError, ProgrammingError
-from ..result_batch import ResultBatch
-from ._blocking_immutable_cursor import BlockingImmutableCursor
-from ._cursor_mixin import (
+from ..cursor._cursor_mixin import (
     CursorMixin,
     DictRow,
     Row,
@@ -33,9 +30,12 @@ from ._cursor_mixin import (
     _requires_open_cursor_not_connection,
     _with_prefetch_hook,
 )
-from ._query_result import _MultiStatementQueryResultState, _QueryResult
-from ._query_result_waiter import QueryResultWaiter
-from ._result_metadata import ResultMetadata
+from ..cursor._immutable_cursor import ImmutableCursor
+from ..cursor._query_result import _MultiStatementQueryResultState, _QueryResult
+from ..cursor._query_result_waiter import QueryResultWaiter
+from ..cursor._result_metadata import ResultMetadata
+from ..errors import InterfaceError, ProgrammingError
+from ..result_batch import ResultBatch
 
 
 if TYPE_CHECKING:
@@ -49,9 +49,8 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T", bound=Sequence[Any])
 
 
-class SnowflakeCursorBase(CursorMixin, ErrorHandlerMixin, abc.ABC):
-    """
-    Base cursor class for synchronous database operations (PEP 249).
+class AsyncSnowflakeCursorBase(CursorMixin, ErrorHandlerMixin, abc.ABC):
+    """Async base cursor for database operations (PEP 249 async flavour).
 
     Concrete subclasses must override :pyattr:`_use_dict_result` and
     :pymeth:`fetchone`.
@@ -59,10 +58,10 @@ class SnowflakeCursorBase(CursorMixin, ErrorHandlerMixin, abc.ABC):
 
     def __init__(self, connection: Connection) -> None:
         self._init_cursor_mixin(connection)
-        self._immutable: BlockingImmutableCursor | None = None
+        self._immutable: ImmutableCursor | None = None
 
     @property
-    def _errorhandler_cursor(self) -> SnowflakeCursorBase:
+    def _errorhandler_cursor(self) -> AsyncSnowflakeCursorBase:
         return self
 
     # ------------------------------------------------------------------
@@ -70,16 +69,15 @@ class SnowflakeCursorBase(CursorMixin, ErrorHandlerMixin, abc.ABC):
     # ------------------------------------------------------------------
 
     @overload
-    def callproc(self, procname: str) -> tuple: ...
+    async def callproc(self, procname: str) -> tuple: ...
 
     @overload
-    def callproc(self, procname: str, args: T) -> T: ...
+    async def callproc(self, procname: str, args: T) -> T: ...
 
     @pep249
     @api_telemetry
     @_requires_open
-    def callproc(self, procname: str, args: Any = None) -> Any:
-        """Call a stored procedure."""
+    async def callproc(self, procname: str, args: Any = None) -> Any:
         if args is None:
             args = ()
         if isinstance(args, (str, bytes)):
@@ -87,41 +85,40 @@ class SnowflakeCursorBase(CursorMixin, ErrorHandlerMixin, abc.ABC):
         if not isinstance(args, Sequence):
             raise TypeError(f"callproc args must be a sequence (e.g. list or tuple), not {type(args).__name__}")
         command = f"CALL {procname}({self._connection.paramstyle.placeholders(len(args))})"
-        self.execute(command, args)
+        await self.execute(command, args)
         return args
 
     @pep249
     @api_telemetry
     @_requires_open
-    def execute(
+    async def execute(
         self,
         operation: str,
         parameters: Sequence[Any] | dict[str, Any] | None = None,
         _is_put_get: bool | None = None,
         num_statements: int | None = None,
         **kwargs: Any,
-    ) -> SnowflakeCursorBase:
-        """Execute a database operation (query or command)."""
+    ) -> AsyncSnowflakeCursorBase:
         if num_statements is not None:
             self.set_statement_parameter("MULTI_STATEMENT_COUNT", num_statements)
 
-        self.reset()
-        return self._execute(operation, parameters, _is_put_get, **kwargs)
+        await self.reset()
+        return await self._execute(operation, parameters, _is_put_get, **kwargs)
 
-    def _execute(
+    async def _execute(
         self,
         operation: str,
         parameters: Sequence[Any] | dict[str, Any] | None = None,
         _is_put_get: bool | None = None,
         **kwargs: Any,
-    ) -> SnowflakeCursorBase:
+    ) -> AsyncSnowflakeCursorBase:
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug("query: [%s]", self._format_query_for_log(operation))
 
         query, bindings = self._prepare_query(operation, parameters)
 
         try:
-            immutable = BlockingImmutableCursor.execute(
+            immutable = await ImmutableCursor.execute(
                 self._connection,
                 query,
                 bindings,
@@ -137,8 +134,7 @@ class SnowflakeCursorBase(CursorMixin, ErrorHandlerMixin, abc.ABC):
         self._rownumber = -1
         return self
 
-    def _adopt_immutable(self, immutable: BlockingImmutableCursor, query: str | None) -> None:
-        """Bind a freshly-built ImmutableCursor to this cursor."""
+    def _adopt_immutable(self, immutable: ImmutableCursor, query: str | None) -> None:
         self._immutable = immutable
         self._query_result = immutable.query_result
 
@@ -155,8 +151,7 @@ class SnowflakeCursorBase(CursorMixin, ErrorHandlerMixin, abc.ABC):
     @pep249
     @api_telemetry
     @_requires_open
-    def executemany(self, operation: str, seq_of_parameters: Sequence[Sequence[Any] | dict[str, Any]]) -> None:
-        """Execute a database operation repeatedly for each element in seq_of_parameters."""
+    async def executemany(self, operation: str, seq_of_parameters: Sequence[Sequence[Any] | dict[str, Any]]) -> None:
         if not seq_of_parameters:
             return
 
@@ -164,11 +159,11 @@ class SnowflakeCursorBase(CursorMixin, ErrorHandlerMixin, abc.ABC):
         first_params = seq_of_parameters[0]
 
         if paramstyle.is_client_side() or isinstance(first_params, dict):
-            self.reset()
+            await self.reset()
             total_rowcount = 0
             unknown_rowcount = False
             for params in seq_of_parameters:
-                self._execute(operation, params)
+                await self._execute(operation, params)
                 rc = self._query_result.rowcount
                 if rc is None or rc == -1:
                     unknown_rowcount = True
@@ -188,22 +183,21 @@ class SnowflakeCursorBase(CursorMixin, ErrorHandlerMixin, abc.ABC):
 
         num_columns = first_len
         transposed = [[row[col_idx] for row in rows] for col_idx in range(num_columns)]
-        self.execute(operation, transposed)
+        await self.execute(operation, transposed)
 
     @api_telemetry
     @_requires_open
-    def describe(
+    async def describe(
         self,
         operation: str,
         parameters: Sequence[Any] | dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> list[ResultMetadata] | None:
-        """Obtain the schema of the result without executing the query."""
-        self.reset()
+        await self.reset()
         query, _bindings = self._prepare_query(operation, parameters)
 
         try:
-            self._query_result = BlockingImmutableCursor.describe(self._connection, query)
+            self._query_result = await ImmutableCursor.describe(self._connection, query)
         except ProgrammingError as exc:
             self._query_result = _QueryResult.from_programming_error(exc)
             raise
@@ -219,24 +213,22 @@ class SnowflakeCursorBase(CursorMixin, ErrorHandlerMixin, abc.ABC):
 
     @_requires_open_cursor_not_connection
     @_with_prefetch_hook
-    def _fetchone(self) -> Row | DictRow | None:
+    async def _fetchone(self) -> Row | DictRow | None:
         if self._immutable is None:
             return None
-        row = self._immutable.fetchone()
+        row = await self._immutable.fetchone()
         self._rownumber = self._immutable.rownumber
         return row
 
     @pep249
     @abc.abstractmethod
-    def fetchone(self) -> Row | DictRow | None:
-        """Fetch the next row of a query result set."""
+    async def fetchone(self) -> Row | DictRow | None: ...
 
     @pep249
     @api_telemetry
     @_requires_open_cursor_not_connection
     @_with_prefetch_hook
-    def fetchmany(self, size: int | None = None) -> list[Any]:
-        """Fetch the next set of rows of a query result."""
+    async def fetchmany(self, size: int | None = None) -> list[Any]:
         if size is None:
             size = self.arraysize
 
@@ -250,7 +242,7 @@ class SnowflakeCursorBase(CursorMixin, ErrorHandlerMixin, abc.ABC):
 
         if self._immutable is None:
             return []
-        rows = self._immutable.fetchmany(size)
+        rows = await self._immutable.fetchmany(size)
         self._rownumber = self._immutable.rownumber
         return rows
 
@@ -258,31 +250,25 @@ class SnowflakeCursorBase(CursorMixin, ErrorHandlerMixin, abc.ABC):
     @api_telemetry
     @_requires_open_cursor_not_connection
     @_with_prefetch_hook
-    def fetchall(self) -> list[Any]:
-        """Fetch all (remaining) rows of a query result."""
+    async def fetchall(self) -> list[Any]:
         if self._immutable is None:
             return []
-        rows = self._immutable.fetchall()
+        rows = await self._immutable.fetchall()
         self._rownumber = self._immutable.rownumber
         return rows
 
     # ------------------------------------------------------------------
-    # Iterator protocol
+    # Async iterator protocol
     # ------------------------------------------------------------------
 
-    @pep249
-    def __iter__(self) -> SnowflakeCursorBase:
+    def __aiter__(self) -> AsyncSnowflakeCursorBase:
         return self
 
-    def __next__(self) -> Row | DictRow:
-        row = self.fetchone()
+    async def __anext__(self) -> Row | DictRow:
+        row = await self.fetchone()
         if row is None:
-            raise StopIteration
+            raise StopAsyncIteration
         return row
-
-    @pep249
-    def next(self) -> Row | DictRow:
-        return self.__next__()
 
     # ------------------------------------------------------------------
     # PEP 249 optional
@@ -291,8 +277,7 @@ class SnowflakeCursorBase(CursorMixin, ErrorHandlerMixin, abc.ABC):
     @pep249
     @api_telemetry
     @_requires_open
-    def nextset(self) -> SnowflakeCursorBase | None:
-        """Skip to the next available result set."""
+    async def nextset(self) -> AsyncSnowflakeCursorBase | None:
         if self._multi_statement is None:
             return None
 
@@ -302,10 +287,10 @@ class SnowflakeCursorBase(CursorMixin, ErrorHandlerMixin, abc.ABC):
 
         ms = self._multi_statement
         self._multi_statement = None
-        self.reset()
+        await self.reset()
         self._multi_statement = ms
 
-        immutable = BlockingImmutableCursor.from_query_id(
+        immutable = await ImmutableCursor.from_query_id(
             self._connection,
             query_id,
             use_dict_result=self._use_dict_result,
@@ -321,24 +306,23 @@ class SnowflakeCursorBase(CursorMixin, ErrorHandlerMixin, abc.ABC):
     # Context manager
     # ------------------------------------------------------------------
 
-    def __enter__(self) -> SnowflakeCursorBase:
+    async def __aenter__(self) -> AsyncSnowflakeCursorBase:
         return self
 
-    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
-        self.close()
+    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        await self.close()
 
     # ------------------------------------------------------------------
     # Lifecycle
     # ------------------------------------------------------------------
 
     @_requires_open_cursor_not_connection
-    def reset(self, closing: bool = False) -> None:
-        """Reset the result set."""
+    async def reset(self, closing: bool = False) -> None:
         del self._messages[:]
         self._query_result.reset(closing=closing)
         if self._immutable is not None:
             try:
-                self._immutable.close()
+                await self._immutable.close()
             except Exception:
                 logger.warning("Failed to close ImmutableCursor during reset", exc_info=True)
             self._immutable = None
@@ -348,12 +332,11 @@ class SnowflakeCursorBase(CursorMixin, ErrorHandlerMixin, abc.ABC):
 
     @pep249
     @api_telemetry
-    def close(self) -> bool | None:
-        """Close the cursor now."""
+    async def close(self) -> bool | None:
         try:
             if self._closed:
                 return False
-            self.reset(closing=True)
+            await self.reset(closing=True)
             self._closed = True
             del self._messages[:]
             return True
@@ -368,15 +351,15 @@ class SnowflakeCursorBase(CursorMixin, ErrorHandlerMixin, abc.ABC):
     @api_telemetry
     @_requires_open
     @_with_prefetch_hook
-    def fetch_arrow_batches(
+    async def fetch_arrow_batches(
         self,
         force_microsecond_precision: bool = False,
-    ) -> Iterator[Table]:
-        """Fetch Arrow Tables in batches."""
+    ) -> AsyncIterator[Table]:
         if self._immutable is None:
             return
+        stream_ptr = await self._immutable.get_arrow_stream_ptr()
         iterator = create_table_iterator(
-            stream_ptr=self._immutable.get_arrow_stream_ptr(),
+            stream_ptr=stream_ptr,
             connection=self._connection,
             number_to_decimal=self._connection.arrow_number_to_decimal,
             force_microsecond_precision=force_microsecond_precision,
@@ -388,16 +371,16 @@ class SnowflakeCursorBase(CursorMixin, ErrorHandlerMixin, abc.ABC):
     @api_telemetry
     @_requires_open
     @_with_prefetch_hook
-    def fetch_arrow_all(
+    async def fetch_arrow_all(
         self,
         force_return_table: bool = False,
         force_microsecond_precision: bool = False,
     ) -> Table | None:
-        """Fetch all results as a single Arrow Table."""
         if self._immutable is None:
             return None
+        stream_ptr = await self._immutable.get_arrow_stream_ptr()
         iterator = create_table_iterator(
-            stream_ptr=self._immutable.get_arrow_stream_ptr(),
+            stream_ptr=stream_ptr,
             connection=self._connection,
             number_to_decimal=self._connection.arrow_number_to_decimal,
             force_microsecond_precision=force_microsecond_precision,
@@ -411,17 +394,15 @@ class SnowflakeCursorBase(CursorMixin, ErrorHandlerMixin, abc.ABC):
     @requires_dependency(pandas)
     @api_telemetry
     @_requires_open
-    def fetch_pandas_batches(self, **kwargs: Any) -> Iterator[DataFrame]:
-        """Fetch Pandas DataFrames in batches."""
-        for table in self.fetch_arrow_batches(**kwargs):
+    async def fetch_pandas_batches(self, **kwargs: Any) -> AsyncIterator[DataFrame]:
+        async for table in self.fetch_arrow_batches(**kwargs):
             yield table.to_pandas()
 
     @requires_dependency(pandas)
     @api_telemetry
     @_requires_open
-    def fetch_pandas_all(self, **kwargs: Any) -> DataFrame:
-        """Fetch all results as a single Pandas DataFrame."""
-        table: Table = self.fetch_arrow_all(force_return_table=True, **kwargs)
+    async def fetch_pandas_all(self, **kwargs: Any) -> DataFrame:
+        table: Table = await self.fetch_arrow_all(force_return_table=True, **kwargs)
         return table.to_pandas()
 
     # ------------------------------------------------------------------
@@ -431,11 +412,10 @@ class SnowflakeCursorBase(CursorMixin, ErrorHandlerMixin, abc.ABC):
     @api_telemetry
     @_requires_open
     @_with_prefetch_hook
-    def get_result_batches(self) -> list[ResultBatch] | None:
-        """Get the previously executed query's ResultBatches if available."""
+    async def get_result_batches(self) -> list[ResultBatch] | None:
         if self._immutable is None:
             return None
-        result_chunks = self._immutable.get_chunks()
+        result_chunks = await self._immutable.get_chunks()
         if result_chunks is None:
             return None
         return ResultBatch.from_chunks(
@@ -451,11 +431,10 @@ class SnowflakeCursorBase(CursorMixin, ErrorHandlerMixin, abc.ABC):
 
     @api_telemetry
     @_requires_open
-    def query_result(self, qid: str) -> SnowflakeCursorBase:
-        """Fetch the result of a previously executed query by its Snowflake Query ID."""
-        self.reset()
+    async def query_result(self, qid: str) -> AsyncSnowflakeCursorBase:
+        await self.reset()
 
-        immutable = BlockingImmutableCursor.from_async_query(
+        immutable = await ImmutableCursor.from_async_query(
             self._connection,
             qid,
             use_dict_result=self._use_dict_result,
@@ -468,35 +447,35 @@ class SnowflakeCursorBase(CursorMixin, ErrorHandlerMixin, abc.ABC):
 
     @api_telemetry
     @_requires_open
-    def get_results_from_sfqid(self, sfqid: str) -> None:
-        """Get results from a previously executed query."""
-        self.reset()
+    async def get_results_from_sfqid(self, sfqid: str) -> None:
+        await self.reset()
         self.connection.get_query_status_throw_if_error(sfqid)
         self._query_result.sfqid = sfqid
         waiter = QueryResultWaiter(self._connection, sfqid)
 
-        def prefetch_hook() -> None:
+        async def prefetch_hook() -> None:
             waiter.wait()
             self._prefetch_hook = None
-            self.query_result(sfqid)
+            await self.query_result(sfqid)
 
         self._prefetch_hook = prefetch_hook
 
     @api_telemetry
     @_requires_open
-    def execute_async(
+    async def execute_async(
         self,
         command: str,
         params: Sequence[Any] | dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> dict[str, str | None]:
-        """Submit a query for async execution and return immediately with the query ID."""
-        self.reset()
-        return self._execute_async(command, params)
+        await self.reset()
+        return await self._execute_async(command, params)
 
-    def _execute_async(self, command: str, params: Sequence[Any] | dict[str, Any] | None) -> dict[str, str | None]:
+    async def _execute_async(
+        self, command: str, params: Sequence[Any] | dict[str, Any] | None
+    ) -> dict[str, str | None]:
         query, bindings = self._prepare_query(command, params)
-        query_id = BlockingImmutableCursor.execute_async(
+        query_id = await ImmutableCursor.execute_async(
             self._connection,
             query,
             bindings,
@@ -507,6 +486,52 @@ class SnowflakeCursorBase(CursorMixin, ErrorHandlerMixin, abc.ABC):
 
     @api_telemetry
     @_requires_open
-    def abort_query(self, qid: str) -> bool:
-        """Abort a running query."""
-        return BlockingImmutableCursor.abort_query(self._connection, qid)
+    async def abort_query(self, qid: str) -> bool:
+        return await ImmutableCursor.abort_query(self._connection, qid)
+
+
+# ------------------------------------------------------------------
+# Concrete subclasses
+# ------------------------------------------------------------------
+
+
+class AsyncSnowflakeCursor(AsyncSnowflakeCursorBase):
+    """Async cursor returning results as tuples (default)."""
+
+    @property
+    def _use_dict_result(self) -> bool:
+        return False
+
+    @api_telemetry
+    async def fetchone(self) -> Row | None:
+        row = await self._fetchone()
+        if not (row is None or isinstance(row, tuple)):
+            raise TypeError(f"fetchone got unexpected result: {row}")
+        return row
+
+    async def fetchmany(self, size: int | None = None) -> list[Row]:
+        return await super().fetchmany(size)
+
+    async def fetchall(self) -> list[Row]:
+        return await super().fetchall()
+
+
+class AsyncDictCursor(AsyncSnowflakeCursorBase):
+    """Async cursor returning results as dictionaries."""
+
+    @property
+    def _use_dict_result(self) -> bool:
+        return True
+
+    @api_telemetry
+    async def fetchone(self) -> DictRow | None:
+        row = await self._fetchone()
+        if not (row is None or isinstance(row, dict)):
+            raise TypeError(f"fetchone got unexpected result: {row}")
+        return row
+
+    async def fetchmany(self, size: int | None = None) -> list[DictRow]:
+        return await super().fetchmany(size)
+
+    async def fetchall(self) -> list[DictRow]:
+        return await super().fetchall()

--- a/python/src/snowflake/connector/cursor/_cursor_mixin.py
+++ b/python/src/snowflake/connector/cursor/_cursor_mixin.py
@@ -1,0 +1,391 @@
+"""Shared cursor logic extracted into a mixin.
+
+``CursorMixin`` contains everything that does **not** differ between the
+sync (:class:`SnowflakeCursorBase`) and async (:class:`AsyncSnowflakeCursorBase`)
+cursor hierarchies: read-only properties, PEP 249 no-ops, session-parameter
+accessors, error-handler wiring, and query-preparation utilities.
+"""
+
+from __future__ import annotations
+
+import abc
+import asyncio
+import ctypes
+import functools
+import logging
+
+from collections.abc import Callable, Sequence
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from .._internal.binding_converters import (
+    ClientSideBindingConverter,
+    JsonBindingConverter,
+    ParamStyle,
+)
+from .._internal.decorators import api_telemetry, pep249
+from .._internal.errorcode import ER_CURSOR_IS_CLOSED, ER_INVALID_VALUE
+from .._internal.extras import check_dependency, pandas, pyarrow
+from .._internal.protobuf_gen.database_driver_v1_pb2 import (
+    BinaryDataPtr,
+    QueryBindings,
+)
+from ..errors import Error, ErrorValue, InterfaceError, NotSupportedError, ProgrammingError
+from ._query_result import _MultiStatementQueryResultState, _QueryResult
+from ._result_metadata import QueryResultStats, ResultMetadata
+
+
+if TYPE_CHECKING:
+    from ..connection import Connection
+
+logger = logging.getLogger(__name__)
+
+Row = tuple[Any, ...]
+DictRow = dict[str, Any]
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+# ------------------------------------------------------------------
+# Guard decorators — async-transparent
+# ------------------------------------------------------------------
+
+
+def _requires_open(func: F) -> F:
+    if asyncio.iscoroutinefunction(func):
+
+        @functools.wraps(func)
+        async def async_wrapper(self: CursorMixin, *args: Any, **kwargs: Any) -> Any:
+            if self.is_closed():
+                raise InterfaceError(msg="Cursor is closed.", errno=ER_CURSOR_IS_CLOSED)
+            return await func(self, *args, **kwargs)
+
+        return cast(F, async_wrapper)
+
+    @functools.wraps(func)
+    def wrapper(self: CursorMixin, *args: Any, **kwargs: Any) -> Any:
+        if self.is_closed():
+            raise InterfaceError(msg="Cursor is closed.", errno=ER_CURSOR_IS_CLOSED)
+        return func(self, *args, **kwargs)
+
+    return cast(F, wrapper)
+
+
+def _requires_open_cursor_not_connection(func: F) -> F:
+    """Guard that only checks ``self._closed``, ignoring the connection state.
+
+    Unlike ``_requires_open`` (which delegates to ``is_closed()`` and therefore
+    also rejects cursors whose *connection* has been closed), this decorator
+    deliberately skips the connection check.  This preserves backward
+    compatibility with the old driver, where fetch methods on a cursor with
+    already-buffered results still worked after ``connection.close()``.
+    """
+    if asyncio.iscoroutinefunction(func):
+
+        @functools.wraps(func)
+        async def async_wrapper(self: CursorMixin, *args: Any, **kwargs: Any) -> Any:
+            if self._closed:
+                raise InterfaceError(msg="Cursor is closed.", errno=ER_CURSOR_IS_CLOSED)
+            return await func(self, *args, **kwargs)
+
+        return cast(F, async_wrapper)
+
+    @functools.wraps(func)
+    def wrapper(self: CursorMixin, *args: Any, **kwargs: Any) -> Any:
+        if self._closed:
+            raise InterfaceError(msg="Cursor is closed.", errno=ER_CURSOR_IS_CLOSED)
+        return func(self, *args, **kwargs)
+
+    return cast(F, wrapper)
+
+
+def _with_prefetch_hook(func: F) -> F:
+    """Invoke the cursor's prefetch hook (if set) before entering the wrapped method."""
+    if asyncio.iscoroutinefunction(func):
+
+        @functools.wraps(func)
+        async def async_wrapper(self: CursorMixin, *args: Any, **kwargs: Any) -> Any:
+            if self._prefetch_hook is not None:
+                hook = self._prefetch_hook
+                if asyncio.iscoroutinefunction(hook):
+                    await hook()
+                else:
+                    hook()
+            return await func(self, *args, **kwargs)
+
+        return cast(F, async_wrapper)
+
+    @functools.wraps(func)
+    def wrapper(self: CursorMixin, *args: Any, **kwargs: Any) -> Any:
+        if self._prefetch_hook is not None:
+            self._prefetch_hook()
+        return func(self, *args, **kwargs)
+
+    return cast(F, wrapper)
+
+
+# ------------------------------------------------------------------
+# Mixin
+# ------------------------------------------------------------------
+
+
+class CursorMixin(abc.ABC):
+    """Shared state, properties, and utilities for sync and async cursors.
+
+    Concrete cursor base classes (:class:`SnowflakeCursorBase`,
+    :class:`AsyncSnowflakeCursorBase`) inherit from this mixin and add
+    their own I/O methods (execute, fetch, close, reset, etc.).
+    """
+
+    def _init_cursor_mixin(self, connection: Connection) -> None:
+        """Initialize shared cursor state. Called from subclass ``__init__``."""
+        self._connection: Connection = connection
+        self._closed: bool = False
+        self._messages: list[tuple[type[Exception], ErrorValue]] = []
+        self._errorhandler: Callable[..., None] = Error.default_errorhandler
+
+        self._arraysize: int = 1
+
+        self._query_result: _QueryResult = _QueryResult()
+        self._rownumber: int = -1
+
+        self._multi_statement: _MultiStatementQueryResultState | None = None
+
+        self._statement_parameters: dict[str, Any] = {}
+
+        self._binding_data: None | bytes = None
+        self._prefetch_hook: Callable[..., Any] | None = None
+
+    # ------------------------------------------------------------------
+    # PEP 249 attributes
+    # ------------------------------------------------------------------
+
+    @property
+    @pep249
+    def connection(self) -> Connection:
+        return self._connection
+
+    @property
+    @pep249
+    def description(self) -> list[ResultMetadata] | None:
+        return self._query_result.description
+
+    @property
+    @pep249
+    def rowcount(self) -> int | None:
+        return self._query_result.rowcount
+
+    @property
+    @pep249
+    def arraysize(self) -> int:
+        return self._arraysize
+
+    @arraysize.setter
+    def arraysize(self, value: int) -> None:
+        self._arraysize = int(value)
+
+    @property
+    @pep249
+    def messages(self) -> list[tuple[type[Exception], ErrorValue]]:
+        return self._messages
+
+    @messages.setter
+    def messages(self, value: list[tuple[type[Exception], ErrorValue]]) -> None:
+        self._messages = value
+
+    @property
+    @abc.abstractmethod
+    def _use_dict_result(self) -> bool:
+        """Whether fetch methods return dicts instead of tuples."""
+
+    @property
+    def query(self) -> str | None:
+        return self._query_result.query
+
+    @property
+    def sfqid(self) -> str | None:
+        return self._query_result.sfqid
+
+    @property
+    def stats(self) -> QueryResultStats:
+        return self._query_result.stats
+
+    @property
+    @pep249
+    def rownumber(self) -> int | None:
+        return self._rownumber if self._rownumber >= 0 else None
+
+    @property
+    def sqlstate(self) -> str | None:
+        return self._query_result.sqlstate
+
+    @property
+    def multi_statement_parent_sfqid(self) -> str | None:
+        return self._multi_statement.parent_qid if self._multi_statement else None
+
+    @property
+    def multi_statement_savedIds(self) -> list[str]:
+        return self._multi_statement.child_query_ids if self._multi_statement else []
+
+    @property
+    @pep249
+    def lastrowid(self) -> None:
+        return None
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def is_closed(self) -> bool:
+        return self._closed or self._connection.is_closed()
+
+    # ------------------------------------------------------------------
+    # PEP 249 no-ops
+    # ------------------------------------------------------------------
+
+    @pep249
+    def setinputsizes(self, sizes: Sequence[Any]) -> None:
+        return None
+
+    @pep249
+    def setoutputsize(self, size: int, column: int | None = None) -> None:
+        return None
+
+    @pep249
+    @api_telemetry
+    def scroll(self, value: int, mode: str = "relative") -> None:
+        raise NotSupportedError("scroll is not supported")
+
+    # ------------------------------------------------------------------
+    # Statement parameters
+    # ------------------------------------------------------------------
+
+    @_requires_open
+    def set_statement_parameter(self, key: str, value: Any) -> None:
+        self._statement_parameters[key] = value
+
+    @property
+    def is_file_transfer(self) -> bool:
+        raise NotImplementedError("is_file_transfer is not yet implemented")
+
+    # ------------------------------------------------------------------
+    # Query preparation (shared between sync and async)
+    # ------------------------------------------------------------------
+
+    def _format_query_for_log(self, query: str) -> str:
+        return self._connection._format_query_for_log(query)
+
+    def _build_query_bindings(self, parameters: Sequence[Any]) -> QueryBindings | None:
+        json_str, length = JsonBindingConverter.serialize_parameters(parameters)
+        if json_str is None:
+            return None
+
+        json_bytes = json_str.encode("utf-8")
+        self._binding_data = json_bytes
+
+        ptr_value = ctypes.cast(ctypes.c_char_p(json_bytes), ctypes.c_void_p).value
+        if ptr_value is None:
+            raise RuntimeError("Failed to obtain memory pointer for binding data")
+
+        ptr_bytes = ptr_value.to_bytes(8, byteorder="little", signed=False)
+
+        binary_data_ptr = BinaryDataPtr(
+            value=ptr_bytes,
+            length=length,
+        )
+        return QueryBindings(json=binary_data_ptr)
+
+    def _prepare_query(
+        self, operation: str, parameters: Sequence[Any] | dict[str, Any] | None
+    ) -> tuple[str, QueryBindings | None]:
+        if parameters is None:
+            return operation, None
+
+        paramstyle = self._connection.paramstyle
+
+        if paramstyle.is_client_side():
+            if paramstyle == ParamStyle.FORMAT and isinstance(parameters, dict):
+                raise ProgrammingError(
+                    msg="Dict parameters not supported with format paramstyle. "
+                    "Use pyformat paramstyle for named parameters, or use a sequence.",
+                    errno=ER_INVALID_VALUE,
+                )
+            query = ClientSideBindingConverter.interpolate_query(
+                operation,
+                parameters,
+                interpolate_empty_sequences=self._connection._interpolate_empty_sequences,
+            )
+            return query, None
+        else:
+            if isinstance(parameters, dict):
+                raise ProgrammingError(
+                    msg="Named parameters (dict) not supported with qmark/numeric paramstyle. "
+                    "Use pyformat paramstyle for named parameters.",
+                    errno=ER_INVALID_VALUE,
+                )
+            bindings = self._build_query_bindings(parameters)
+            return operation, bindings
+
+    # ------------------------------------------------------------------
+    # Session parameter accessors
+    # ------------------------------------------------------------------
+
+    @property
+    def timestamp_output_format(self) -> str | None:
+        return self._connection._get_session_parameter("TIMESTAMP_OUTPUT_FORMAT")
+
+    @property
+    def timestamp_ltz_output_format(self) -> str | None:
+        return self._connection._get_session_parameter("TIMESTAMP_LTZ_OUTPUT_FORMAT") or self.timestamp_output_format
+
+    @property
+    def timestamp_tz_output_format(self) -> str | None:
+        return self._connection._get_session_parameter("TIMESTAMP_TZ_OUTPUT_FORMAT") or self.timestamp_output_format
+
+    @property
+    def timestamp_ntz_output_format(self) -> str | None:
+        return self._connection._get_session_parameter("TIMESTAMP_NTZ_OUTPUT_FORMAT") or self.timestamp_output_format
+
+    @property
+    def date_output_format(self) -> str | None:
+        return self._connection._get_session_parameter("DATE_OUTPUT_FORMAT")
+
+    @property
+    def time_output_format(self) -> str | None:
+        return self._connection._get_session_parameter("TIME_OUTPUT_FORMAT")
+
+    @property
+    def timezone(self) -> str | None:
+        return self._connection._get_session_parameter("TIMEZONE")
+
+    @property
+    def binary_output_format(self) -> str | None:
+        return self._connection._get_session_parameter("BINARY_OUTPUT_FORMAT")
+
+    # ------------------------------------------------------------------
+    # Error handling
+    # ------------------------------------------------------------------
+
+    @property
+    @pep249
+    def errorhandler(self) -> Callable:
+        return self._errorhandler
+
+    @errorhandler.setter
+    def errorhandler(self, value: Callable | None) -> None:
+        if value is None:
+            raise ProgrammingError("Invalid errorhandler is specified")
+        self._errorhandler = value
+
+    @property
+    def _errorhandler_connection(self) -> Connection:
+        return self._connection
+
+    # ------------------------------------------------------------------
+    # Dependency checks
+    # ------------------------------------------------------------------
+
+    def check_can_use_arrow_resultset(self) -> None:
+        check_dependency(pyarrow)
+
+    def check_can_use_pandas(self) -> None:
+        check_dependency(pandas)

--- a/python/src/snowflake/connector/errors.py
+++ b/python/src/snowflake/connector/errors.py
@@ -44,7 +44,7 @@ from ._internal.decorators import backward_compatibility
 
 if TYPE_CHECKING:
     from .connection import Connection
-    from .cursor import SnowflakeCursorBase
+    from .cursor._cursor_mixin import CursorMixin
 
 ErrorValue = dict[str, Any]
 
@@ -103,7 +103,7 @@ class Error(Exception):
     @staticmethod
     def errorhandler_wrapper(
         connection: Connection | None,
-        cursor: SnowflakeCursorBase | None,
+        cursor: CursorMixin | None,
         error_class: type[Error] | type[Exception],
         error_value: ErrorValue,
     ) -> None:
@@ -124,7 +124,7 @@ class Error(Exception):
     @staticmethod
     def hand_to_other_handler(
         connection: Connection | None,
-        cursor: SnowflakeCursorBase | None,
+        cursor: CursorMixin | None,
         error_class: type[Error] | type[Exception],
         error_value: ErrorValue,
     ) -> bool:
@@ -169,7 +169,7 @@ class Error(Exception):
     @staticmethod
     def default_errorhandler(
         connection: Connection | None,
-        cursor: SnowflakeCursorBase | None,
+        cursor: CursorMixin | None,
         error_class: type[Error] | type[Exception],
         error_value: ErrorValue,
     ) -> None:

--- a/python/tests/unit/test_async_cursor.py
+++ b/python/tests/unit/test_async_cursor.py
@@ -1,0 +1,404 @@
+"""Unit tests for async cursor classes.
+
+Tests mock at the :class:`ImmutableCursor` boundary — the async cursor never
+touches the FFI layer.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from snowflake.connector.aio.cursor import AsyncDictCursor, AsyncSnowflakeCursor, AsyncSnowflakeCursorBase
+from snowflake.connector.cursor._immutable_cursor import ImmutableCursor
+from snowflake.connector.cursor._query_result import _QueryResult
+from snowflake.connector.cursor._result_metadata import QueryResultStats
+from snowflake.connector.errors import InterfaceError, ProgrammingError
+from tests.compatibility import IS_UNIVERSAL_DRIVER
+
+
+pytestmark = pytest.mark.skipif(not IS_UNIVERSAL_DRIVER, reason="Requires universal driver")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_immutable(
+    rows=None,
+    *,
+    description=None,
+    rowcount=None,
+    sfqid=None,
+    query=None,
+    sqlstate=None,
+    stats=None,
+    multi_query_ids=None,
+):
+    """Build a mock :class:`ImmutableCursor` with canned async fetch behaviour."""
+    mock = AsyncMock(spec=ImmutableCursor)
+
+    qr = _QueryResult(
+        description=description,
+        rowcount=rowcount,
+        sfqid=sfqid,
+        query=query,
+        sqlstate=sqlstate,
+        stats=stats,
+    )
+    mock.query_result = qr
+    mock.multi_query_ids = multi_query_ids
+
+    if rows is None:
+        rows = []
+    pos = [0]
+    rownumber = [-1]
+
+    async def _fetchone():
+        if pos[0] >= len(rows):
+            return None
+        row = rows[pos[0]]
+        pos[0] += 1
+        rownumber[0] = pos[0] - 1
+        mock.rownumber = rownumber[0]
+        return row
+
+    async def _fetchmany(size=None):
+        if size is None:
+            size = 1
+        batch = rows[pos[0] : pos[0] + size]
+        pos[0] += len(batch)
+        if batch:
+            rownumber[0] = pos[0] - 1
+            mock.rownumber = rownumber[0]
+        return batch
+
+    async def _fetchall():
+        batch = rows[pos[0] :]
+        pos[0] = len(rows)
+        if batch:
+            rownumber[0] = pos[0] - 1
+            mock.rownumber = rownumber[0]
+        return batch
+
+    mock.fetchone.side_effect = _fetchone
+    mock.fetchmany.side_effect = _fetchmany
+    mock.fetchall.side_effect = _fetchall
+    mock.rownumber = rownumber[0]
+    mock.description = description
+    mock.rowcount = rowcount
+    mock.sfqid = sfqid
+    mock.query = query
+    mock.sqlstate = sqlstate
+    mock.stats = stats if stats is not None else QueryResultStats()
+
+    return mock
+
+
+def _inject_immutable(cursor, mock_immutable):
+    cursor._immutable = mock_immutable
+    cursor._query_result = mock_immutable.query_result
+
+
+def _mock_connection():
+    conn = MagicMock()
+    conn.is_closed.return_value = False
+    conn.config.numpy = False
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# Basic fetch tests
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncFetchone:
+    @pytest.fixture
+    def cursor(self):
+        return AsyncSnowflakeCursor(_mock_connection())
+
+    @pytest.mark.asyncio
+    async def test_fetchone_returns_single_row(self, cursor):
+        _inject_immutable(cursor, _make_mock_immutable([(1,), (2,), (3,)]))
+        assert await cursor.fetchone() == (1,)
+
+    @pytest.mark.asyncio
+    async def test_fetchone_returns_none_when_exhausted(self, cursor):
+        _inject_immutable(cursor, _make_mock_immutable([]))
+        assert await cursor.fetchone() is None
+
+    @pytest.mark.asyncio
+    async def test_fetchone_sequential_calls(self, cursor):
+        _inject_immutable(cursor, _make_mock_immutable([(1,), (2,), (3,)]))
+        assert await cursor.fetchone() == (1,)
+        assert await cursor.fetchone() == (2,)
+        assert await cursor.fetchone() == (3,)
+        assert await cursor.fetchone() is None
+
+
+class TestAsyncFetchall:
+    @pytest.fixture
+    def cursor(self):
+        return AsyncSnowflakeCursor(_mock_connection())
+
+    @pytest.mark.asyncio
+    async def test_fetchall_returns_all_rows(self, cursor):
+        _inject_immutable(cursor, _make_mock_immutable([(1,), (2,), (3,)]))
+        assert await cursor.fetchall() == [(1,), (2,), (3,)]
+
+    @pytest.mark.asyncio
+    async def test_fetchall_returns_empty_list_when_no_rows(self, cursor):
+        _inject_immutable(cursor, _make_mock_immutable([]))
+        assert await cursor.fetchall() == []
+
+    @pytest.mark.asyncio
+    async def test_fetchall_after_partial_fetchone(self, cursor):
+        _inject_immutable(cursor, _make_mock_immutable([(1,), (2,), (3,), (4,), (5,)]))
+        await cursor.fetchone()
+        await cursor.fetchone()
+        assert await cursor.fetchall() == [(3,), (4,), (5,)]
+
+
+class TestAsyncFetchmany:
+    @pytest.fixture
+    def cursor(self):
+        return AsyncSnowflakeCursor(_mock_connection())
+
+    @pytest.mark.asyncio
+    async def test_fetchmany_default_uses_arraysize(self, cursor):
+        cursor.arraysize = 3
+        _inject_immutable(cursor, _make_mock_immutable([(1,), (2,), (3,), (4,), (5,)]))
+        assert await cursor.fetchmany() == [(1,), (2,), (3,)]
+
+    @pytest.mark.asyncio
+    async def test_fetchmany_with_explicit_size(self, cursor):
+        _inject_immutable(cursor, _make_mock_immutable([(1,), (2,), (3,), (4,), (5,)]))
+        assert await cursor.fetchmany(2) == [(1,), (2,)]
+
+    @pytest.mark.asyncio
+    async def test_fetchmany_negative_size_raises(self, cursor):
+        with pytest.raises(ProgrammingError, match="not zero or positive"):
+            await cursor.fetchmany(-1)
+
+    @pytest.mark.asyncio
+    async def test_fetchmany_sequential_calls(self, cursor):
+        _inject_immutable(cursor, _make_mock_immutable([(1,), (2,), (3,), (4,), (5,)]))
+        assert await cursor.fetchmany(2) == [(1,), (2,)]
+        assert await cursor.fetchmany(2) == [(3,), (4,)]
+        assert await cursor.fetchmany(2) == [(5,)]
+
+
+# ---------------------------------------------------------------------------
+# Dict cursor
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncDictCursor:
+    @pytest.fixture
+    def cursor(self):
+        return AsyncDictCursor(_mock_connection())
+
+    @pytest.mark.asyncio
+    async def test_fetchone_returns_dict(self, cursor):
+        _inject_immutable(cursor, _make_mock_immutable([{"ID": 1, "NAME": "alice"}]))
+        row = await cursor.fetchone()
+        assert row == {"ID": 1, "NAME": "alice"}
+        assert isinstance(row, dict)
+
+    @pytest.mark.asyncio
+    async def test_fetchall_returns_list_of_dicts(self, cursor):
+        _inject_immutable(cursor, _make_mock_immutable([{"ID": 1}, {"ID": 2}]))
+        assert await cursor.fetchall() == [{"ID": 1}, {"ID": 2}]
+
+
+# ---------------------------------------------------------------------------
+# Rownumber
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncRownumber:
+    @pytest.fixture
+    def cursor(self):
+        return AsyncSnowflakeCursor(_mock_connection())
+
+    @pytest.mark.asyncio
+    async def test_rownumber_increments_with_fetchone(self, cursor):
+        _inject_immutable(cursor, _make_mock_immutable([(1,), (2,), (3,)]))
+        await cursor.fetchone()
+        assert cursor.rownumber == 0
+        await cursor.fetchone()
+        assert cursor.rownumber == 1
+        await cursor.fetchone()
+        assert cursor.rownumber == 2
+
+    @pytest.mark.asyncio
+    async def test_rownumber_updated_by_fetchall(self, cursor):
+        _inject_immutable(cursor, _make_mock_immutable([(1,), (2,), (3,), (4,), (5,)]))
+        await cursor.fetchall()
+        assert cursor.rownumber == 4
+
+
+# ---------------------------------------------------------------------------
+# Async iteration (async for)
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncIteration:
+    @pytest.fixture
+    def cursor(self):
+        return AsyncSnowflakeCursor(_mock_connection())
+
+    @pytest.mark.asyncio
+    async def test_async_for(self, cursor):
+        _inject_immutable(cursor, _make_mock_immutable([(1,), (2,), (3,)]))
+        collected = []
+        async for row in cursor:
+            collected.append(row)
+        assert collected == [(1,), (2,), (3,)]
+
+    @pytest.mark.asyncio
+    async def test_async_for_empty_result(self, cursor):
+        _inject_immutable(cursor, _make_mock_immutable([]))
+        collected = []
+        async for row in cursor:
+            collected.append(row)
+        assert collected == []
+
+
+# ---------------------------------------------------------------------------
+# Async context manager
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncContextManager:
+    @pytest.mark.asyncio
+    async def test_async_with_closes_cursor(self):
+        conn = _mock_connection()
+        async with AsyncSnowflakeCursor(conn) as cur:
+            assert not cur._closed
+        assert cur._closed is True
+
+    @pytest.mark.asyncio
+    async def test_async_with_returns_cursor(self):
+        conn = _mock_connection()
+        async with AsyncSnowflakeCursor(conn) as cur:
+            assert isinstance(cur, AsyncSnowflakeCursorBase)
+
+
+# ---------------------------------------------------------------------------
+# Execute lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncExecuteLifecycle:
+    @pytest.fixture
+    def cursor(self):
+        conn = _mock_connection()
+        conn.conn_handle = MagicMock()
+        conn.paramstyle = MagicMock()
+        conn.paramstyle.is_client_side.return_value = True
+        return AsyncSnowflakeCursor(conn)
+
+    @pytest.mark.asyncio
+    async def test_execute_creates_immutable(self, cursor):
+        immutable = _make_mock_immutable(sfqid="test-qid")
+        with patch.object(ImmutableCursor, "execute", return_value=immutable):
+            await cursor.execute("SELECT 1")
+        assert cursor._immutable is immutable
+        assert cursor.sfqid == "test-qid"
+
+    @pytest.mark.asyncio
+    async def test_execute_resets_previous_state(self, cursor):
+        old_immutable = _make_mock_immutable()
+        _inject_immutable(cursor, old_immutable)
+
+        new_immutable = _make_mock_immutable()
+        with patch.object(ImmutableCursor, "execute", return_value=new_immutable):
+            await cursor.execute("SELECT 1")
+        old_immutable.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_execute_propagates_error_and_captures_metadata(self, cursor):
+        with patch.object(ImmutableCursor, "execute", side_effect=ProgrammingError("bad sql", sqlstate="42601")):
+            with pytest.raises(ProgrammingError):
+                await cursor.execute("INVALID SQL")
+        assert cursor.sqlstate == "42601"
+
+
+# ---------------------------------------------------------------------------
+# Close / reset
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncClose:
+    @pytest.mark.asyncio
+    async def test_close_returns_true_on_success(self):
+        cur = AsyncSnowflakeCursor(_mock_connection())
+        assert await cur.close() is True
+
+    @pytest.mark.asyncio
+    async def test_close_returns_false_when_already_closed(self):
+        cur = AsyncSnowflakeCursor(_mock_connection())
+        await cur.close()
+        assert await cur.close() is False
+
+    @pytest.mark.asyncio
+    async def test_close_closes_immutable(self):
+        cur = AsyncSnowflakeCursor(_mock_connection())
+        immutable = _make_mock_immutable()
+        _inject_immutable(cur, immutable)
+        await cur.close()
+        immutable.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_closed_cursor_raises_on_fetch(self):
+        cur = AsyncSnowflakeCursor(_mock_connection())
+        await cur.close()
+        with pytest.raises(InterfaceError, match="Cursor is closed"):
+            await cur.fetchone()
+
+
+# ---------------------------------------------------------------------------
+# Properties shared via mixin
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncMixinProperties:
+    @pytest.fixture
+    def cursor(self):
+        return AsyncSnowflakeCursor(_mock_connection())
+
+    def test_description_before_execute(self, cursor):
+        assert cursor.description is None
+
+    def test_rowcount_before_execute(self, cursor):
+        assert cursor.rowcount is None
+
+    def test_arraysize_default(self, cursor):
+        assert cursor.arraysize == 1
+
+    def test_arraysize_settable(self, cursor):
+        cursor.arraysize = 10
+        assert cursor.arraysize == 10
+
+    def test_lastrowid_is_none(self, cursor):
+        assert cursor.lastrowid is None
+
+    def test_rownumber_none_before_fetch(self, cursor):
+        assert cursor.rownumber is None
+
+    def test_sqlstate_none_before_execute(self, cursor):
+        assert cursor.sqlstate is None
+
+    def test_stats_default(self, cursor):
+        assert cursor.stats == QueryResultStats()
+
+    def test_is_closed_false_initially(self, cursor):
+        assert not cursor.is_closed()
+
+    @pytest.mark.asyncio
+    async def test_is_closed_true_after_close(self, cursor):
+        await cursor.close()
+        assert cursor.is_closed()

--- a/python/tests/unit/test_cursor.py
+++ b/python/tests/unit/test_cursor.py
@@ -20,7 +20,7 @@ from snowflake.connector._internal.extras import (
     check_dependency as _real_check_dependency,
 )
 from snowflake.connector.constants import QueryStatus
-from snowflake.connector.cursor import QueryResultStats, SnowflakeCursor, SnowflakeCursorBase
+from snowflake.connector.cursor import QueryResultStats, SnowflakeCursor
 from snowflake.connector.cursor._blocking_immutable_cursor import BlockingImmutableCursor
 from snowflake.connector.cursor._query_result import _QueryResult
 from snowflake.connector.cursor._query_result_waiter import QueryResultWaiter
@@ -678,7 +678,9 @@ class TestFetchmanyArraysizeAttribute:
         assert cursor.arraysize == 1
 
     def test_arraysize_is_property(self):
-        assert isinstance(SnowflakeCursorBase.__dict__["arraysize"], property)
+        from snowflake.connector.cursor._cursor_mixin import CursorMixin
+
+        assert isinstance(CursorMixin.__dict__["arraysize"], property)
 
     def test_arraysize_instance_independent(self, cursor):
         assert cursor.arraysize == 1
@@ -781,13 +783,13 @@ class TestCheckCanUseArrowResultset:
             cursor.check_can_use_arrow_resultset()
 
     def test_raises_programming_error_when_pyarrow_missing(self, cursor):
-        with patch("snowflake.connector.cursor._base.pyarrow", MissingOptionalDependency(dep="pyarrow")):
+        with patch("snowflake.connector.cursor._cursor_mixin.pyarrow", MissingOptionalDependency(dep="pyarrow")):
             with pytest.raises(ProgrammingError) as excinfo:
                 cursor.check_can_use_arrow_resultset()
             assert excinfo.value.errno == ER_NO_PYARROW
 
     def test_error_message_contains_install_link(self, cursor):
-        with patch("snowflake.connector.cursor._base.pyarrow", MissingOptionalDependency(dep="pyarrow")):
+        with patch("snowflake.connector.cursor._cursor_mixin.pyarrow", MissingOptionalDependency(dep="pyarrow")):
             with pytest.raises(ProgrammingError, match="python-connector-pandas"):
                 cursor.check_can_use_arrow_resultset()
 
@@ -806,13 +808,13 @@ class TestCheckCanUsePandas:
             cursor.check_can_use_pandas()
 
     def test_raises_programming_error_when_pandas_missing(self, cursor):
-        with patch("snowflake.connector.cursor._base.pandas", MissingOptionalDependency(dep="pandas")):
+        with patch("snowflake.connector.cursor._cursor_mixin.pandas", MissingOptionalDependency(dep="pandas")):
             with pytest.raises(ProgrammingError) as excinfo:
                 cursor.check_can_use_pandas()
             assert excinfo.value.errno == ER_NO_PYARROW
 
     def test_error_message_contains_install_link(self, cursor):
-        with patch("snowflake.connector.cursor._base.pandas", MissingOptionalDependency(dep="pandas")):
+        with patch("snowflake.connector.cursor._cursor_mixin.pandas", MissingOptionalDependency(dep="pandas")):
             with pytest.raises(ProgrammingError, match="python-connector-pandas"):
                 cursor.check_can_use_pandas()
 


### PR DESCRIPTION
## Summary
- Extract `CursorMixin` from `SnowflakeCursorBase` containing shared state, read-only properties, PEP 249 no-ops, session-parameter accessors, query-preparation utilities, and error-handler wiring
- Refactor `SnowflakeCursorBase` to inherit from `CursorMixin` — no behavior change, all 1032 existing sync tests pass unchanged
- Introduce `AsyncSnowflakeCursorBase`, `AsyncSnowflakeCursor`, and `AsyncDictCursor` in new `snowflake.connector.aio.cursor` package, using `ImmutableCursor` directly with `async def` throughout
- Make `ErrorHandlerMixin._wrap_method` and `api_telemetry` decorator async-aware so they correctly wrap coroutine methods on the async cursor
- Guard decorators (`_requires_open`, `_requires_open_cursor_not_connection`, `_with_prefetch_hook`) detect coroutine functions and produce sync or async wrappers transparently

## Context
Second PR in the async cursor stack. Builds on the `ImmutableCursor` + `BlockingImmutableCursor` foundation (SNOW-3487075) to split cursor logic into a reusable mixin and introduce the async cursor hierarchy that operates directly on the async `ImmutableCursor` primitive without blocking wrappers.

## Test plan
- All 1032 existing sync unit tests pass without modification (verifies mixin extraction is behavior-preserving)
- 35 new async cursor tests covering:
  - `fetchone`, `fetchmany`, `fetchall` on `AsyncSnowflakeCursor`
  - Dict cursor (`AsyncDictCursor`) fetch behavior
  - Rownumber tracking across async fetches
  - `async for` iteration protocol
  - `async with` context manager (auto-close)
  - Execute lifecycle (mock at `ImmutableCursor` boundary)
  - Close/reset behavior and closed-cursor error raising
  - Shared mixin property defaults (description, rowcount, arraysize, etc.)