### PR TITLE
SNOW-3487099: python - AsyncResultBatch for async distributed fetch

### DIFF
--- a/python/src/snowflake/connector/aio/__init__.py
+++ b/python/src/snowflake/connector/aio/__init__.py
@@ -6,11 +6,13 @@ but uses ``async def`` throughout.
 
 from __future__ import annotations
 
+from ._result_batch import AsyncResultBatch
 from .cursor import AsyncDictCursor, AsyncSnowflakeCursor, AsyncSnowflakeCursorBase
 
 
 __all__ = [
     "AsyncDictCursor",
+    "AsyncResultBatch",
     "AsyncSnowflakeCursor",
     "AsyncSnowflakeCursorBase",
 ]

--- a/python/src/snowflake/connector/aio/_result_batch.py
+++ b/python/src/snowflake/connector/aio/_result_batch.py
@@ -1,0 +1,245 @@
+"""Async result batch for distributed fetch.
+
+``AsyncResultBatch`` mirrors :class:`~snowflake.connector.result_batch.ResultBatch`
+but uses ``async_core_driver`` for chunk fetching so all I/O is non-blocking.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterator
+from typing import TYPE_CHECKING, Any, cast
+
+from .._internal.api_client.client_api import async_core_driver
+from .._internal.arrow_stream_utils import (
+    collect_arrow_table,
+    create_row_iterator,
+    create_table_iterator,
+)
+from .._internal.extras import pandas, pyarrow, requires_dependency
+from .._internal.protobuf_gen.database_driver_v1_pb2 import (
+    ColumnMetadata,
+    ResultChunk,
+)
+from .._internal.statement_utils import get_stream_ptr
+from ..errors import InterfaceError
+from ..result_batch import IterTableStructure, IterUnit
+
+
+if TYPE_CHECKING:
+    from pandas import DataFrame
+    from pyarrow import Table
+
+    from ..connection import Connection
+    from ..cursor import ResultMetadata
+
+
+class AsyncResultBatch:
+    """Async-native result batch for distributed fetch.
+
+    Each batch corresponds to a result chunk from the Snowflake back-end.
+    Data is fetched lazily via ``async_core_driver.database_fetch_chunk``
+    when :meth:`populate_data`, :meth:`create_iter`, :meth:`to_arrow`, or
+    :meth:`to_pandas` is awaited.
+    """
+
+    def __init__(
+        self,
+        chunk: ResultChunk,
+        description: list[ResultMetadata],
+        connection: Connection | None,
+        columns: list[ColumnMetadata] | None = None,
+    ) -> None:
+        self._chunk = chunk
+        self._description = description
+        self._connection = connection
+        self._columns: list[ColumnMetadata] = list(columns) if columns else []
+        self._arrow_stream_ptr: int | None = None
+
+    @classmethod
+    def from_chunks(
+        cls,
+        chunks: list[ResultChunk] | None,
+        description: list[ResultMetadata] | None,
+        connection: Connection | None,
+        columns: list[ColumnMetadata] | None = None,
+    ) -> list[AsyncResultBatch] | None:
+        if chunks is None or description is None:
+            return None
+        return [cls(chunk=chunk, description=description, connection=connection, columns=columns) for chunk in chunks]
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+
+    @property
+    def rowcount(self) -> int:
+        return self._chunk.row_count
+
+    @property
+    def compressed_size(self) -> int | None:
+        if self._chunk.HasField("remote"):
+            return self._chunk.remote.compressed_size
+        return None
+
+    @property
+    def uncompressed_size(self) -> int | None:
+        if self._chunk.HasField("remote"):
+            return self._chunk.remote.uncompressed_size
+        return None
+
+    @property
+    def column_names(self) -> list[str]:
+        return [col.name for col in self._description]
+
+    @property
+    def connection(self) -> Connection | None:
+        return self._connection
+
+    @connection.setter
+    def connection(self, value: Connection | None) -> None:
+        self._connection = value
+
+    # ------------------------------------------------------------------
+    # Data fetching (async)
+    # ------------------------------------------------------------------
+
+    def _resolve_connection(self, connection: Connection | None = None) -> Connection:
+        conn = connection or self._connection
+        if conn is None:
+            raise InterfaceError("ResultBatch is not connected to a database driver. Pass a connection argument.")
+        return conn
+
+    async def _fetch_arrow_stream_ptr(self, connection: Connection) -> int:
+        response = await async_core_driver.database_fetch_chunk(
+            db_handle=connection.db_handle,  # type: ignore[arg-type]
+            chunk=self._chunk,
+            columns=self._columns,
+        )
+        return get_stream_ptr(response)
+
+    async def _take_arrow_stream_ptr(self, connection: Connection) -> int:
+        if self._arrow_stream_ptr is None:
+            await self.populate_data(connection=connection)
+        stream_ptr = cast(int, self._arrow_stream_ptr)
+        self._arrow_stream_ptr = None
+        return stream_ptr
+
+    async def populate_data(self, connection: Connection | None = None, **kwargs: Any) -> AsyncResultBatch:
+        """Pre-fetch this batch's data asynchronously."""
+        conn = self._resolve_connection(connection)
+        self._arrow_stream_ptr = await self._fetch_arrow_stream_ptr(conn)
+        return self
+
+    def __aiter__(self) -> AsyncIterator[tuple | dict | Exception]:
+        return self._async_row_iter()
+
+    async def _async_row_iter(self) -> AsyncIterator[tuple | dict | Exception]:
+        """Yield rows from the batch asynchronously.
+
+        The actual chunk fetch is async; once the Arrow stream pointer is
+        obtained, row iteration is synchronous (CPU-bound decoding).
+        """
+        conn = self._resolve_connection()
+        stream_ptr = await self._take_arrow_stream_ptr(conn)
+        for row in create_row_iterator(stream_ptr, connection=conn, use_dict_result=False):
+            yield row
+
+    async def create_iter(
+        self,
+        connection: Connection | None = None,
+        iter_unit: IterUnit | str = IterUnit.ROW_UNIT,
+        structure: IterTableStructure | str = IterTableStructure.PANDAS,
+        use_dict_result: bool = False,
+        number_to_decimal: bool = False,
+        force_microsecond_precision: bool = False,
+    ) -> Iterator[tuple | dict | Exception] | Iterator[Table] | Iterator[DataFrame]:
+        """Create an iterator over this batch's data.
+
+        The chunk fetch is async; the returned iterator is synchronous
+        (Arrow decoding is CPU-bound and doesn't benefit from async).
+        """
+        iter_unit = IterUnit.of(iter_unit)
+        structure = IterTableStructure.of(structure)
+
+        conn = self._resolve_connection(connection)
+        if iter_unit == IterUnit.TABLE_UNIT:
+            if structure == IterTableStructure.PANDAS:
+                return iter(
+                    [
+                        await self.to_pandas(
+                            connection=conn,
+                            number_to_decimal=number_to_decimal,
+                            force_microsecond_precision=force_microsecond_precision,
+                        )
+                    ]
+                )
+            return iter(
+                [
+                    await self.to_arrow(
+                        connection=conn,
+                        number_to_decimal=number_to_decimal,
+                        force_microsecond_precision=force_microsecond_precision,
+                    )
+                ]
+            )
+
+        stream_ptr = await self._take_arrow_stream_ptr(conn)
+        return create_row_iterator(stream_ptr, connection=conn, use_dict_result=use_dict_result)
+
+    @requires_dependency(pyarrow)
+    async def to_arrow(
+        self,
+        connection: Connection | None = None,
+        number_to_decimal: bool = False,
+        force_microsecond_precision: bool = False,
+    ) -> Table:
+        conn = self._resolve_connection(connection)
+        stream_ptr = await self._take_arrow_stream_ptr(conn)
+        return collect_arrow_table(
+            create_table_iterator(
+                stream_ptr,
+                connection=conn,
+                number_to_decimal=number_to_decimal,
+                force_microsecond_precision=force_microsecond_precision,
+            ),
+            self._description,
+        )
+
+    @requires_dependency(pandas)
+    async def to_pandas(
+        self,
+        connection: Connection | None = None,
+        number_to_decimal: bool = False,
+        force_microsecond_precision: bool = False,
+    ) -> DataFrame:
+        table = await self.to_arrow(
+            connection=connection,
+            number_to_decimal=number_to_decimal,
+            force_microsecond_precision=force_microsecond_precision,
+        )
+        return table.to_pandas()
+
+    # ------------------------------------------------------------------
+    # Pickle support
+    # ------------------------------------------------------------------
+
+    def __getstate__(self) -> dict[str, Any]:
+        return {
+            "chunk_bytes": self._chunk.SerializeToString(),
+            "description": self._description,
+            "column_bytes": [c.SerializeToString() for c in self._columns],
+        }
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        chunk = ResultChunk()
+        chunk.ParseFromString(state["chunk_bytes"])
+        self._chunk = chunk
+        self._description = state["description"]
+        columns: list[ColumnMetadata] = []
+        for raw in state.get("column_bytes", []):
+            col = ColumnMetadata()
+            col.ParseFromString(raw)
+            columns.append(col)
+        self._columns = columns
+        self._connection = None
+        self._arrow_stream_ptr = None

--- a/python/src/snowflake/connector/aio/cursor.py
+++ b/python/src/snowflake/connector/aio/cursor.py
@@ -35,7 +35,7 @@ from ..cursor._query_result import _MultiStatementQueryResultState, _QueryResult
 from ..cursor._query_result_waiter import QueryResultWaiter
 from ..cursor._result_metadata import ResultMetadata
 from ..errors import InterfaceError, ProgrammingError
-from ..result_batch import ResultBatch
+from ._result_batch import AsyncResultBatch
 
 
 if TYPE_CHECKING:
@@ -412,13 +412,13 @@ class AsyncSnowflakeCursorBase(CursorMixin, ErrorHandlerMixin, abc.ABC):
     @api_telemetry
     @_requires_open
     @_with_prefetch_hook
-    async def get_result_batches(self) -> list[ResultBatch] | None:
+    async def get_result_batches(self) -> list[AsyncResultBatch] | None:
         if self._immutable is None:
             return None
         result_chunks = await self._immutable.get_chunks()
         if result_chunks is None:
             return None
-        return ResultBatch.from_chunks(
+        return AsyncResultBatch.from_chunks(
             list(result_chunks.chunks),
             self._query_result.description,
             self._connection,

--- a/python/tests/unit/test_async_result_batch.py
+++ b/python/tests/unit/test_async_result_batch.py
@@ -1,0 +1,328 @@
+"""Unit tests for AsyncResultBatch."""
+
+from __future__ import annotations
+
+import pickle
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from snowflake.connector._internal.protobuf_gen.database_driver_v1_pb2 import (
+    RemoteChunk,
+    ResultChunk,
+)
+from snowflake.connector.aio._result_batch import AsyncResultBatch
+from snowflake.connector.errors import InterfaceError
+from snowflake.connector.result_batch import IterTableStructure, IterUnit
+from tests.compatibility import IS_UNIVERSAL_DRIVER
+
+
+pytestmark = pytest.mark.skipif(not IS_UNIVERSAL_DRIVER, reason="Requires universal driver")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_description(*names: str) -> list:
+    return [SimpleNamespace(name=n) for n in names]
+
+
+def _make_batch(connection=None, description=None) -> AsyncResultBatch:
+    return AsyncResultBatch(
+        chunk=ResultChunk(),
+        description=description or _make_description("ID"),
+        connection=connection,
+    )
+
+
+# ---------------------------------------------------------------------------
+# from_chunks
+# ---------------------------------------------------------------------------
+
+
+class TestFromChunks:
+    def test_returns_none_when_chunks_is_none(self):
+        assert AsyncResultBatch.from_chunks(None, _make_description("ID"), MagicMock()) is None
+
+    def test_returns_none_when_description_is_none(self):
+        assert AsyncResultBatch.from_chunks([ResultChunk()], None, MagicMock()) is None
+
+    def test_returns_list_of_async_batches(self):
+        chunks = [ResultChunk(), ResultChunk(), ResultChunk()]
+        desc = _make_description("A", "B")
+        conn = MagicMock()
+        batches = AsyncResultBatch.from_chunks(chunks, desc, conn)
+        assert len(batches) == 3
+        for batch in batches:
+            assert isinstance(batch, AsyncResultBatch)
+            assert batch.connection is conn
+
+    def test_returns_empty_list_for_empty_chunks(self):
+        assert AsyncResultBatch.from_chunks([], _make_description("ID"), MagicMock()) == []
+
+
+# ---------------------------------------------------------------------------
+# Properties
+# ---------------------------------------------------------------------------
+
+
+class TestProperties:
+    def test_column_names(self):
+        desc = _make_description("COL_A", "COL_B")
+        batch = _make_batch(description=desc)
+        assert batch.column_names == ["COL_A", "COL_B"]
+
+    def test_connection_getter_and_setter(self):
+        batch = _make_batch()
+        assert batch.connection is None
+        conn = MagicMock()
+        batch.connection = conn
+        assert batch.connection is conn
+
+    def test_rowcount_defaults_to_zero(self):
+        assert _make_batch().rowcount == 0
+
+    def test_rowcount_from_chunk(self):
+        chunk = ResultChunk(row_count=42)
+        batch = AsyncResultBatch(chunk=chunk, description=_make_description("ID"), connection=None)
+        assert batch.rowcount == 42
+
+    def test_compressed_size_none_when_unset(self):
+        assert _make_batch().compressed_size is None
+
+    def test_compressed_size_from_chunk(self):
+        chunk = ResultChunk(remote=RemoteChunk(url="http://example.com", compressed_size=1024))
+        batch = AsyncResultBatch(chunk=chunk, description=_make_description("ID"), connection=None)
+        assert batch.compressed_size == 1024
+
+    def test_uncompressed_size_none_when_unset(self):
+        assert _make_batch().uncompressed_size is None
+
+    def test_uncompressed_size_from_chunk(self):
+        chunk = ResultChunk(remote=RemoteChunk(url="http://example.com", uncompressed_size=4096))
+        batch = AsyncResultBatch(chunk=chunk, description=_make_description("ID"), connection=None)
+        assert batch.uncompressed_size == 4096
+
+
+# ---------------------------------------------------------------------------
+# _resolve_connection
+# ---------------------------------------------------------------------------
+
+
+class TestResolveConnection:
+    def test_prefers_explicit_connection(self):
+        stored = MagicMock()
+        explicit = MagicMock()
+        batch = _make_batch(connection=stored)
+        assert batch._resolve_connection(explicit) is explicit
+
+    def test_falls_back_to_stored_connection(self):
+        stored = MagicMock()
+        batch = _make_batch(connection=stored)
+        assert batch._resolve_connection() is stored
+
+    def test_raises_when_no_connection(self):
+        batch = _make_batch()
+        with pytest.raises(InterfaceError, match="not connected"):
+            batch._resolve_connection()
+
+
+# ---------------------------------------------------------------------------
+# populate_data (async)
+# ---------------------------------------------------------------------------
+
+
+class TestPopulateData:
+    @pytest.mark.asyncio
+    async def test_populate_data_caches_stream_ptr(self):
+        conn = MagicMock()
+        batch = _make_batch(connection=conn)
+        with patch.object(batch, "_fetch_arrow_stream_ptr", new_callable=AsyncMock, return_value=12345):
+            result = await batch.populate_data()
+        assert result is batch
+        assert batch._arrow_stream_ptr == 12345
+
+    @pytest.mark.asyncio
+    async def test_populate_data_uses_explicit_connection(self):
+        batch = _make_batch()
+        explicit = MagicMock()
+        with patch.object(batch, "_fetch_arrow_stream_ptr", new_callable=AsyncMock, return_value=1) as mock_fetch:
+            await batch.populate_data(connection=explicit)
+        mock_fetch.assert_awaited_once_with(explicit)
+
+
+# ---------------------------------------------------------------------------
+# _take_arrow_stream_ptr (async)
+# ---------------------------------------------------------------------------
+
+
+class TestTakeArrowStreamPtr:
+    @pytest.mark.asyncio
+    async def test_fetches_on_first_call(self):
+        conn = MagicMock()
+        batch = _make_batch(connection=conn)
+        with patch.object(batch, "_fetch_arrow_stream_ptr", new_callable=AsyncMock, return_value=42):
+            ptr = await batch._take_arrow_stream_ptr(conn)
+        assert ptr == 42
+        assert batch._arrow_stream_ptr is None  # consumed
+
+    @pytest.mark.asyncio
+    async def test_uses_cached_ptr(self):
+        conn = MagicMock()
+        batch = _make_batch(connection=conn)
+        batch._arrow_stream_ptr = 99
+        with patch.object(batch, "_fetch_arrow_stream_ptr", new_callable=AsyncMock) as mock_fetch:
+            ptr = await batch._take_arrow_stream_ptr(conn)
+        mock_fetch.assert_not_awaited()
+        assert ptr == 99
+        assert batch._arrow_stream_ptr is None
+
+
+# ---------------------------------------------------------------------------
+# create_iter (async)
+# ---------------------------------------------------------------------------
+
+
+class TestCreateIter:
+    @pytest.mark.asyncio
+    async def test_row_unit_calls_create_row_iterator(self):
+        conn = MagicMock()
+        batch = _make_batch(connection=conn)
+        with (
+            patch.object(batch, "_fetch_arrow_stream_ptr", new_callable=AsyncMock, return_value=0),
+            patch("snowflake.connector.aio._result_batch.create_row_iterator") as mock_iter,
+        ):
+            mock_iter.return_value = iter([(1,), (2,)])
+            result = await batch.create_iter(iter_unit=IterUnit.ROW_UNIT)
+            rows = list(result)
+        assert rows == [(1,), (2,)]
+        mock_iter.assert_called_once_with(0, connection=conn, use_dict_result=False)
+
+    @pytest.mark.asyncio
+    async def test_row_unit_with_dict_result(self):
+        conn = MagicMock()
+        batch = _make_batch(connection=conn)
+        with (
+            patch.object(batch, "_fetch_arrow_stream_ptr", new_callable=AsyncMock, return_value=0),
+            patch("snowflake.connector.aio._result_batch.create_row_iterator") as mock_iter,
+        ):
+            mock_iter.return_value = iter([{"id": 1}])
+            await batch.create_iter(iter_unit=IterUnit.ROW_UNIT, use_dict_result=True)
+        mock_iter.assert_called_once_with(0, connection=conn, use_dict_result=True)
+
+    @pytest.mark.asyncio
+    async def test_table_unit_arrow(self):
+        batch = _make_batch(connection=MagicMock())
+        sentinel = MagicMock()
+        with patch.object(batch, "to_arrow", new_callable=AsyncMock, return_value=sentinel):
+            result = list(await batch.create_iter(iter_unit=IterUnit.TABLE_UNIT, structure=IterTableStructure.ARROW))
+        assert result == [sentinel]
+
+    @pytest.mark.asyncio
+    async def test_table_unit_pandas(self):
+        batch = _make_batch(connection=MagicMock())
+        sentinel = MagicMock()
+        with patch.object(batch, "to_pandas", new_callable=AsyncMock, return_value=sentinel):
+            result = list(await batch.create_iter(iter_unit=IterUnit.TABLE_UNIT, structure=IterTableStructure.PANDAS))
+        assert result == [sentinel]
+
+
+# ---------------------------------------------------------------------------
+# to_arrow / to_pandas (async)
+# ---------------------------------------------------------------------------
+
+
+class TestToArrow:
+    @pytest.fixture(autouse=True)
+    def _patch_deps(self):
+        with patch("snowflake.connector._internal.extras.check_dependency"):
+            yield
+
+    @pytest.mark.asyncio
+    async def test_to_arrow_uses_explicit_connection(self):
+        batch = _make_batch()
+        explicit = MagicMock()
+        with (
+            patch.object(batch, "_fetch_arrow_stream_ptr", new_callable=AsyncMock, return_value=0) as mock_fetch,
+            patch("snowflake.connector.aio._result_batch.create_table_iterator"),
+            patch("snowflake.connector.aio._result_batch.collect_arrow_table"),
+        ):
+            await batch.to_arrow(connection=explicit)
+        mock_fetch.assert_awaited_once_with(explicit)
+
+    @pytest.mark.asyncio
+    async def test_to_arrow_raises_without_connection(self):
+        batch = _make_batch()
+        with pytest.raises(InterfaceError):
+            await batch.to_arrow()
+
+    @pytest.mark.asyncio
+    async def test_to_arrow_forwards_params(self):
+        conn = MagicMock()
+        batch = _make_batch(connection=conn)
+        with (
+            patch.object(batch, "_fetch_arrow_stream_ptr", new_callable=AsyncMock, return_value=0),
+            patch("snowflake.connector.aio._result_batch.create_table_iterator") as mock_table_iter,
+            patch("snowflake.connector.aio._result_batch.collect_arrow_table"),
+        ):
+            await batch.to_arrow(number_to_decimal=True, force_microsecond_precision=True)
+        mock_table_iter.assert_called_once_with(
+            0, connection=conn, number_to_decimal=True, force_microsecond_precision=True
+        )
+
+
+class TestToPandas:
+    @pytest.fixture(autouse=True)
+    def _patch_deps(self):
+        with patch("snowflake.connector._internal.extras.check_dependency"):
+            yield
+
+    @pytest.mark.asyncio
+    async def test_to_pandas_delegates_to_to_arrow(self):
+        conn = MagicMock()
+        batch = _make_batch(connection=conn)
+        mock_table = MagicMock()
+        with patch.object(batch, "to_arrow", new_callable=AsyncMock, return_value=mock_table):
+            await batch.to_pandas(connection=conn, number_to_decimal=True, force_microsecond_precision=True)
+        mock_table.to_pandas.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# async for iteration
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncIteration:
+    @pytest.mark.asyncio
+    async def test_async_for_yields_rows(self):
+        conn = MagicMock()
+        batch = _make_batch(connection=conn)
+        with (
+            patch.object(batch, "_fetch_arrow_stream_ptr", new_callable=AsyncMock, return_value=0),
+            patch("snowflake.connector.aio._result_batch.create_row_iterator") as mock_iter,
+        ):
+            mock_iter.return_value = iter([(1,), (2,), (3,)])
+            rows = [row async for row in batch]
+        assert rows == [(1,), (2,), (3,)]
+
+
+# ---------------------------------------------------------------------------
+# Pickle
+# ---------------------------------------------------------------------------
+
+
+class TestPickle:
+    def test_pickle_round_trip_preserves_description(self):
+        desc = _make_description("X", "Y")
+        batch = _make_batch(connection=MagicMock(), description=desc)
+        restored = pickle.loads(pickle.dumps(batch))
+        assert restored.column_names == ["X", "Y"]
+
+    def test_pickle_clears_connection(self):
+        batch = _make_batch(connection=MagicMock())
+        restored = pickle.loads(pickle.dumps(batch))
+        assert restored.connection is None


### PR DESCRIPTION
## Summary
- Introduce `AsyncResultBatch` in `snowflake.connector.aio` — async-native result batch that uses `async_core_driver.database_fetch_chunk` for non-blocking chunk materialization
- Async methods: `populate_data`, `create_iter`, `to_arrow`, `to_pandas`, plus `async for` iteration via `__aiter__`
- Wire `AsyncSnowflakeCursorBase.get_result_batches()` to return `list[AsyncResultBatch]` instead of `list[ResultBatch]`
- Existing sync `ResultBatch` unchanged — no behavior change

## Context
Third PR in the async cursor stack. Adds the async distributed-fetch primitive so that `async for row in batch` and `await batch.to_arrow()` work end-to-end on the async cursor.

## Test plan
- All 1067 existing sync tests pass without modification (including all 48 sync `ResultBatch` tests)
- 30 new async tests covering:
  - `from_chunks` factory
  - Properties (rowcount, compressed/uncompressed size, column_names, connection)
  - `_resolve_connection` validation
  - `populate_data` caching and connection override
  - `_take_arrow_stream_ptr` fetch-on-demand and cache consumption
  - `create_iter` dispatch (row unit, table unit with arrow/pandas, dict result)
  - `to_arrow` / `to_pandas` connection resolution and parameter forwarding
  - `async for` iteration protocol
  - Pickle round-trip