### PR TITLE
NO-SNOW: add code-review design discipline rule and end-of-task self-review skill for Cursor + Claude Code

### DIFF
--- a/.claude/rules/code-review-design-discipline.md
+++ b/.claude/rules/code-review-design-discipline.md
@@ -1,0 +1,152 @@
+# Code Review Design Discipline
+
+Six principles that came up repeatedly during cross-driver review.
+Apply them while writing the change, not after.
+
+## 1. Don't ship test seams as global mutable state
+
+When you need test-time behavior to differ from production, in priority
+order:
+
+1. **Dependency injection through configuration** — pass the overridable
+   behavior as a field on a struct that's already flowing through the
+   system. Zero global state.
+2. **Compile-time substitution** via `cfg(any(test, feature = "test-utils"))`
+   defaults. No runtime cost, no atomic loads, no unreachable production
+   branches.
+3. **Per-test scoping** (e.g. `tokio::task_local!`) when DI is awkward.
+4. **Process-global state**, only if cfg-gated so production can't see it.
+   Use `Relaxed` ordering for kill switches; `SeqCst` is overkill.
+
+If the codebase already has a DI seam (`Box<dyn …>`, `Arc<dyn …>`,
+function-pointer field), plumb it through instead of adding a static.
+
+```rust
+// ❌ Process-wide irreversible kill switch in production code
+pub(super) static BROWSER_LAUNCH_DISABLED: AtomicBool = AtomicBool::new(false);
+fn default_launch() -> Launcher {
+    Box::new(|url| async move {
+        if BROWSER_LAUNCH_DISABLED.load(SeqCst) { return; }  // ← read on every prod login
+        webbrowser::open(url)
+    })
+}
+
+// ✅ Config-injected, cfg-defaulted, no global state
+pub(crate) browser_launcher: Option<Arc<dyn Fn() -> Launcher + Send + Sync>>,
+// in from_settings():
+#[cfg(any(test, feature = "test-utils"))]
+let browser_launcher = Some(Arc::new(|| Box::new(|_| async {})));
+#[cfg(not(any(test, feature = "test-utils")))]
+let browser_launcher = None;
+```
+
+## 2. Don't parse the same thing twice
+
+Before adding a parser/builder for a config type, grep for existing
+functions that produce the same target from the same inputs. If you find
+a parallel pipeline, **delegate to a shared parser** or hoist one out.
+
+Self-check: "if I add one new field, how many places do I touch?"
+If the answer is >2 (struct definition + one parser), you have shallow
+modules and change amplification. Particularly common smell: typed
+config and wire-level config as two parallel views of the same
+settings — collapse them.
+
+For `From`-style conversions between near-identical structs, derive
+`Clone` and write `cfg.clone()` instead of field-by-field copies that
+silently miss new fields.
+
+## 3. Layer boundaries must preserve discriminability
+
+When designing error types across FFI / proto / IPC boundaries, the
+outer layer must be at least as expressive as the inner one for the
+discriminations callers actually need.
+
+```rust
+// ❌ Rich inner enum collapses to opaque string at the boundary
+enum OAuthError { BrowserTimeout, StateMismatch, TokenExchange { status: u16 } }
+//      ↓ FFI
+message AuthenticationError { string detail = 1; }
+// Tests downstream now have only substring matching to assert on.
+
+// ✅ Carry a discriminant across the boundary
+message AuthenticationError {
+    AuthErrorKind kind = 1;  // enum
+    string detail = 2;
+}
+```
+
+If you can't fix the boundary in this PR, **don't `format!("{e:?}")`**
+in test infrastructure — preserve the typed error up to the assertion
+site. When you're forced into substring matching, write the strictest
+pattern you can and track the proper fix as a `TODO(TICKET-N)`.
+
+## 4. Visibility should be internally consistent
+
+`pub field: T` where `T` is `pub(crate)` is functionally broken — external
+consumers can't name the type. When tempted to mix:
+
+- Field is part of the public contract → promote the type to `pub`.
+- Type is genuinely internal → tighten the field to `pub(crate)`.
+
+Mixed visibility usually means the field is an internal injection seam
+(test override, observability hook) that shouldn't be on the public
+surface at all. APoSD: information hiding.
+
+## 5. Prefer newtypes over manual `Debug` / `Clone` / `Hash` impls
+
+A non-`Debug` field forces a hand-rolled `Debug` listing every other
+field. Future field adds will silently drop from the output with no
+compiler reminder — that's change amplification re-introduced inside one
+file.
+
+```rust
+// ❌ Manual Debug; adding a field requires touching two places
+impl fmt::Debug for Cfg {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Cfg")
+            .field("a", &self.a).field("b", &self.b).field("c", &self.c)
+            // someone adds field d — and forgets here. Silent.
+            .finish()
+    }
+}
+
+// ✅ Newtype the offending field; #[derive] stays in charge
+struct OpaqueLauncher(Arc<dyn Fn() + Send + Sync>);
+impl fmt::Debug for OpaqueLauncher {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { f.write_str("<opaque>") }
+}
+
+#[derive(Debug, Clone)]
+struct Cfg { a: A, b: B, c: C, launcher: OpaqueLauncher }
+```
+
+## 6. Uphold documented contracts when adding match arms
+
+When adding an arm to a `match` whose surrounding code has a documented
+uniform contract (e.g. `validate_settings` "collect ALL errors"),
+**uphold the contract** — or update the doc to mark the exception.
+
+Empty arms with comments like "X is validated elsewhere" are a smell:
+either the work happens here, or the contract has an exception worth
+documenting at the function level. Refactor-stale comments (e.g.
+"validated by `OldFn`" after the work moved to `NewFn`) are worse than
+no comment — fix them when you move the code.
+
+---
+
+These are *design-time* principles. For *end-of-task* self-checks
+(scope discipline, assertion strictness, stale comments), invoke the
+`end-of-task-self-review` skill.
+
+<!-- sync-target: .cursor/rules/code-review-design-discipline.mdc carries an identical body
+     (the full content of this file) plus Cursor-specific frontmatter.
+     WHY both files need full content instead of a pointer:
+       alwaysApply rules are injected into the agent system prompt at session start.
+       A pointer file loads the body via tool call, putting it in conversation history
+       where context compaction can silently drop it mid-session. Full content in both
+       files keeps the rule in context for the lifetime of any session.
+     TO UPDATE: edit this file, copy its complete contents into the body of
+       .cursor/rules/code-review-design-discipline.mdc (below the closing ---
+       of the Cursor frontmatter), then run: bash scripts/check-ai-rules-sync.sh
+     The pre-commit hook (ai-rules-sync) catches drift automatically. -->

--- a/.claude/rules/code-review-design-discipline.md
+++ b/.claude/rules/code-review-design-discipline.md
@@ -31,7 +31,18 @@ fn default_launch() -> Launcher {
     })
 }
 
-// ✅ Config-injected, cfg-defaulted, no global state
+// ✅ Primary: inject from the call site — zero global state, no cfg needed
+pub struct Connection {
+    browser_launcher: Arc<dyn Fn(&str) + Send + Sync>,
+}
+// In tests — thread the no-op from the test itself:
+Connection::new(config, Arc::new(|_url| {}))
+// In production — wire the real launcher at the top-level entry point:
+Connection::new(config, Arc::new(|url| { webbrowser::open(url).ok(); }))
+
+// ⚠️ Workaround (last resort): compile-time substitution via cfg, when threading DI
+//    through the call stack is impractical in the near term. No global state, but the
+//    override is binary (test vs. prod) and can't be varied per test.
 pub(crate) browser_launcher: Option<Arc<dyn Fn() -> Launcher + Send + Sync>>,
 // in from_settings():
 #[cfg(any(test, feature = "test-utils"))]

--- a/.claude/skills/end-of-task-self-review/SKILL.md
+++ b/.claude/skills/end-of-task-self-review/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: end-of-task-self-review
+description: Self-review checklist run before declaring a coding task done, opening a PR, or pushing the final commit. Catches commit-scope drift, loose test assertions, refactor-stale comments, error-string changes that need callouts, test fixtures that self-sabotage, dead-code helpers, and signature smells. Use after implementing a feature, completing a bug fix, finishing a refactor, or whenever about to write a commit message or open a PR. Distilled from review findings on the OAuth-core PR series.
+# Canonical source. .cursor/skills/end-of-task-self-review/SKILL.md is a pointer to this file.
+# Skills fire on demand so pointer files are safe there — the agent reads this file fresh
+# at invocation time. alwaysApply rules cannot use pointers for the same reason; see
+# .cursor/rules/*.mdc frontmatter for the detailed explanation.
+---
+
+# End-of-Task Self-Review
+
+Run this checklist after substantial changes, before writing the final
+commit message or opening a PR. Each item is something a reviewer
+catches that you can catch first.
+
+## Checklist
+
+```
+- [ ] Commit scope matches the subject (no surprise production changes)
+- [ ] Every assertion is as strict as the layer allows
+- [ ] Renamed/moved code: no stale comments referencing the old location
+- [ ] Changed user-facing strings (errors, logs): called out in commit body
+- [ ] Test fixtures don't permanently disable what other tests need
+- [ ] No dead-code helpers (added but never called)
+- [ ] Public test helpers' return values are actually used
+- [ ] Mock path matchers are anchored or exact (no substring footguns)
+- [ ] `assert!(matches!(...))` calls include a context message
+- [ ] `#[ignore]`'d tests either have assertions or aren't `#[test]`
+```
+
+## How to run each check
+
+### 1. Commit scope matches the subject
+
+List every changed file. Ask: "is this consistent with what the subject
+claims?"
+
+- Subject says "testing" → production files in the diff are a smell.
+- Subject says "refactor" → behavioral changes need a callout.
+- Subject says "fix bug X" → drive-by cleanups should split out.
+
+If the diff genuinely spans both production and tests, the subject
+should reflect that. Use a two-section commit body:
+
+```
+SUBJECT-PREFIX: <honest summary that covers both>
+
+Production changes:
+- bullet per behavioral change
+
+Tests:
+- bullet per test addition / fixture / mock
+```
+
+### 2. Assertion strictness
+
+Default to the **strictest** assertion that captures the intent. Move
+down this ladder only when the layer above forces you to:
+
+1. `assert_eq!(err.code(), 390303)` — typed, exact.
+2. `assert!(matches!(err, ErrorKind::TokenExpired { .. }), "got {err:?}")` — typed variant.
+3. `assert!(err.to_string().contains("390303"), "got {err}")` — string, exact substring.
+4. `assert!(patterns.iter().any(|p| s.contains(p)))` — only as last resort.
+
+If you're at level 3-4 because of an architectural boundary (FFI, proto,
+RPC) flattening the error, **say so explicitly** with a `TODO(TICKET-N)`
+and write the strictest pattern you can. Never use `any(...)` over an
+array containing a word like `OAuth` or `Error` — that matches almost
+anything and silently defangs the test.
+
+### 3. Refactor-stale comments
+
+After moving or renaming a function/type, grep for:
+
+```bash
+rg 'OldFnName|OldTypeName' --type rust
+```
+
+Two places that especially go stale:
+
+- Inline `// validated by X` / `// see Y` comments.
+- Module-level docs that name internal helpers.
+
+Comments that name the *wrong* function are worse than no comment.
+
+### 4. User-facing string changes
+
+If the diff touches an error `Display` impl, a `tracing::error!`
+message, or any user-visible string, call it out in the commit body.
+SREs grep for these strings; dashboards and runbooks remember the old
+wording.
+
+```bash
+git diff -U0 main..HEAD -- '**/*.rs' | rg '^\+' | rg -i 'display|tracing::|println|panic'
+```
+
+Verify the new wording against any cross-driver / cross-language
+consistency requirement.
+
+### 5. Test fixtures don't self-sabotage
+
+If a fixture mutates global state, sets a kill switch, or installs a
+no-op stub, scan every test that uses it for cases that need the *real*
+behavior. Common smells:
+
+- `Once::call_once` setting an irreversible flag in a fixture
+  constructor — any test that wants the un-flagged behavior is broken
+  by construction.
+- A no-op default stub installed via `cfg(test)` with no override path.
+
+If a test exists to drive the suppressed path, the fixture needs an
+opt-out (`with_X_interactive(...)`), or the test belongs in a different
+binary that doesn't build with the suppressed cfg.
+
+### 6. No dead-code helpers
+
+```bash
+cargo clippy --tests -- -W dead_code 2>&1 | rg 'never used'
+```
+
+`pub fn helper(...)` in a test module that no test calls is dead weight.
+Either wire it in or delete it. Write the test first, mount the fixture,
+see it fire, **then** commit the helper.
+
+### 7. Return values that callers discard
+
+If a helper returns `&Self` "for chaining" but every caller discards it,
+drop the return type. Same for `Result<...>` that callers always
+`.unwrap()` at the same layer — return the inner type.
+
+```bash
+rg '\) -> &Self \{' --type rust  # find the candidates
+```
+
+### 8. Mock path matchers
+
+Substring matchers in test infrastructure are footguns. Anchor with
+`^…$` or use exact-match.
+
+```rust
+// ❌ Matches /oauth/token-request-evil too
+.and(path_regex(r"/oauth/token-request"))
+
+// ✅
+.and(path_regex(r"^/oauth/token-request$"))
+// or
+.and(path("/oauth/token-request"))
+```
+
+### 9. `assert!(matches!(...))` without context
+
+Failure prints "assertion failed: matches!(...)" — useless. Always pair
+with a context message:
+
+```rust
+assert!(
+    matches!(err, OAuthError::StateMismatch { .. }),
+    "expected StateMismatch, got {err:?}"
+);
+```
+
+### 10. `#[ignore]`'d tests need assertions or a different home
+
+A `#[test]` with `#[ignore]` and no assertions is almost always wrong:
+
+- Real test that should run → de-ignore it, or move to a feature-gated
+  bundle that does run.
+- Documentation artifact → move to a doc comment or `examples/`.
+- Manual reproducer → fixture must support manual driving (print the
+  URL, don't suppress the launcher in *this* fixture, etc.).
+
+## Output
+
+If any item fails, fix it before declaring done. If a fix needs to be
+deferred (e.g. assertion strictness blocked by an FFI boundary that's
+out of scope), add a `TODO(TICKET-N)` with a real ticket reference and
+note it in the PR description so reviewers don't catch it cold.
+
+For *design-time* discipline (test seams, parsing duplication, error
+structure across layers, visibility, manual `Debug`/`Clone` impls,
+documented contracts), see the
+`.claude/rules/code-review-design-discipline.md` rule (auto-loaded via
+`CLAUDE.md`).

--- a/.cursor/rules/code-review-design-discipline.mdc
+++ b/.cursor/rules/code-review-design-discipline.mdc
@@ -1,0 +1,163 @@
+---
+description: Design-time discipline for changes that touch existing pipelines, error types, public APIs, or test seams. Distilled from review findings across the OAuth-core work; applies to any non-trivial change.
+alwaysApply: true
+# DERIVED FROM .claude/rules/code-review-design-discipline.md (canonical source).
+# Full content is required here — alwaysApply rules are injected into the agent system
+# prompt at session start. A pointer file would load the body via tool call, placing it
+# in conversation history where context compaction can silently drop it mid-session.
+# Edit the .claude/ file first, then copy its full contents below. The pre-commit hook
+# (ai-rules-sync) or scripts/check-ai-rules-sync.sh will catch any drift.
+---
+
+# Code Review Design Discipline
+
+Six principles that came up repeatedly during cross-driver review.
+Apply them while writing the change, not after.
+
+## 1. Don't ship test seams as global mutable state
+
+When you need test-time behavior to differ from production, in priority
+order:
+
+1. **Dependency injection through configuration** — pass the overridable
+   behavior as a field on a struct that's already flowing through the
+   system. Zero global state.
+2. **Compile-time substitution** via `cfg(any(test, feature = "test-utils"))`
+   defaults. No runtime cost, no atomic loads, no unreachable production
+   branches.
+3. **Per-test scoping** (e.g. `tokio::task_local!`) when DI is awkward.
+4. **Process-global state**, only if cfg-gated so production can't see it.
+   Use `Relaxed` ordering for kill switches; `SeqCst` is overkill.
+
+If the codebase already has a DI seam (`Box<dyn …>`, `Arc<dyn …>`,
+function-pointer field), plumb it through instead of adding a static.
+
+```rust
+// ❌ Process-wide irreversible kill switch in production code
+pub(super) static BROWSER_LAUNCH_DISABLED: AtomicBool = AtomicBool::new(false);
+fn default_launch() -> Launcher {
+    Box::new(|url| async move {
+        if BROWSER_LAUNCH_DISABLED.load(SeqCst) { return; }  // ← read on every prod login
+        webbrowser::open(url)
+    })
+}
+
+// ✅ Config-injected, cfg-defaulted, no global state
+pub(crate) browser_launcher: Option<Arc<dyn Fn() -> Launcher + Send + Sync>>,
+// in from_settings():
+#[cfg(any(test, feature = "test-utils"))]
+let browser_launcher = Some(Arc::new(|| Box::new(|_| async {})));
+#[cfg(not(any(test, feature = "test-utils")))]
+let browser_launcher = None;
+```
+
+## 2. Don't parse the same thing twice
+
+Before adding a parser/builder for a config type, grep for existing
+functions that produce the same target from the same inputs. If you find
+a parallel pipeline, **delegate to a shared parser** or hoist one out.
+
+Self-check: "if I add one new field, how many places do I touch?"
+If the answer is >2 (struct definition + one parser), you have shallow
+modules and change amplification. Particularly common smell: typed
+config and wire-level config as two parallel views of the same
+settings — collapse them.
+
+For `From`-style conversions between near-identical structs, derive
+`Clone` and write `cfg.clone()` instead of field-by-field copies that
+silently miss new fields.
+
+## 3. Layer boundaries must preserve discriminability
+
+When designing error types across FFI / proto / IPC boundaries, the
+outer layer must be at least as expressive as the inner one for the
+discriminations callers actually need.
+
+```rust
+// ❌ Rich inner enum collapses to opaque string at the boundary
+enum OAuthError { BrowserTimeout, StateMismatch, TokenExchange { status: u16 } }
+//      ↓ FFI
+message AuthenticationError { string detail = 1; }
+// Tests downstream now have only substring matching to assert on.
+
+// ✅ Carry a discriminant across the boundary
+message AuthenticationError {
+    AuthErrorKind kind = 1;  // enum
+    string detail = 2;
+}
+```
+
+If you can't fix the boundary in this PR, **don't `format!("{e:?}")`**
+in test infrastructure — preserve the typed error up to the assertion
+site. When you're forced into substring matching, write the strictest
+pattern you can and track the proper fix as a `TODO(TICKET-N)`.
+
+## 4. Visibility should be internally consistent
+
+`pub field: T` where `T` is `pub(crate)` is functionally broken — external
+consumers can't name the type. When tempted to mix:
+
+- Field is part of the public contract → promote the type to `pub`.
+- Type is genuinely internal → tighten the field to `pub(crate)`.
+
+Mixed visibility usually means the field is an internal injection seam
+(test override, observability hook) that shouldn't be on the public
+surface at all. APoSD: information hiding.
+
+## 5. Prefer newtypes over manual `Debug` / `Clone` / `Hash` impls
+
+A non-`Debug` field forces a hand-rolled `Debug` listing every other
+field. Future field adds will silently drop from the output with no
+compiler reminder — that's change amplification re-introduced inside one
+file.
+
+```rust
+// ❌ Manual Debug; adding a field requires touching two places
+impl fmt::Debug for Cfg {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Cfg")
+            .field("a", &self.a).field("b", &self.b).field("c", &self.c)
+            // someone adds field d — and forgets here. Silent.
+            .finish()
+    }
+}
+
+// ✅ Newtype the offending field; #[derive] stays in charge
+struct OpaqueLauncher(Arc<dyn Fn() + Send + Sync>);
+impl fmt::Debug for OpaqueLauncher {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { f.write_str("<opaque>") }
+}
+
+#[derive(Debug, Clone)]
+struct Cfg { a: A, b: B, c: C, launcher: OpaqueLauncher }
+```
+
+## 6. Uphold documented contracts when adding match arms
+
+When adding an arm to a `match` whose surrounding code has a documented
+uniform contract (e.g. `validate_settings` "collect ALL errors"),
+**uphold the contract** — or update the doc to mark the exception.
+
+Empty arms with comments like "X is validated elsewhere" are a smell:
+either the work happens here, or the contract has an exception worth
+documenting at the function level. Refactor-stale comments (e.g.
+"validated by `OldFn`" after the work moved to `NewFn`) are worse than
+no comment — fix them when you move the code.
+
+---
+
+These are *design-time* principles. For *end-of-task* self-checks
+(scope discipline, assertion strictness, stale comments), invoke the
+`end-of-task-self-review` skill.
+
+<!-- sync-target: .cursor/rules/code-review-design-discipline.mdc carries an identical body
+     (the full content of this file) plus Cursor-specific frontmatter.
+     WHY both files need full content instead of a pointer:
+       alwaysApply rules are injected into the agent system prompt at session start.
+       A pointer file loads the body via tool call, putting it in conversation history
+       where context compaction can silently drop it mid-session. Full content in both
+       files keeps the rule in context for the lifetime of any session.
+     TO UPDATE: edit this file, copy its complete contents into the body of
+       .cursor/rules/code-review-design-discipline.mdc (below the closing ---
+       of the Cursor frontmatter), then run: bash scripts/check-ai-rules-sync.sh
+     The pre-commit hook (ai-rules-sync) catches drift automatically. -->

--- a/.cursor/rules/code-review-design-discipline.mdc
+++ b/.cursor/rules/code-review-design-discipline.mdc
@@ -42,7 +42,18 @@ fn default_launch() -> Launcher {
     })
 }
 
-// ✅ Config-injected, cfg-defaulted, no global state
+// ✅ Primary: inject from the call site — zero global state, no cfg needed
+pub struct Connection {
+    browser_launcher: Arc<dyn Fn(&str) + Send + Sync>,
+}
+// In tests — thread the no-op from the test itself:
+Connection::new(config, Arc::new(|_url| {}))
+// In production — wire the real launcher at the top-level entry point:
+Connection::new(config, Arc::new(|url| { webbrowser::open(url).ok(); }))
+
+// ⚠️ Workaround (last resort): compile-time substitution via cfg, when threading DI
+//    through the call stack is impractical in the near term. No global state, but the
+//    override is binary (test vs. prod) and can't be varied per test.
 pub(crate) browser_launcher: Option<Arc<dyn Fn() -> Launcher + Send + Sync>>,
 // in from_settings():
 #[cfg(any(test, feature = "test-utils"))]

--- a/.cursor/skills/end-of-task-self-review/SKILL.md
+++ b/.cursor/skills/end-of-task-self-review/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: end-of-task-self-review
+description: Self-review checklist run before declaring a coding task done, opening a PR, or pushing the final commit. Catches commit-scope drift, loose test assertions, refactor-stale comments, error-string changes that need callouts, test fixtures that self-sabotage, dead-code helpers, and signature smells. Use after implementing a feature, completing a bug fix, finishing a refactor, or whenever about to write a commit message or open a PR. Distilled from review findings on the OAuth-core PR series.
+# Pointer to .claude/skills/end-of-task-self-review/SKILL.md (canonical source).
+# Skills fire on demand — when invoked the agent reads the canonical file fresh, so
+# a pointer here is safe. This avoids duplicating ~180 lines of content.
+# WHY alwaysApply rules cannot use the same approach: see .cursor/rules/*.mdc frontmatter.
+---
+
+The full skill definition is in `.claude/skills/end-of-task-self-review/SKILL.md`.
+Read that file for the complete checklist and how-to instructions.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -90,3 +90,14 @@ repos:
         entry: ./tests/tests_format_validator/run_validator.sh
         pass_filenames: false
         language: system
+    -   id: ai-rules-sync
+        name: AI rules sync check
+        description: >
+          Verify .cursor/rules/*.mdc body matches the .claude/rules/*.md canonical source.
+          alwaysApply rules need full content in both files (pointer files place the body
+          in tool-call history where context compaction can drop it). Edit .claude/ first,
+          then copy the body to .cursor/rules/. Run scripts/check-ai-rules-sync.sh to fix.
+        entry: bash scripts/check-ai-rules-sync.sh
+        pass_filenames: false
+        files: (\.claude/rules/|\.cursor/rules/)
+        language: system

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -93,11 +93,13 @@ repos:
     -   id: ai-rules-sync
         name: AI rules sync check
         description: >
-          Verify .cursor/rules/*.mdc body matches the .claude/rules/*.md canonical source.
-          alwaysApply rules need full content in both files (pointer files place the body
-          in tool-call history where context compaction can drop it). Edit .claude/ first,
+          Two checks: (1) verify .cursor/rules/*.mdc body matches .claude/rules/*.md
+          canonical source (alwaysApply rules need full content in both — pointer files
+          place the body in tool-call history where context compaction can drop it);
+          (2) verify every .claude/skills/*/SKILL.md has a matching .cursor/skills/
+          pointer so Cursor users can invoke the skill. Edit .claude/ first for rules,
           then copy the body to .cursor/rules/. Run scripts/check-ai-rules-sync.sh to fix.
         entry: bash scripts/check-ai-rules-sync.sh
         pass_filenames: false
-        files: (\.claude/rules/|\.cursor/rules/)
+        files: (\.claude/rules/|\.cursor/rules/|\.claude/skills/|\.cursor/skills/)
         language: system

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,26 @@
+# universal-driver — Claude memory
+
+Project-level guidance for Claude Code agents working in this repo.
+Keep this file thin; put substantive content in `.claude/rules/*.md` and
+`.claude/skills/*/SKILL.md`.
+
+## AI file conventions
+
+Two types of agent-config files live in this repo, with different sync rules:
+
+**Rules** (`.claude/rules/*.md` ↔ `.cursor/rules/*.mdc`)
+Both files carry identical body content. `alwaysApply` rules are injected into
+the agent system prompt at session start; a pointer file would place the body in
+tool-call history where context compaction can silently drop it mid-session.
+Edit the `.claude/rules/*.md` file (canonical source), then copy its full body
+into the matching `.cursor/rules/*.mdc` (below the Cursor frontmatter). The
+pre-commit hook `ai-rules-sync` (or `bash scripts/check-ai-rules-sync.sh`) will
+catch any drift. See the `sync-target` comment at the bottom of each
+`.claude/rules/*.md` file for per-file instructions.
+
+**Skills** (`.claude/skills/*/SKILL.md` ↔ `.cursor/skills/*/SKILL.md`)
+Canonical definition lives in `.claude/skills/`. The `.cursor/skills/` files are
+thin pointers that reference the canonical. Skills fire on demand — the agent
+reads the canonical file fresh at invocation — so pointer files are safe.
+
+@./.claude/rules/code-review-design-discipline.md

--- a/scripts/check-ai-rules-sync.sh
+++ b/scripts/check-ai-rules-sync.sh
@@ -1,22 +1,26 @@
 #!/usr/bin/env bash
-# Verifies that .cursor/rules/*.mdc body content is byte-for-byte identical to the
-# corresponding .claude/rules/*.md canonical source (after stripping frontmatter).
+# Two checks in one script:
+#
+# 1. RULE SYNC — verifies .cursor/rules/*.mdc body is byte-for-byte identical to the
+#    corresponding .claude/rules/*.md canonical source (after stripping frontmatter).
+#    alwaysApply rules must carry full content in both files; a pointer file places the
+#    body in tool-call history where context compaction can drop it mid-session.
+#    TO FIX: edit .claude/rules/<name>.md, copy its full contents into the body of
+#    .cursor/rules/<name>.mdc (below the closing --- of the Cursor frontmatter).
+#
+# 2. SKILL MIRROR — verifies every .claude/skills/*/SKILL.md has a matching pointer
+#    file at .cursor/skills/*/SKILL.md. Skills fire on demand so a pointer is safe,
+#    but the mirror must exist so Cursor users can invoke the skill too.
+#    TO FIX: create .cursor/skills/<name>/SKILL.md as a thin pointer that reads:
+#      "The full skill definition is in .claude/skills/<name>/SKILL.md."
 #
 # Run automatically via the ai-rules-sync pre-commit hook, or manually:
 #   bash scripts/check-ai-rules-sync.sh
-#
-# WHY this check exists:
-#   alwaysApply rules must carry full content in both .claude/ and .cursor/ — pointer
-#   files place the body in tool-call history where context compaction can drop it
-#   mid-session. The .claude/ file is the canonical source; the .cursor/ file carries
-#   an identical body plus Cursor-specific frontmatter. This script catches drift.
-#
-# TO FIX a failure: edit .claude/rules/<name>.md, then copy its full contents into
-#   the body of .cursor/rules/<name>.mdc (below the closing --- of the frontmatter).
 set -euo pipefail
 
 FAIL=0
 
+# ── 1. Rule sync ──────────────────────────────────────────────────────────────
 for claude_file in .claude/rules/*.md; do
     base=$(basename "$claude_file" .md)
     cursor_file=".cursor/rules/${base}.mdc"
@@ -43,7 +47,21 @@ for claude_file in .claude/rules/*.md; do
     fi
 done
 
+# ── 2. Skill mirror ───────────────────────────────────────────────────────────
+for claude_skill in .claude/skills/*/SKILL.md; do
+    skill_name=$(basename "$(dirname "$claude_skill")")
+    cursor_skill=".cursor/skills/${skill_name}/SKILL.md"
+    if [[ ! -f "$cursor_skill" ]]; then
+        echo "FAIL: $cursor_skill is missing — every .claude/skills/<name>/SKILL.md"
+        echo "      needs a matching pointer at .cursor/skills/<name>/SKILL.md so"
+        echo "      Cursor users can invoke the skill."
+        echo "      Create it as a thin pointer referencing $claude_skill."
+        FAIL=1
+    fi
+done
+
 if [[ $FAIL -eq 0 ]]; then
     echo "OK: all .cursor/rules/*.mdc files are in sync with .claude/rules/*.md"
+    echo "    all .claude/skills/ have matching .cursor/skills/ pointers"
 fi
 exit $FAIL

--- a/scripts/check-ai-rules-sync.sh
+++ b/scripts/check-ai-rules-sync.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Verifies that .cursor/rules/*.mdc body content is byte-for-byte identical to the
+# corresponding .claude/rules/*.md canonical source (after stripping frontmatter).
+#
+# Run automatically via the ai-rules-sync pre-commit hook, or manually:
+#   bash scripts/check-ai-rules-sync.sh
+#
+# WHY this check exists:
+#   alwaysApply rules must carry full content in both .claude/ and .cursor/ — pointer
+#   files place the body in tool-call history where context compaction can drop it
+#   mid-session. The .claude/ file is the canonical source; the .cursor/ file carries
+#   an identical body plus Cursor-specific frontmatter. This script catches drift.
+#
+# TO FIX a failure: edit .claude/rules/<name>.md, then copy its full contents into
+#   the body of .cursor/rules/<name>.mdc (below the closing --- of the frontmatter).
+set -euo pipefail
+
+FAIL=0
+
+for claude_file in .claude/rules/*.md; do
+    base=$(basename "$claude_file" .md)
+    cursor_file=".cursor/rules/${base}.mdc"
+    [[ -f "$cursor_file" ]] || continue
+
+    # Strip YAML frontmatter from the .mdc file using a state machine:
+    # transition out of frontmatter on the second '---', then print everything
+    # including any '---' horizontal rules in the body.
+    cursor_body=$(awk '
+        BEGIN { done=0; n=0 }
+        /^---$/ && !done { n++; if (n==2) { done=1 }; next }
+        done { print }
+    ' "$cursor_file" | sed '1{/^$/d}')
+
+    claude_body=$(cat "$claude_file")
+
+    if [[ "$cursor_body" != "$claude_body" ]]; then
+        echo "FAIL: $cursor_file body has drifted from canonical $claude_file"
+        echo "      Edit $claude_file first, then copy its full contents into the"
+        echo "      body of $cursor_file (below the closing --- of the frontmatter)."
+        echo "Diff (< canonical  > cursor):"
+        diff <(echo "$claude_body") <(echo "$cursor_body") || true
+        FAIL=1
+    fi
+done
+
+if [[ $FAIL -eq 0 ]]; then
+    echo "OK: all .cursor/rules/*.mdc files are in sync with .claude/rules/*.md"
+fi
+exit $FAIL


### PR DESCRIPTION
Distill recurring review findings into two complementary artifacts for Cursor and Claude Code, with proper sync infrastructure to prevent drift.

## What changed

**Rule: code-review design discipline** (`alwaysApply`)

- `.claude/rules/code-review-design-discipline.md` — canonical source; full content lives here.
- `.cursor/rules/code-review-design-discipline.mdc` — derived copy with Cursor frontmatter; body is byte-identical to the Claude file.

Both files carry full content (not a pointer). `alwaysApply` rules are injected into the agent system prompt at session start. A pointer file would load the body via tool call, placing it in conversation history where context compaction can silently drop it mid-session. Full content in both files keeps the rule in context for the lifetime of any session.

The code example in section 1 was restructured per review: DI (threading from the call site) is now the primary `✅` example; cfg-based compile-time substitution is demoted to a clearly labeled `⚠️ Workaround` with an explanation of its limitations.

**Skill: end-of-task self-review** (on-demand)

- `.claude/skills/end-of-task-self-review/SKILL.md` — canonical source; full content lives here.
- `.cursor/skills/end-of-task-self-review/SKILL.md` — thin pointer that tells the agent to read the canonical file.

Skills fire on demand. The agent reads the canonical file fresh at invocation time, so a pointer is safe and avoids duplicating ~180 lines of content.

**Sync infrastructure** (`scripts/check-ai-rules-sync.sh` + pre-commit hook `ai-rules-sync`)

Two checks run automatically on every commit that touches `.claude/` or `.cursor/` AI files:

1. **Rule sync** — `.cursor/rules/*.mdc` body must be byte-identical to `.claude/rules/*.md`. Catches drift before it reaches the remote.
2. **Skill mirror** — every `.claude/skills/*/SKILL.md` must have a matching `.cursor/skills/*/SKILL.md` pointer. Catches the case where a dev adds a Claude skill but forgets the Cursor pointer, which would silently leave Cursor users unable to invoke it.

The hook fires on commit (early feedback, before push) via the `files:` pattern covering all four directories.

**Breadcrumbs for future maintainers**

- `CLAUDE.md` — documents both artifact types and their sync rules with rationale.
- `.claude/rules/*.md` — HTML `<!-- sync-target: ... -->` comment explaining the derive→sync workflow and why pointers are unsafe for `alwaysApply` rules.
- `.cursor/rules/*.mdc` — YAML `#` comments in frontmatter citing the canonical source and the compaction risk.
- `.claude/skills/*/SKILL.md` and `.cursor/skills/*/SKILL.md` — YAML `#` comments explaining the pointer-is-safe rationale.

## Principles covered (rule)

Test seams without global mutable state, no double parsing, error discriminability across layer boundaries, internally consistent visibility, newtypes over manual Debug/Clone impls, upholding documented contracts when adding match arms.

## Checklist covered (skill)

Commit-scope discipline, assertion strictness, refactor-stale comments, user-facing string changes called out, fixture self-sabotage, dead-code helpers, discarded return values, mock path anchoring, matches! context messages, ignored-test hygiene.

The rule fires while writing; the skill fires before declaring done. The two cross-reference each other at their footers.