### PR TITLE
NO-SNOW: Fix shared wiremock session-renewal mappings

### DIFF
--- a/tests/wiremock/mappings/auth/login_for_session_renewal.json
+++ b/tests/wiremock/mappings/auth/login_for_session_renewal.json
@@ -1,0 +1,32 @@
+{
+  "name": "Login returning tokens that match the session-refresh scenario matchers",
+  "request": {
+    "urlPathPattern": "/session/v1/login-request.*",
+    "method": "POST"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "success": true,
+      "data": {
+        "token": "expired-session-token",
+        "masterToken": "valid-master-token",
+        "sessionId": 12345,
+        "validityInSeconds": 3600,
+        "masterValidityInSeconds": 14400,
+        "sessionInfo": {
+          "databaseName": "",
+          "schemaName": "",
+          "warehouseName": "",
+          "roleName": ""
+        },
+        "parameters": [
+          {"name": "CLIENT_TELEMETRY_ENABLED", "value": false}
+        ]
+      }
+    }
+  }
+}

--- a/tests/wiremock/mappings/session/query_success_after_refresh.json
+++ b/tests/wiremock/mappings/session/query_success_after_refresh.json
@@ -17,8 +17,22 @@
       "success": true,
       "data": {
         "queryId": "test-query-id",
-        "rowtype": [],
-        "rowset": [[1]]
+        "rowtype": [
+          {
+            "name": "STATUS",
+            "type": "text",
+            "nullable": true,
+            "length": 16777216,
+            "byteLength": 16777216,
+            "precision": null,
+            "scale": null
+          }
+        ],
+        "rowset": [],
+        "total": 0,
+        "returned": 0,
+        "queryResultFormat": "json",
+        "statementTypeId": 16384
       }
     },
     "headers": {


### PR DESCRIPTION
The four mappings under tests/wiremock/mappings/session/ that exercise the
401 -> /session/token-request -> retry flow were scaffolded but never
consumed by a real test, and contained two bugs that surfaced when wiring
them up to a JDBC end-to-end test:

1. query_success_after_refresh.json had rowset=[[1]] (number) but
   sf_core declares rowset as Option<Vec<Vec<Option<String>>>>; serde
   refused to deserialise integer 1 as Option<String>. Switched to an
   empty rowset with a single STATUS column descriptor in rowtype so the
   downstream Arrow conversion has at least one column.
2. The response did not carry statementTypeId, so the JDBC wrapper's
   StatementTypeClassifier defaulted to UNKNOWN (producesResultSet=true)
   and tried to materialise a result stream. Added
   statementTypeId=16384 (SCL, non-result-set) so callers using
   Statement.execute(sql) return cleanly.

Also adds tests/wiremock/mappings/auth/login_for_session_renewal.json
which returns tokens whose substrings ("expired-session-token",
"valid-master-token") match the existing renewal mappings' Authorization
matchers. The existing auth/login_success_any.json returns generic
"mock_session_token"/"mock_master_token" which never satisfy those
matchers, so it could not be reused.

The actual JDBC test that consumes these mappings lands in the next PR
in the stack.