### PR TITLE
ci: run ODBC CI on push to main and release branches

### DIFF
--- a/.github/workflows/build-python-release.yml
+++ b/.github/workflows/build-python-release.yml
@@ -2,7 +2,7 @@ name: Python Release Build
 
 on:
   push:
-    branches: [main]
+    branches: [main, 'release/**']
   workflow_dispatch:
 
 env:

--- a/.github/workflows/build-python-release.yml
+++ b/.github/workflows/build-python-release.yml
@@ -2,7 +2,7 @@ name: Python Release Build
 
 on:
   push:
-    branches: [main, 'release/**']
+    branches: [main, 'release/python-**']
   workflow_dispatch:
 
 env:

--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - 'release/**'
+      - 'release/odbc-**'
   pull_request:
     # `labeled` is included so applying ci:scope-merge / ci:scope-nightly to
     # a PR re-runs the workflow at the upgraded scope without needing a new

--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -1,6 +1,10 @@
 name: ODBC CI
 
 on:
+  push:
+    branches:
+      - main
+      - 'release/**'
   pull_request:
     # `labeled` is included so applying ci:scope-merge / ci:scope-nightly to
     # a PR re-runs the workflow at the upgraded scope without needing a new
@@ -13,9 +17,9 @@ on:
     types: [ checks_requested ]
 
 concurrency:
-  # Group by PR number for PRs; fall back to run ID for merge_group runs
-  # (each run is unique so they won't cancel each other).
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  # Group by PR number for PRs; by branch for pushes; fall back to run ID for
+  # merge_group runs (each run is unique so they won't cancel each other).
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
   # Don't cancel an in-flight run when an unrelated label is added/removed —
   # only scope-up labels (ci:scope-merge, ci:scope-nightly) and normal
   # push/synchronize/reopen events should replace the running matrix.


### PR DESCRIPTION
## Summary
- Adds `push:` trigger for `main` and `release/**` branches to the ODBC CI workflow
- Ensures ODBC packages (MSI, RPM, DMG) and all ODBC tests are always built on main and release branches
- Updates concurrency group to properly handle push-triggered runs

## Test plan
- [ ] Verify workflow triggers on next push to main
- [ ] Confirm all ODBC jobs (unit tests, integration tests, reference tests, packages) run unconditionally on push events

🤖 Generated with [Claude Code](https://claude.com/claude-code)