### PR TITLE
NO-SNOW: Add SessionRenewalWiremockTest end-to-end

### DIFF
--- a/jdbc/src/test/java/net/snowflake/jdbc/wiremock/SessionRenewalWiremockTest.java
+++ b/jdbc/src/test/java/net/snowflake/jdbc/wiremock/SessionRenewalWiremockTest.java
@@ -1,0 +1,51 @@
+package net.snowflake.jdbc.wiremock;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.Properties;
+import net.snowflake.client.api.driver.SnowflakeDriver;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that JDBC sees transparent session renewal: a query that hits a 401 "session expired"
+ * response triggers sf_core's {@code execute_with_refresh} loop, which calls {@code
+ * /session/token-request} and retries the query exactly once. From the JDBC caller's perspective
+ * the {@code Statement.execute} call simply succeeds.
+ */
+public class SessionRenewalWiremockTest extends BaseWiremockTest {
+
+  @Test
+  public void queryRefreshesSessionOn401AndRetriesTransparently() throws Exception {
+    // The four mappings together form the renewal scenario state machine
+    // (Started -> Token Expired -> Token Refreshed):
+    //   * login returns tokens with substrings expected by the renewal matchers
+    //     (session "expired-session-token" + master "valid-master-token")
+    //   * first query is 401, transitions state to "Token Expired"
+    //   * token-request returns new tokens, transitions state to "Token Refreshed"
+    //   * retry query returns success with statementTypeId=SCL (no result set)
+    wiremock.addMapping("auth/login_for_session_renewal.json");
+    wiremock.addMapping("session/query_401_then_refresh_then_success.json");
+    wiremock.addMapping("session/token_refresh_success.json");
+    wiremock.addMapping("session/query_success_after_refresh.json");
+
+    Properties props = new Properties();
+    props.setProperty("account", "test_account");
+    props.setProperty("user", "test_user");
+    props.setProperty("password", "test_password");
+    props.setProperty("protocol", "http");
+
+    Class.forName(SnowflakeDriver.class.getName());
+    try (Connection conn = DriverManager.getConnection(wiremockJdbcUrl(), props);
+        Statement stmt = conn.createStatement()) {
+      // Statement.execute() returning without exception is the success criterion: sf_core
+      // saw 401, refreshed the session, retried the query, and got back a valid response.
+      // The mock response carries statementTypeId=SCL (non-result-set) so the JDBC wrapper
+      // skips the result-stream materialisation path.
+      stmt.execute("USE DATABASE TEST_DB");
+    }
+
+    wiremock.verifyRequestCount(2, "/queries/v1/query-request");
+    wiremock.verifyRequestCount(1, "/session/token-request");
+  }
+}

--- a/tests/wiremock/mappings/auth/login_for_session_renewal.json
+++ b/tests/wiremock/mappings/auth/login_for_session_renewal.json
@@ -1,0 +1,32 @@
+{
+  "name": "Login returning tokens that match the session-refresh scenario matchers",
+  "request": {
+    "urlPathPattern": "/session/v1/login-request.*",
+    "method": "POST"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "success": true,
+      "data": {
+        "token": "expired-session-token",
+        "masterToken": "valid-master-token",
+        "sessionId": 12345,
+        "validityInSeconds": 3600,
+        "masterValidityInSeconds": 14400,
+        "sessionInfo": {
+          "databaseName": "",
+          "schemaName": "",
+          "warehouseName": "",
+          "roleName": ""
+        },
+        "parameters": [
+          {"name": "CLIENT_TELEMETRY_ENABLED", "value": false}
+        ]
+      }
+    }
+  }
+}

--- a/tests/wiremock/mappings/session/query_success_after_refresh.json
+++ b/tests/wiremock/mappings/session/query_success_after_refresh.json
@@ -17,8 +17,22 @@
       "success": true,
       "data": {
         "queryId": "test-query-id",
-        "rowtype": [],
-        "rowset": [[1]]
+        "rowtype": [
+          {
+            "name": "STATUS",
+            "type": "text",
+            "nullable": true,
+            "length": 16777216,
+            "byteLength": 16777216,
+            "precision": null,
+            "scale": null
+          }
+        ],
+        "rowset": [],
+        "total": 0,
+        "returned": 0,
+        "queryResultFormat": "json",
+        "statementTypeId": 16384
       }
     },
     "headers": {


### PR DESCRIPTION
End-to-end test that proves JDBC sees transparent session renewal: a
query that hits a 401 "session expired" response is internally refreshed
via /session/token-request and retried by sf_core's execute_with_refresh
loop. From the JDBC caller's perspective Statement.execute() simply
returns successfully.

The test wires up four shared wiremock mappings (login + 401 + refresh +
retry-success) to drive the scenario state machine, then verifies
exactly two POSTs to /queries/v1/query-request and one to
/session/token-request hit the mock server. Confirms the renewal flow
works end-to-end through the FFI: DriverManager.getConnection ->
SnowflakeConnectionImpl -> FFI -> sf_core::execute_with_refresh ->
HTTP -> sf_core (refresh, retry) -> JDBC.

Verified locally on Java 11 (passes) and Java 8 (skipped via the
BaseWiremockTest gate).