### PR TITLE
SNOW-3406377, gap 12: support PARQUET/ORC auto-detect for PUT (Python parity)

### DIFF
--- a/sf_core/src/apis/database_driver_v1/global_state.rs
+++ b/sf_core/src/apis/database_driver_v1/global_state.rs
@@ -35,7 +35,7 @@ pub struct WrapperPresets {
     /// detection consults a short-prefix table (2-byte gzip, 2-byte
     /// zlib mapped to `Deflate`, 4-byte snowflake brotli marker) ahead
     /// of the `infer` crate.
-    pub legacy_compression_autodetect_libsnowflakeclient_behavior: bool,
+    pub legacy_odbc_compression_autodetect: bool,
 }
 
 impl WrapperPresets {
@@ -52,7 +52,7 @@ impl WrapperPresets {
     pub fn odbc() -> Self {
         Self {
             put_get_resultset_flavor: PutGetResultsetFlavor::Odbc,
-            legacy_compression_autodetect_libsnowflakeclient_behavior: true,
+            legacy_odbc_compression_autodetect: true,
             ..Self::default()
         }
     }

--- a/sf_core/src/apis/database_driver_v1/query.rs
+++ b/sf_core/src/apis/database_driver_v1/query.rs
@@ -88,7 +88,7 @@ pub(super) async fn perform_put_get_transfer(
             let file_upload_data = data
                 .to_file_upload_data(
                     wrapper_presets.put_get_resultset_flavor.clone(),
-                    wrapper_presets.legacy_compression_autodetect_libsnowflakeclient_behavior,
+                    wrapper_presets.legacy_odbc_compression_autodetect,
                     use_s3_regional_url_session_param,
                 )
                 .context(FileTransferPreparationSnafu)?;

--- a/sf_core/src/compression_types.rs
+++ b/sf_core/src/compression_types.rs
@@ -9,6 +9,8 @@ pub enum CompressionType {
     Zstd,
     Deflate,
     RawDeflate,
+    Parquet,
+    Orc,
     None,
 }
 
@@ -21,6 +23,8 @@ impl CompressionType {
             CompressionType::Zstd => "ZSTD",
             CompressionType::Deflate => "DEFLATE",
             CompressionType::RawDeflate => "RAW_DEFLATE",
+            CompressionType::Parquet => "PARQUET",
+            CompressionType::Orc => "ORC",
             CompressionType::None => "NONE",
         }
     }
@@ -36,6 +40,8 @@ fn get_compression_type_from_extension(
         "zst" => Ok(Some(CompressionType::Zstd)),
         "deflate" => Ok(Some(CompressionType::Deflate)),
         "raw_deflate" => Ok(Some(CompressionType::RawDeflate)),
+        "parquet" => Ok(Some(CompressionType::Parquet)),
+        "orc" => Ok(Some(CompressionType::Orc)),
         "lz" => UnsupportedCompressionTypeSnafu {
             type_name: "LZ".to_string(),
         }
@@ -54,14 +60,6 @@ fn get_compression_type_from_extension(
         .fail(),
         "Z" => UnsupportedCompressionTypeSnafu {
             type_name: "COMPRESS".to_string(),
-        }
-        .fail(),
-        "parquet" => UnsupportedCompressionTypeSnafu {
-            type_name: "PARQUET".to_string(),
-        }
-        .fail(),
-        "orc" => UnsupportedCompressionTypeSnafu {
-            type_name: "ORC".to_string(),
         }
         .fail(),
         _ => Ok(None),
@@ -143,10 +141,22 @@ fn try_match_short_prefix(file_buffer: &[u8]) -> Option<CompressionType> {
         .find_map(|(prefix, kind)| file_buffer.starts_with(prefix).then(|| kind.clone()))
 }
 
+// Parquet and ORC magic bytes are sniffed explicitly because the `infer`
+// crate (as of 0.16) has no matchers for them. Mirrors the legacy
+// libsnowflakeclient `FileCompressionType` table — PAR1 (4 bytes) for
+// Parquet, ORC (3 bytes) for Orc. Sniffing happens before the `infer`
+// fallback so a buffer that *also* happens to look like something else
+// to `infer` still gets identified correctly.
 // TODO: DEFLATE cannot be detected by the infer crate - we might need a custom implementation for that
 fn try_guess_compression_type_from_buffer(
     file_buffer: &[u8],
 ) -> Result<Option<CompressionType>, CompressionTypeError> {
+    if file_buffer.starts_with(b"PAR1") {
+        return Ok(Some(CompressionType::Parquet));
+    }
+    if file_buffer.starts_with(b"ORC") {
+        return Ok(Some(CompressionType::Orc));
+    }
     // Use the infer crate to guess the file type based on content
     match infer::get(file_buffer) {
         Some(kind) => get_compression_type_from_extension(kind.extension()),
@@ -168,8 +178,6 @@ pub enum CompressionTypeError {
 mod tests {
     use super::*;
 
-    // Supported extensions: each maps to the matching `CompressionType`
-    // variant via `try_guess_compression_type` (filename branch).
     #[test]
     fn extension_gz_maps_to_gzip() {
         let result = try_guess_compression_type("file.gz", b"", false).unwrap();
@@ -204,6 +212,37 @@ mod tests {
     fn extension_raw_deflate_maps_to_raw_deflate() {
         let result = try_guess_compression_type("file.raw_deflate", b"", false).unwrap();
         assert_eq!(result, CompressionType::RawDeflate);
+    }
+
+    // Parquet and ORC are now first-class supported types. The earlier
+    // `extension_parquet_errors_*` / `extension_orc_errors_*` tests from
+    // PR1 are gone — they locked a behavior PR2 deliberately changes.
+    #[test]
+    fn extension_parquet_returns_parquet() {
+        let result = try_guess_compression_type("data.parquet", b"", false).unwrap();
+        assert_eq!(result, CompressionType::Parquet);
+    }
+
+    #[test]
+    fn extension_orc_returns_orc() {
+        let result = try_guess_compression_type("data.orc", b"", false).unwrap();
+        assert_eq!(result, CompressionType::Orc);
+    }
+
+    // Magic-byte sniffing for Parquet (`PAR1`) and ORC (`ORC`) — both run
+    // ahead of the `infer` crate fallback and don't require the legacy
+    // libsnowflakeclient flag (these matchers are a Python/JDBC parity
+    // feature, not an ODBC-only one).
+    #[test]
+    fn parquet_magic_in_buffer_returns_parquet() {
+        let result = try_guess_compression_type("noext", b"PAR1trailing-bytes", false).unwrap();
+        assert_eq!(result, CompressionType::Parquet);
+    }
+
+    #[test]
+    fn orc_magic_in_buffer_returns_orc() {
+        let result = try_guess_compression_type("noext", b"ORCtrailing-bytes", false).unwrap();
+        assert_eq!(result, CompressionType::Orc);
     }
 
     // Unsupported extensions: each errors with `UnsupportedCompressionType`
@@ -246,16 +285,6 @@ mod tests {
         assert_unsupported_with_name("file.Z", "COMPRESS");
     }
 
-    #[test]
-    fn extension_parquet_errors_with_parquet_type_name() {
-        assert_unsupported_with_name("file.parquet", "PARQUET");
-    }
-
-    #[test]
-    fn extension_orc_errors_with_orc_type_name() {
-        assert_unsupported_with_name("file.orc", "ORC");
-    }
-
     // Extension match is case-sensitive: `foo.GZ` does not match by
     // extension and must fall through to the magic-byte branch (here:
     // empty buffer => None).
@@ -266,13 +295,31 @@ mod tests {
     }
 
     #[test]
+    fn parquet_magic_exact_4_bytes_returns_parquet() {
+        let result = try_guess_compression_type("noext", b"PAR1", false).unwrap();
+        assert_eq!(result, CompressionType::Parquet);
+    }
+
+    #[test]
+    fn orc_magic_exact_3_bytes_returns_orc() {
+        let result = try_guess_compression_type("noext", b"ORC", false).unwrap();
+        assert_eq!(result, CompressionType::Orc);
+    }
+
+    #[test]
+    fn buffer_too_short_does_not_match_either_parquet_or_orc() {
+        // A 2-byte buffer can't carry either magic; must fall through to
+        // None (no extension, no infer match).
+        let result = try_guess_compression_type("noext", b"OR", false).unwrap();
+        assert_eq!(result, CompressionType::None);
+    }
+
+    #[test]
     fn unknown_extension_with_empty_buffer_returns_none() {
         let result = try_guess_compression_type("file.unknownext", b"", false).unwrap();
         assert_eq!(result, CompressionType::None);
     }
 
-    // Magic-byte sniffing detects gzip, bzip2, and zstd when the filename
-    // has no recognized extension.
     #[test]
     fn magic_bytes_detect_gzip() {
         let gzip_magic: &[u8] = &[0x1F, 0x8B, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
@@ -321,8 +368,8 @@ mod tests {
     }
 
     // Buffer-detection branch surfaces unsupported magic bytes (e.g. xz
-    // / 7z) as `UnsupportedCompressionType` — locks current behavior so
-    // PR2 has a baseline to change against.
+    // / 7z) as `UnsupportedCompressionType` — `infer` matches xz before
+    // the parquet/orc branch can run.
     #[test]
     fn magic_bytes_detect_xz_as_unsupported() {
         let xz_magic: &[u8] = b"\xFD7zXZ\x00\x00\x01\x69\x22\xDE\x36";
@@ -333,6 +380,19 @@ mod tests {
             }
             other => panic!("Expected UnsupportedCompressionType for xz magic, got: {other:?}"),
         }
+    }
+
+    #[test]
+    fn parquet_snowflake_representation() {
+        assert_eq!(
+            CompressionType::Parquet.get_snowflake_representation(),
+            "PARQUET"
+        );
+    }
+
+    #[test]
+    fn orc_snowflake_representation() {
+        assert_eq!(CompressionType::Orc.get_snowflake_representation(), "ORC");
     }
 
     // Extension/magic conflict: filename says gzip, magic bytes say bzip2.

--- a/sf_core/src/compression_types.rs
+++ b/sf_core/src/compression_types.rs
@@ -141,12 +141,9 @@ fn try_match_short_prefix(file_buffer: &[u8]) -> Option<CompressionType> {
         .find_map(|(prefix, kind)| file_buffer.starts_with(prefix).then(|| kind.clone()))
 }
 
-// Parquet and ORC magic bytes are sniffed explicitly because the `infer`
-// crate has no matchers for them. Mirrors the legacy libsnowflakeclient
-// `FileCompressionType` table — PAR1 (4 bytes) for Parquet, ORC (3 bytes)
-// for Orc. Sniffing happens before the `infer` fallback so a buffer that
-// *also* happens to look like something else to `infer` still gets
-// identified correctly.
+// Parquet (PAR1, 4 bytes) and ORC ("ORC", 3 bytes) magic bytes are
+// sniffed explicitly because the `infer` crate has no matchers for them.
+// Mirrors current Python / JDBC / libsnowflakeclient behavior.
 // TODO: DEFLATE cannot be detected by the infer crate - we might need a custom implementation for that
 fn try_guess_compression_type_from_buffer(
     file_buffer: &[u8],

--- a/sf_core/src/compression_types.rs
+++ b/sf_core/src/compression_types.rs
@@ -142,11 +142,11 @@ fn try_match_short_prefix(file_buffer: &[u8]) -> Option<CompressionType> {
 }
 
 // Parquet and ORC magic bytes are sniffed explicitly because the `infer`
-// crate (as of 0.16) has no matchers for them. Mirrors the legacy
-// libsnowflakeclient `FileCompressionType` table — PAR1 (4 bytes) for
-// Parquet, ORC (3 bytes) for Orc. Sniffing happens before the `infer`
-// fallback so a buffer that *also* happens to look like something else
-// to `infer` still gets identified correctly.
+// crate has no matchers for them. Mirrors the legacy libsnowflakeclient
+// `FileCompressionType` table — PAR1 (4 bytes) for Parquet, ORC (3 bytes)
+// for Orc. Sniffing happens before the `infer` fallback so a buffer that
+// *also* happens to look like something else to `infer` still gets
+// identified correctly.
 // TODO: DEFLATE cannot be detected by the infer crate - we might need a custom implementation for that
 fn try_guess_compression_type_from_buffer(
     file_buffer: &[u8],

--- a/sf_core/src/compression_types.rs
+++ b/sf_core/src/compression_types.rs
@@ -70,7 +70,7 @@ fn get_compression_type_from_extension(
 /// `FileCompressionType.cpp`. Each entry is matched with `starts_with` —
 /// shorter than what the `infer` crate requires (e.g. infer's gzip matcher
 /// needs the 3-byte `1F 8B 08`; ODBC accepts the 2-byte `1F 8B`). Used
-/// only when `legacy_compression_autodetect_libsnowflakeclient_behavior`
+/// only when `legacy_odbc_compression_autodetect`
 /// is true; Python/JDBC do not consult this table.
 ///
 /// `0x78 0x01 / 0x9C / 0xDA` are zlib stream headers. UD has no separate
@@ -93,7 +93,7 @@ const SHORT_MAGIC_PREFIXES: &[(&[u8], CompressionType)] = &[
 // If both fail, it returns CompressionType::None
 // Returns an error if the compression type is unsupported
 //
-// `legacy_compression_autodetect_libsnowflakeclient_behavior` enables a
+// `legacy_odbc_compression_autodetect` enables a
 // libsnowflakeclient-style short-prefix match (see `SHORT_MAGIC_PREFIXES`)
 // ahead of the `infer` crate's full-buffer detection. ODBC sets this to
 // true to keep parity with legacy behavior; Python / JDBC keep it false.
@@ -102,7 +102,7 @@ const SHORT_MAGIC_PREFIXES: &[(&[u8], CompressionType)] = &[
 pub fn try_guess_compression_type(
     filename: &str,
     file_buffer: &[u8],
-    legacy_compression_autodetect_libsnowflakeclient_behavior: bool,
+    legacy_odbc_compression_autodetect: bool,
 ) -> Result<CompressionType, CompressionTypeError> {
     let compression_type = try_guess_compression_type_from_filename(filename)?;
 
@@ -110,7 +110,7 @@ pub fn try_guess_compression_type(
         return Ok(compression_type);
     }
 
-    if legacy_compression_autodetect_libsnowflakeclient_behavior
+    if legacy_odbc_compression_autodetect
         && let Some(compression_type) = try_match_short_prefix(file_buffer)
     {
         return Ok(compression_type);
@@ -136,23 +136,33 @@ fn try_guess_compression_type_from_filename(
 }
 
 fn try_match_short_prefix(file_buffer: &[u8]) -> Option<CompressionType> {
-    SHORT_MAGIC_PREFIXES
+    try_match_magic_prefix(SHORT_MAGIC_PREFIXES, file_buffer)
+}
+
+// Parquet ("PAR1", 4 bytes) and ORC ("ORC", 3 bytes) magic bytes are
+// sniffed explicitly because the `infer` crate has no matchers for them.
+// These are real format markers — applied for all wrappers, not gated
+// on the ODBC-only legacy flag.
+const FILE_FORMAT_MAGIC_PREFIXES: &[(&[u8], CompressionType)] = &[
+    (b"PAR1", CompressionType::Parquet),
+    (b"ORC", CompressionType::Orc),
+];
+
+fn try_match_magic_prefix(
+    table: &[(&[u8], CompressionType)],
+    file_buffer: &[u8],
+) -> Option<CompressionType> {
+    table
         .iter()
         .find_map(|(prefix, kind)| file_buffer.starts_with(prefix).then(|| kind.clone()))
 }
 
-// Parquet (PAR1, 4 bytes) and ORC ("ORC", 3 bytes) magic bytes are
-// sniffed explicitly because the `infer` crate has no matchers for them.
-// Mirrors current Python / JDBC / libsnowflakeclient behavior.
 // TODO: DEFLATE cannot be detected by the infer crate - we might need a custom implementation for that
 fn try_guess_compression_type_from_buffer(
     file_buffer: &[u8],
 ) -> Result<Option<CompressionType>, CompressionTypeError> {
-    if file_buffer.starts_with(b"PAR1") {
-        return Ok(Some(CompressionType::Parquet));
-    }
-    if file_buffer.starts_with(b"ORC") {
-        return Ok(Some(CompressionType::Orc));
+    if let Some(kind) = try_match_magic_prefix(FILE_FORMAT_MAGIC_PREFIXES, file_buffer) {
+        return Ok(Some(kind));
     }
     // Use the infer crate to guess the file type based on content
     match infer::get(file_buffer) {

--- a/sf_core/src/file_manager/mod.rs
+++ b/sf_core/src/file_manager/mod.rs
@@ -702,15 +702,8 @@ mod tests {
     // = true`) restores that behavior; Python / JDBC (false) keep surfacing
     // the error. JDBC behavior verified equivalent to Python via
     // `SnowflakeFileTransferAgent.java:3163-3308`.
-    const UNSUPPORTED_COMPRESSION_FILENAMES: &[&str] = &[
-        "test.xz",
-        "test.lzma",
-        "test.lz",
-        "test.lzo",
-        "test.Z",
-        "test.parquet",
-        "test.orc",
-    ];
+    const UNSUPPORTED_COMPRESSION_FILENAMES: &[&str] =
+        &["test.xz", "test.lzma", "test.lz", "test.lzo", "test.Z"];
 
     #[test]
     fn auto_detect_source_compression_legacy_flag_true_swallows_unsupported_error() {
@@ -787,6 +780,54 @@ mod tests {
         }
     }
 
+    #[test]
+    fn auto_detect_source_compression_recognizes_parquet_regardless_of_flag() {
+        for legacy in [false, true] {
+            let result = auto_detect_source_compression("test.parquet", b"", legacy);
+            assert_eq!(
+                result.unwrap(),
+                CompressionType::Parquet,
+                "must recognize .parquet regardless of legacy flag (legacy={legacy})",
+            );
+        }
+    }
+
+    #[test]
+    fn auto_detect_source_compression_recognizes_orc_regardless_of_flag() {
+        for legacy in [false, true] {
+            let result = auto_detect_source_compression("test.orc", b"", legacy);
+            assert_eq!(
+                result.unwrap(),
+                CompressionType::Orc,
+                "must recognize .orc regardless of legacy flag (legacy={legacy})",
+            );
+        }
+    }
+
+    #[test]
+    fn auto_detect_source_compression_recognizes_parquet_magic_regardless_of_flag() {
+        for legacy in [false, true] {
+            let result = auto_detect_source_compression("noext", b"PAR1payload", legacy);
+            assert_eq!(
+                result.unwrap(),
+                CompressionType::Parquet,
+                "must recognize PAR1 magic regardless of legacy flag (legacy={legacy})",
+            );
+        }
+    }
+
+    #[test]
+    fn auto_detect_source_compression_recognizes_orc_magic_regardless_of_flag() {
+        for legacy in [false, true] {
+            let result = auto_detect_source_compression("noext", b"ORCpayload", legacy);
+            assert_eq!(
+                result.unwrap(),
+                CompressionType::Orc,
+                "must recognize ORC magic regardless of legacy flag (legacy={legacy})",
+            );
+        }
+    }
+
     // Partial-prefix detection: `\x1F\x8B` is the first 2 bytes of gzip's
     // 3-byte magic. With the legacy flag false (Python/JDBC default)
     // `infer` requires the full 3 bytes and returns `None` here. With the
@@ -813,15 +854,119 @@ mod tests {
         // auto-detect path, so the flag branch is a no-op here.
         for legacy in [false, true] {
             assert_eq!(
-                get_source_compression("ignored.xz", b"", &SourceCompressionParam::Gzip, legacy,)
+                get_source_compression("ignored.xz", b"", &SourceCompressionParam::Gzip, legacy)
                     .unwrap(),
                 CompressionType::Gzip,
             );
             assert_eq!(
-                get_source_compression("ignored.xz", b"", &SourceCompressionParam::None, legacy,)
+                get_source_compression("ignored.xz", b"", &SourceCompressionParam::None, legacy)
                     .unwrap(),
                 CompressionType::None,
             );
+        }
+    }
+
+    // Upload-prep passthrough: a `.parquet` source under
+    // `auto_compress = true` must NOT be re-wrapped in gzip. The target
+    // filename keeps its original `.parquet` suffix (no `.gz` appended)
+    // and `target_compression` is reported as `Parquet`. Asserting the
+    // payload is bit-identical to the input distinguishes "didn't gzip"
+    // from "gzipped a tiny buffer that happens to start with PAR1".
+    #[test]
+    fn preprocess_parquet_passthrough_under_auto_compress() {
+        let payload = b"PAR1\x00\x01\x02\x03some-parquet-bytes-go-here".to_vec();
+        let data = SingleUploadData {
+            file_path: "/tmp/data.parquet".to_string(),
+            filename: "data.parquet".to_string(),
+            stage_info: dummy_stage_info(),
+            encryption_material: None,
+            auto_compress: true,
+            source_compression: SourceCompressionParam::AutoDetect,
+            overwrite: false,
+            flavor: PutGetResultsetFlavor::Python,
+            legacy_compression_autodetect_libsnowflakeclient_behavior: false,
+        };
+
+        let (prepared, metadata) = preprocess_file_before_upload(payload.clone(), &data).unwrap();
+
+        assert_eq!(metadata.target, "data.parquet", "no .gz suffix expected");
+        assert_eq!(metadata.target_compression, CompressionType::Parquet);
+        assert_eq!(metadata.source_compression, CompressionType::Parquet);
+        assert_eq!(
+            prepared.data, payload,
+            "payload must pass through bit-identical (no gzip wrap)",
+        );
+    }
+
+    #[test]
+    fn preprocess_orc_passthrough_under_auto_compress() {
+        let payload = b"ORC\x00\x01\x02some-orc-bytes-go-here".to_vec();
+        let data = SingleUploadData {
+            file_path: "/tmp/data.orc".to_string(),
+            filename: "data.orc".to_string(),
+            stage_info: dummy_stage_info(),
+            encryption_material: None,
+            auto_compress: true,
+            source_compression: SourceCompressionParam::AutoDetect,
+            overwrite: false,
+            flavor: PutGetResultsetFlavor::Python,
+            legacy_compression_autodetect_libsnowflakeclient_behavior: false,
+        };
+
+        let (prepared, metadata) = preprocess_file_before_upload(payload.clone(), &data).unwrap();
+
+        assert_eq!(metadata.target, "data.orc", "no .gz suffix expected");
+        assert_eq!(metadata.target_compression, CompressionType::Orc);
+        assert_eq!(metadata.source_compression, CompressionType::Orc);
+        assert_eq!(
+            prepared.data, payload,
+            "payload must pass through bit-identical"
+        );
+    }
+
+    #[test]
+    fn preprocess_parquet_passthrough_when_unsupported_compression_swallowed() {
+        // Locks in PR2 of Gap-12: parquet detection is independent of the
+        // unsupported-compression flag (ODBC sets the flag to true,
+        // matching legacy libsnowflakeclient which detects PAR1 magic via
+        // FileCompressionType::PARQUET with isSupported=true).
+        let payload = b"PAR1\x00\x01\x02\x03more-bytes".to_vec();
+        let data = SingleUploadData {
+            file_path: "/tmp/data.parquet".to_string(),
+            filename: "data.parquet".to_string(),
+            stage_info: dummy_stage_info(),
+            encryption_material: None,
+            auto_compress: true,
+            source_compression: SourceCompressionParam::AutoDetect,
+            overwrite: false,
+            flavor: PutGetResultsetFlavor::Odbc,
+            legacy_compression_autodetect_libsnowflakeclient_behavior: true,
+        };
+
+        let (prepared, metadata) = preprocess_file_before_upload(payload.clone(), &data).unwrap();
+
+        assert_eq!(metadata.target, "data.parquet");
+        assert_eq!(metadata.target_compression, CompressionType::Parquet);
+        assert_eq!(prepared.data, payload);
+    }
+
+    fn dummy_stage_info() -> StageInfo {
+        StageInfo {
+            location_type: LocationType::S3,
+            bucket: "b".to_string(),
+            key_prefix: "p".to_string(),
+            region: "us-east-1".to_string(),
+            creds: CloudCredentials::S3 {
+                aws_key_id: String::new(),
+                aws_secret_key: crate::sensitive::SensitiveString::from(String::new()),
+                aws_token: crate::sensitive::SensitiveString::from(String::new()),
+            },
+            endpoint: None,
+            presigned_url: None,
+            use_virtual_url: false,
+            use_regional_url: false,
+            use_s3_regional_url: false,
+            storage_account: None,
         }
     }
 }

--- a/sf_core/src/file_manager/mod.rs
+++ b/sf_core/src/file_manager/mod.rs
@@ -64,8 +64,7 @@ pub async fn upload_files(
             source_compression: data.source_compression.clone(),
             overwrite: data.overwrite,
             flavor: data.flavor.clone(),
-            legacy_compression_autodetect_libsnowflakeclient_behavior: data
-                .legacy_compression_autodetect_libsnowflakeclient_behavior,
+            legacy_odbc_compression_autodetect: data.legacy_odbc_compression_autodetect,
         };
 
         let result = upload_single_file(single_upload_data, &mut refresher).await?;
@@ -196,7 +195,7 @@ fn preprocess_file_before_upload(
         data.filename.as_str(),
         file_buffer.as_slice(),
         &data.source_compression,
-        data.legacy_compression_autodetect_libsnowflakeclient_behavior,
+        data.legacy_odbc_compression_autodetect,
     )
     .context(CompressionTypeSnafu)?;
 
@@ -250,13 +249,13 @@ fn get_source_compression(
     filename: &str,
     file_buffer: &[u8],
     source_compression: &SourceCompressionParam,
-    legacy_compression_autodetect_libsnowflakeclient_behavior: bool,
+    legacy_odbc_compression_autodetect: bool,
 ) -> Result<CompressionType, CompressionTypeError> {
     match source_compression {
         SourceCompressionParam::AutoDetect => auto_detect_source_compression(
             filename,
             file_buffer,
-            legacy_compression_autodetect_libsnowflakeclient_behavior,
+            legacy_odbc_compression_autodetect,
         ),
         SourceCompressionParam::None => Ok(CompressionType::None),
         SourceCompressionParam::Gzip => Ok(CompressionType::Gzip),
@@ -269,7 +268,7 @@ fn get_source_compression(
 }
 
 /// Returns the resolved compression type for the `AUTO_DETECT` path.
-/// `legacy_compression_autodetect_libsnowflakeclient_behavior` (true) opts
+/// `legacy_odbc_compression_autodetect` (true) opts
 /// into two libsnowflakeclient-parity behaviors at once (see
 /// `WrapperPresets` for the full doc-comment):
 ///
@@ -285,14 +284,11 @@ fn get_source_compression(
 fn auto_detect_source_compression(
     filename: &str,
     file_buffer: &[u8],
-    legacy_compression_autodetect_libsnowflakeclient_behavior: bool,
+    legacy_odbc_compression_autodetect: bool,
 ) -> Result<CompressionType, CompressionTypeError> {
-    let detected = try_guess_compression_type(
-        filename,
-        file_buffer,
-        legacy_compression_autodetect_libsnowflakeclient_behavior,
-    );
-    if legacy_compression_autodetect_libsnowflakeclient_behavior {
+    let detected =
+        try_guess_compression_type(filename, file_buffer, legacy_odbc_compression_autodetect);
+    if legacy_odbc_compression_autodetect {
         match detected {
             Err(CompressionTypeError::UnsupportedCompressionType { .. }) => {
                 Ok(CompressionType::None)
@@ -698,9 +694,9 @@ mod tests {
 
     // BD#6 — when SOURCE_COMPRESSION=AUTO_DETECT detects an unsupported
     // compression format, legacy libsnowflakeclient silently fell back to
-    // no compression. ODBC (`legacy_compression_autodetect_libsnowflakeclient_behavior
-    // = true`) restores that behavior; Python / JDBC (false) keep surfacing
-    // the error. JDBC behavior verified equivalent to Python via
+    // no compression. ODBC (`legacy_odbc_compression_autodetect = true`)
+    // restores that behavior; Python / JDBC (false) keep surfacing the
+    // error. JDBC behavior verified equivalent to Python via
     // `SnowflakeFileTransferAgent.java:3163-3308`.
     #[rustfmt::skip]
     const UNSUPPORTED_COMPRESSION_FILENAMES: &[&str] = &[
@@ -941,7 +937,7 @@ mod tests {
     fn passthrough_upload_data(
         filename: &str,
         flavor: PutGetResultsetFlavor,
-        legacy_compression_autodetect_libsnowflakeclient_behavior: bool,
+        legacy_odbc_compression_autodetect: bool,
     ) -> SingleUploadData {
         SingleUploadData {
             file_path: format!("/tmp/{filename}"),
@@ -952,7 +948,7 @@ mod tests {
             source_compression: SourceCompressionParam::AutoDetect,
             overwrite: false,
             flavor,
-            legacy_compression_autodetect_libsnowflakeclient_behavior,
+            legacy_odbc_compression_autodetect,
         }
     }
 

--- a/sf_core/src/file_manager/mod.rs
+++ b/sf_core/src/file_manager/mod.rs
@@ -702,8 +702,14 @@ mod tests {
     // = true`) restores that behavior; Python / JDBC (false) keep surfacing
     // the error. JDBC behavior verified equivalent to Python via
     // `SnowflakeFileTransferAgent.java:3163-3308`.
-    const UNSUPPORTED_COMPRESSION_FILENAMES: &[&str] =
-        &["test.xz", "test.lzma", "test.lz", "test.lzo", "test.Z"];
+    #[rustfmt::skip]
+    const UNSUPPORTED_COMPRESSION_FILENAMES: &[&str] = &[
+        "test.xz",
+        "test.lzma",
+        "test.lz",
+        "test.lzo",
+        "test.Z",
+    ];
 
     #[test]
     fn auto_detect_source_compression_legacy_flag_true_swallows_unsupported_error() {
@@ -875,17 +881,7 @@ mod tests {
     #[test]
     fn preprocess_parquet_passthrough_under_auto_compress() {
         let payload = b"PAR1\x00\x01\x02\x03some-parquet-bytes-go-here".to_vec();
-        let data = SingleUploadData {
-            file_path: "/tmp/data.parquet".to_string(),
-            filename: "data.parquet".to_string(),
-            stage_info: dummy_stage_info(),
-            encryption_material: None,
-            auto_compress: true,
-            source_compression: SourceCompressionParam::AutoDetect,
-            overwrite: false,
-            flavor: PutGetResultsetFlavor::Python,
-            legacy_compression_autodetect_libsnowflakeclient_behavior: false,
-        };
+        let data = passthrough_upload_data("data.parquet", PutGetResultsetFlavor::Python, false);
 
         let (prepared, metadata) = preprocess_file_before_upload(payload.clone(), &data).unwrap();
 
@@ -901,17 +897,7 @@ mod tests {
     #[test]
     fn preprocess_orc_passthrough_under_auto_compress() {
         let payload = b"ORC\x00\x01\x02some-orc-bytes-go-here".to_vec();
-        let data = SingleUploadData {
-            file_path: "/tmp/data.orc".to_string(),
-            filename: "data.orc".to_string(),
-            stage_info: dummy_stage_info(),
-            encryption_material: None,
-            auto_compress: true,
-            source_compression: SourceCompressionParam::AutoDetect,
-            overwrite: false,
-            flavor: PutGetResultsetFlavor::Python,
-            legacy_compression_autodetect_libsnowflakeclient_behavior: false,
-        };
+        let data = passthrough_upload_data("data.orc", PutGetResultsetFlavor::Python, false);
 
         let (prepared, metadata) = preprocess_file_before_upload(payload.clone(), &data).unwrap();
 
@@ -924,30 +910,50 @@ mod tests {
         );
     }
 
+    // Locks in PR2 of Gap-12: parquet/orc detection is independent of the
+    // unsupported-compression flag (ODBC sets the flag to true, matching
+    // legacy libsnowflakeclient which detects PAR1/ORC magic via
+    // FileCompressionType::PARQUET / ::ORC with isSupported=true).
     #[test]
     fn preprocess_parquet_passthrough_when_unsupported_compression_swallowed() {
-        // Locks in PR2 of Gap-12: parquet detection is independent of the
-        // unsupported-compression flag (ODBC sets the flag to true,
-        // matching legacy libsnowflakeclient which detects PAR1 magic via
-        // FileCompressionType::PARQUET with isSupported=true).
         let payload = b"PAR1\x00\x01\x02\x03more-bytes".to_vec();
-        let data = SingleUploadData {
-            file_path: "/tmp/data.parquet".to_string(),
-            filename: "data.parquet".to_string(),
-            stage_info: dummy_stage_info(),
-            encryption_material: None,
-            auto_compress: true,
-            source_compression: SourceCompressionParam::AutoDetect,
-            overwrite: false,
-            flavor: PutGetResultsetFlavor::Odbc,
-            legacy_compression_autodetect_libsnowflakeclient_behavior: true,
-        };
+        let data = passthrough_upload_data("data.parquet", PutGetResultsetFlavor::Odbc, true);
 
         let (prepared, metadata) = preprocess_file_before_upload(payload.clone(), &data).unwrap();
 
         assert_eq!(metadata.target, "data.parquet");
         assert_eq!(metadata.target_compression, CompressionType::Parquet);
         assert_eq!(prepared.data, payload);
+    }
+
+    #[test]
+    fn preprocess_orc_passthrough_when_unsupported_compression_swallowed() {
+        let payload = b"ORC\x00\x01\x02more-bytes".to_vec();
+        let data = passthrough_upload_data("data.orc", PutGetResultsetFlavor::Odbc, true);
+
+        let (prepared, metadata) = preprocess_file_before_upload(payload.clone(), &data).unwrap();
+
+        assert_eq!(metadata.target, "data.orc");
+        assert_eq!(metadata.target_compression, CompressionType::Orc);
+        assert_eq!(prepared.data, payload);
+    }
+
+    fn passthrough_upload_data(
+        filename: &str,
+        flavor: PutGetResultsetFlavor,
+        legacy_compression_autodetect_libsnowflakeclient_behavior: bool,
+    ) -> SingleUploadData {
+        SingleUploadData {
+            file_path: format!("/tmp/{filename}"),
+            filename: filename.to_string(),
+            stage_info: dummy_stage_info(),
+            encryption_material: None,
+            auto_compress: true,
+            source_compression: SourceCompressionParam::AutoDetect,
+            overwrite: false,
+            flavor,
+            legacy_compression_autodetect_libsnowflakeclient_behavior,
+        }
     }
 
     fn dummy_stage_info() -> StageInfo {

--- a/sf_core/src/file_manager/types.rs
+++ b/sf_core/src/file_manager/types.rs
@@ -41,7 +41,7 @@ pub struct UploadData {
     /// detection consults a short-prefix table (2-byte gzip, 2-byte
     /// zlib mapped to `Deflate`, 4-byte snowflake brotli marker) ahead
     /// of the `infer` crate.
-    pub legacy_compression_autodetect_libsnowflakeclient_behavior: bool,
+    pub legacy_odbc_compression_autodetect: bool,
 }
 
 pub struct SingleUploadData {
@@ -53,7 +53,7 @@ pub struct SingleUploadData {
     pub source_compression: SourceCompressionParam,
     pub overwrite: bool,
     pub flavor: PutGetResultsetFlavor,
-    pub legacy_compression_autodetect_libsnowflakeclient_behavior: bool,
+    pub legacy_odbc_compression_autodetect: bool,
 }
 
 #[derive(Debug)]

--- a/sf_core/src/rest/snowflake/query_response.rs
+++ b/sf_core/src/rest/snowflake/query_response.rs
@@ -320,6 +320,10 @@ impl Data {
     /// result set; it is forwarded into `SingleUploadData` so that
     /// `file_manager::upload_single_file` can populate the `message` column
     /// per `BehaviorDifferences.yaml` BD#3.
+    /// `legacy_compression_autodetect_libsnowflakeclient_behavior` opts the
+    /// PUT auto-detect path into the libsnowflakeclient-parity behaviors
+    /// (short-prefix magic-byte detection plus error-swallowing on
+    /// unsupported formats). See `WrapperPresets` for the full doc-comment.
     pub fn to_file_upload_data(
         &self,
         flavor: PutGetResultsetFlavor,

--- a/sf_core/src/rest/snowflake/query_response.rs
+++ b/sf_core/src/rest/snowflake/query_response.rs
@@ -389,6 +389,11 @@ impl Data {
             })?
             .clone();
 
+        // TODO: explicit `SOURCE_COMPRESSION=PARQUET` / `=ORC` is accepted
+        // by the Python connector (both have `is_supported=True` in
+        // `file_compression_type.py`) and would skip auto-detect. Universal
+        // driver currently rejects them via the catch-all arm below; PR2 of
+        // Gap-12 only covers the AUTO_DETECT path. Track as follow-up.
         let source_compression = match source_compression_string.to_uppercase().as_str() {
             "AUTO_DETECT" => SourceCompressionParam::AutoDetect,
             "GZIP" => SourceCompressionParam::Gzip,

--- a/sf_core/src/rest/snowflake/query_response.rs
+++ b/sf_core/src/rest/snowflake/query_response.rs
@@ -320,14 +320,14 @@ impl Data {
     /// result set; it is forwarded into `SingleUploadData` so that
     /// `file_manager::upload_single_file` can populate the `message` column
     /// per `BehaviorDifferences.yaml` BD#3.
-    /// `legacy_compression_autodetect_libsnowflakeclient_behavior` opts the
+    /// `legacy_odbc_compression_autodetect` opts the
     /// PUT auto-detect path into the libsnowflakeclient-parity behaviors
     /// (short-prefix magic-byte detection plus error-swallowing on
     /// unsupported formats). See `WrapperPresets` for the full doc-comment.
     pub fn to_file_upload_data(
         &self,
         flavor: PutGetResultsetFlavor,
-        legacy_compression_autodetect_libsnowflakeclient_behavior: bool,
+        legacy_odbc_compression_autodetect: bool,
         use_s3_regional_url_session_param: bool,
     ) -> Result<file_manager::UploadData, QueryResponseError> {
         let src_locations = self.src_locations.as_ref().context(MissingParameterSnafu {
@@ -389,11 +389,6 @@ impl Data {
             })?
             .clone();
 
-        // TODO: explicit `SOURCE_COMPRESSION=PARQUET` / `=ORC` is accepted
-        // by the Python connector (both have `is_supported=True` in
-        // `file_compression_type.py`) and would skip auto-detect. Universal
-        // driver currently rejects them via the catch-all arm below; PR2 of
-        // Gap-12 only covers the AUTO_DETECT path. Track as follow-up.
         let source_compression = match source_compression_string.to_uppercase().as_str() {
             "AUTO_DETECT" => SourceCompressionParam::AutoDetect,
             "GZIP" => SourceCompressionParam::Gzip,
@@ -419,7 +414,7 @@ impl Data {
             source_compression,
             overwrite,
             flavor,
-            legacy_compression_autodetect_libsnowflakeclient_behavior,
+            legacy_odbc_compression_autodetect,
         })
     }
 
@@ -1357,25 +1352,25 @@ mod tests {
     }
 
     #[test]
-    fn upload_data_forwards_legacy_compression_autodetect_libsnowflakeclient_behavior_false() {
+    fn upload_data_forwards_legacy_odbc_compression_autodetect_false() {
         let json = make_upload_json("");
         let data: Data = serde_json::from_str(&json).unwrap();
         let upload = data
             .to_file_upload_data(PutGetResultsetFlavor::Python, false, false)
             .unwrap();
         assert_eq!(upload.flavor, PutGetResultsetFlavor::Python);
-        assert!(!upload.legacy_compression_autodetect_libsnowflakeclient_behavior);
+        assert!(!upload.legacy_odbc_compression_autodetect);
     }
 
     #[test]
-    fn upload_data_forwards_legacy_compression_autodetect_libsnowflakeclient_behavior_true() {
+    fn upload_data_forwards_legacy_odbc_compression_autodetect_true() {
         let json = make_upload_json("");
         let data: Data = serde_json::from_str(&json).unwrap();
         let upload = data
             .to_file_upload_data(PutGetResultsetFlavor::Odbc, true, false)
             .unwrap();
         assert_eq!(upload.flavor, PutGetResultsetFlavor::Odbc);
-        assert!(upload.legacy_compression_autodetect_libsnowflakeclient_behavior);
+        assert!(upload.legacy_odbc_compression_autodetect);
     }
 
     fn make_download_json() -> String {


### PR DESCRIPTION
## Summary

PR2 of the [Gap-12](https://snowflakecomputing.atlassian.net/browse/SNOW-3406388) series. Brings the **PUT `AUTO_DETECT` path** into parity with the Python connector (and legacy libsnowflakeclient) for `.parquet` and `.orc` files: detected by extension or magic bytes, uploaded as-is, with no gzip rewrap and no `.gz` suffix on the destination filename.

- Add `Parquet`/`Orc` variants to `CompressionType` (Snowflake names `PARQUET` / `ORC`); map the `.parquet` / `.orc` extensions to them.
- Sniff `PAR1` (4 bytes) and `ORC` (3 bytes) magic bytes ahead of the `infer`-crate fallback (`infer` has no matchers for either format). Unconditional — Python/JDBC and ODBC all want this.
- Upload-prep verified: `auto_compress=true` on a `.parquet` source produces `target_compression=Parquet`, no `.gz` suffix, payload bit-identical to input.

libsnowflakeclient parity confirmed by reading `cpp/FileCompressionType.{cpp,hpp}` — registers PARQUET/ORC as `isSupported=true` with the same magic tables.

## Scope

**In scope:** the `SOURCE_COMPRESSION=AUTO_DETECT` code path only. With AUTO_DETECT (the default), users today hit `UnsupportedCompressionType: PARQUET` on a `.parquet` upload and the file never uploads. After this PR, the file uploads bit-identical with `target_compression=Parquet`. That's the entire user-visible win.

**Out of scope (follow-up #1296):** the explicit-string path `SOURCE_COMPRESSION=PARQUET` / `=ORC`. Python accepts these via `lookup_by_mime_sub_type` (both have `is_supported=True` in `file_compression_type.py`); the universal driver currently rejects them via the catch-all arm in `query_response.rs`. That gap requires new `SourceCompressionParam::Parquet` / `::Orc` variants and additional match arms — orthogonal to the auto-detect plumbing, so split off into a separate PR.

## Stack

 * #1247
 * #1248 (this PR)
 * #1296 (follow-up — explicit `SOURCE_COMPRESSION=PARQUET` / `=ORC`)

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test -p sf_core --lib` (1003 passed, 0 failed)
- [x] `PARAMETER_PATH=parameters.json cargo test -p sf_core --test e2e_tests --release` (77 passed, 0 failed)
