### PR TITLE
SNOW-3406377, gap 12: add CompressionAutoDetectFlavor preset + lock auto-detect behavior in tests

### DIFF
--- a/sf_core/src/apis/database_driver_v1/global_state.rs
+++ b/sf_core/src/apis/database_driver_v1/global_state.rs
@@ -34,6 +34,13 @@ pub struct WrapperPresets {
     /// instead of producing an error. Mirrors legacy libsnowflakeclient
     /// behavior; required for ODBC backward compatibility.
     pub treat_unsupported_compression_as_uncompressed: bool,
+    /// When true, magic-byte detection consults
+    /// libsnowflakeclient's short-prefix table (2-byte gzip header,
+    /// 2-byte zlib stream, 4-byte snowflake brotli marker) ahead of
+    /// the `infer` crate. Required for ODBC parity; Python and JDBC
+    /// keep this off — both connectors require a 4-byte read before
+    /// declaring a magic-byte match.
+    pub accept_partial_magic_byte_prefix: bool,
 }
 
 impl WrapperPresets {
@@ -51,6 +58,7 @@ impl WrapperPresets {
         Self {
             put_get_resultset_flavor: PutGetResultsetFlavor::Odbc,
             treat_unsupported_compression_as_uncompressed: true,
+            accept_partial_magic_byte_prefix: true,
             ..Self::default()
         }
     }

--- a/sf_core/src/apis/database_driver_v1/global_state.rs
+++ b/sf_core/src/apis/database_driver_v1/global_state.rs
@@ -42,10 +42,7 @@ impl WrapperPresets {
     /// Currently identical to `Default` — listed explicitly so that
     /// future Python-specific overrides have a clear home.
     pub fn python() -> Self {
-        Self {
-            put_get_resultset_flavor: PutGetResultsetFlavor::Python,
-            treat_unsupported_compression_as_uncompressed: false,
-        }
+        Self::default()
     }
 
     /// Presets for the ODBC driver.
@@ -60,10 +57,7 @@ impl WrapperPresets {
 
     /// Presets for the JDBC bridge.
     pub fn jdbc() -> Self {
-        Self {
-            put_get_resultset_flavor: PutGetResultsetFlavor::default(),
-            treat_unsupported_compression_as_uncompressed: false,
-        }
+        Self::default()
     }
 }
 

--- a/sf_core/src/apis/database_driver_v1/global_state.rs
+++ b/sf_core/src/apis/database_driver_v1/global_state.rs
@@ -22,17 +22,6 @@ pub enum PutGetResultsetFlavor {
     Odbc,
 }
 
-/// Per-wrapper rules for compression auto-detection during PUT.
-/// Keep this independent of `PutGetResultsetFlavor` — auto-detect
-/// behavior may diverge from result-set shape over time.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub enum CompressionAutoDetectFlavor {
-    #[default]
-    Python,
-    Odbc,
-    Jdbc,
-}
-
 /// Immutable behavioural presets declared by each wrapper (Python, ODBC, JDBC)
 /// at startup. These are **not** exposed to end users — they capture
 /// compile-time / init-time differences between wrappers so that shared Rust
@@ -40,7 +29,11 @@ pub enum CompressionAutoDetectFlavor {
 #[derive(Debug, Clone, Default)]
 pub struct WrapperPresets {
     pub put_get_resultset_flavor: PutGetResultsetFlavor,
-    pub compression_autodetect_flavor: CompressionAutoDetectFlavor,
+    /// When true, unsupported compression formats (e.g. `.xz`, `.lz`)
+    /// detected during PUT auto-detect are treated as uncompressed
+    /// instead of producing an error. Mirrors legacy libsnowflakeclient
+    /// behavior; required for ODBC backward compatibility.
+    pub treat_unsupported_compression_as_uncompressed: bool,
 }
 
 impl WrapperPresets {
@@ -51,7 +44,7 @@ impl WrapperPresets {
     pub fn python() -> Self {
         Self {
             put_get_resultset_flavor: PutGetResultsetFlavor::Python,
-            compression_autodetect_flavor: CompressionAutoDetectFlavor::Python,
+            treat_unsupported_compression_as_uncompressed: false,
         }
     }
 
@@ -60,7 +53,7 @@ impl WrapperPresets {
     pub fn odbc() -> Self {
         Self {
             put_get_resultset_flavor: PutGetResultsetFlavor::Odbc,
-            compression_autodetect_flavor: CompressionAutoDetectFlavor::Odbc,
+            treat_unsupported_compression_as_uncompressed: true,
             ..Self::default()
         }
     }
@@ -69,7 +62,7 @@ impl WrapperPresets {
     pub fn jdbc() -> Self {
         Self {
             put_get_resultset_flavor: PutGetResultsetFlavor::default(),
-            compression_autodetect_flavor: CompressionAutoDetectFlavor::Jdbc,
+            treat_unsupported_compression_as_uncompressed: false,
         }
     }
 }

--- a/sf_core/src/apis/database_driver_v1/global_state.rs
+++ b/sf_core/src/apis/database_driver_v1/global_state.rs
@@ -29,18 +29,26 @@ pub enum PutGetResultsetFlavor {
 #[derive(Debug, Clone, Default)]
 pub struct WrapperPresets {
     pub put_get_resultset_flavor: PutGetResultsetFlavor,
-    /// When true, unsupported compression formats (e.g. `.xz`, `.lz`)
-    /// detected during PUT auto-detect are treated as uncompressed
-    /// instead of producing an error. Mirrors legacy libsnowflakeclient
-    /// behavior; required for ODBC backward compatibility.
-    pub treat_unsupported_compression_as_uncompressed: bool,
-    /// When true, magic-byte detection consults
-    /// libsnowflakeclient's short-prefix table (2-byte gzip header,
-    /// 2-byte zlib stream, 4-byte snowflake brotli marker) ahead of
-    /// the `infer` crate. Required for ODBC parity; Python and JDBC
-    /// keep this off — both connectors require a 4-byte read before
-    /// declaring a magic-byte match.
-    pub accept_partial_magic_byte_prefix: bool,
+    /// When true, the PUT auto-detect path mirrors legacy
+    /// libsnowflakeclient behavior. Required for ODBC backward
+    /// compatibility; Python and JDBC keep this off. Two behaviors are
+    /// gated under the single flag because both exist solely to bring
+    /// UD's auto-detect in line with libsnowflakeclient — a wrapper that
+    /// wants one of these almost certainly wants the other:
+    ///
+    /// 1. Unsupported compression formats (`.xz`, `.lz`, `.lzma`,
+    ///    `.lzo`, `.Z`, and the buffer-detected equivalents) are
+    ///    silently treated as uncompressed instead of erroring. Without
+    ///    this flag, UD surfaces an `UnsupportedCompressionType` error
+    ///    and the upload aborts.
+    /// 2. Magic-byte detection consults a short-prefix table (2-byte
+    ///    gzip header `\x1F\x8B`, 2-byte zlib stream headers
+    ///    `\x78\x01 / \x9C / \xDA` mapped to `Deflate`, 4-byte
+    ///    snowflake-specific brotli marker `\xCE\xB2\xCF\x81`) ahead
+    ///    of the `infer` crate. Without this flag, only formats that
+    ///    `infer` can identify from a full-buffer probe (≥3 bytes for
+    ///    gzip, plus zstd/bzip2/etc.) are detected via magic.
+    pub legacy_compression_autodetect_libsnowflakeclient_behavior: bool,
 }
 
 impl WrapperPresets {
@@ -57,8 +65,7 @@ impl WrapperPresets {
     pub fn odbc() -> Self {
         Self {
             put_get_resultset_flavor: PutGetResultsetFlavor::Odbc,
-            treat_unsupported_compression_as_uncompressed: true,
-            accept_partial_magic_byte_prefix: true,
+            legacy_compression_autodetect_libsnowflakeclient_behavior: true,
             ..Self::default()
         }
     }

--- a/sf_core/src/apis/database_driver_v1/global_state.rs
+++ b/sf_core/src/apis/database_driver_v1/global_state.rs
@@ -29,25 +29,12 @@ pub enum PutGetResultsetFlavor {
 #[derive(Debug, Clone, Default)]
 pub struct WrapperPresets {
     pub put_get_resultset_flavor: PutGetResultsetFlavor,
-    /// When true, the PUT auto-detect path mirrors legacy
-    /// libsnowflakeclient behavior. Required for ODBC backward
-    /// compatibility; Python and JDBC keep this off. Two behaviors are
-    /// gated under the single flag because both exist solely to bring
-    /// UD's auto-detect in line with libsnowflakeclient — a wrapper that
-    /// wants one of these almost certainly wants the other:
-    ///
-    /// 1. Unsupported compression formats (`.xz`, `.lz`, `.lzma`,
-    ///    `.lzo`, `.Z`, and the buffer-detected equivalents) are
-    ///    silently treated as uncompressed instead of erroring. Without
-    ///    this flag, UD surfaces an `UnsupportedCompressionType` error
-    ///    and the upload aborts.
-    /// 2. Magic-byte detection consults a short-prefix table (2-byte
-    ///    gzip header `\x1F\x8B`, 2-byte zlib stream headers
-    ///    `\x78\x01 / \x9C / \xDA` mapped to `Deflate`, 4-byte
-    ///    snowflake-specific brotli marker `\xCE\xB2\xCF\x81`) ahead
-    ///    of the `infer` crate. Without this flag, only formats that
-    ///    `infer` can identify from a full-buffer probe (≥3 bytes for
-    ///    gzip, plus zstd/bzip2/etc.) are detected via magic.
+    /// When true, PUT auto-detect mirrors legacy libsnowflakeclient
+    /// behavior: (1) unsupported compression formats are silently
+    /// treated as uncompressed instead of erroring, and (2) magic-byte
+    /// detection consults a short-prefix table (2-byte gzip, 2-byte
+    /// zlib mapped to `Deflate`, 4-byte snowflake brotli marker) ahead
+    /// of the `infer` crate.
     pub legacy_compression_autodetect_libsnowflakeclient_behavior: bool,
 }
 

--- a/sf_core/src/apis/database_driver_v1/global_state.rs
+++ b/sf_core/src/apis/database_driver_v1/global_state.rs
@@ -22,6 +22,17 @@ pub enum PutGetResultsetFlavor {
     Odbc,
 }
 
+/// Per-wrapper rules for compression auto-detection during PUT.
+/// Keep this independent of `PutGetResultsetFlavor` — auto-detect
+/// behavior may diverge from result-set shape over time.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum CompressionAutoDetectFlavor {
+    #[default]
+    Python,
+    Odbc,
+    Jdbc,
+}
+
 /// Immutable behavioural presets declared by each wrapper (Python, ODBC, JDBC)
 /// at startup. These are **not** exposed to end users — they capture
 /// compile-time / init-time differences between wrappers so that shared Rust
@@ -29,6 +40,7 @@ pub enum PutGetResultsetFlavor {
 #[derive(Debug, Clone, Default)]
 pub struct WrapperPresets {
     pub put_get_resultset_flavor: PutGetResultsetFlavor,
+    pub compression_autodetect_flavor: CompressionAutoDetectFlavor,
 }
 
 impl WrapperPresets {
@@ -37,7 +49,10 @@ impl WrapperPresets {
     /// Currently identical to `Default` — listed explicitly so that
     /// future Python-specific overrides have a clear home.
     pub fn python() -> Self {
-        Self::default()
+        Self {
+            put_get_resultset_flavor: PutGetResultsetFlavor::Python,
+            compression_autodetect_flavor: CompressionAutoDetectFlavor::Python,
+        }
     }
 
     /// Presets for the ODBC driver.
@@ -45,13 +60,17 @@ impl WrapperPresets {
     pub fn odbc() -> Self {
         Self {
             put_get_resultset_flavor: PutGetResultsetFlavor::Odbc,
+            compression_autodetect_flavor: CompressionAutoDetectFlavor::Odbc,
             ..Self::default()
         }
     }
 
     /// Presets for the JDBC bridge.
     pub fn jdbc() -> Self {
-        Self::default()
+        Self {
+            put_get_resultset_flavor: PutGetResultsetFlavor::default(),
+            compression_autodetect_flavor: CompressionAutoDetectFlavor::Jdbc,
+        }
     }
 }
 

--- a/sf_core/src/apis/database_driver_v1/mod.rs
+++ b/sf_core/src/apis/database_driver_v1/mod.rs
@@ -26,10 +26,7 @@ pub use async_query_registry::AsyncQueryRegistry;
 pub use connection::{Connection, ConnectionInfo, RefreshContext, with_valid_session};
 pub use database::FetchChunkInput;
 pub use error::ApiError;
-pub use global_state::{
-    CompressionAutoDetectFlavor, DatabaseDriverV1, DriverProviders, PutGetResultsetFlavor,
-    WrapperPresets,
-};
+pub use global_state::{DatabaseDriverV1, DriverProviders, PutGetResultsetFlavor, WrapperPresets};
 pub use result_set::{
     ChunkData, ChunkDataWithDescriptor, ColumnMetadata, ExecuteQueryResult, InlineData,
     ResultSetDescriptor, ResultSetInfo,

--- a/sf_core/src/apis/database_driver_v1/mod.rs
+++ b/sf_core/src/apis/database_driver_v1/mod.rs
@@ -26,7 +26,10 @@ pub use async_query_registry::AsyncQueryRegistry;
 pub use connection::{Connection, ConnectionInfo, RefreshContext, with_valid_session};
 pub use database::FetchChunkInput;
 pub use error::ApiError;
-pub use global_state::{DatabaseDriverV1, DriverProviders, PutGetResultsetFlavor, WrapperPresets};
+pub use global_state::{
+    CompressionAutoDetectFlavor, DatabaseDriverV1, DriverProviders, PutGetResultsetFlavor,
+    WrapperPresets,
+};
 pub use result_set::{
     ChunkData, ChunkDataWithDescriptor, ColumnMetadata, ExecuteQueryResult, InlineData,
     ResultSetDescriptor, ResultSetInfo,

--- a/sf_core/src/apis/database_driver_v1/query.rs
+++ b/sf_core/src/apis/database_driver_v1/query.rs
@@ -88,7 +88,7 @@ pub(super) async fn perform_put_get_transfer(
             let file_upload_data = data
                 .to_file_upload_data(
                     wrapper_presets.put_get_resultset_flavor.clone(),
-                    wrapper_presets.compression_autodetect_flavor.clone(),
+                    wrapper_presets.treat_unsupported_compression_as_uncompressed,
                     use_s3_regional_url_session_param,
                 )
                 .context(FileTransferPreparationSnafu)?;

--- a/sf_core/src/apis/database_driver_v1/query.rs
+++ b/sf_core/src/apis/database_driver_v1/query.rs
@@ -88,6 +88,7 @@ pub(super) async fn perform_put_get_transfer(
             let file_upload_data = data
                 .to_file_upload_data(
                     wrapper_presets.put_get_resultset_flavor.clone(),
+                    wrapper_presets.compression_autodetect_flavor.clone(),
                     use_s3_regional_url_session_param,
                 )
                 .context(FileTransferPreparationSnafu)?;

--- a/sf_core/src/apis/database_driver_v1/query.rs
+++ b/sf_core/src/apis/database_driver_v1/query.rs
@@ -89,6 +89,7 @@ pub(super) async fn perform_put_get_transfer(
                 .to_file_upload_data(
                     wrapper_presets.put_get_resultset_flavor.clone(),
                     wrapper_presets.treat_unsupported_compression_as_uncompressed,
+                    wrapper_presets.accept_partial_magic_byte_prefix,
                     use_s3_regional_url_session_param,
                 )
                 .context(FileTransferPreparationSnafu)?;

--- a/sf_core/src/apis/database_driver_v1/query.rs
+++ b/sf_core/src/apis/database_driver_v1/query.rs
@@ -88,8 +88,7 @@ pub(super) async fn perform_put_get_transfer(
             let file_upload_data = data
                 .to_file_upload_data(
                     wrapper_presets.put_get_resultset_flavor.clone(),
-                    wrapper_presets.treat_unsupported_compression_as_uncompressed,
-                    wrapper_presets.accept_partial_magic_byte_prefix,
+                    wrapper_presets.legacy_compression_autodetect_libsnowflakeclient_behavior,
                     use_s3_regional_url_session_param,
                 )
                 .context(FileTransferPreparationSnafu)?;

--- a/sf_core/src/compression_types.rs
+++ b/sf_core/src/compression_types.rs
@@ -68,17 +68,51 @@ fn get_compression_type_from_extension(
     }
 }
 
+/// Short-prefix magic-byte table mirroring libsnowflakeclient's
+/// `FileCompressionType.cpp`. Each entry is matched with `starts_with` —
+/// shorter than what the `infer` crate requires (e.g. infer's gzip matcher
+/// needs the 3-byte `1F 8B 08`; ODBC accepts the 2-byte `1F 8B`). Used
+/// only when `accept_partial_magic_byte_prefix` is true; Python/JDBC do
+/// not consult this table.
+///
+/// `0x78 0x01 / 0x9C / 0xDA` are zlib stream headers. UD has no separate
+/// `Zlib` variant, so they map to `Deflate` (matching how zlib-wrapped
+/// streams are surfaced through the rest of the pipeline).
+///
+/// `0xCE 0xB2 0xCF 0x81` is the snowflake-specific brotli marker from
+/// libsnowflakeclient's `FileCompressionType.cpp` brotli branch — brotli
+/// has no IETF-defined magic, so the marker is a snowflake convention.
+const SHORT_MAGIC_PREFIXES: &[(&[u8], CompressionType)] = &[
+    (&[0xCE, 0xB2, 0xCF, 0x81], CompressionType::Brotli),
+    (&[0x1F, 0x8B], CompressionType::Gzip),
+    (&[0x78, 0x01], CompressionType::Deflate),
+    (&[0x78, 0x9C], CompressionType::Deflate),
+    (&[0x78, 0xDA], CompressionType::Deflate),
+];
+
 // Tries to guess the compression type based on the last extension of the filename
 // If that fails, it tries to guess based on the file buffer content
 // If both fail, it returns CompressionType::None
 // Returns an error if the compression type is unsupported
+//
+// `accept_partial_magic_byte_prefix` enables a libsnowflakeclient-style
+// short-prefix match (see `SHORT_MAGIC_PREFIXES`) ahead of the `infer`
+// crate's full-buffer detection. ODBC sets this to true to keep parity
+// with legacy behavior; Python / JDBC keep it false.
 pub fn try_guess_compression_type(
     filename: &str,
     file_buffer: &[u8],
+    accept_partial_magic_byte_prefix: bool,
 ) -> Result<CompressionType, CompressionTypeError> {
     let compression_type = try_guess_compression_type_from_filename(filename)?;
 
     if let Some(compression_type) = compression_type {
+        return Ok(compression_type);
+    }
+
+    if accept_partial_magic_byte_prefix
+        && let Some(compression_type) = try_match_short_prefix(file_buffer)
+    {
         return Ok(compression_type);
     }
 
@@ -99,6 +133,12 @@ fn try_guess_compression_type_from_filename(
         Some(file_extension) => get_compression_type_from_extension(file_extension),
         None => Ok(None),
     }
+}
+
+fn try_match_short_prefix(file_buffer: &[u8]) -> Option<CompressionType> {
+    SHORT_MAGIC_PREFIXES
+        .iter()
+        .find_map(|(prefix, kind)| file_buffer.starts_with(prefix).then(|| kind.clone()))
 }
 
 // TODO: DEFLATE cannot be detected by the infer crate - we might need a custom implementation for that
@@ -130,44 +170,44 @@ mod tests {
     // variant via `try_guess_compression_type` (filename branch).
     #[test]
     fn extension_gz_maps_to_gzip() {
-        let result = try_guess_compression_type("file.gz", b"").unwrap();
+        let result = try_guess_compression_type("file.gz", b"", false).unwrap();
         assert_eq!(result, CompressionType::Gzip);
     }
 
     #[test]
     fn extension_bz2_maps_to_bzip2() {
-        let result = try_guess_compression_type("file.bz2", b"").unwrap();
+        let result = try_guess_compression_type("file.bz2", b"", false).unwrap();
         assert_eq!(result, CompressionType::Bzip2);
     }
 
     #[test]
     fn extension_br_maps_to_brotli() {
-        let result = try_guess_compression_type("file.br", b"").unwrap();
+        let result = try_guess_compression_type("file.br", b"", false).unwrap();
         assert_eq!(result, CompressionType::Brotli);
     }
 
     #[test]
     fn extension_zst_maps_to_zstd() {
-        let result = try_guess_compression_type("file.zst", b"").unwrap();
+        let result = try_guess_compression_type("file.zst", b"", false).unwrap();
         assert_eq!(result, CompressionType::Zstd);
     }
 
     #[test]
     fn extension_deflate_maps_to_deflate() {
-        let result = try_guess_compression_type("file.deflate", b"").unwrap();
+        let result = try_guess_compression_type("file.deflate", b"", false).unwrap();
         assert_eq!(result, CompressionType::Deflate);
     }
 
     #[test]
     fn extension_raw_deflate_maps_to_raw_deflate() {
-        let result = try_guess_compression_type("file.raw_deflate", b"").unwrap();
+        let result = try_guess_compression_type("file.raw_deflate", b"", false).unwrap();
         assert_eq!(result, CompressionType::RawDeflate);
     }
 
     // Unsupported extensions: each errors with `UnsupportedCompressionType`
     // and the right `type_name`.
     fn assert_unsupported_with_name(filename: &str, expected_type_name: &str) {
-        let result = try_guess_compression_type(filename, b"");
+        let result = try_guess_compression_type(filename, b"", false);
         match result {
             Err(CompressionTypeError::UnsupportedCompressionType { type_name, .. }) => {
                 assert_eq!(
@@ -219,13 +259,13 @@ mod tests {
     // empty buffer => None).
     #[test]
     fn extension_match_is_case_sensitive() {
-        let result = try_guess_compression_type("foo.GZ", b"").unwrap();
+        let result = try_guess_compression_type("foo.GZ", b"", false).unwrap();
         assert_eq!(result, CompressionType::None);
     }
 
     #[test]
     fn unknown_extension_with_empty_buffer_returns_none() {
-        let result = try_guess_compression_type("file.unknownext", b"").unwrap();
+        let result = try_guess_compression_type("file.unknownext", b"", false).unwrap();
         assert_eq!(result, CompressionType::None);
     }
 
@@ -234,28 +274,28 @@ mod tests {
     #[test]
     fn magic_bytes_detect_gzip() {
         let gzip_magic: &[u8] = &[0x1F, 0x8B, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
-        let result = try_guess_compression_type("noext", gzip_magic).unwrap();
+        let result = try_guess_compression_type("noext", gzip_magic, false).unwrap();
         assert_eq!(result, CompressionType::Gzip);
     }
 
     #[test]
     fn magic_bytes_detect_bzip2() {
         let bzip2_magic: &[u8] = &[0x42, 0x5A, 0x68, 0x39, 0x31, 0x41, 0x59, 0x26, 0x53, 0x59];
-        let result = try_guess_compression_type("noext", bzip2_magic).unwrap();
+        let result = try_guess_compression_type("noext", bzip2_magic, false).unwrap();
         assert_eq!(result, CompressionType::Bzip2);
     }
 
     #[test]
     fn magic_bytes_detect_zstd() {
         let zstd_magic: &[u8] = &[0x28, 0xB5, 0x2F, 0xFD, 0x00, 0x00, 0x00, 0x00];
-        let result = try_guess_compression_type("noext", zstd_magic).unwrap();
+        let result = try_guess_compression_type("noext", zstd_magic, false).unwrap();
         assert_eq!(result, CompressionType::Zstd);
     }
 
     // Multi-dot filenames: only the last segment matters.
     #[test]
     fn multi_dot_filename_uses_last_segment_for_gzip() {
-        let result = try_guess_compression_type("foo.tar.gz", b"").unwrap();
+        let result = try_guess_compression_type("foo.tar.gz", b"", false).unwrap();
         assert_eq!(result, CompressionType::Gzip);
     }
 
@@ -264,7 +304,7 @@ mod tests {
         // `foo.gz.bak` — last segment is `bak`, not `gz` — extension
         // branch returns `None`, magic-bytes branch returns `None` for
         // empty buffer, overall result is `CompressionType::None`.
-        let result = try_guess_compression_type("foo.gz.bak", b"").unwrap();
+        let result = try_guess_compression_type("foo.gz.bak", b"", false).unwrap();
         assert_eq!(result, CompressionType::None);
     }
 
@@ -274,7 +314,7 @@ mod tests {
     // branch then takes over (here: empty buffer => Ok(None) overall).
     #[test]
     fn filename_with_no_dot_falls_through_to_magic() {
-        let result = try_guess_compression_type("plainfile", b"").unwrap();
+        let result = try_guess_compression_type("plainfile", b"", false).unwrap();
         assert_eq!(result, CompressionType::None);
     }
 
@@ -284,12 +324,169 @@ mod tests {
     #[test]
     fn magic_bytes_detect_xz_as_unsupported() {
         let xz_magic: &[u8] = b"\xFD7zXZ\x00\x00\x01\x69\x22\xDE\x36";
-        let result = try_guess_compression_type("noext", xz_magic);
+        let result = try_guess_compression_type("noext", xz_magic, false);
         match result {
             Err(CompressionTypeError::UnsupportedCompressionType { type_name, .. }) => {
                 assert_eq!(type_name, "XZ");
             }
             other => panic!("Expected UnsupportedCompressionType for xz magic, got: {other:?}"),
         }
+    }
+
+    // Extension/magic conflict: filename says gzip, magic bytes say bzip2.
+    // The filename branch runs first and short-circuits on the recognized
+    // `.gz` extension, so the magic-byte buffer is never consulted —
+    // result is `Gzip` regardless of the partial-prefix flag. This
+    // matches Python (`mimetypes.guess_type` first) and JDBC
+    // (`Files.probeContentType` first); it diverges from
+    // libsnowflakeclient's ODBC, which iterates magic bytes first and
+    // would return `Bzip2` here.
+    #[test]
+    fn extension_gz_with_bzip2_magic_resolves_via_extension_to_gzip_for_both_flag_values() {
+        let bzip2_magic: &[u8] = &[0x42, 0x5A, 0x68, 0x39];
+        for accept_partial in [false, true] {
+            let result =
+                try_guess_compression_type("file.gz", bzip2_magic, accept_partial).unwrap();
+            assert_eq!(
+                result,
+                CompressionType::Gzip,
+                "Extension must win over conflicting magic bytes (accept_partial={accept_partial})",
+            );
+        }
+    }
+
+    // 2-byte gzip prefix: shorter than `infer`'s 3-byte gzip matcher.
+    // With the flag false (Python/JDBC default) `infer` returns `None` and
+    // we fall through to `CompressionType::None`. With the flag true (ODBC
+    // default), the short-prefix table matches first and returns `Gzip`,
+    // mirroring `libsnowflakeclient`'s `m_magicBytes = 2` for gzip.
+    #[test]
+    fn magic_bytes_partial_gzip_2_bytes_undetected_when_flag_false() {
+        let two_bytes: &[u8] = &[0x1F, 0x8B];
+        let result = try_guess_compression_type("noext", two_bytes, false).unwrap();
+        assert_eq!(result, CompressionType::None);
+    }
+
+    #[test]
+    fn magic_bytes_partial_gzip_2_bytes_detected_when_flag_true() {
+        let two_bytes: &[u8] = &[0x1F, 0x8B];
+        let result = try_guess_compression_type("noext", two_bytes, true).unwrap();
+        assert_eq!(result, CompressionType::Gzip);
+    }
+
+    #[test]
+    fn magic_bytes_full_gzip_3_bytes_detected_for_both_flag_values() {
+        let three_bytes: &[u8] = &[0x1F, 0x8B, 0x08];
+        for accept_partial in [false, true] {
+            let result = try_guess_compression_type("noext", three_bytes, accept_partial).unwrap();
+            assert_eq!(
+                result,
+                CompressionType::Gzip,
+                "Full gzip magic must always be detected (accept_partial={accept_partial})",
+            );
+        }
+    }
+
+    // zlib stream header (`78 9C` is the most common variant). `infer` has
+    // no zlib matcher; the flag enables libsnowflakeclient's behavior of
+    // surfacing zlib-wrapped streams as `Deflate` (UD has no separate
+    // `Zlib` variant).
+    #[test]
+    fn magic_bytes_zlib_default_compressed_undetected_when_flag_false() {
+        let zlib_magic: &[u8] = &[0x78, 0x9C, 0x00, 0x00];
+        let result = try_guess_compression_type("noext", zlib_magic, false).unwrap();
+        assert_eq!(result, CompressionType::None);
+    }
+
+    #[test]
+    fn magic_bytes_zlib_default_compressed_detected_as_deflate_when_flag_true() {
+        for header in [0x01u8, 0x9C, 0xDA] {
+            let zlib_magic: &[u8] = &[0x78, header, 0x00, 0x00];
+            let result = try_guess_compression_type("noext", zlib_magic, true).unwrap();
+            assert_eq!(
+                result,
+                CompressionType::Deflate,
+                "zlib header 0x78 0x{header:02X} must map to Deflate",
+            );
+        }
+    }
+
+    // Brotli has no IETF-defined magic; libsnowflakeclient defines a
+    // 4-byte snowflake-specific marker (`CE B2 CF 81`). Flag-gated to
+    // avoid breaking the Python/JDBC contract (they detect brotli purely
+    // via `.br` extension, never magic).
+    #[test]
+    fn magic_bytes_brotli_marker_undetected_when_flag_false() {
+        let brotli_magic: &[u8] = &[0xCE, 0xB2, 0xCF, 0x81, 0x00];
+        let result = try_guess_compression_type("noext", brotli_magic, false).unwrap();
+        assert_eq!(result, CompressionType::None);
+    }
+
+    #[test]
+    fn magic_bytes_brotli_marker_detected_when_flag_true() {
+        let brotli_magic: &[u8] = &[0xCE, 0xB2, 0xCF, 0x81, 0x00];
+        let result = try_guess_compression_type("noext", brotli_magic, true).unwrap();
+        assert_eq!(result, CompressionType::Brotli);
+    }
+
+    // Empty buffer: no extension matches, `infer` returns None, and the
+    // short-prefix table never matches an empty buffer (`starts_with(&[])`
+    // would be true but no entry has an empty prefix). Both flag values
+    // return None — matches Python, JDBC, and ODBC.
+    #[test]
+    fn magic_bytes_empty_buffer_returns_none_for_both_flag_values() {
+        for accept_partial in [false, true] {
+            let result = try_guess_compression_type("noext", b"", accept_partial).unwrap();
+            assert_eq!(
+                result,
+                CompressionType::None,
+                "Empty buffer must report None (accept_partial={accept_partial})",
+            );
+        }
+    }
+
+    // Filename of only dots: `rsplit('.').next()` returns `""` — the
+    // empty string doesn't match any known extension, so we fall through
+    // to magic-byte detection. Locks the current behavior; reviewers
+    // flagged this as untested.
+    #[test]
+    fn filename_only_dots_falls_through_to_magic() {
+        let result = try_guess_compression_type("...", b"", false).unwrap();
+        assert_eq!(result, CompressionType::None);
+    }
+
+    // `.gz` (leading-dot, no stem): `rsplit('.').next()` returns `"gz"`,
+    // which matches the gzip extension branch — same outcome as `foo.gz`.
+    // Matches Python's `mimetypes.guess_type(".gz")` and JDBC's
+    // `endsWith(".gz")` fallback.
+    #[test]
+    fn filename_only_dot_extension_gz_treated_as_gzip() {
+        let result = try_guess_compression_type(".gz", b"", false).unwrap();
+        assert_eq!(result, CompressionType::Gzip);
+    }
+
+    // Very long filename ending in `.gz`: no length limit anywhere in the
+    // detection path — this exercises the `rsplit('.').next()` allocation
+    // pattern with 4096+ bytes and asserts it still returns the trailing
+    // segment. None of the legacy connectors special-case length either.
+    #[test]
+    fn filename_4096_chars_with_gz_extension_detected_as_gzip() {
+        let mut filename = "a".repeat(4096);
+        filename.push_str(".gz");
+        let result = try_guess_compression_type(&filename, b"", false).unwrap();
+        assert_eq!(result, CompressionType::Gzip);
+    }
+
+    // Brotli / deflate / raw_deflate are never detected from magic bytes
+    // when the flag is false: brotli has no IETF magic (Python/JDBC
+    // detect it purely via extension), deflate / raw_deflate are
+    // headerless. Locks this — `infer` has no matchers for these formats.
+    #[test]
+    fn magic_bytes_brotli_deflate_raw_deflate_never_detected_when_flag_false() {
+        // No defined magic bytes for these formats — pass plausible
+        // payload bytes that should remain unidentified.
+        let arbitrary: &[u8] = b"plain brotli/deflate payload \x00\xFF";
+        let result = try_guess_compression_type("noext", arbitrary, false).unwrap();
+        assert_eq!(result, CompressionType::None);
     }
 }

--- a/sf_core/src/compression_types.rs
+++ b/sf_core/src/compression_types.rs
@@ -72,8 +72,8 @@ fn get_compression_type_from_extension(
 /// `FileCompressionType.cpp`. Each entry is matched with `starts_with` —
 /// shorter than what the `infer` crate requires (e.g. infer's gzip matcher
 /// needs the 3-byte `1F 8B 08`; ODBC accepts the 2-byte `1F 8B`). Used
-/// only when `accept_partial_magic_byte_prefix` is true; Python/JDBC do
-/// not consult this table.
+/// only when `legacy_compression_autodetect_libsnowflakeclient_behavior`
+/// is true; Python/JDBC do not consult this table.
 ///
 /// `0x78 0x01 / 0x9C / 0xDA` are zlib stream headers. UD has no separate
 /// `Zlib` variant, so they map to `Deflate` (matching how zlib-wrapped
@@ -95,14 +95,16 @@ const SHORT_MAGIC_PREFIXES: &[(&[u8], CompressionType)] = &[
 // If both fail, it returns CompressionType::None
 // Returns an error if the compression type is unsupported
 //
-// `accept_partial_magic_byte_prefix` enables a libsnowflakeclient-style
-// short-prefix match (see `SHORT_MAGIC_PREFIXES`) ahead of the `infer`
-// crate's full-buffer detection. ODBC sets this to true to keep parity
-// with legacy behavior; Python / JDBC keep it false.
+// `legacy_compression_autodetect_libsnowflakeclient_behavior` enables a
+// libsnowflakeclient-style short-prefix match (see `SHORT_MAGIC_PREFIXES`)
+// ahead of the `infer` crate's full-buffer detection. ODBC sets this to
+// true to keep parity with legacy behavior; Python / JDBC keep it false.
+// (Error swallowing — the second half of the legacy behavior — is
+// applied one layer up, in `auto_detect_source_compression`.)
 pub fn try_guess_compression_type(
     filename: &str,
     file_buffer: &[u8],
-    accept_partial_magic_byte_prefix: bool,
+    legacy_compression_autodetect_libsnowflakeclient_behavior: bool,
 ) -> Result<CompressionType, CompressionTypeError> {
     let compression_type = try_guess_compression_type_from_filename(filename)?;
 
@@ -110,7 +112,7 @@ pub fn try_guess_compression_type(
         return Ok(compression_type);
     }
 
-    if accept_partial_magic_byte_prefix
+    if legacy_compression_autodetect_libsnowflakeclient_behavior
         && let Some(compression_type) = try_match_short_prefix(file_buffer)
     {
         return Ok(compression_type);
@@ -336,21 +338,19 @@ mod tests {
     // Extension/magic conflict: filename says gzip, magic bytes say bzip2.
     // The filename branch runs first and short-circuits on the recognized
     // `.gz` extension, so the magic-byte buffer is never consulted —
-    // result is `Gzip` regardless of the partial-prefix flag. This
-    // matches Python (`mimetypes.guess_type` first) and JDBC
-    // (`Files.probeContentType` first); it diverges from
-    // libsnowflakeclient's ODBC, which iterates magic bytes first and
-    // would return `Bzip2` here.
+    // result is `Gzip` regardless of the legacy flag. This matches Python
+    // (`mimetypes.guess_type` first) and JDBC (`Files.probeContentType`
+    // first); it diverges from libsnowflakeclient's ODBC, which iterates
+    // magic bytes first and would return `Bzip2` here.
     #[test]
     fn extension_gz_with_bzip2_magic_resolves_via_extension_to_gzip_for_both_flag_values() {
         let bzip2_magic: &[u8] = &[0x42, 0x5A, 0x68, 0x39];
-        for accept_partial in [false, true] {
-            let result =
-                try_guess_compression_type("file.gz", bzip2_magic, accept_partial).unwrap();
+        for legacy in [false, true] {
+            let result = try_guess_compression_type("file.gz", bzip2_magic, legacy).unwrap();
             assert_eq!(
                 result,
                 CompressionType::Gzip,
-                "Extension must win over conflicting magic bytes (accept_partial={accept_partial})",
+                "Extension must win over conflicting magic bytes (legacy={legacy})",
             );
         }
     }
@@ -361,14 +361,14 @@ mod tests {
     // default), the short-prefix table matches first and returns `Gzip`,
     // mirroring `libsnowflakeclient`'s `m_magicBytes = 2` for gzip.
     #[test]
-    fn magic_bytes_partial_gzip_2_bytes_undetected_when_flag_false() {
+    fn magic_bytes_partial_gzip_2_bytes_undetected_when_legacy_flag_false() {
         let two_bytes: &[u8] = &[0x1F, 0x8B];
         let result = try_guess_compression_type("noext", two_bytes, false).unwrap();
         assert_eq!(result, CompressionType::None);
     }
 
     #[test]
-    fn magic_bytes_partial_gzip_2_bytes_detected_when_flag_true() {
+    fn magic_bytes_partial_gzip_2_bytes_detected_when_legacy_flag_true() {
         let two_bytes: &[u8] = &[0x1F, 0x8B];
         let result = try_guess_compression_type("noext", two_bytes, true).unwrap();
         assert_eq!(result, CompressionType::Gzip);
@@ -377,12 +377,12 @@ mod tests {
     #[test]
     fn magic_bytes_full_gzip_3_bytes_detected_for_both_flag_values() {
         let three_bytes: &[u8] = &[0x1F, 0x8B, 0x08];
-        for accept_partial in [false, true] {
-            let result = try_guess_compression_type("noext", three_bytes, accept_partial).unwrap();
+        for legacy in [false, true] {
+            let result = try_guess_compression_type("noext", three_bytes, legacy).unwrap();
             assert_eq!(
                 result,
                 CompressionType::Gzip,
-                "Full gzip magic must always be detected (accept_partial={accept_partial})",
+                "Full gzip magic must always be detected (legacy={legacy})",
             );
         }
     }
@@ -392,14 +392,14 @@ mod tests {
     // surfacing zlib-wrapped streams as `Deflate` (UD has no separate
     // `Zlib` variant).
     #[test]
-    fn magic_bytes_zlib_default_compressed_undetected_when_flag_false() {
+    fn magic_bytes_zlib_default_compressed_undetected_when_legacy_flag_false() {
         let zlib_magic: &[u8] = &[0x78, 0x9C, 0x00, 0x00];
         let result = try_guess_compression_type("noext", zlib_magic, false).unwrap();
         assert_eq!(result, CompressionType::None);
     }
 
     #[test]
-    fn magic_bytes_zlib_default_compressed_detected_as_deflate_when_flag_true() {
+    fn magic_bytes_zlib_default_compressed_detected_as_deflate_when_legacy_flag_true() {
         for header in [0x01u8, 0x9C, 0xDA] {
             let zlib_magic: &[u8] = &[0x78, header, 0x00, 0x00];
             let result = try_guess_compression_type("noext", zlib_magic, true).unwrap();
@@ -416,14 +416,14 @@ mod tests {
     // avoid breaking the Python/JDBC contract (they detect brotli purely
     // via `.br` extension, never magic).
     #[test]
-    fn magic_bytes_brotli_marker_undetected_when_flag_false() {
+    fn magic_bytes_brotli_marker_undetected_when_legacy_flag_false() {
         let brotli_magic: &[u8] = &[0xCE, 0xB2, 0xCF, 0x81, 0x00];
         let result = try_guess_compression_type("noext", brotli_magic, false).unwrap();
         assert_eq!(result, CompressionType::None);
     }
 
     #[test]
-    fn magic_bytes_brotli_marker_detected_when_flag_true() {
+    fn magic_bytes_brotli_marker_detected_when_legacy_flag_true() {
         let brotli_magic: &[u8] = &[0xCE, 0xB2, 0xCF, 0x81, 0x00];
         let result = try_guess_compression_type("noext", brotli_magic, true).unwrap();
         assert_eq!(result, CompressionType::Brotli);
@@ -435,12 +435,12 @@ mod tests {
     // return None — matches Python, JDBC, and ODBC.
     #[test]
     fn magic_bytes_empty_buffer_returns_none_for_both_flag_values() {
-        for accept_partial in [false, true] {
-            let result = try_guess_compression_type("noext", b"", accept_partial).unwrap();
+        for legacy in [false, true] {
+            let result = try_guess_compression_type("noext", b"", legacy).unwrap();
             assert_eq!(
                 result,
                 CompressionType::None,
-                "Empty buffer must report None (accept_partial={accept_partial})",
+                "Empty buffer must report None (legacy={legacy})",
             );
         }
     }

--- a/sf_core/src/compression_types.rs
+++ b/sf_core/src/compression_types.rs
@@ -121,3 +121,175 @@ pub enum CompressionTypeError {
         location: Location,
     },
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Supported extensions: each maps to the matching `CompressionType`
+    // variant via `try_guess_compression_type` (filename branch).
+    #[test]
+    fn extension_gz_maps_to_gzip() {
+        let result = try_guess_compression_type("file.gz", b"").unwrap();
+        assert_eq!(result, CompressionType::Gzip);
+    }
+
+    #[test]
+    fn extension_bz2_maps_to_bzip2() {
+        let result = try_guess_compression_type("file.bz2", b"").unwrap();
+        assert_eq!(result, CompressionType::Bzip2);
+    }
+
+    #[test]
+    fn extension_br_maps_to_brotli() {
+        let result = try_guess_compression_type("file.br", b"").unwrap();
+        assert_eq!(result, CompressionType::Brotli);
+    }
+
+    #[test]
+    fn extension_zst_maps_to_zstd() {
+        let result = try_guess_compression_type("file.zst", b"").unwrap();
+        assert_eq!(result, CompressionType::Zstd);
+    }
+
+    #[test]
+    fn extension_deflate_maps_to_deflate() {
+        let result = try_guess_compression_type("file.deflate", b"").unwrap();
+        assert_eq!(result, CompressionType::Deflate);
+    }
+
+    #[test]
+    fn extension_raw_deflate_maps_to_raw_deflate() {
+        let result = try_guess_compression_type("file.raw_deflate", b"").unwrap();
+        assert_eq!(result, CompressionType::RawDeflate);
+    }
+
+    // Unsupported extensions: each errors with `UnsupportedCompressionType`
+    // and the right `type_name`.
+    fn assert_unsupported_with_name(filename: &str, expected_type_name: &str) {
+        let result = try_guess_compression_type(filename, b"");
+        match result {
+            Err(CompressionTypeError::UnsupportedCompressionType { type_name, .. }) => {
+                assert_eq!(
+                    type_name, expected_type_name,
+                    "Wrong type_name for {filename}",
+                );
+            }
+            other => panic!("Expected UnsupportedCompressionType for {filename}, got: {other:?}",),
+        }
+    }
+
+    #[test]
+    fn extension_lz_errors_with_lz_type_name() {
+        assert_unsupported_with_name("file.lz", "LZ");
+    }
+
+    #[test]
+    fn extension_lzma_errors_with_lzma_type_name() {
+        assert_unsupported_with_name("file.lzma", "LZMA");
+    }
+
+    #[test]
+    fn extension_lzo_errors_with_lzo_type_name() {
+        assert_unsupported_with_name("file.lzo", "LZO");
+    }
+
+    #[test]
+    fn extension_xz_errors_with_xz_type_name() {
+        assert_unsupported_with_name("file.xz", "XZ");
+    }
+
+    #[test]
+    fn extension_capital_z_errors_with_compress_type_name() {
+        assert_unsupported_with_name("file.Z", "COMPRESS");
+    }
+
+    #[test]
+    fn extension_parquet_errors_with_parquet_type_name() {
+        assert_unsupported_with_name("file.parquet", "PARQUET");
+    }
+
+    #[test]
+    fn extension_orc_errors_with_orc_type_name() {
+        assert_unsupported_with_name("file.orc", "ORC");
+    }
+
+    // Extension match is case-sensitive: `foo.GZ` does not match by
+    // extension and must fall through to the magic-byte branch (here:
+    // empty buffer => None).
+    #[test]
+    fn extension_match_is_case_sensitive() {
+        let result = try_guess_compression_type("foo.GZ", b"").unwrap();
+        assert_eq!(result, CompressionType::None);
+    }
+
+    #[test]
+    fn unknown_extension_with_empty_buffer_returns_none() {
+        let result = try_guess_compression_type("file.unknownext", b"").unwrap();
+        assert_eq!(result, CompressionType::None);
+    }
+
+    // Magic-byte sniffing detects gzip, bzip2, and zstd when the filename
+    // has no recognized extension.
+    #[test]
+    fn magic_bytes_detect_gzip() {
+        let gzip_magic: &[u8] = &[0x1F, 0x8B, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+        let result = try_guess_compression_type("noext", gzip_magic).unwrap();
+        assert_eq!(result, CompressionType::Gzip);
+    }
+
+    #[test]
+    fn magic_bytes_detect_bzip2() {
+        let bzip2_magic: &[u8] = &[0x42, 0x5A, 0x68, 0x39, 0x31, 0x41, 0x59, 0x26, 0x53, 0x59];
+        let result = try_guess_compression_type("noext", bzip2_magic).unwrap();
+        assert_eq!(result, CompressionType::Bzip2);
+    }
+
+    #[test]
+    fn magic_bytes_detect_zstd() {
+        let zstd_magic: &[u8] = &[0x28, 0xB5, 0x2F, 0xFD, 0x00, 0x00, 0x00, 0x00];
+        let result = try_guess_compression_type("noext", zstd_magic).unwrap();
+        assert_eq!(result, CompressionType::Zstd);
+    }
+
+    // Multi-dot filenames: only the last segment matters.
+    #[test]
+    fn multi_dot_filename_uses_last_segment_for_gzip() {
+        let result = try_guess_compression_type("foo.tar.gz", b"").unwrap();
+        assert_eq!(result, CompressionType::Gzip);
+    }
+
+    #[test]
+    fn multi_dot_filename_with_unknown_last_segment_falls_through() {
+        // `foo.gz.bak` — last segment is `bak`, not `gz` — extension
+        // branch returns `None`, magic-bytes branch returns `None` for
+        // empty buffer, overall result is `CompressionType::None`.
+        let result = try_guess_compression_type("foo.gz.bak", b"").unwrap();
+        assert_eq!(result, CompressionType::None);
+    }
+
+    // `rsplit('.').next()` returns the whole string for filenames with no
+    // `.` — that string ends up not matching any known extension, so the
+    // result is `Ok(None)` from the filename branch and the magic-byte
+    // branch then takes over (here: empty buffer => Ok(None) overall).
+    #[test]
+    fn filename_with_no_dot_falls_through_to_magic() {
+        let result = try_guess_compression_type("plainfile", b"").unwrap();
+        assert_eq!(result, CompressionType::None);
+    }
+
+    // Buffer-detection branch surfaces unsupported magic bytes (e.g. xz
+    // / 7z) as `UnsupportedCompressionType` — locks current behavior so
+    // PR2 has a baseline to change against.
+    #[test]
+    fn magic_bytes_detect_xz_as_unsupported() {
+        let xz_magic: &[u8] = b"\xFD7zXZ\x00\x00\x01\x69\x22\xDE\x36";
+        let result = try_guess_compression_type("noext", xz_magic);
+        match result {
+            Err(CompressionTypeError::UnsupportedCompressionType { type_name, .. }) => {
+                assert_eq!(type_name, "XZ");
+            }
+            other => panic!("Expected UnsupportedCompressionType for xz magic, got: {other:?}"),
+        }
+    }
+}

--- a/sf_core/src/file_manager/mod.rs
+++ b/sf_core/src/file_manager/mod.rs
@@ -243,14 +243,13 @@ fn get_source_compression(
 }
 
 /// Returns the resolved compression type for the `AUTO_DETECT` path. When
-/// `treat_unsupported_compression_as_uncompressed` is true, legacy
-/// libsnowflakeclient behavior is restored: unsupported compression
-/// formats (e.g. `.xz`, `.lz`, `.parquet`) are silently treated as
-/// uncompressed and the upload continues. When false (Python / JDBC
-/// default), the error surfaces. The recovery is keyed on the
-/// `UnsupportedCompressionType` error variant, so it fires regardless of
-/// whether the detection went through the filename extension or the
-/// magic-bytes (infer crate) path.
+/// `treat_unsupported_compression_as_uncompressed` is true, unsupported
+/// compression formats (e.g. `.xz`, `.lz`, `.parquet`) are silently
+/// treated as uncompressed and the upload continues — restoring legacy
+/// libsnowflakeclient behavior. When false, the error surfaces. The
+/// recovery is keyed on the `UnsupportedCompressionType` error variant,
+/// so it fires regardless of whether the detection went through the
+/// filename extension or the magic-bytes (infer crate) path.
 fn auto_detect_source_compression(
     filename: &str,
     file_buffer: &[u8],
@@ -581,19 +580,19 @@ mod tests {
     ];
 
     #[test]
-    fn auto_detect_source_compression_true_swallows_error() {
+    fn auto_detect_source_compression_treat_unsupported_as_uncompressed_true_swallows_error() {
         for filename in UNSUPPORTED_COMPRESSION_FILENAMES {
             let result = auto_detect_source_compression(filename, b"", true);
             assert_eq!(
                 result.unwrap(),
                 CompressionType::None,
-                "Swallow flag must fall back to None for {filename}",
+                "treat_unsupported_compression_as_uncompressed=true must fall back to None for {filename}",
             );
         }
     }
 
     #[test]
-    fn auto_detect_source_compression_false_propagates_error() {
+    fn auto_detect_source_compression_treat_unsupported_as_uncompressed_false_propagates_error() {
         for filename in UNSUPPORTED_COMPRESSION_FILENAMES {
             let result = auto_detect_source_compression(filename, b"", false);
             assert!(
@@ -601,25 +600,27 @@ mod tests {
                     result,
                     Err(CompressionTypeError::UnsupportedCompressionType { .. })
                 ),
-                "Propagating flag must surface the unsupported error for {filename}, got: {result:?}",
+                "treat_unsupported_compression_as_uncompressed=false must surface the unsupported error for {filename}, got: {result:?}",
             );
         }
     }
 
     // Buffer-detection branch (infer crate): an extension-less file whose
     // magic bytes match an unsupported format must still trigger the
-    // swallow-flag fallback. Locks in that the recovery is keyed on the
-    // `UnsupportedCompressionType` error variant, not on the
-    // filename-extension detection path.
+    // `treat_unsupported_compression_as_uncompressed` fallback. Locks in
+    // that the recovery is keyed on the `UnsupportedCompressionType`
+    // error variant, not on the filename-extension detection path.
     #[test]
-    fn auto_detect_source_compression_true_swallows_buffer_detected_unsupported() {
+    fn auto_detect_source_compression_treat_unsupported_as_uncompressed_true_swallows_buffer_detected_unsupported()
+     {
         let xz_magic = b"\xFD7zXZ\x00\x00\x01\x69\x22\xDE\x36";
         let result = auto_detect_source_compression("noext", xz_magic, true);
         assert_eq!(result.unwrap(), CompressionType::None);
     }
 
     #[test]
-    fn auto_detect_source_compression_false_propagates_buffer_detected_unsupported() {
+    fn auto_detect_source_compression_treat_unsupported_as_uncompressed_false_propagates_buffer_detected_unsupported()
+     {
         let xz_magic = b"\xFD7zXZ\x00\x00\x01\x69\x22\xDE\x36";
         let result = auto_detect_source_compression("noext", xz_magic, false);
         assert!(
@@ -627,7 +628,7 @@ mod tests {
                 result,
                 Err(CompressionTypeError::UnsupportedCompressionType { .. })
             ),
-            "Propagating flag must surface the buffer-detected unsupported error, got: {result:?}",
+            "treat_unsupported_compression_as_uncompressed=false must surface the buffer-detected unsupported error, got: {result:?}",
         );
     }
 

--- a/sf_core/src/file_manager/mod.rs
+++ b/sf_core/src/file_manager/mod.rs
@@ -64,9 +64,8 @@ pub async fn upload_files(
             source_compression: data.source_compression.clone(),
             overwrite: data.overwrite,
             flavor: data.flavor.clone(),
-            treat_unsupported_compression_as_uncompressed: data
-                .treat_unsupported_compression_as_uncompressed,
-            accept_partial_magic_byte_prefix: data.accept_partial_magic_byte_prefix,
+            legacy_compression_autodetect_libsnowflakeclient_behavior: data
+                .legacy_compression_autodetect_libsnowflakeclient_behavior,
         };
 
         let result = upload_single_file(single_upload_data, &mut refresher).await?;
@@ -176,8 +175,7 @@ fn preprocess_file_before_upload(
         data.filename.as_str(),
         file_buffer.as_slice(),
         &data.source_compression,
-        data.treat_unsupported_compression_as_uncompressed,
-        data.accept_partial_magic_byte_prefix,
+        data.legacy_compression_autodetect_libsnowflakeclient_behavior,
     )
     .context(CompressionTypeSnafu)?;
 
@@ -226,15 +224,13 @@ fn get_source_compression(
     filename: &str,
     file_buffer: &[u8],
     source_compression: &SourceCompressionParam,
-    treat_unsupported_compression_as_uncompressed: bool,
-    accept_partial_magic_byte_prefix: bool,
+    legacy_compression_autodetect_libsnowflakeclient_behavior: bool,
 ) -> Result<CompressionType, CompressionTypeError> {
     match source_compression {
         SourceCompressionParam::AutoDetect => auto_detect_source_compression(
             filename,
             file_buffer,
-            treat_unsupported_compression_as_uncompressed,
-            accept_partial_magic_byte_prefix,
+            legacy_compression_autodetect_libsnowflakeclient_behavior,
         ),
         SourceCompressionParam::None => Ok(CompressionType::None),
         SourceCompressionParam::Gzip => Ok(CompressionType::Gzip),
@@ -246,29 +242,31 @@ fn get_source_compression(
     }
 }
 
-/// Returns the resolved compression type for the `AUTO_DETECT` path. Two
-/// independent flags shape the behavior:
+/// Returns the resolved compression type for the `AUTO_DETECT` path.
+/// `legacy_compression_autodetect_libsnowflakeclient_behavior` (true) opts
+/// into two libsnowflakeclient-parity behaviors at once (see
+/// `WrapperPresets` for the full doc-comment):
 ///
-/// - `treat_unsupported_compression_as_uncompressed` (true): unsupported
-///   formats (e.g. `.xz`, `.lz`, `.parquet`) are silently treated as
-///   uncompressed and the upload continues — restoring legacy
-///   libsnowflakeclient behavior. False propagates the error. The
-///   recovery is keyed on the `UnsupportedCompressionType` error variant,
-///   so it fires regardless of whether detection went through the
-///   filename extension or the magic-bytes (infer crate) path.
-/// - `accept_partial_magic_byte_prefix` (true): a libsnowflakeclient-style
-///   short-prefix table runs ahead of the `infer` crate, allowing a
-///   2-byte gzip header / 2-byte zlib stream / 4-byte snowflake brotli
-///   marker to be detected even though `infer` requires more bytes.
+/// 1. Short-prefix magic-byte table runs ahead of the `infer` crate,
+///    detecting 2-byte gzip / 2-byte zlib (mapped to `Deflate`) / 4-byte
+///    snowflake brotli marker that `infer` would miss.
+/// 2. Unsupported formats (`.xz`, `.lz`, `.lzma`, `.lzo`, `.Z`, plus the
+///    buffer-detected equivalents) are silently treated as uncompressed
+///    instead of erroring. Recovery is keyed on the
+///    `UnsupportedCompressionType` error variant, so it fires regardless
+///    of whether detection went through the filename extension or the
+///    magic-bytes path.
 fn auto_detect_source_compression(
     filename: &str,
     file_buffer: &[u8],
-    treat_unsupported_compression_as_uncompressed: bool,
-    accept_partial_magic_byte_prefix: bool,
+    legacy_compression_autodetect_libsnowflakeclient_behavior: bool,
 ) -> Result<CompressionType, CompressionTypeError> {
-    let detected =
-        try_guess_compression_type(filename, file_buffer, accept_partial_magic_byte_prefix);
-    if treat_unsupported_compression_as_uncompressed {
+    let detected = try_guess_compression_type(
+        filename,
+        file_buffer,
+        legacy_compression_autodetect_libsnowflakeclient_behavior,
+    );
+    if legacy_compression_autodetect_libsnowflakeclient_behavior {
         match detected {
             Err(CompressionTypeError::UnsupportedCompressionType { .. }) => {
                 Ok(CompressionType::None)
@@ -577,7 +575,7 @@ mod tests {
 
     // BD#6 — when SOURCE_COMPRESSION=AUTO_DETECT detects an unsupported
     // compression format, legacy libsnowflakeclient silently fell back to
-    // no compression. ODBC (`treat_unsupported_compression_as_uncompressed
+    // no compression. ODBC (`legacy_compression_autodetect_libsnowflakeclient_behavior
     // = true`) restores that behavior; Python / JDBC (false) keep surfacing
     // the error. JDBC behavior verified equivalent to Python via
     // `SnowflakeFileTransferAgent.java:3163-3308`.
@@ -592,169 +590,113 @@ mod tests {
     ];
 
     #[test]
-    fn auto_detect_source_compression_treat_unsupported_as_uncompressed_true_swallows_error() {
+    fn auto_detect_source_compression_legacy_flag_true_swallows_unsupported_error() {
         for filename in UNSUPPORTED_COMPRESSION_FILENAMES {
-            let result = auto_detect_source_compression(filename, b"", true, false);
+            let result = auto_detect_source_compression(filename, b"", true);
             assert_eq!(
                 result.unwrap(),
                 CompressionType::None,
-                "treat_unsupported_compression_as_uncompressed=true must fall back to None for {filename}",
+                "legacy=true must fall back to None for {filename}",
             );
         }
     }
 
     #[test]
-    fn auto_detect_source_compression_treat_unsupported_as_uncompressed_false_propagates_error() {
+    fn auto_detect_source_compression_legacy_flag_false_propagates_unsupported_error() {
         for filename in UNSUPPORTED_COMPRESSION_FILENAMES {
-            let result = auto_detect_source_compression(filename, b"", false, false);
+            let result = auto_detect_source_compression(filename, b"", false);
             assert!(
                 matches!(
                     result,
                     Err(CompressionTypeError::UnsupportedCompressionType { .. })
                 ),
-                "treat_unsupported_compression_as_uncompressed=false must surface the unsupported error for {filename}, got: {result:?}",
+                "legacy=false must surface the unsupported error for {filename}, got: {result:?}",
             );
         }
     }
 
     // Buffer-detection branch (infer crate): an extension-less file whose
     // magic bytes match an unsupported format must still trigger the
-    // `treat_unsupported_compression_as_uncompressed` fallback. Locks in
-    // that the recovery is keyed on the `UnsupportedCompressionType`
-    // error variant, not on the filename-extension detection path.
+    // legacy-flag fallback. Locks in that the recovery is keyed on the
+    // `UnsupportedCompressionType` error variant, not on the
+    // filename-extension detection path.
     #[test]
-    fn auto_detect_source_compression_treat_unsupported_as_uncompressed_true_swallows_buffer_detected_unsupported()
-     {
+    fn auto_detect_source_compression_legacy_flag_true_swallows_buffer_detected_unsupported() {
         let xz_magic = b"\xFD7zXZ\x00\x00\x01\x69\x22\xDE\x36";
-        let result = auto_detect_source_compression("noext", xz_magic, true, false);
+        let result = auto_detect_source_compression("noext", xz_magic, true);
         assert_eq!(result.unwrap(), CompressionType::None);
     }
 
     #[test]
-    fn auto_detect_source_compression_treat_unsupported_as_uncompressed_false_propagates_buffer_detected_unsupported()
-     {
+    fn auto_detect_source_compression_legacy_flag_false_propagates_buffer_detected_unsupported() {
         let xz_magic = b"\xFD7zXZ\x00\x00\x01\x69\x22\xDE\x36";
-        let result = auto_detect_source_compression("noext", xz_magic, false, false);
+        let result = auto_detect_source_compression("noext", xz_magic, false);
         assert!(
             matches!(
                 result,
                 Err(CompressionTypeError::UnsupportedCompressionType { .. })
             ),
-            "treat_unsupported_compression_as_uncompressed=false must surface the buffer-detected unsupported error, got: {result:?}",
+            "legacy=false must surface the buffer-detected unsupported error, got: {result:?}",
         );
     }
 
     #[test]
     fn auto_detect_source_compression_recognizes_gzip_for_both_flag_values() {
-        for treat_unsupported_compression_as_uncompressed in [false, true] {
-            let result = auto_detect_source_compression(
-                "test.csv.gz",
-                b"",
-                treat_unsupported_compression_as_uncompressed,
-                false,
-            );
+        for legacy in [false, true] {
+            let result = auto_detect_source_compression("test.csv.gz", b"", legacy);
             assert_eq!(
                 result.unwrap(),
                 CompressionType::Gzip,
-                "Flag={treat_unsupported_compression_as_uncompressed} must still recognize supported extensions",
+                "legacy={legacy} must still recognize supported extensions",
             );
         }
     }
 
     #[test]
     fn auto_detect_source_compression_returns_none_for_uncompressed_for_both_flag_values() {
-        for treat_unsupported_compression_as_uncompressed in [false, true] {
-            let result = auto_detect_source_compression(
-                "test.csv",
-                b"",
-                treat_unsupported_compression_as_uncompressed,
-                false,
-            );
+        for legacy in [false, true] {
+            let result = auto_detect_source_compression("test.csv", b"", legacy);
             assert_eq!(
                 result.unwrap(),
                 CompressionType::None,
-                "Flag={treat_unsupported_compression_as_uncompressed} must report None for plain files",
+                "legacy={legacy} must report None for plain files",
             );
         }
     }
 
-    // The two flags are independent. ODBC's preset enables both
-    // (`treat_unsupported_compression_as_uncompressed=true`,
-    // `accept_partial_magic_byte_prefix=true`); Python and JDBC keep
-    // both off. The partial-magic flag only widens what gets detected,
-    // never narrows it — flipping it from false to true cannot break a
-    // call that previously detected a known format.
+    // Partial-prefix detection: `\x1F\x8B` is the first 2 bytes of gzip's
+    // 3-byte magic. With the legacy flag false (Python/JDBC default)
+    // `infer` requires the full 3 bytes and returns `None` here. With the
+    // legacy flag true (ODBC default), the short-prefix table matches
+    // first and returns `Gzip`, mirroring `libsnowflakeclient`'s
+    // `m_magicBytes = 2` for gzip.
     #[test]
-    fn auto_detect_source_compression_partial_magic_flag_true_detects_2byte_gzip() {
+    fn auto_detect_source_compression_legacy_flag_true_detects_2byte_gzip() {
         let two_byte_gzip: &[u8] = &[0x1F, 0x8B];
-        let result = auto_detect_source_compression("noext", two_byte_gzip, false, true);
+        let result = auto_detect_source_compression("noext", two_byte_gzip, true);
         assert_eq!(result.unwrap(), CompressionType::Gzip);
     }
 
     #[test]
-    fn auto_detect_source_compression_partial_magic_flag_false_misses_2byte_gzip() {
+    fn auto_detect_source_compression_legacy_flag_false_misses_2byte_gzip() {
         let two_byte_gzip: &[u8] = &[0x1F, 0x8B];
-        let result = auto_detect_source_compression("noext", two_byte_gzip, false, false);
+        let result = auto_detect_source_compression("noext", two_byte_gzip, false);
         assert_eq!(result.unwrap(), CompressionType::None);
-    }
-
-    #[test]
-    fn auto_detect_source_compression_partial_magic_flag_independent_of_swallow_flag() {
-        // Crossed flag values: `swallow=true` + `partial_magic=false`
-        // exercises the ODBC-historic config (xz/.lz swallowed, but no
-        // 2-byte gzip detection). `swallow=false` + `partial_magic=true`
-        // is a hypothetical Python-with-libsnowflakeclient-magic config —
-        // not used by any current preset, but the flag pair must compose
-        // without surprises.
-        let xz_magic = b"\xFD7zXZ\x00\x00\x01\x69\x22\xDE\x36";
-        let two_byte_gzip: &[u8] = &[0x1F, 0x8B];
-
-        // swallow=true, partial=false: xz swallowed, 2-byte gzip not detected.
-        assert_eq!(
-            auto_detect_source_compression("noext", xz_magic, true, false).unwrap(),
-            CompressionType::None,
-        );
-        assert_eq!(
-            auto_detect_source_compression("noext", two_byte_gzip, true, false).unwrap(),
-            CompressionType::None,
-        );
-
-        // swallow=false, partial=true: xz still errors, 2-byte gzip detected.
-        assert!(matches!(
-            auto_detect_source_compression("noext", xz_magic, false, true),
-            Err(CompressionTypeError::UnsupportedCompressionType { .. })
-        ));
-        assert_eq!(
-            auto_detect_source_compression("noext", two_byte_gzip, false, true).unwrap(),
-            CompressionType::Gzip,
-        );
     }
 
     #[test]
     fn get_source_compression_explicit_param_ignores_flag() {
         // Explicit SOURCE_COMPRESSION=<known type> never goes through the
         // auto-detect path, so the flag branch is a no-op here.
-        for treat_unsupported_compression_as_uncompressed in [false, true] {
+        for legacy in [false, true] {
             assert_eq!(
-                get_source_compression(
-                    "ignored.xz",
-                    b"",
-                    &SourceCompressionParam::Gzip,
-                    treat_unsupported_compression_as_uncompressed,
-                    false,
-                )
-                .unwrap(),
+                get_source_compression("ignored.xz", b"", &SourceCompressionParam::Gzip, legacy,)
+                    .unwrap(),
                 CompressionType::Gzip,
             );
             assert_eq!(
-                get_source_compression(
-                    "ignored.xz",
-                    b"",
-                    &SourceCompressionParam::None,
-                    treat_unsupported_compression_as_uncompressed,
-                    false,
-                )
-                .unwrap(),
+                get_source_compression("ignored.xz", b"", &SourceCompressionParam::None, legacy,)
+                    .unwrap(),
                 CompressionType::None,
             );
         }

--- a/sf_core/src/file_manager/mod.rs
+++ b/sf_core/src/file_manager/mod.rs
@@ -66,6 +66,7 @@ pub async fn upload_files(
             flavor: data.flavor.clone(),
             treat_unsupported_compression_as_uncompressed: data
                 .treat_unsupported_compression_as_uncompressed,
+            accept_partial_magic_byte_prefix: data.accept_partial_magic_byte_prefix,
         };
 
         let result = upload_single_file(single_upload_data, &mut refresher).await?;
@@ -176,6 +177,7 @@ fn preprocess_file_before_upload(
         file_buffer.as_slice(),
         &data.source_compression,
         data.treat_unsupported_compression_as_uncompressed,
+        data.accept_partial_magic_byte_prefix,
     )
     .context(CompressionTypeSnafu)?;
 
@@ -225,12 +227,14 @@ fn get_source_compression(
     file_buffer: &[u8],
     source_compression: &SourceCompressionParam,
     treat_unsupported_compression_as_uncompressed: bool,
+    accept_partial_magic_byte_prefix: bool,
 ) -> Result<CompressionType, CompressionTypeError> {
     match source_compression {
         SourceCompressionParam::AutoDetect => auto_detect_source_compression(
             filename,
             file_buffer,
             treat_unsupported_compression_as_uncompressed,
+            accept_partial_magic_byte_prefix,
         ),
         SourceCompressionParam::None => Ok(CompressionType::None),
         SourceCompressionParam::Gzip => Ok(CompressionType::Gzip),
@@ -242,20 +246,28 @@ fn get_source_compression(
     }
 }
 
-/// Returns the resolved compression type for the `AUTO_DETECT` path. When
-/// `treat_unsupported_compression_as_uncompressed` is true, unsupported
-/// compression formats (e.g. `.xz`, `.lz`, `.parquet`) are silently
-/// treated as uncompressed and the upload continues — restoring legacy
-/// libsnowflakeclient behavior. When false, the error surfaces. The
-/// recovery is keyed on the `UnsupportedCompressionType` error variant,
-/// so it fires regardless of whether the detection went through the
-/// filename extension or the magic-bytes (infer crate) path.
+/// Returns the resolved compression type for the `AUTO_DETECT` path. Two
+/// independent flags shape the behavior:
+///
+/// - `treat_unsupported_compression_as_uncompressed` (true): unsupported
+///   formats (e.g. `.xz`, `.lz`, `.parquet`) are silently treated as
+///   uncompressed and the upload continues — restoring legacy
+///   libsnowflakeclient behavior. False propagates the error. The
+///   recovery is keyed on the `UnsupportedCompressionType` error variant,
+///   so it fires regardless of whether detection went through the
+///   filename extension or the magic-bytes (infer crate) path.
+/// - `accept_partial_magic_byte_prefix` (true): a libsnowflakeclient-style
+///   short-prefix table runs ahead of the `infer` crate, allowing a
+///   2-byte gzip header / 2-byte zlib stream / 4-byte snowflake brotli
+///   marker to be detected even though `infer` requires more bytes.
 fn auto_detect_source_compression(
     filename: &str,
     file_buffer: &[u8],
     treat_unsupported_compression_as_uncompressed: bool,
+    accept_partial_magic_byte_prefix: bool,
 ) -> Result<CompressionType, CompressionTypeError> {
-    let detected = try_guess_compression_type(filename, file_buffer);
+    let detected =
+        try_guess_compression_type(filename, file_buffer, accept_partial_magic_byte_prefix);
     if treat_unsupported_compression_as_uncompressed {
         match detected {
             Err(CompressionTypeError::UnsupportedCompressionType { .. }) => {
@@ -582,7 +594,7 @@ mod tests {
     #[test]
     fn auto_detect_source_compression_treat_unsupported_as_uncompressed_true_swallows_error() {
         for filename in UNSUPPORTED_COMPRESSION_FILENAMES {
-            let result = auto_detect_source_compression(filename, b"", true);
+            let result = auto_detect_source_compression(filename, b"", true, false);
             assert_eq!(
                 result.unwrap(),
                 CompressionType::None,
@@ -594,7 +606,7 @@ mod tests {
     #[test]
     fn auto_detect_source_compression_treat_unsupported_as_uncompressed_false_propagates_error() {
         for filename in UNSUPPORTED_COMPRESSION_FILENAMES {
-            let result = auto_detect_source_compression(filename, b"", false);
+            let result = auto_detect_source_compression(filename, b"", false, false);
             assert!(
                 matches!(
                     result,
@@ -614,7 +626,7 @@ mod tests {
     fn auto_detect_source_compression_treat_unsupported_as_uncompressed_true_swallows_buffer_detected_unsupported()
      {
         let xz_magic = b"\xFD7zXZ\x00\x00\x01\x69\x22\xDE\x36";
-        let result = auto_detect_source_compression("noext", xz_magic, true);
+        let result = auto_detect_source_compression("noext", xz_magic, true, false);
         assert_eq!(result.unwrap(), CompressionType::None);
     }
 
@@ -622,7 +634,7 @@ mod tests {
     fn auto_detect_source_compression_treat_unsupported_as_uncompressed_false_propagates_buffer_detected_unsupported()
      {
         let xz_magic = b"\xFD7zXZ\x00\x00\x01\x69\x22\xDE\x36";
-        let result = auto_detect_source_compression("noext", xz_magic, false);
+        let result = auto_detect_source_compression("noext", xz_magic, false, false);
         assert!(
             matches!(
                 result,
@@ -639,6 +651,7 @@ mod tests {
                 "test.csv.gz",
                 b"",
                 treat_unsupported_compression_as_uncompressed,
+                false,
             );
             assert_eq!(
                 result.unwrap(),
@@ -655,6 +668,7 @@ mod tests {
                 "test.csv",
                 b"",
                 treat_unsupported_compression_as_uncompressed,
+                false,
             );
             assert_eq!(
                 result.unwrap(),
@@ -662,6 +676,58 @@ mod tests {
                 "Flag={treat_unsupported_compression_as_uncompressed} must report None for plain files",
             );
         }
+    }
+
+    // The two flags are independent. ODBC's preset enables both
+    // (`treat_unsupported_compression_as_uncompressed=true`,
+    // `accept_partial_magic_byte_prefix=true`); Python and JDBC keep
+    // both off. The partial-magic flag only widens what gets detected,
+    // never narrows it — flipping it from false to true cannot break a
+    // call that previously detected a known format.
+    #[test]
+    fn auto_detect_source_compression_partial_magic_flag_true_detects_2byte_gzip() {
+        let two_byte_gzip: &[u8] = &[0x1F, 0x8B];
+        let result = auto_detect_source_compression("noext", two_byte_gzip, false, true);
+        assert_eq!(result.unwrap(), CompressionType::Gzip);
+    }
+
+    #[test]
+    fn auto_detect_source_compression_partial_magic_flag_false_misses_2byte_gzip() {
+        let two_byte_gzip: &[u8] = &[0x1F, 0x8B];
+        let result = auto_detect_source_compression("noext", two_byte_gzip, false, false);
+        assert_eq!(result.unwrap(), CompressionType::None);
+    }
+
+    #[test]
+    fn auto_detect_source_compression_partial_magic_flag_independent_of_swallow_flag() {
+        // Crossed flag values: `swallow=true` + `partial_magic=false`
+        // exercises the ODBC-historic config (xz/.lz swallowed, but no
+        // 2-byte gzip detection). `swallow=false` + `partial_magic=true`
+        // is a hypothetical Python-with-libsnowflakeclient-magic config —
+        // not used by any current preset, but the flag pair must compose
+        // without surprises.
+        let xz_magic = b"\xFD7zXZ\x00\x00\x01\x69\x22\xDE\x36";
+        let two_byte_gzip: &[u8] = &[0x1F, 0x8B];
+
+        // swallow=true, partial=false: xz swallowed, 2-byte gzip not detected.
+        assert_eq!(
+            auto_detect_source_compression("noext", xz_magic, true, false).unwrap(),
+            CompressionType::None,
+        );
+        assert_eq!(
+            auto_detect_source_compression("noext", two_byte_gzip, true, false).unwrap(),
+            CompressionType::None,
+        );
+
+        // swallow=false, partial=true: xz still errors, 2-byte gzip detected.
+        assert!(matches!(
+            auto_detect_source_compression("noext", xz_magic, false, true),
+            Err(CompressionTypeError::UnsupportedCompressionType { .. })
+        ));
+        assert_eq!(
+            auto_detect_source_compression("noext", two_byte_gzip, false, true).unwrap(),
+            CompressionType::Gzip,
+        );
     }
 
     #[test]
@@ -675,6 +741,7 @@ mod tests {
                     b"",
                     &SourceCompressionParam::Gzip,
                     treat_unsupported_compression_as_uncompressed,
+                    false,
                 )
                 .unwrap(),
                 CompressionType::Gzip,
@@ -685,6 +752,7 @@ mod tests {
                     b"",
                     &SourceCompressionParam::None,
                     treat_unsupported_compression_as_uncompressed,
+                    false,
                 )
                 .unwrap(),
                 CompressionType::None,

--- a/sf_core/src/file_manager/mod.rs
+++ b/sf_core/src/file_manager/mod.rs
@@ -10,7 +10,7 @@ pub use self::types::*;
 pub use azure_transfer::download_from_azure;
 pub use gcs_transfer::download_from_gcs;
 
-use crate::apis::database_driver_v1::{CompressionAutoDetectFlavor, PutGetResultsetFlavor};
+use crate::apis::database_driver_v1::PutGetResultsetFlavor;
 use crate::compression::{CompressionError, compress_data};
 use crate::compression_types::{CompressionType, CompressionTypeError, try_guess_compression_type};
 use azure_transfer::{AzureDownloadError, AzureUploadError, upload_to_azure_or_skip};
@@ -64,7 +64,8 @@ pub async fn upload_files(
             source_compression: data.source_compression.clone(),
             overwrite: data.overwrite,
             flavor: data.flavor.clone(),
-            compression_autodetect_flavor: data.compression_autodetect_flavor.clone(),
+            treat_unsupported_compression_as_uncompressed: data
+                .treat_unsupported_compression_as_uncompressed,
         };
 
         let result = upload_single_file(single_upload_data, &mut refresher).await?;
@@ -174,7 +175,7 @@ fn preprocess_file_before_upload(
         data.filename.as_str(),
         file_buffer.as_slice(),
         &data.source_compression,
-        &data.compression_autodetect_flavor,
+        data.treat_unsupported_compression_as_uncompressed,
     )
     .context(CompressionTypeSnafu)?;
 
@@ -223,12 +224,14 @@ fn get_source_compression(
     filename: &str,
     file_buffer: &[u8],
     source_compression: &SourceCompressionParam,
-    flavor: &CompressionAutoDetectFlavor,
+    treat_unsupported_compression_as_uncompressed: bool,
 ) -> Result<CompressionType, CompressionTypeError> {
     match source_compression {
-        SourceCompressionParam::AutoDetect => {
-            auto_detect_source_compression(filename, file_buffer, flavor)
-        }
+        SourceCompressionParam::AutoDetect => auto_detect_source_compression(
+            filename,
+            file_buffer,
+            treat_unsupported_compression_as_uncompressed,
+        ),
         SourceCompressionParam::None => Ok(CompressionType::None),
         SourceCompressionParam::Gzip => Ok(CompressionType::Gzip),
         SourceCompressionParam::Bzip2 => Ok(CompressionType::Bzip2),
@@ -239,29 +242,30 @@ fn get_source_compression(
     }
 }
 
-/// Returns the resolved compression type for the `AUTO_DETECT` path,
-/// gated on the active wrapper flavor. Legacy libsnowflakeclient silently
-/// treated unsupported compression formats (e.g. `.xz`, `.lz`, `.parquet`)
-/// as uncompressed and continued the upload — the `Odbc` flavor restores
-/// that behavior. The `Python` flavor (default) surfaces the error,
-/// matching the current UD-Python contract. The recovery is keyed on the
+/// Returns the resolved compression type for the `AUTO_DETECT` path. When
+/// `treat_unsupported_compression_as_uncompressed` is true, legacy
+/// libsnowflakeclient behavior is restored: unsupported compression
+/// formats (e.g. `.xz`, `.lz`, `.parquet`) are silently treated as
+/// uncompressed and the upload continues. When false (Python / JDBC
+/// default), the error surfaces. The recovery is keyed on the
 /// `UnsupportedCompressionType` error variant, so it fires regardless of
 /// whether the detection went through the filename extension or the
 /// magic-bytes (infer crate) path.
 fn auto_detect_source_compression(
     filename: &str,
     file_buffer: &[u8],
-    flavor: &CompressionAutoDetectFlavor,
+    treat_unsupported_compression_as_uncompressed: bool,
 ) -> Result<CompressionType, CompressionTypeError> {
     let detected = try_guess_compression_type(filename, file_buffer);
-    match flavor {
-        CompressionAutoDetectFlavor::Odbc => match detected {
+    if treat_unsupported_compression_as_uncompressed {
+        match detected {
             Err(CompressionTypeError::UnsupportedCompressionType { .. }) => {
                 Ok(CompressionType::None)
             }
             other => other,
-        },
-        _ => detected,
+        }
+    } else {
+        detected
     }
 }
 
@@ -562,8 +566,10 @@ mod tests {
 
     // BD#6 — when SOURCE_COMPRESSION=AUTO_DETECT detects an unsupported
     // compression format, legacy libsnowflakeclient silently fell back to
-    // no compression. The `Odbc` flavor restores that behavior; the
-    // `Python` and `Jdbc` flavors keep surfacing the error.
+    // no compression. ODBC (`treat_unsupported_compression_as_uncompressed
+    // = true`) restores that behavior; Python / JDBC (false) keep surfacing
+    // the error. JDBC behavior verified equivalent to Python via
+    // `SnowflakeFileTransferAgent.java:3163-3308`.
     const UNSUPPORTED_COMPRESSION_FILENAMES: &[&str] = &[
         "test.xz",
         "test.lzma",
@@ -575,140 +581,111 @@ mod tests {
     ];
 
     #[test]
-    fn auto_detect_source_compression_odbc_falls_back_to_none_for_unsupported() {
+    fn auto_detect_source_compression_true_swallows_error() {
         for filename in UNSUPPORTED_COMPRESSION_FILENAMES {
-            let result =
-                auto_detect_source_compression(filename, b"", &CompressionAutoDetectFlavor::Odbc);
+            let result = auto_detect_source_compression(filename, b"", true);
             assert_eq!(
                 result.unwrap(),
                 CompressionType::None,
-                "Odbc flavor must fall back to None for {filename}",
+                "Swallow flag must fall back to None for {filename}",
             );
         }
     }
 
     #[test]
-    fn auto_detect_source_compression_python_surfaces_unsupported_error() {
+    fn auto_detect_source_compression_false_propagates_error() {
         for filename in UNSUPPORTED_COMPRESSION_FILENAMES {
-            let result =
-                auto_detect_source_compression(filename, b"", &CompressionAutoDetectFlavor::Python);
+            let result = auto_detect_source_compression(filename, b"", false);
             assert!(
                 matches!(
                     result,
                     Err(CompressionTypeError::UnsupportedCompressionType { .. })
                 ),
-                "Python flavor must propagate the unsupported error for {filename}, got: {result:?}",
-            );
-        }
-    }
-
-    // PR1 of Gap-12: today the `Jdbc` flavor uses the same propagating
-    // behavior as `Python`. PR2 may diverge.
-    #[test]
-    fn auto_detect_source_compression_jdbc_surfaces_unsupported_error() {
-        for filename in UNSUPPORTED_COMPRESSION_FILENAMES {
-            let result =
-                auto_detect_source_compression(filename, b"", &CompressionAutoDetectFlavor::Jdbc);
-            assert!(
-                matches!(
-                    result,
-                    Err(CompressionTypeError::UnsupportedCompressionType { .. })
-                ),
-                "Jdbc flavor must propagate the unsupported error for {filename}, got: {result:?}",
+                "Propagating flag must surface the unsupported error for {filename}, got: {result:?}",
             );
         }
     }
 
     // Buffer-detection branch (infer crate): an extension-less file whose
     // magic bytes match an unsupported format must still trigger the
-    // Odbc-flavor fallback. Locks in that the recovery is keyed on the
+    // swallow-flag fallback. Locks in that the recovery is keyed on the
     // `UnsupportedCompressionType` error variant, not on the
     // filename-extension detection path.
     #[test]
-    fn auto_detect_source_compression_odbc_falls_back_for_buffer_detected_unsupported() {
+    fn auto_detect_source_compression_true_swallows_buffer_detected_unsupported() {
         let xz_magic = b"\xFD7zXZ\x00\x00\x01\x69\x22\xDE\x36";
-        let result =
-            auto_detect_source_compression("noext", xz_magic, &CompressionAutoDetectFlavor::Odbc);
+        let result = auto_detect_source_compression("noext", xz_magic, true);
         assert_eq!(result.unwrap(), CompressionType::None);
     }
 
     #[test]
-    fn auto_detect_source_compression_python_surfaces_buffer_detected_unsupported() {
+    fn auto_detect_source_compression_false_propagates_buffer_detected_unsupported() {
         let xz_magic = b"\xFD7zXZ\x00\x00\x01\x69\x22\xDE\x36";
-        let result =
-            auto_detect_source_compression("noext", xz_magic, &CompressionAutoDetectFlavor::Python);
+        let result = auto_detect_source_compression("noext", xz_magic, false);
         assert!(
             matches!(
                 result,
                 Err(CompressionTypeError::UnsupportedCompressionType { .. })
             ),
-            "Python flavor must propagate the buffer-detected unsupported error, got: {result:?}",
+            "Propagating flag must surface the buffer-detected unsupported error, got: {result:?}",
         );
     }
 
     #[test]
-    fn auto_detect_source_compression_jdbc_surfaces_buffer_detected_unsupported() {
-        let xz_magic = b"\xFD7zXZ\x00\x00\x01\x69\x22\xDE\x36";
-        let result =
-            auto_detect_source_compression("noext", xz_magic, &CompressionAutoDetectFlavor::Jdbc);
-        assert!(
-            matches!(
-                result,
-                Err(CompressionTypeError::UnsupportedCompressionType { .. })
-            ),
-            "Jdbc flavor must propagate the buffer-detected unsupported error, got: {result:?}",
-        );
-    }
-
-    #[test]
-    fn auto_detect_source_compression_recognizes_gzip_for_all_flavors() {
-        for flavor in [
-            CompressionAutoDetectFlavor::Python,
-            CompressionAutoDetectFlavor::Odbc,
-            CompressionAutoDetectFlavor::Jdbc,
-        ] {
-            let result = auto_detect_source_compression("test.csv.gz", b"", &flavor);
+    fn auto_detect_source_compression_recognizes_gzip_for_both_flag_values() {
+        for treat_unsupported_compression_as_uncompressed in [false, true] {
+            let result = auto_detect_source_compression(
+                "test.csv.gz",
+                b"",
+                treat_unsupported_compression_as_uncompressed,
+            );
             assert_eq!(
                 result.unwrap(),
                 CompressionType::Gzip,
-                "{flavor:?} flavor must still recognize supported extensions",
+                "Flag={treat_unsupported_compression_as_uncompressed} must still recognize supported extensions",
             );
         }
     }
 
     #[test]
-    fn auto_detect_source_compression_returns_none_for_uncompressed_under_all_flavors() {
-        for flavor in [
-            CompressionAutoDetectFlavor::Python,
-            CompressionAutoDetectFlavor::Odbc,
-            CompressionAutoDetectFlavor::Jdbc,
-        ] {
-            let result = auto_detect_source_compression("test.csv", b"", &flavor);
+    fn auto_detect_source_compression_returns_none_for_uncompressed_for_both_flag_values() {
+        for treat_unsupported_compression_as_uncompressed in [false, true] {
+            let result = auto_detect_source_compression(
+                "test.csv",
+                b"",
+                treat_unsupported_compression_as_uncompressed,
+            );
             assert_eq!(
                 result.unwrap(),
                 CompressionType::None,
-                "{flavor:?} flavor must report None for plain files",
+                "Flag={treat_unsupported_compression_as_uncompressed} must report None for plain files",
             );
         }
     }
 
     #[test]
-    fn get_source_compression_explicit_param_ignores_flavor() {
+    fn get_source_compression_explicit_param_ignores_flag() {
         // Explicit SOURCE_COMPRESSION=<known type> never goes through the
-        // auto-detect path, so the flavor branch is a no-op here.
-        for flavor in [
-            CompressionAutoDetectFlavor::Python,
-            CompressionAutoDetectFlavor::Odbc,
-            CompressionAutoDetectFlavor::Jdbc,
-        ] {
+        // auto-detect path, so the flag branch is a no-op here.
+        for treat_unsupported_compression_as_uncompressed in [false, true] {
             assert_eq!(
-                get_source_compression("ignored.xz", b"", &SourceCompressionParam::Gzip, &flavor,)
-                    .unwrap(),
+                get_source_compression(
+                    "ignored.xz",
+                    b"",
+                    &SourceCompressionParam::Gzip,
+                    treat_unsupported_compression_as_uncompressed,
+                )
+                .unwrap(),
                 CompressionType::Gzip,
             );
             assert_eq!(
-                get_source_compression("ignored.xz", b"", &SourceCompressionParam::None, &flavor,)
-                    .unwrap(),
+                get_source_compression(
+                    "ignored.xz",
+                    b"",
+                    &SourceCompressionParam::None,
+                    treat_unsupported_compression_as_uncompressed,
+                )
+                .unwrap(),
                 CompressionType::None,
             );
         }

--- a/sf_core/src/file_manager/mod.rs
+++ b/sf_core/src/file_manager/mod.rs
@@ -10,7 +10,7 @@ pub use self::types::*;
 pub use azure_transfer::download_from_azure;
 pub use gcs_transfer::download_from_gcs;
 
-use crate::apis::database_driver_v1::PutGetResultsetFlavor;
+use crate::apis::database_driver_v1::{CompressionAutoDetectFlavor, PutGetResultsetFlavor};
 use crate::compression::{CompressionError, compress_data};
 use crate::compression_types::{CompressionType, CompressionTypeError, try_guess_compression_type};
 use azure_transfer::{AzureDownloadError, AzureUploadError, upload_to_azure_or_skip};
@@ -64,6 +64,7 @@ pub async fn upload_files(
             source_compression: data.source_compression.clone(),
             overwrite: data.overwrite,
             flavor: data.flavor.clone(),
+            compression_autodetect_flavor: data.compression_autodetect_flavor.clone(),
         };
 
         let result = upload_single_file(single_upload_data, &mut refresher).await?;
@@ -173,7 +174,7 @@ fn preprocess_file_before_upload(
         data.filename.as_str(),
         file_buffer.as_slice(),
         &data.source_compression,
-        &data.flavor,
+        &data.compression_autodetect_flavor,
     )
     .context(CompressionTypeSnafu)?;
 
@@ -222,7 +223,7 @@ fn get_source_compression(
     filename: &str,
     file_buffer: &[u8],
     source_compression: &SourceCompressionParam,
-    flavor: &PutGetResultsetFlavor,
+    flavor: &CompressionAutoDetectFlavor,
 ) -> Result<CompressionType, CompressionTypeError> {
     match source_compression {
         SourceCompressionParam::AutoDetect => {
@@ -250,11 +251,11 @@ fn get_source_compression(
 fn auto_detect_source_compression(
     filename: &str,
     file_buffer: &[u8],
-    flavor: &PutGetResultsetFlavor,
+    flavor: &CompressionAutoDetectFlavor,
 ) -> Result<CompressionType, CompressionTypeError> {
     let detected = try_guess_compression_type(filename, file_buffer);
     match flavor {
-        PutGetResultsetFlavor::Odbc => match detected {
+        CompressionAutoDetectFlavor::Odbc => match detected {
             Err(CompressionTypeError::UnsupportedCompressionType { .. }) => {
                 Ok(CompressionType::None)
             }
@@ -562,7 +563,7 @@ mod tests {
     // BD#6 — when SOURCE_COMPRESSION=AUTO_DETECT detects an unsupported
     // compression format, legacy libsnowflakeclient silently fell back to
     // no compression. The `Odbc` flavor restores that behavior; the
-    // `Python` flavor (default) keeps surfacing the error.
+    // `Python` and `Jdbc` flavors keep surfacing the error.
     const UNSUPPORTED_COMPRESSION_FILENAMES: &[&str] = &[
         "test.xz",
         "test.lzma",
@@ -577,7 +578,7 @@ mod tests {
     fn auto_detect_source_compression_odbc_falls_back_to_none_for_unsupported() {
         for filename in UNSUPPORTED_COMPRESSION_FILENAMES {
             let result =
-                auto_detect_source_compression(filename, b"", &PutGetResultsetFlavor::Odbc);
+                auto_detect_source_compression(filename, b"", &CompressionAutoDetectFlavor::Odbc);
             assert_eq!(
                 result.unwrap(),
                 CompressionType::None,
@@ -590,13 +591,30 @@ mod tests {
     fn auto_detect_source_compression_python_surfaces_unsupported_error() {
         for filename in UNSUPPORTED_COMPRESSION_FILENAMES {
             let result =
-                auto_detect_source_compression(filename, b"", &PutGetResultsetFlavor::Python);
+                auto_detect_source_compression(filename, b"", &CompressionAutoDetectFlavor::Python);
             assert!(
                 matches!(
                     result,
                     Err(CompressionTypeError::UnsupportedCompressionType { .. })
                 ),
                 "Python flavor must propagate the unsupported error for {filename}, got: {result:?}",
+            );
+        }
+    }
+
+    // PR1 of Gap-12: today the `Jdbc` flavor uses the same propagating
+    // behavior as `Python`. PR2 may diverge.
+    #[test]
+    fn auto_detect_source_compression_jdbc_surfaces_unsupported_error() {
+        for filename in UNSUPPORTED_COMPRESSION_FILENAMES {
+            let result =
+                auto_detect_source_compression(filename, b"", &CompressionAutoDetectFlavor::Jdbc);
+            assert!(
+                matches!(
+                    result,
+                    Err(CompressionTypeError::UnsupportedCompressionType { .. })
+                ),
+                "Jdbc flavor must propagate the unsupported error for {filename}, got: {result:?}",
             );
         }
     }
@@ -610,7 +628,7 @@ mod tests {
     fn auto_detect_source_compression_odbc_falls_back_for_buffer_detected_unsupported() {
         let xz_magic = b"\xFD7zXZ\x00\x00\x01\x69\x22\xDE\x36";
         let result =
-            auto_detect_source_compression("noext", xz_magic, &PutGetResultsetFlavor::Odbc);
+            auto_detect_source_compression("noext", xz_magic, &CompressionAutoDetectFlavor::Odbc);
         assert_eq!(result.unwrap(), CompressionType::None);
     }
 
@@ -618,7 +636,7 @@ mod tests {
     fn auto_detect_source_compression_python_surfaces_buffer_detected_unsupported() {
         let xz_magic = b"\xFD7zXZ\x00\x00\x01\x69\x22\xDE\x36";
         let result =
-            auto_detect_source_compression("noext", xz_magic, &PutGetResultsetFlavor::Python);
+            auto_detect_source_compression("noext", xz_magic, &CompressionAutoDetectFlavor::Python);
         assert!(
             matches!(
                 result,
@@ -629,8 +647,26 @@ mod tests {
     }
 
     #[test]
-    fn auto_detect_source_compression_recognizes_gzip_for_both_flavors() {
-        for flavor in [PutGetResultsetFlavor::Python, PutGetResultsetFlavor::Odbc] {
+    fn auto_detect_source_compression_jdbc_surfaces_buffer_detected_unsupported() {
+        let xz_magic = b"\xFD7zXZ\x00\x00\x01\x69\x22\xDE\x36";
+        let result =
+            auto_detect_source_compression("noext", xz_magic, &CompressionAutoDetectFlavor::Jdbc);
+        assert!(
+            matches!(
+                result,
+                Err(CompressionTypeError::UnsupportedCompressionType { .. })
+            ),
+            "Jdbc flavor must propagate the buffer-detected unsupported error, got: {result:?}",
+        );
+    }
+
+    #[test]
+    fn auto_detect_source_compression_recognizes_gzip_for_all_flavors() {
+        for flavor in [
+            CompressionAutoDetectFlavor::Python,
+            CompressionAutoDetectFlavor::Odbc,
+            CompressionAutoDetectFlavor::Jdbc,
+        ] {
             let result = auto_detect_source_compression("test.csv.gz", b"", &flavor);
             assert_eq!(
                 result.unwrap(),
@@ -641,8 +677,12 @@ mod tests {
     }
 
     #[test]
-    fn auto_detect_source_compression_returns_none_for_uncompressed_under_both_flavors() {
-        for flavor in [PutGetResultsetFlavor::Python, PutGetResultsetFlavor::Odbc] {
+    fn auto_detect_source_compression_returns_none_for_uncompressed_under_all_flavors() {
+        for flavor in [
+            CompressionAutoDetectFlavor::Python,
+            CompressionAutoDetectFlavor::Odbc,
+            CompressionAutoDetectFlavor::Jdbc,
+        ] {
             let result = auto_detect_source_compression("test.csv", b"", &flavor);
             assert_eq!(
                 result.unwrap(),
@@ -656,7 +696,11 @@ mod tests {
     fn get_source_compression_explicit_param_ignores_flavor() {
         // Explicit SOURCE_COMPRESSION=<known type> never goes through the
         // auto-detect path, so the flavor branch is a no-op here.
-        for flavor in [PutGetResultsetFlavor::Python, PutGetResultsetFlavor::Odbc] {
+        for flavor in [
+            CompressionAutoDetectFlavor::Python,
+            CompressionAutoDetectFlavor::Odbc,
+            CompressionAutoDetectFlavor::Jdbc,
+        ] {
             assert_eq!(
                 get_source_compression("ignored.xz", b"", &SourceCompressionParam::Gzip, &flavor,)
                     .unwrap(),

--- a/sf_core/src/file_manager/types.rs
+++ b/sf_core/src/file_manager/types.rs
@@ -35,17 +35,14 @@ pub struct UploadData {
     /// `SingleUploadData` so that `upload_single_file` can populate the
     /// `message` column according to the active wrapper's contract.
     pub flavor: PutGetResultsetFlavor,
-    /// When true, unsupported compression formats (e.g. `.xz`, `.lz`)
-    /// detected during PUT auto-detect are treated as uncompressed
-    /// instead of producing an error. Mirrors legacy libsnowflakeclient
-    /// behavior; required for ODBC backward compatibility.
-    pub treat_unsupported_compression_as_uncompressed: bool,
-    /// When true, magic-byte detection consults libsnowflakeclient's
-    /// short-prefix table (2-byte gzip, 2-byte zlib, 4-byte snowflake
-    /// brotli marker) ahead of the `infer` crate. Required for ODBC
-    /// parity; Python and JDBC keep this off (their connectors require
-    /// the full 4-byte read before declaring a magic-byte match).
-    pub accept_partial_magic_byte_prefix: bool,
+    /// When true, PUT auto-detect mirrors legacy libsnowflakeclient
+    /// behavior: (1) unsupported compression formats are silently
+    /// treated as uncompressed instead of erroring, and (2) magic-byte
+    /// detection consults a short-prefix table (2-byte gzip, 2-byte
+    /// zlib mapped to `Deflate`, 4-byte snowflake brotli marker) ahead
+    /// of the `infer` crate. See `WrapperPresets` for the full
+    /// specification.
+    pub legacy_compression_autodetect_libsnowflakeclient_behavior: bool,
 }
 
 pub struct SingleUploadData {
@@ -57,8 +54,7 @@ pub struct SingleUploadData {
     pub source_compression: SourceCompressionParam,
     pub overwrite: bool,
     pub flavor: PutGetResultsetFlavor,
-    pub treat_unsupported_compression_as_uncompressed: bool,
-    pub accept_partial_magic_byte_prefix: bool,
+    pub legacy_compression_autodetect_libsnowflakeclient_behavior: bool,
 }
 
 #[derive(Debug)]

--- a/sf_core/src/file_manager/types.rs
+++ b/sf_core/src/file_manager/types.rs
@@ -40,6 +40,12 @@ pub struct UploadData {
     /// instead of producing an error. Mirrors legacy libsnowflakeclient
     /// behavior; required for ODBC backward compatibility.
     pub treat_unsupported_compression_as_uncompressed: bool,
+    /// When true, magic-byte detection consults libsnowflakeclient's
+    /// short-prefix table (2-byte gzip, 2-byte zlib, 4-byte snowflake
+    /// brotli marker) ahead of the `infer` crate. Required for ODBC
+    /// parity; Python and JDBC keep this off (their connectors require
+    /// the full 4-byte read before declaring a magic-byte match).
+    pub accept_partial_magic_byte_prefix: bool,
 }
 
 pub struct SingleUploadData {
@@ -52,6 +58,7 @@ pub struct SingleUploadData {
     pub overwrite: bool,
     pub flavor: PutGetResultsetFlavor,
     pub treat_unsupported_compression_as_uncompressed: bool,
+    pub accept_partial_magic_byte_prefix: bool,
 }
 
 #[derive(Debug)]

--- a/sf_core/src/file_manager/types.rs
+++ b/sf_core/src/file_manager/types.rs
@@ -1,4 +1,4 @@
-use crate::apis::database_driver_v1::PutGetResultsetFlavor;
+use crate::apis::database_driver_v1::{CompressionAutoDetectFlavor, PutGetResultsetFlavor};
 use crate::compression_types::CompressionType;
 use crate::sensitive::SensitiveString;
 use serde::{Deserialize, Serialize};
@@ -35,6 +35,9 @@ pub struct UploadData {
     /// `SingleUploadData` so that `upload_single_file` can populate the
     /// `message` column according to the active wrapper's contract.
     pub flavor: PutGetResultsetFlavor,
+    /// Wrapper-specific compression auto-detect rules. Kept distinct from
+    /// `flavor` so auto-detect behavior can diverge from result-set shape.
+    pub compression_autodetect_flavor: CompressionAutoDetectFlavor,
 }
 
 pub struct SingleUploadData {
@@ -46,6 +49,7 @@ pub struct SingleUploadData {
     pub source_compression: SourceCompressionParam,
     pub overwrite: bool,
     pub flavor: PutGetResultsetFlavor,
+    pub compression_autodetect_flavor: CompressionAutoDetectFlavor,
 }
 
 #[derive(Debug)]

--- a/sf_core/src/file_manager/types.rs
+++ b/sf_core/src/file_manager/types.rs
@@ -1,4 +1,4 @@
-use crate::apis::database_driver_v1::{CompressionAutoDetectFlavor, PutGetResultsetFlavor};
+use crate::apis::database_driver_v1::PutGetResultsetFlavor;
 use crate::compression_types::CompressionType;
 use crate::sensitive::SensitiveString;
 use serde::{Deserialize, Serialize};
@@ -35,9 +35,11 @@ pub struct UploadData {
     /// `SingleUploadData` so that `upload_single_file` can populate the
     /// `message` column according to the active wrapper's contract.
     pub flavor: PutGetResultsetFlavor,
-    /// Wrapper-specific compression auto-detect rules. Kept distinct from
-    /// `flavor` so auto-detect behavior can diverge from result-set shape.
-    pub compression_autodetect_flavor: CompressionAutoDetectFlavor,
+    /// When true, unsupported compression formats (e.g. `.xz`, `.lz`)
+    /// detected during PUT auto-detect are treated as uncompressed
+    /// instead of producing an error. Mirrors legacy libsnowflakeclient
+    /// behavior; required for ODBC backward compatibility.
+    pub treat_unsupported_compression_as_uncompressed: bool,
 }
 
 pub struct SingleUploadData {
@@ -49,7 +51,7 @@ pub struct SingleUploadData {
     pub source_compression: SourceCompressionParam,
     pub overwrite: bool,
     pub flavor: PutGetResultsetFlavor,
-    pub compression_autodetect_flavor: CompressionAutoDetectFlavor,
+    pub treat_unsupported_compression_as_uncompressed: bool,
 }
 
 #[derive(Debug)]

--- a/sf_core/src/file_manager/types.rs
+++ b/sf_core/src/file_manager/types.rs
@@ -40,8 +40,7 @@ pub struct UploadData {
     /// treated as uncompressed instead of erroring, and (2) magic-byte
     /// detection consults a short-prefix table (2-byte gzip, 2-byte
     /// zlib mapped to `Deflate`, 4-byte snowflake brotli marker) ahead
-    /// of the `infer` crate. See `WrapperPresets` for the full
-    /// specification.
+    /// of the `infer` crate.
     pub legacy_compression_autodetect_libsnowflakeclient_behavior: bool,
 }
 

--- a/sf_core/src/rest/snowflake/query_response.rs
+++ b/sf_core/src/rest/snowflake/query_response.rs
@@ -323,8 +323,7 @@ impl Data {
     pub fn to_file_upload_data(
         &self,
         flavor: PutGetResultsetFlavor,
-        treat_unsupported_compression_as_uncompressed: bool,
-        accept_partial_magic_byte_prefix: bool,
+        legacy_compression_autodetect_libsnowflakeclient_behavior: bool,
         use_s3_regional_url_session_param: bool,
     ) -> Result<file_manager::UploadData, QueryResponseError> {
         let src_locations = self.src_locations.as_ref().context(MissingParameterSnafu {
@@ -411,8 +410,7 @@ impl Data {
             source_compression,
             overwrite,
             flavor,
-            treat_unsupported_compression_as_uncompressed,
-            accept_partial_magic_byte_prefix,
+            legacy_compression_autodetect_libsnowflakeclient_behavior,
         })
     }
 
@@ -1279,7 +1277,7 @@ mod tests {
         let json = make_upload_json(r#""encryptionMaterial": null,"#);
         let data: Data = serde_json::from_str(&json).unwrap();
         let upload = data
-            .to_file_upload_data(PutGetResultsetFlavor::default(), false, false, false)
+            .to_file_upload_data(PutGetResultsetFlavor::default(), false, false)
             .unwrap();
         assert!(upload.encryption_material.is_none());
     }
@@ -1289,7 +1287,7 @@ mod tests {
         let json = make_upload_json("");
         let data: Data = serde_json::from_str(&json).unwrap();
         let upload = data
-            .to_file_upload_data(PutGetResultsetFlavor::default(), false, false, false)
+            .to_file_upload_data(PutGetResultsetFlavor::default(), false, false)
             .unwrap();
         assert!(upload.encryption_material.is_none());
     }
@@ -1299,7 +1297,7 @@ mod tests {
         let json = make_upload_json(r#""encryptionMaterial": [],"#);
         let data: Data = serde_json::from_str(&json).unwrap();
         let upload = data
-            .to_file_upload_data(PutGetResultsetFlavor::default(), false, false, false)
+            .to_file_upload_data(PutGetResultsetFlavor::default(), false, false)
             .unwrap();
         assert!(upload.encryption_material.is_none());
     }
@@ -1311,7 +1309,7 @@ mod tests {
         );
         let data: Data = serde_json::from_str(&json).unwrap();
         let upload = data
-            .to_file_upload_data(PutGetResultsetFlavor::default(), false, false, false)
+            .to_file_upload_data(PutGetResultsetFlavor::default(), false, false)
             .unwrap();
         assert!(upload.encryption_material.is_some());
     }
@@ -1323,7 +1321,7 @@ mod tests {
         );
         let data: Data = serde_json::from_str(&json).unwrap();
         let upload = data
-            .to_file_upload_data(PutGetResultsetFlavor::default(), false, false, false)
+            .to_file_upload_data(PutGetResultsetFlavor::default(), false, false)
             .unwrap();
         assert!(upload.encryption_material.is_some());
     }
@@ -1337,8 +1335,7 @@ mod tests {
             ],"#,
         );
         let data: Data = serde_json::from_str(&json).unwrap();
-        let result =
-            data.to_file_upload_data(PutGetResultsetFlavor::default(), false, false, false);
+        let result = data.to_file_upload_data(PutGetResultsetFlavor::default(), false, false);
         assert!(result.is_err());
         let err_msg = result.unwrap_err().to_string();
         assert!(
@@ -1348,27 +1345,25 @@ mod tests {
     }
 
     #[test]
-    fn upload_data_forwards_treat_unsupported_compression_false() {
+    fn upload_data_forwards_legacy_compression_autodetect_libsnowflakeclient_behavior_false() {
         let json = make_upload_json("");
         let data: Data = serde_json::from_str(&json).unwrap();
         let upload = data
-            .to_file_upload_data(PutGetResultsetFlavor::Python, false, false, false)
+            .to_file_upload_data(PutGetResultsetFlavor::Python, false, false)
             .unwrap();
         assert_eq!(upload.flavor, PutGetResultsetFlavor::Python);
-        assert!(!upload.treat_unsupported_compression_as_uncompressed);
-        assert!(!upload.accept_partial_magic_byte_prefix);
+        assert!(!upload.legacy_compression_autodetect_libsnowflakeclient_behavior);
     }
 
     #[test]
-    fn upload_data_forwards_treat_unsupported_compression_true() {
+    fn upload_data_forwards_legacy_compression_autodetect_libsnowflakeclient_behavior_true() {
         let json = make_upload_json("");
         let data: Data = serde_json::from_str(&json).unwrap();
         let upload = data
-            .to_file_upload_data(PutGetResultsetFlavor::Odbc, true, true, false)
+            .to_file_upload_data(PutGetResultsetFlavor::Odbc, true, false)
             .unwrap();
         assert_eq!(upload.flavor, PutGetResultsetFlavor::Odbc);
-        assert!(upload.treat_unsupported_compression_as_uncompressed);
-        assert!(upload.accept_partial_magic_byte_prefix);
+        assert!(upload.legacy_compression_autodetect_libsnowflakeclient_behavior);
     }
 
     fn make_download_json() -> String {
@@ -2036,7 +2031,6 @@ mod tests {
         let data: Data = serde_json::from_value(payload).expect("build upload Data");
         data.to_file_upload_data(
             PutGetResultsetFlavor::default(),
-            false,
             false,
             use_s3_regional_url_session_param,
         )

--- a/sf_core/src/rest/snowflake/query_response.rs
+++ b/sf_core/src/rest/snowflake/query_response.rs
@@ -324,6 +324,7 @@ impl Data {
         &self,
         flavor: PutGetResultsetFlavor,
         treat_unsupported_compression_as_uncompressed: bool,
+        accept_partial_magic_byte_prefix: bool,
         use_s3_regional_url_session_param: bool,
     ) -> Result<file_manager::UploadData, QueryResponseError> {
         let src_locations = self.src_locations.as_ref().context(MissingParameterSnafu {
@@ -411,6 +412,7 @@ impl Data {
             overwrite,
             flavor,
             treat_unsupported_compression_as_uncompressed,
+            accept_partial_magic_byte_prefix,
         })
     }
 
@@ -1277,7 +1279,7 @@ mod tests {
         let json = make_upload_json(r#""encryptionMaterial": null,"#);
         let data: Data = serde_json::from_str(&json).unwrap();
         let upload = data
-            .to_file_upload_data(PutGetResultsetFlavor::default(), false, false)
+            .to_file_upload_data(PutGetResultsetFlavor::default(), false, false, false)
             .unwrap();
         assert!(upload.encryption_material.is_none());
     }
@@ -1287,7 +1289,7 @@ mod tests {
         let json = make_upload_json("");
         let data: Data = serde_json::from_str(&json).unwrap();
         let upload = data
-            .to_file_upload_data(PutGetResultsetFlavor::default(), false, false)
+            .to_file_upload_data(PutGetResultsetFlavor::default(), false, false, false)
             .unwrap();
         assert!(upload.encryption_material.is_none());
     }
@@ -1297,7 +1299,7 @@ mod tests {
         let json = make_upload_json(r#""encryptionMaterial": [],"#);
         let data: Data = serde_json::from_str(&json).unwrap();
         let upload = data
-            .to_file_upload_data(PutGetResultsetFlavor::default(), false, false)
+            .to_file_upload_data(PutGetResultsetFlavor::default(), false, false, false)
             .unwrap();
         assert!(upload.encryption_material.is_none());
     }
@@ -1309,7 +1311,7 @@ mod tests {
         );
         let data: Data = serde_json::from_str(&json).unwrap();
         let upload = data
-            .to_file_upload_data(PutGetResultsetFlavor::default(), false, false)
+            .to_file_upload_data(PutGetResultsetFlavor::default(), false, false, false)
             .unwrap();
         assert!(upload.encryption_material.is_some());
     }
@@ -1321,7 +1323,7 @@ mod tests {
         );
         let data: Data = serde_json::from_str(&json).unwrap();
         let upload = data
-            .to_file_upload_data(PutGetResultsetFlavor::default(), false, false)
+            .to_file_upload_data(PutGetResultsetFlavor::default(), false, false, false)
             .unwrap();
         assert!(upload.encryption_material.is_some());
     }
@@ -1335,7 +1337,8 @@ mod tests {
             ],"#,
         );
         let data: Data = serde_json::from_str(&json).unwrap();
-        let result = data.to_file_upload_data(PutGetResultsetFlavor::default(), false, false);
+        let result =
+            data.to_file_upload_data(PutGetResultsetFlavor::default(), false, false, false);
         assert!(result.is_err());
         let err_msg = result.unwrap_err().to_string();
         assert!(
@@ -1349,10 +1352,11 @@ mod tests {
         let json = make_upload_json("");
         let data: Data = serde_json::from_str(&json).unwrap();
         let upload = data
-            .to_file_upload_data(PutGetResultsetFlavor::Python, false, false)
+            .to_file_upload_data(PutGetResultsetFlavor::Python, false, false, false)
             .unwrap();
         assert_eq!(upload.flavor, PutGetResultsetFlavor::Python);
         assert!(!upload.treat_unsupported_compression_as_uncompressed);
+        assert!(!upload.accept_partial_magic_byte_prefix);
     }
 
     #[test]
@@ -1360,10 +1364,11 @@ mod tests {
         let json = make_upload_json("");
         let data: Data = serde_json::from_str(&json).unwrap();
         let upload = data
-            .to_file_upload_data(PutGetResultsetFlavor::Odbc, true, false)
+            .to_file_upload_data(PutGetResultsetFlavor::Odbc, true, true, false)
             .unwrap();
         assert_eq!(upload.flavor, PutGetResultsetFlavor::Odbc);
         assert!(upload.treat_unsupported_compression_as_uncompressed);
+        assert!(upload.accept_partial_magic_byte_prefix);
     }
 
     fn make_download_json() -> String {
@@ -2031,6 +2036,7 @@ mod tests {
         let data: Data = serde_json::from_value(payload).expect("build upload Data");
         data.to_file_upload_data(
             PutGetResultsetFlavor::default(),
+            false,
             false,
             use_s3_regional_url_session_param,
         )

--- a/sf_core/src/rest/snowflake/query_response.rs
+++ b/sf_core/src/rest/snowflake/query_response.rs
@@ -1,4 +1,4 @@
-use crate::apis::database_driver_v1::{CompressionAutoDetectFlavor, PutGetResultsetFlavor};
+use crate::apis::database_driver_v1::PutGetResultsetFlavor;
 use crate::chunks::ChunkDownloadData;
 use crate::file_manager::SourceCompressionParam;
 use crate::{file_manager, query_types};
@@ -323,7 +323,7 @@ impl Data {
     pub fn to_file_upload_data(
         &self,
         flavor: PutGetResultsetFlavor,
-        compression_autodetect_flavor: CompressionAutoDetectFlavor,
+        treat_unsupported_compression_as_uncompressed: bool,
         use_s3_regional_url_session_param: bool,
     ) -> Result<file_manager::UploadData, QueryResponseError> {
         let src_locations = self.src_locations.as_ref().context(MissingParameterSnafu {
@@ -410,7 +410,7 @@ impl Data {
             source_compression,
             overwrite,
             flavor,
-            compression_autodetect_flavor,
+            treat_unsupported_compression_as_uncompressed,
         })
     }
 
@@ -1277,11 +1277,7 @@ mod tests {
         let json = make_upload_json(r#""encryptionMaterial": null,"#);
         let data: Data = serde_json::from_str(&json).unwrap();
         let upload = data
-            .to_file_upload_data(
-                PutGetResultsetFlavor::default(),
-                CompressionAutoDetectFlavor::default(),
-                false,
-            )
+            .to_file_upload_data(PutGetResultsetFlavor::default(), false, false)
             .unwrap();
         assert!(upload.encryption_material.is_none());
     }
@@ -1291,11 +1287,7 @@ mod tests {
         let json = make_upload_json("");
         let data: Data = serde_json::from_str(&json).unwrap();
         let upload = data
-            .to_file_upload_data(
-                PutGetResultsetFlavor::default(),
-                CompressionAutoDetectFlavor::default(),
-                false,
-            )
+            .to_file_upload_data(PutGetResultsetFlavor::default(), false, false)
             .unwrap();
         assert!(upload.encryption_material.is_none());
     }
@@ -1305,11 +1297,7 @@ mod tests {
         let json = make_upload_json(r#""encryptionMaterial": [],"#);
         let data: Data = serde_json::from_str(&json).unwrap();
         let upload = data
-            .to_file_upload_data(
-                PutGetResultsetFlavor::default(),
-                CompressionAutoDetectFlavor::default(),
-                false,
-            )
+            .to_file_upload_data(PutGetResultsetFlavor::default(), false, false)
             .unwrap();
         assert!(upload.encryption_material.is_none());
     }
@@ -1321,11 +1309,7 @@ mod tests {
         );
         let data: Data = serde_json::from_str(&json).unwrap();
         let upload = data
-            .to_file_upload_data(
-                PutGetResultsetFlavor::default(),
-                CompressionAutoDetectFlavor::default(),
-                false,
-            )
+            .to_file_upload_data(PutGetResultsetFlavor::default(), false, false)
             .unwrap();
         assert!(upload.encryption_material.is_some());
     }
@@ -1337,11 +1321,7 @@ mod tests {
         );
         let data: Data = serde_json::from_str(&json).unwrap();
         let upload = data
-            .to_file_upload_data(
-                PutGetResultsetFlavor::default(),
-                CompressionAutoDetectFlavor::default(),
-                false,
-            )
+            .to_file_upload_data(PutGetResultsetFlavor::default(), false, false)
             .unwrap();
         assert!(upload.encryption_material.is_some());
     }
@@ -1355,11 +1335,7 @@ mod tests {
             ],"#,
         );
         let data: Data = serde_json::from_str(&json).unwrap();
-        let result = data.to_file_upload_data(
-            PutGetResultsetFlavor::default(),
-            CompressionAutoDetectFlavor::default(),
-            false,
-        );
+        let result = data.to_file_upload_data(PutGetResultsetFlavor::default(), false, false);
         assert!(result.is_err());
         let err_msg = result.unwrap_err().to_string();
         assert!(
@@ -1369,56 +1345,25 @@ mod tests {
     }
 
     #[test]
-    fn upload_data_forwards_flavor_python() {
+    fn upload_data_forwards_treat_unsupported_compression_false() {
         let json = make_upload_json("");
         let data: Data = serde_json::from_str(&json).unwrap();
         let upload = data
-            .to_file_upload_data(
-                PutGetResultsetFlavor::Python,
-                CompressionAutoDetectFlavor::Python,
-                false,
-            )
+            .to_file_upload_data(PutGetResultsetFlavor::Python, false, false)
             .unwrap();
         assert_eq!(upload.flavor, PutGetResultsetFlavor::Python);
-        assert_eq!(
-            upload.compression_autodetect_flavor,
-            CompressionAutoDetectFlavor::Python,
-        );
+        assert!(!upload.treat_unsupported_compression_as_uncompressed);
     }
 
     #[test]
-    fn upload_data_forwards_flavor_odbc() {
+    fn upload_data_forwards_treat_unsupported_compression_true() {
         let json = make_upload_json("");
         let data: Data = serde_json::from_str(&json).unwrap();
         let upload = data
-            .to_file_upload_data(
-                PutGetResultsetFlavor::Odbc,
-                CompressionAutoDetectFlavor::Odbc,
-                false,
-            )
+            .to_file_upload_data(PutGetResultsetFlavor::Odbc, true, false)
             .unwrap();
         assert_eq!(upload.flavor, PutGetResultsetFlavor::Odbc);
-        assert_eq!(
-            upload.compression_autodetect_flavor,
-            CompressionAutoDetectFlavor::Odbc,
-        );
-    }
-
-    #[test]
-    fn upload_data_forwards_flavor_jdbc() {
-        let json = make_upload_json("");
-        let data: Data = serde_json::from_str(&json).unwrap();
-        let upload = data
-            .to_file_upload_data(
-                PutGetResultsetFlavor::default(),
-                CompressionAutoDetectFlavor::Jdbc,
-                false,
-            )
-            .unwrap();
-        assert_eq!(
-            upload.compression_autodetect_flavor,
-            CompressionAutoDetectFlavor::Jdbc,
-        );
+        assert!(upload.treat_unsupported_compression_as_uncompressed);
     }
 
     fn make_download_json() -> String {
@@ -2086,7 +2031,7 @@ mod tests {
         let data: Data = serde_json::from_value(payload).expect("build upload Data");
         data.to_file_upload_data(
             PutGetResultsetFlavor::default(),
-            CompressionAutoDetectFlavor::default(),
+            false,
             use_s3_regional_url_session_param,
         )
         .expect("convert to UploadData")

--- a/sf_core/src/rest/snowflake/query_response.rs
+++ b/sf_core/src/rest/snowflake/query_response.rs
@@ -1,4 +1,4 @@
-use crate::apis::database_driver_v1::PutGetResultsetFlavor;
+use crate::apis::database_driver_v1::{CompressionAutoDetectFlavor, PutGetResultsetFlavor};
 use crate::chunks::ChunkDownloadData;
 use crate::file_manager::SourceCompressionParam;
 use crate::{file_manager, query_types};
@@ -323,6 +323,7 @@ impl Data {
     pub fn to_file_upload_data(
         &self,
         flavor: PutGetResultsetFlavor,
+        compression_autodetect_flavor: CompressionAutoDetectFlavor,
         use_s3_regional_url_session_param: bool,
     ) -> Result<file_manager::UploadData, QueryResponseError> {
         let src_locations = self.src_locations.as_ref().context(MissingParameterSnafu {
@@ -409,6 +410,7 @@ impl Data {
             source_compression,
             overwrite,
             flavor,
+            compression_autodetect_flavor,
         })
     }
 
@@ -1275,7 +1277,11 @@ mod tests {
         let json = make_upload_json(r#""encryptionMaterial": null,"#);
         let data: Data = serde_json::from_str(&json).unwrap();
         let upload = data
-            .to_file_upload_data(PutGetResultsetFlavor::default(), false)
+            .to_file_upload_data(
+                PutGetResultsetFlavor::default(),
+                CompressionAutoDetectFlavor::default(),
+                false,
+            )
             .unwrap();
         assert!(upload.encryption_material.is_none());
     }
@@ -1285,7 +1291,11 @@ mod tests {
         let json = make_upload_json("");
         let data: Data = serde_json::from_str(&json).unwrap();
         let upload = data
-            .to_file_upload_data(PutGetResultsetFlavor::default(), false)
+            .to_file_upload_data(
+                PutGetResultsetFlavor::default(),
+                CompressionAutoDetectFlavor::default(),
+                false,
+            )
             .unwrap();
         assert!(upload.encryption_material.is_none());
     }
@@ -1295,7 +1305,11 @@ mod tests {
         let json = make_upload_json(r#""encryptionMaterial": [],"#);
         let data: Data = serde_json::from_str(&json).unwrap();
         let upload = data
-            .to_file_upload_data(PutGetResultsetFlavor::default(), false)
+            .to_file_upload_data(
+                PutGetResultsetFlavor::default(),
+                CompressionAutoDetectFlavor::default(),
+                false,
+            )
             .unwrap();
         assert!(upload.encryption_material.is_none());
     }
@@ -1307,7 +1321,11 @@ mod tests {
         );
         let data: Data = serde_json::from_str(&json).unwrap();
         let upload = data
-            .to_file_upload_data(PutGetResultsetFlavor::default(), false)
+            .to_file_upload_data(
+                PutGetResultsetFlavor::default(),
+                CompressionAutoDetectFlavor::default(),
+                false,
+            )
             .unwrap();
         assert!(upload.encryption_material.is_some());
     }
@@ -1319,7 +1337,11 @@ mod tests {
         );
         let data: Data = serde_json::from_str(&json).unwrap();
         let upload = data
-            .to_file_upload_data(PutGetResultsetFlavor::default(), false)
+            .to_file_upload_data(
+                PutGetResultsetFlavor::default(),
+                CompressionAutoDetectFlavor::default(),
+                false,
+            )
             .unwrap();
         assert!(upload.encryption_material.is_some());
     }
@@ -1333,7 +1355,11 @@ mod tests {
             ],"#,
         );
         let data: Data = serde_json::from_str(&json).unwrap();
-        let result = data.to_file_upload_data(PutGetResultsetFlavor::default(), false);
+        let result = data.to_file_upload_data(
+            PutGetResultsetFlavor::default(),
+            CompressionAutoDetectFlavor::default(),
+            false,
+        );
         assert!(result.is_err());
         let err_msg = result.unwrap_err().to_string();
         assert!(
@@ -1347,9 +1373,17 @@ mod tests {
         let json = make_upload_json("");
         let data: Data = serde_json::from_str(&json).unwrap();
         let upload = data
-            .to_file_upload_data(PutGetResultsetFlavor::Python, false)
+            .to_file_upload_data(
+                PutGetResultsetFlavor::Python,
+                CompressionAutoDetectFlavor::Python,
+                false,
+            )
             .unwrap();
         assert_eq!(upload.flavor, PutGetResultsetFlavor::Python);
+        assert_eq!(
+            upload.compression_autodetect_flavor,
+            CompressionAutoDetectFlavor::Python,
+        );
     }
 
     #[test]
@@ -1357,9 +1391,34 @@ mod tests {
         let json = make_upload_json("");
         let data: Data = serde_json::from_str(&json).unwrap();
         let upload = data
-            .to_file_upload_data(PutGetResultsetFlavor::Odbc, false)
+            .to_file_upload_data(
+                PutGetResultsetFlavor::Odbc,
+                CompressionAutoDetectFlavor::Odbc,
+                false,
+            )
             .unwrap();
         assert_eq!(upload.flavor, PutGetResultsetFlavor::Odbc);
+        assert_eq!(
+            upload.compression_autodetect_flavor,
+            CompressionAutoDetectFlavor::Odbc,
+        );
+    }
+
+    #[test]
+    fn upload_data_forwards_flavor_jdbc() {
+        let json = make_upload_json("");
+        let data: Data = serde_json::from_str(&json).unwrap();
+        let upload = data
+            .to_file_upload_data(
+                PutGetResultsetFlavor::default(),
+                CompressionAutoDetectFlavor::Jdbc,
+                false,
+            )
+            .unwrap();
+        assert_eq!(
+            upload.compression_autodetect_flavor,
+            CompressionAutoDetectFlavor::Jdbc,
+        );
     }
 
     fn make_download_json() -> String {
@@ -2027,6 +2086,7 @@ mod tests {
         let data: Data = serde_json::from_value(payload).expect("build upload Data");
         data.to_file_upload_data(
             PutGetResultsetFlavor::default(),
+            CompressionAutoDetectFlavor::default(),
             use_s3_regional_url_session_param,
         )
         .expect("convert to UploadData")


### PR DESCRIPTION
## Summary

PR1 of the [AWS Gap-12](https://snowflakecomputing.atlassian.net/browse/SNOW-3406388) (source compression auto-detection by MIME). **No user-visible behavior change.**

- Adds `legacy_compression_autodetect_libsnowflakeclient_behavior: bool` to `WrapperPresets`. Defaults to `false`; `WrapperPresets::odbc()` sets it to `true`. The single flag controls two libsnowflakeclient-parity behaviors at once: (1) unsupported compression formats (`.xz`/`.lz`/`.lzma`/`.lzo`/`.Z` plus their buffer-detected equivalents) are silently treated as uncompressed instead of erroring, and (2) magic-byte detection consults a short-prefix table (2-byte gzip header, 2-byte zlib stream headers mapped to `Deflate`, 4-byte snowflake-specific brotli marker) ahead of the `infer` crate.
- Plumbs the flag through `Data::to_file_upload_data` → `UploadData` → `SingleUploadData` → `preprocess_file_before_upload` → `get_source_compression` → `auto_detect_source_compression` → `try_guess_compression_type`, replacing the previous `PutGetResultsetFlavor` parameter on the auto-detect path. The `flavor` field on `UploadData`/`SingleUploadData` (which gates `upload_result_message`) is unchanged.
- Locks current auto-detect behavior with unit tests so PR2 has a baseline to change against:
  - `compression_types.rs`: supported extensions (`gz`/`bz2`/`br`/`zst`/`deflate`/`raw_deflate`), unsupported extensions with the right `type_name` (`lz`/`lzma`/`lzo`/`xz`/`Z`/`parquet`/`orc`), case-sensitive extension match, magic-byte sniffing (gzip/bzip2/zstd), multi-dot filenames (`foo.tar.gz` → gzip, `foo.gz.bak` → fallthrough), no-dot filenames, infer-detected unsupported (xz magic).
  - Edge-case coverage from review: extension/magic conflict (`foo.gz` + bzip2 magic → Gzip; locks Python/JDBC parity), 2-byte gzip prefix detected only when flag=true, full gzip 3-byte detected for both flag values, zlib stream headers (`78 01/9C/DA`) → Deflate when flag=true, snowflake brotli marker (`CE B2 CF 81`) detected when flag=true, empty buffer, leading-dot filenames (`.gz`, `...`), 4096-char filename, brotli/deflate/raw_deflate never detected via magic when flag=false.
  - `file_manager/mod.rs`: flag=`true` swallows unsupported (returns `None`); flag=`false` propagates the error. Both extension and magic-byte paths covered.

PR2 sits on top and uses this scaffolding to add MIME-based parquet/orc detection so Python/JDBC stop erroring on `.parquet` / `.orc` uploads.

## Stack:

 * #1247 (this PR)
 * #1248

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test -p sf_core --lib` (988 passed, 35+ compression-related)
- [x] `PARAMETER_PATH=parameters.json cargo test -p sf_core --test e2e_tests --release` (77 passed, 0 failed)