### PR TITLE
SNOW-2872467: reject empty account string in sf_core validation

### DIFF
--- a/python/tests/integ/test_connection.py
+++ b/python/tests/integ/test_connection.py
@@ -45,6 +45,21 @@ class TestConnectionParameters:
     These tests exercise that behavior against both drivers.
     """
 
+    def test_connect_with_empty_account_raises_missing_required(self, connector_adapter):
+        """An empty account string should be rejected by sf_core's validation,
+        matching the legacy 'Account must be specified' (251001) behavior.
+
+        Validation runs in sf_core before any network I/O, so this test does
+        not depend on the test backend being reachable.
+        """
+        with pytest.raises(ProgrammingError, match=r"[Mm]issing required parameter.*account"):
+            connector_adapter.connect(
+                account="",
+                user="u",
+                password="p",
+                host="h.example.com",
+            )
+
     def test_connect_with_account_only_no_host_or_server_url(self, connector_adapter):
         """Connection succeeds when only ``account`` is given — host/server_url are derived.
 

--- a/sf_core/src/config/connection_config.rs
+++ b/sf_core/src/config/connection_config.rs
@@ -573,7 +573,7 @@ pub fn validate_settings(settings: &ParamStore) -> Vec<ValidationIssue> {
     // wrong-typed values can surface as InvalidType.
 
     // --- MissingRequired: account ---
-    if settings.get_string(ACCOUNT).is_none() {
+    if non_empty_string(settings, ACCOUNT).is_none() {
         issues.push(ValidationIssue {
             severity: ValidationSeverity::Error,
             parameter: ACCOUNT.into(),
@@ -1261,6 +1261,23 @@ mod tests {
             .filter(|i| i.parameter == "account" && i.code == ValidationCode::MissingRequired)
             .collect();
         assert!(!account_issues.is_empty());
+    }
+
+    #[test]
+    fn validate_empty_account_reports_issue() {
+        let settings = settings_from(&[
+            ("account", Setting::String(String::new())),
+            ("user", Setting::String("u".into())),
+            ("password", Setting::String("p".into())),
+            ("host", Setting::String("h.com".into())),
+        ]);
+        let issues = validate_settings(&settings);
+        assert!(
+            issues
+                .iter()
+                .any(|i| i.parameter == "account" && i.code == ValidationCode::MissingRequired),
+            "Expected empty account to be treated as missing, got: {issues:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- sf_core's `validate_settings` used `is_none()` for the account check, so `account=\"\"` slipped through as a missing-required check failure. Switched to the empty-string-aware `non_empty_string` helper.
- The legacy Python connector errored with `251001 Account must be specified` for both missing *and* empty accounts; this restores parity.

## Changes
- `sf_core/src/config/connection_config.rs`: tighten the ACCOUNT check + new unit test `validate_empty_account_reports_issue`.
- `python/tests/integ/test_connection.py`: integ test asserts `ProgrammingError` surfaces with "Missing required parameter ... account" through the protobuf error mapping.

## Context
Part of [SNOW-2314137](https://snowflakecomputing.atlassian.net/browse/SNOW-2314137) (Authentication / Log in epic) and the [SNOW-937559](https://snowflakecomputing.atlassian.net/browse/SNOW-937559) postmortem analysis.

Out of scope (intentionally) — to be addressed in follow-ups:
- 404 from `/session/v1/login-request` for wrong-but-formatted account names (runtime behavior, needs wiremock).
- Malformed account names (`org.account` instead of `org-account`) — both drivers currently fail at TLS layer with no early validation.
- Account-format regex validation.

## Test plan
- [x] `cargo test -p sf_core --lib config::connection_config` (45 pass, including the new test)
- [ ] Run the new Python integ test against a fresh wheel build: `pytest python/tests/integ/test_connection.py::TestConnectionParameters::test_connect_with_empty_account_raises_missing_required`
- [ ] Verify no behavior change for non-empty account values (existing tests cover this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SNOW-2314137]: https://snowflakecomputing.atlassian.net/browse/SNOW-2314137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SNOW-937559]: https://snowflakecomputing.atlassian.net/browse/SNOW-937559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ