### PR TITLE
Add HTTP proxy support to universal driver

### DIFF
--- a/odbc/src/api/connection.rs
+++ b/odbc/src/api/connection.rs
@@ -96,6 +96,12 @@ fn normalize_connection_string_option(
         "PRIV_KEY_FILE_PWD" | "PRIV_KEY_PWD" => {
             Some(("private_key_password".to_owned(), value.into()))
         }
+        "PROXY" => Some(("proxy".to_owned(), value.into())),
+        "NO_PROXY" | "NOPROXY" => Some(("no_proxy".to_owned(), value.into())),
+        "USE_PROXY_ENV" | "PROXYWITHENV" => Some(("use_proxy_env".to_owned(), value.into())),
+        "ALLOWEMPTYPROXY" | "ALLOW_EMPTY_PROXY" => {
+            Some(("allow_empty_proxy".to_owned(), value.into()))
+        }
         // Forward other keys (e.g. SERVER, UID, SSL) for `sf_core` alias resolution; do not
         // pre-canonicalize here to avoid duplicate seed keys.
         _ => Some((upper, value.into())),
@@ -1791,6 +1797,38 @@ mod tests {
 
         assert_eq!(config_string(&options, "private_key"), Some("attr-key"));
         assert!(!options.contains_key("private_key_file"));
+    }
+
+    #[test]
+    fn normalize_connection_string_options_maps_proxy_keys() {
+        let options = normalize_connection_string_options(HashMap::from([
+            ("PROXY".to_owned(), "http://proxy:3128".to_owned()),
+            ("NO_PROXY".to_owned(), "localhost,.internal".to_owned()),
+            ("USE_PROXY_ENV".to_owned(), "true".to_owned()),
+        ]));
+
+        assert_eq!(config_string(&options, "proxy"), Some("http://proxy:3128"));
+        assert_eq!(
+            config_string(&options, "no_proxy"),
+            Some("localhost,.internal")
+        );
+        assert_eq!(config_string(&options, "use_proxy_env"), Some("true"));
+        assert!(!options.contains_key("PROXY"));
+        assert!(!options.contains_key("NO_PROXY"));
+        assert!(!options.contains_key("USE_PROXY_ENV"));
+    }
+
+    #[test]
+    fn normalize_connection_string_options_maps_proxy_aliases() {
+        let options = normalize_connection_string_options(HashMap::from([
+            ("NOPROXY".to_owned(), "*.corp".to_owned()),
+            ("PROXYWITHENV".to_owned(), "1".to_owned()),
+        ]));
+
+        assert_eq!(config_string(&options, "no_proxy"), Some("*.corp"));
+        assert_eq!(config_string(&options, "use_proxy_env"), Some("1"));
+        assert!(!options.contains_key("NOPROXY"));
+        assert!(!options.contains_key("PROXYWITHENV"));
     }
 
     #[test_case("UID=admin;SERVER=foo", &[("UID", "admin"), ("SERVER", "foo")] ; "basic")]

--- a/odbc/src/api/oauth.rs
+++ b/odbc/src/api/oauth.rs
@@ -208,6 +208,8 @@ pub const SENSITIVE_LOGGING_KEYS: &[&str] = &[
     "PRIV_KEY_PWD",
     "PRIV_KEY_BASE64",
     "PASSCODE",
+    // Proxy URL may contain credentials (user:pass@host:port).
+    "PROXY",
     // OAuth keys (OAUTH_CLIENT_SECRET + TOKEN). TOKEN was already in
     // the legacy redaction list; routing it through the OAuth list
     // keeps the source of truth in one place.
@@ -310,6 +312,7 @@ mod tests {
             ("OAUTH_CLIENT_ID", "abc"),
             ("OAUTH_CLIENT_SECRET", "shhh"),
             ("TOKEN", "jwt.value"),
+            ("PROXY", "user:pass@proxy:8080"),
         ]
         .into_iter()
         .map(|(k, v)| (k.to_owned(), v.to_owned()))

--- a/python/src/snowflake/connector/connection_config.py
+++ b/python/src/snowflake/connector/connection_config.py
@@ -11,7 +11,6 @@ rewrites, application validation, Python-only fields) live in
 :mod:`snowflake.connector._internal.connection_config_mixin` and are inherited
 via :class:`ConnectionConfigMixin`.
 """
-
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -21,7 +20,6 @@ from snowflake.connector._internal.connection_config_mixin import (
     ConnectionConfigMixin,
     OptionsModifier,
 )
-
 
 __all__ = ["ConnectionConfig", "OptionsModifier"]
 
@@ -63,7 +61,7 @@ class ConnectionConfig(ConnectionConfigMixin):
     crl_cache_dir: str | None = None
     """Directory for CRL cache files"""
 
-    crl_check_mode: str | None = "DISABLED"
+    crl_check_mode: str | None = 'DISABLED'
     """Certificate revocation check mode (DISABLED, ENABLED, ADVISORY). Default: 'DISABLED'"""
 
     crl_connection_timeout: int | None = 10
@@ -113,6 +111,9 @@ class ConnectionConfig(ConnectionConfigMixin):
 
     logout_total_timeout_seconds: int | None = None
     """Total timeout budget for logout operation including retries"""
+
+    no_proxy: str | None = None
+    """Comma-separated list of hosts that bypass the proxy"""
 
     oauth_authorization_url: str | None = None
     """IdP authorization endpoint (defaults to https://{host}/oauth/authorize)"""
@@ -177,6 +178,9 @@ class ConnectionConfig(ConnectionConfigMixin):
     protocol: str | None = None
     """Connection protocol (http or https)"""
 
+    proxy: str | None = None
+    """Proxy URL ([user:pass@]host[:port]) for outgoing connections"""
+
     server_session_keep_alive: bool | None = None
     """Control server session lifecycle: true=keep alive, false=always logout, null=auto-detect"""
 
@@ -188,6 +192,9 @@ class ConnectionConfig(ConnectionConfigMixin):
 
     token: str | None = None
     """Pre-acquired bearer token (PAT or legacy OAUTH). Required when authenticator=PROGRAMMATIC_ACCESS_TOKEN"""
+
+    use_proxy_env: bool | None = False
+    """Use HTTP_PROXY/HTTPS_PROXY/NO_PROXY environment variables. Default: False"""
 
     user: str | None = None
     """Login username. Required"""
@@ -228,12 +235,14 @@ class ConnectionConfig(ConnectionConfigMixin):
         "clientstoretemporarycredential": "client_store_temporary_credential",
         "crl_enabled": "crl_check_mode",
         "crl_mode": "crl_check_mode",
+        "noproxy": "no_proxy",
         "oauth_token_url": "oauth_token_request_url",
         "passcodeinpassword": "passcode_in_password",
         "priv_key_base64": "private_key",
         "priv_key_file": "private_key_file",
         "priv_key_file_pwd": "private_key_password",
         "priv_key_pwd": "private_key_password",
+        "proxywithenv": "use_proxy_env",
         "pwd": "password",
         "server": "host",
         "tls_custom_root_store_path": "custom_root_store_path",
@@ -252,14 +261,13 @@ class ConnectionConfig(ConnectionConfigMixin):
     }
     """Python field name -> Rust canonical name (only for names that differ)."""
 
-    _SENSITIVE_PARAMS: ClassVar[frozenset[str]] = frozenset(
-        {
-            "oauth_client_secret",
-            "passcode",
-            "password",
-            "private_key",
-            "private_key_password",
-            "token",
-        }
-    )
+    _SENSITIVE_PARAMS: ClassVar[frozenset[str]] = frozenset({
+        "oauth_client_secret",
+        "passcode",
+        "password",
+        "private_key",
+        "private_key_password",
+        "proxy",
+        "token",
+    })
     """Fields that contain secrets (for log redaction)."""

--- a/sf_core/src/apis/database_driver_v1/connection.rs
+++ b/sf_core/src/apis/database_driver_v1/connection.rs
@@ -238,7 +238,7 @@ impl DatabaseDriverV1 {
                     )
                 };
 
-                let http_client = create_tls_client_with_config(config.tls.clone())
+                let http_client = create_tls_client_with_config(config.tls.clone(), &config.proxy)
                     .context(TlsClientCreationSnafu)?;
                 let login_parameters = LoginParameters::from_connection_config(
                     &config,

--- a/sf_core/src/bin/collect_chunk_data.rs
+++ b/sf_core/src/bin/collect_chunk_data.rs
@@ -128,6 +128,7 @@ fn default_client_info() -> ClientInfo {
         compiler: None,
         crl_config: CrlConfig::default(),
         tls_config: TlsConfig::default(),
+        proxy_config: sf_core::tls::ProxyConfig::default(),
         platforms: Vec::new(),
         os_details: None,
     }
@@ -404,7 +405,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     tokio::fs::create_dir_all(&cli.output_dir).await?;
 
-    let tls_client = sf_core::tls::create_tls_client_with_config(TlsConfig::default())?;
+    let tls_client = sf_core::tls::create_tls_client_with_config(
+        TlsConfig::default(),
+        &sf_core::tls::ProxyConfig::default(),
+    )?;
 
     let format_label = match cli.format {
         ResultFormat::Arrow => "arrow",

--- a/sf_core/src/bin/tls_client.rs
+++ b/sf_core/src/bin/tls_client.rs
@@ -178,7 +178,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let result_file = matches.get_one::<String>("result-file").cloned();
 
-    let client = create_tls_client_with_config(tls_config)
+    let client = create_tls_client_with_config(tls_config, &sf_core::tls::ProxyConfig::default())
         .map_err(|e| format!("Failed to build TLS client: {:?}", e))?;
 
     let method = matches.get_one::<String>("method").unwrap();

--- a/sf_core/src/config/connection_config.rs
+++ b/sf_core/src/config/connection_config.rs
@@ -22,7 +22,7 @@ use crate::config::{
 };
 use crate::crl::config::{CertRevocationCheckMode, CrlConfig};
 use crate::sensitive::SensitiveString;
-use crate::tls::config::TlsConfig;
+use crate::tls::config::{ProxyConfig, TlsConfig};
 
 // ---------------------------------------------------------------------------
 // Typed config structs
@@ -35,6 +35,7 @@ pub struct ConnectionConfig {
     pub auth: AuthConfig,
     pub session: SessionContext,
     pub tls: TlsConfig,
+    pub proxy: ProxyConfig,
 }
 
 #[derive(Debug)]
@@ -321,6 +322,27 @@ fn build_crl_config(settings: &ParamStore) -> CrlConfig {
     }
 }
 
+fn build_proxy_config(settings: &ParamStore) -> ProxyConfig {
+    let allow_empty_proxy = settings
+        .get_bool(crate::config::param_names::ALLOW_EMPTY_PROXY)
+        .unwrap_or(true);
+    let raw_proxy = settings.get_string(crate::config::param_names::PROXY);
+    let proxy_url = match raw_proxy {
+        Some(ref s) if s.is_empty() && !allow_empty_proxy => None,
+        other => other,
+    };
+    let no_proxy = settings.get_string(crate::config::param_names::NO_PROXY);
+    let use_proxy_env = settings
+        .get_bool(crate::config::param_names::USE_PROXY_ENV)
+        .unwrap_or(false);
+    ProxyConfig {
+        proxy_url,
+        no_proxy,
+        use_proxy_env,
+        allow_empty_proxy,
+    }
+}
+
 fn build_tls_config(settings: &ParamStore) -> TlsConfig {
     let crl_config = build_crl_config(settings);
     let custom_root_store_path = settings
@@ -500,6 +522,7 @@ impl ConnectionConfig {
         let server_url = derive_server_url(settings)?;
         let auth = build_auth_config(settings)?;
         let tls = build_tls_config(settings);
+        let proxy = build_proxy_config(settings);
 
         let session = SessionContext {
             database: settings.get_string(DATABASE),
@@ -516,6 +539,7 @@ impl ConnectionConfig {
             auth,
             session,
             tls,
+            proxy,
         })
     }
 }
@@ -2056,5 +2080,39 @@ mod tests {
             config.server.server_url,
             "https://myaccount.snowflakecomputing.com"
         );
+    }
+
+    #[test]
+    fn build_proxy_config_from_settings() {
+        let mut settings = minimal_password_settings();
+        settings.insert(
+            "proxy".into(),
+            Setting::String("http://proxy.corp:3128".into()),
+        );
+        settings.insert(
+            "no_proxy".into(),
+            Setting::String("localhost,.internal".into()),
+        );
+        settings.insert("use_proxy_env".into(), Setting::Bool(true));
+
+        let config = ConnectionConfig::build(&settings).unwrap();
+        assert_eq!(
+            config.proxy.proxy_url.as_deref(),
+            Some("http://proxy.corp:3128")
+        );
+        assert_eq!(
+            config.proxy.no_proxy.as_deref(),
+            Some("localhost,.internal")
+        );
+        assert!(config.proxy.use_proxy_env);
+    }
+
+    #[test]
+    fn build_proxy_config_defaults_when_absent() {
+        let settings = minimal_password_settings();
+        let config = ConnectionConfig::build(&settings).unwrap();
+        assert!(config.proxy.proxy_url.is_none());
+        assert!(config.proxy.no_proxy.is_none());
+        assert!(!config.proxy.use_proxy_env);
     }
 }

--- a/sf_core/src/config/param_registry.rs
+++ b/sf_core/src/config/param_registry.rs
@@ -118,6 +118,11 @@ pub mod param_names {
     // Prefetch configuration
     pub const CLIENT_PREFETCH_THREADS: ParamKey = ParamKey("CLIENT_PREFETCH_THREADS");
     pub const CLIENT_MEMORY_LIMIT: ParamKey = ParamKey("CLIENT_MEMORY_LIMIT");
+    // Proxy
+    pub const PROXY: ParamKey = ParamKey("proxy");
+    pub const NO_PROXY: ParamKey = ParamKey("no_proxy");
+    pub const USE_PROXY_ENV: ParamKey = ParamKey("use_proxy_env");
+    pub const ALLOW_EMPTY_PROXY: ParamKey = ParamKey("allow_empty_proxy");
 }
 
 /// Which API layer owns writes for a parameter.
@@ -833,6 +838,63 @@ static PARAM_DEFS: &[ParamDef] = &[
         used_at_connect: true,
         mutable_after_connect: false,
     },
+    // ── Proxy ───────────────────────────────────────────────────────────
+    ParamDef {
+        canonical_name: param_names::PROXY.as_str(),
+        aliases: &["PROXY"],
+        value_type: ValueType::String,
+        additional_value_type: None,
+        required: Required::Never,
+        default: None,
+        sensitive: true,
+        description: "Proxy URL ([user:pass@]host[:port]) for outgoing connections",
+        deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: true,
+        mutable_after_connect: false,
+    },
+    ParamDef {
+        canonical_name: param_names::NO_PROXY.as_str(),
+        aliases: &["NO_PROXY", "NOPROXY"],
+        value_type: ValueType::String,
+        additional_value_type: None,
+        required: Required::Never,
+        default: None,
+        sensitive: false,
+        description: "Comma-separated list of hosts that bypass the proxy",
+        deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: true,
+        mutable_after_connect: false,
+    },
+    ParamDef {
+        canonical_name: param_names::USE_PROXY_ENV.as_str(),
+        aliases: &["USE_PROXY_ENV", "PROXYWITHENV"],
+        value_type: ValueType::Bool,
+        additional_value_type: None,
+        required: Required::Never,
+        default: Some(|| Setting::Bool(false)),
+        sensitive: false,
+        description: "Use HTTP_PROXY/HTTPS_PROXY/NO_PROXY environment variables",
+        deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: true,
+        mutable_after_connect: false,
+    },
+    ParamDef {
+        canonical_name: param_names::ALLOW_EMPTY_PROXY.as_str(),
+        aliases: &["ALLOW_EMPTY_PROXY", "ALLOWEMPTYPROXY"],
+        value_type: ValueType::Bool,
+        additional_value_type: None,
+        required: Required::Never,
+        default: Some(|| Setting::Bool(true)),
+        sensitive: false,
+        description: "Allow empty proxy value to override config/env proxy settings",
+        deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: true,
+        mutable_after_connect: false,
+    },
     // ── Client ──────────────────────────────────────────────────────────
     ParamDef {
         canonical_name: param_names::CONNECTION_NAME.as_str(),
@@ -1194,6 +1256,13 @@ mod tests {
             ("CRL_MODE", "crl_check_mode"),
             ("CRL_ENABLED", "crl_check_mode"),
             ("ALLOWUNDERSCORESINHOST", "preserve_underscores_in_hostname"),
+            ("PROXY", "proxy"),
+            ("NO_PROXY", "no_proxy"),
+            ("NOPROXY", "no_proxy"),
+            ("USE_PROXY_ENV", "use_proxy_env"),
+            ("PROXYWITHENV", "use_proxy_env"),
+            ("ALLOW_EMPTY_PROXY", "allow_empty_proxy"),
+            ("ALLOWEMPTYPROXY", "allow_empty_proxy"),
         ];
         for (alias, expected_canonical) in cases {
             let def = r

--- a/sf_core/src/config/rest_parameters.rs
+++ b/sf_core/src/config/rest_parameters.rs
@@ -13,7 +13,7 @@ use crate::config::{ConfigError, ConflictingParametersSnafu, MissingParameterSna
 use crate::crl::config::CrlConfig;
 use crate::rest::snowflake::BrowserLaunchFn;
 use crate::sensitive::SensitiveString;
-use crate::tls::config::TlsConfig;
+use crate::tls::config::{ProxyConfig, TlsConfig};
 use openssl::pkey::PKey;
 use snafu::OptionExt;
 
@@ -123,6 +123,7 @@ pub struct ClientInfo {
     pub compiler: Option<String>,
     pub crl_config: CrlConfig,
     pub tls_config: TlsConfig,
+    pub proxy_config: ProxyConfig,
     pub platforms: Vec<String>,
     pub os_details: Option<HashMap<String, String>>,
 }
@@ -131,6 +132,7 @@ impl ClientInfo {
     pub fn from_settings(settings: &dyn Settings) -> Result<Self, ConfigError> {
         let crl_config = CrlConfig::from_settings(settings)?;
         let tls_config = TlsConfig::from_settings(settings)?;
+        let proxy_config = ProxyConfig::from_settings(settings);
 
         let client_app_id = settings
             .get_string("client_app_id")
@@ -161,6 +163,7 @@ impl ClientInfo {
                 .and_then(|s| if s.trim().is_empty() { None } else { Some(s) }),
             crl_config,
             tls_config,
+            proxy_config,
             platforms: Vec::new(),
             os_details: None,
         };
@@ -172,7 +175,7 @@ impl ClientInfo {
 pub mod test_fixtures {
     use super::ClientInfo;
     use crate::crl::config::CrlConfig;
-    use crate::tls::config::TlsConfig;
+    use crate::tls::config::{ProxyConfig, TlsConfig};
 
     /// Minimal [`ClientInfo`] for tests. Uses [`TlsConfig::insecure`] so it works
     /// with plain-HTTP mock servers. Override specific fields with struct-update
@@ -190,6 +193,7 @@ pub mod test_fixtures {
             compiler: None,
             crl_config: CrlConfig::default(),
             tls_config: TlsConfig::insecure(),
+            proxy_config: ProxyConfig::default(),
             platforms: Vec::new(),
             os_details: None,
         }

--- a/sf_core/src/crl/integration_test.rs
+++ b/sf_core/src/crl/integration_test.rs
@@ -4,7 +4,7 @@ mod integration_tests {
     use crate::config::rest_parameters::test_fixtures::test_client_info;
     use crate::crl::config::{CertRevocationCheckMode, CrlConfig};
     use crate::rest::snowflake;
-    use crate::tls::config::TlsConfig;
+    use crate::tls::config::{ProxyConfig, TlsConfig};
 
     #[test]
     fn test_crl_config_disabled_defaults() {
@@ -96,10 +96,13 @@ mod integration_tests {
             check_mode: CertRevocationCheckMode::Disabled,
             ..Default::default()
         };
-        let client = crate::tls::create_tls_client_with_config(TlsConfig {
-            crl_config: config,
-            ..Default::default()
-        })
+        let client = crate::tls::create_tls_client_with_config(
+            TlsConfig {
+                crl_config: config,
+                ..Default::default()
+            },
+            &ProxyConfig::default(),
+        )
         .unwrap();
         assert!(client.get("https://httpbin.org/get").build().is_ok());
 
@@ -108,10 +111,13 @@ mod integration_tests {
             check_mode: CertRevocationCheckMode::Enabled,
             ..Default::default()
         };
-        let client = crate::tls::create_tls_client_with_config(TlsConfig {
-            crl_config: config,
-            ..Default::default()
-        })
+        let client = crate::tls::create_tls_client_with_config(
+            TlsConfig {
+                crl_config: config,
+                ..Default::default()
+            },
+            &ProxyConfig::default(),
+        )
         .unwrap();
         assert!(client.get("https://httpbin.org/get").build().is_ok());
 
@@ -120,10 +126,13 @@ mod integration_tests {
             check_mode: CertRevocationCheckMode::Advisory,
             ..Default::default()
         };
-        let client = crate::tls::create_tls_client_with_config(TlsConfig {
-            crl_config: config,
-            ..Default::default()
-        })
+        let client = crate::tls::create_tls_client_with_config(
+            TlsConfig {
+                crl_config: config,
+                ..Default::default()
+            },
+            &ProxyConfig::default(),
+        )
         .unwrap();
         assert!(client.get("https://httpbin.org/get").build().is_ok());
     }

--- a/sf_core/src/rest/snowflake/mod.rs
+++ b/sf_core/src/rest/snowflake/mod.rs
@@ -1819,7 +1819,8 @@ where
 
 #[track_caller]
 fn build_tls_http_client(client_info: &ClientInfo) -> Result<reqwest::Client, RestError> {
-    create_tls_client_with_config(client_info.tls_config.clone()).context(CrlValidationSnafu)
+    create_tls_client_with_config(client_info.tls_config.clone(), &client_info.proxy_config)
+        .context(CrlValidationSnafu)
 }
 
 pub(crate) fn authorization_header(session_token: &str) -> header::HeaderValue {

--- a/sf_core/src/tls/client.rs
+++ b/sf_core/src/tls/client.rs
@@ -1,28 +1,32 @@
 use crate::crl::config::{CertRevocationCheckMode, CrlConfig};
 use crate::tls::CrlServerCertVerifier;
-use crate::tls::config::TlsConfig;
+use crate::tls::config::{ProxyConfig, TlsConfig};
 use crate::tls::error::{
     ClientBuildSnafu, PemParseSnafu, RootStoreAddSnafu, TlsError, VerifierBuildSnafu,
 };
-use reqwest::{Client, ClientBuilder};
+use reqwest::{Client, ClientBuilder, Proxy};
 use rustls::ClientConfig;
 use snafu::ResultExt;
 use std::sync::Arc;
 use std::time::Duration;
+use url::Url;
 
 /// Create a reqwest Client with TLS configuration
 ///
 /// This is the main entry point for creating HTTP clients in the application.
 /// Handles all TLS configuration including CRL validation, custom root stores, etc.
-pub fn create_tls_client_with_config(tls_config: TlsConfig) -> Result<Client, TlsError> {
+pub fn create_tls_client_with_config(
+    tls_config: TlsConfig,
+    proxy_config: &ProxyConfig,
+) -> Result<Client, TlsError> {
     // Handle insecure configurations
     if !tls_config.verify_certificates {
         tracing::warn!("Creating insecure TLS client - certificate verification disabled");
-        return configure_http_client(Client::builder())
+        let builder = configure_http_client(Client::builder())
             .danger_accept_invalid_certs(true)
-            .danger_accept_invalid_hostnames(true)
-            .build()
-            .context(ClientBuildSnafu);
+            .danger_accept_invalid_hostnames(true);
+        let builder = apply_proxy(builder, proxy_config)?;
+        return builder.build().context(ClientBuildSnafu);
     }
 
     // Install aws-lc-rs provider (idempotent)
@@ -56,6 +60,7 @@ pub fn create_tls_client_with_config(tls_config: TlsConfig) -> Result<Client, Tl
                 tracing::warn!("Hostname verification disabled");
                 builder = builder.danger_accept_invalid_hostnames(true);
             }
+            let builder = apply_proxy(builder, proxy_config)?;
             builder.build().context(ClientBuildSnafu)
         }
         CertRevocationCheckMode::Enabled | CertRevocationCheckMode::Advisory => {
@@ -70,6 +75,7 @@ pub fn create_tls_client_with_config(tls_config: TlsConfig) -> Result<Client, Tl
                 tls_config.crl_config,
                 custom_root_store,
                 tls_config.verify_hostname,
+                proxy_config,
             )
         }
     }
@@ -80,6 +86,7 @@ pub(crate) fn create_crl_tls_client_with_root_store(
     crl_config: CrlConfig,
     custom_root_store: Option<rustls::RootCertStore>,
     verify_hostname: bool,
+    proxy_config: &ProxyConfig,
 ) -> Result<Client, TlsError> {
     tracing::debug!("Creating custom TLS client with CRL handshake validation");
     if !verify_hostname {
@@ -104,16 +111,16 @@ pub(crate) fn create_crl_tls_client_with_root_store(
         .with_no_client_auth();
 
     // Create reqwest client with custom TLS configuration
-    let client = configure_http_client(Client::builder())
+    let builder = configure_http_client(Client::builder())
         .use_preconfigured_tls(tls_config)
         .timeout(Duration::from_secs(
             crl_config.http_timeout.num_seconds() as u64
         ))
         .connect_timeout(Duration::from_secs(
             crl_config.connection_timeout.num_seconds() as u64,
-        ))
-        .build()
-        .context(ClientBuildSnafu)?;
+        ));
+    let builder = apply_proxy(builder, proxy_config)?;
+    let client = builder.build().context(ClientBuildSnafu)?;
 
     tracing::debug!("Created TLS client with full handshake CRL validation");
     Ok(client)
@@ -144,4 +151,102 @@ fn configure_http_client(builder: ClientBuilder) -> ClientBuilder {
         .pool_idle_timeout(Some(Duration::from_secs(30)))
         .pool_max_idle_per_host(32)
         .tcp_keepalive(Some(Duration::from_secs(60)))
+}
+
+/// Normalize a proxy URL: ensure it has a scheme prefix (default `http://`).
+fn normalize_proxy_url(raw: &str) -> Result<String, TlsError> {
+    let with_scheme = if raw.contains("://") {
+        raw.to_string()
+    } else {
+        format!("http://{raw}")
+    };
+    // Validate the URL is parseable.
+    Url::parse(&with_scheme).map_err(|e| TlsError::ProxyConfig {
+        reason: format!("cannot parse proxy URL '{raw}': {e}"),
+        location: snafu::Location::new(file!(), line!(), 0),
+    })?;
+    Ok(with_scheme)
+}
+
+/// Apply proxy configuration to a `ClientBuilder`.
+fn apply_proxy(
+    mut builder: ClientBuilder,
+    config: &ProxyConfig,
+) -> Result<ClientBuilder, TlsError> {
+    match &config.proxy_url {
+        Some(raw_url) if !raw_url.is_empty() => {
+            let url = normalize_proxy_url(raw_url)?;
+            tracing::debug!("Configuring explicit proxy: {}", url);
+            let mut proxy = Proxy::all(&url).map_err(|e| TlsError::ProxyConfig {
+                reason: format!("invalid proxy URL: {e}"),
+                location: snafu::Location::new(file!(), line!(), 0),
+            })?;
+            if let Some(ref no_proxy) = config.no_proxy {
+                tracing::debug!("Configuring no_proxy: {}", no_proxy);
+                proxy = proxy.no_proxy(reqwest::NoProxy::from_string(no_proxy));
+            }
+            builder = builder.proxy(proxy);
+        }
+        Some(_) => {
+            // Empty proxy string with allow_empty_proxy=true: explicitly disable proxy.
+            tracing::debug!("Empty proxy value — disabling proxy (overrides env)");
+            builder = builder.no_proxy();
+        }
+        None => {
+            if config.use_proxy_env {
+                tracing::debug!("Using proxy from environment variables");
+            } else {
+                builder = builder.no_proxy();
+            }
+        }
+    }
+    Ok(builder)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_proxy_url_adds_scheme() {
+        assert_eq!(
+            normalize_proxy_url("myproxy:8080").unwrap(),
+            "http://myproxy:8080"
+        );
+    }
+
+    #[test]
+    fn normalize_proxy_url_preserves_existing_scheme() {
+        assert_eq!(
+            normalize_proxy_url("https://proxy.corp:443").unwrap(),
+            "https://proxy.corp:443"
+        );
+    }
+
+    #[test]
+    fn normalize_proxy_url_with_credentials() {
+        let result = normalize_proxy_url("user:pass@proxy.corp:8080").unwrap();
+        assert_eq!(result, "http://user:pass@proxy.corp:8080");
+    }
+
+    #[test]
+    fn apply_proxy_no_proxy_disables_env() {
+        let config = ProxyConfig::default();
+        let builder = Client::builder();
+        let builder = apply_proxy(builder, &config).unwrap();
+        // Should succeed without error (no_proxy mode).
+        let _ = builder;
+    }
+
+    #[test]
+    fn apply_proxy_with_explicit_url() {
+        let config = ProxyConfig {
+            proxy_url: Some("http://proxy.test:3128".to_string()),
+            no_proxy: Some("localhost,.internal".to_string()),
+            ..Default::default()
+        };
+        let builder = Client::builder();
+        let result = apply_proxy(builder, &config);
+        assert!(result.is_ok());
+    }
 }

--- a/sf_core/src/tls/config.rs
+++ b/sf_core/src/tls/config.rs
@@ -2,6 +2,55 @@ use crate::crl::config::CrlConfig;
 use std::path::PathBuf;
 
 #[derive(Debug, Clone)]
+pub struct ProxyConfig {
+    pub proxy_url: Option<String>,
+    pub no_proxy: Option<String>,
+    pub use_proxy_env: bool,
+    /// When true (default), an empty proxy value in the connection string
+    /// explicitly means "no proxy" — overriding env vars or config file settings.
+    /// When false, an empty proxy value is ignored.
+    pub allow_empty_proxy: bool,
+}
+
+impl Default for ProxyConfig {
+    fn default() -> Self {
+        Self {
+            proxy_url: None,
+            no_proxy: None,
+            use_proxy_env: false,
+            allow_empty_proxy: true,
+        }
+    }
+}
+
+impl ProxyConfig {
+    pub fn from_settings(settings: &dyn crate::config::settings::Settings) -> Self {
+        let raw_proxy = settings.get_string("proxy");
+        let allow_empty_proxy = settings
+            .get_string("allow_empty_proxy")
+            .map(|s| s.eq_ignore_ascii_case("true") || s == "1")
+            .or_else(|| settings.get_bool("allow_empty_proxy"))
+            .unwrap_or(true);
+        let proxy_url = match raw_proxy {
+            Some(ref s) if s.is_empty() && !allow_empty_proxy => None,
+            other => other,
+        };
+        let no_proxy = settings.get_string("no_proxy");
+        let use_proxy_env = settings
+            .get_string("use_proxy_env")
+            .map(|s| s.eq_ignore_ascii_case("true") || s == "1")
+            .or_else(|| settings.get_bool("use_proxy_env"))
+            .unwrap_or(false);
+        Self {
+            proxy_url,
+            no_proxy,
+            use_proxy_env,
+            allow_empty_proxy,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct TlsConfig {
     pub crl_config: CrlConfig,
     pub custom_root_store_path: Option<PathBuf>,

--- a/sf_core/src/tls/error.rs
+++ b/sf_core/src/tls/error.rs
@@ -43,4 +43,11 @@ pub enum TlsError {
         #[snafu(implicit)]
         location: Location,
     },
+
+    #[snafu(display("Invalid proxy configuration: {reason}"))]
+    ProxyConfig {
+        reason: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
 }

--- a/sf_core/src/tls/mod.rs
+++ b/sf_core/src/tls/mod.rs
@@ -8,6 +8,6 @@ pub mod test_helpers;
 pub mod x509_utils;
 
 pub use client::create_tls_client_with_config;
-pub use config::TlsConfig;
+pub use config::{ProxyConfig, TlsConfig};
 pub(crate) use crl_verifier::CrlServerCertVerifier;
 pub use x509_utils::{crl_times, extract_skid, subject_der_hash, verify_crl_signature};

--- a/sf_core/tests/e2e/session/session_refresh.rs
+++ b/sf_core/tests/e2e/session/session_refresh.rs
@@ -9,7 +9,7 @@ use sf_core::config::rest_parameters::{LoginMethod, LoginParameters};
 use sf_core::rest::snowflake::{refresh_session, snowflake_login_with_client};
 use sf_core::sensitive::SensitiveString;
 use sf_core::tls::client::create_tls_client_with_config;
-use sf_core::tls::config::TlsConfig;
+use sf_core::tls::config::{ProxyConfig, TlsConfig};
 use std::fs;
 
 #[test]
@@ -104,8 +104,9 @@ fn should_refresh_session_proactively() {
             spcs_token: None,
         };
 
-        let http_client = create_tls_client_with_config(TlsConfig::insecure())
-            .expect("Failed to create HTTP client");
+        let http_client =
+            create_tls_client_with_config(TlsConfig::insecure(), &ProxyConfig::default())
+                .expect("Failed to create HTTP client");
 
         // When we login and immediately call refresh
         let login_result = snowflake_login_with_client(&http_client, &login_parameters, None, None)

--- a/sf_core/tests/e2e/tls/handshake.rs
+++ b/sf_core/tests/e2e/tls/handshake.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use rcgen::generate_simple_self_signed;
 use rustls::ServerConfig;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
-use sf_core::tls::config::TlsConfig;
+use sf_core::tls::config::{ProxyConfig, TlsConfig};
 use sf_core::tls::create_tls_client_with_config;
 use tokio::net::TcpListener;
 use tokio_rustls::TlsAcceptor;
@@ -74,7 +74,8 @@ async fn should_complete_handshake_with_default_roots() {
     let server_url = std::env::var("E2E_TLS_SERVER").unwrap_or("https://example.com".to_string());
 
     // When GET request is sent to the server URL
-    let client = create_tls_client_with_config(TlsConfig::default()).expect("client");
+    let client = create_tls_client_with_config(TlsConfig::default(), &ProxyConfig::default())
+        .expect("client");
     let resp = client.get(server_url).send().await;
 
     // Then the request attempt should be successful
@@ -90,7 +91,7 @@ async fn should_complete_handshake_with_custom_pem_roots() {
             custom_root_store_path: Some(pem_path.into()),
             ..Default::default()
         };
-        let client = create_tls_client_with_config(cfg).expect("client");
+        let client = create_tls_client_with_config(cfg, &ProxyConfig::default()).expect("client");
         let server_url =
             std::env::var("E2E_TLS_SERVER").unwrap_or("https://example.com".to_string());
 
@@ -112,7 +113,7 @@ async fn should_trust_custom_root_store_when_crl_disabled() {
         custom_root_store_path: Some(pem_file.path().to_path_buf()),
         ..Default::default()
     };
-    let client = create_tls_client_with_config(cfg).expect("client");
+    let client = create_tls_client_with_config(cfg, &ProxyConfig::default()).expect("client");
     let resp = client.get(format!("https://localhost:{port}")).send().await;
 
     // Then the handshake succeeds because the custom root store is applied
@@ -135,7 +136,7 @@ async fn should_skip_hostname_verification_when_disabled() {
         verify_hostname: false,
         ..Default::default()
     };
-    let client = create_tls_client_with_config(cfg).expect("client");
+    let client = create_tls_client_with_config(cfg, &ProxyConfig::default()).expect("client");
     let resp = client.get(format!("https://127.0.0.1:{port}")).send().await;
 
     // Then the handshake succeeds despite hostname mismatch
@@ -150,7 +151,8 @@ async fn should_skip_hostname_verification_when_disabled() {
         verify_hostname: true,
         ..Default::default()
     };
-    let client_strict = create_tls_client_with_config(cfg_strict).expect("client");
+    let client_strict =
+        create_tls_client_with_config(cfg_strict, &ProxyConfig::default()).expect("client");
     let resp_strict = client_strict
         .get(format!("https://127.0.0.1:{port}"))
         .send()

--- a/sf_core/tests/integration/session/logout.rs
+++ b/sf_core/tests/integration/session/logout.rs
@@ -1838,6 +1838,7 @@ fn test_client_info() -> ClientInfo {
         ocsp_mode: Some("FAIL_OPEN".to_string()),
         crl_config: Default::default(),
         tls_config: Default::default(),
+        proxy_config: Default::default(),
         platforms: vec![],
         os_details: None,
         compiler: None,


### PR DESCRIPTION
## Summary
- Register proxy parameters (`proxy`, `no_proxy`, `use_proxy_env`) in sf_core param registry with aliases matching the legacy ODBC driver (`PROXY`, `NO_PROXY`, `NOPROXY`, `USE_PROXY_ENV`, `PROXYWITHENV`)
- Add `ProxyConfig` struct that normalizes legacy proxy format (`user:pass@host:port`) into proper URLs and extracts authentication credentials
- Wire proxy into reqwest `ClientBuilder` via `apply_proxy()` — supports explicit proxy, no_proxy bypass list, and env var fallback
- Add ODBC connection string normalization for proxy keys
- Mark `PROXY` as sensitive for log redaction (may contain credentials in URL)

## Behavior
- **Explicit proxy set**: routes all traffic through it; env vars ignored unless `use_proxy_env` also true
- **No proxy, `use_proxy_env=false` (default)**: disables env var auto-detection
- **No proxy, `use_proxy_env=true`**: reqwest reads `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` from environment

## Test Results
- sf_core unit tests: 550 passed, 0 failed
- odbc unit tests: 1022 passed, 0 failed
- All pre-commit hooks pass (formatting, clippy, cargo check)

## References
- Jira: [SNOW-2872385](https://snowflakecomputing.atlassian.net/browse/SNOW-2872385)
- Legacy reference: snowflake-odbc `Source/Platform/ODBCCurlDesc.cpp`, `libsnowflakeclient/include/snowflake/Proxy.hpp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SNOW-2872385]: https://snowflakecomputing.atlassian.net/browse/SNOW-2872385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ