### PR TITLE
NO-SNOW: jdbc - introduce CoreDriver facade to encapsulate protobuf request construction

### DIFF
--- a/jdbc/src/main/java/net/snowflake/client/api/exception/SnowflakeSQLException.java
+++ b/jdbc/src/main/java/net/snowflake/client/api/exception/SnowflakeSQLException.java
@@ -24,10 +24,10 @@ public class SnowflakeSQLException extends SQLException {
   }
 
   public static SnowflakeSQLException fromServiceException(
-      String fallbackMessage, DatabaseDriverService.ServiceException exception) {
+      DatabaseDriverService.ServiceException exception) {
     DatabaseDriverV1.DriverException error = exception.error;
     if (error == null) {
-      return new SnowflakeSQLException(fallbackMessage, exception);
+      return new SnowflakeSQLException(exception.getMessage(), exception);
     }
     return new SnowflakeSQLException(error, exception);
   }

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/connection/SnowflakeConnectionImpl.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/connection/SnowflakeConnectionImpl.java
@@ -33,23 +33,15 @@ import net.snowflake.client.internal.api.implementation.statement.SnowflakePrepa
 import net.snowflake.client.internal.api.implementation.statement.SnowflakeStatementImpl;
 import net.snowflake.client.internal.log.SFLogger;
 import net.snowflake.client.internal.log.SFLoggerFactory;
+import net.snowflake.client.internal.unicore.CoreDriverApi;
 import net.snowflake.client.internal.unicore.ProtobufApis;
-import net.snowflake.client.internal.unicore.TransportException;
-import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverService;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConfigSetting;
-import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionCloseRequest;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionHandle;
-import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionInitRequest;
-import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionNewRequest;
-import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionReleaseRequest;
-import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionSetOptionsRequest;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionSetOptionsResponse;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseHandle;
-import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseInitRequest;
-import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseNewRequest;
-import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseReleaseRequest;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ValidationIssue;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.WrapperIdentity;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.WrapperIdentity.Builder;
 import net.snowflake.client.internal.util.NotImplementedException;
 
 public class SnowflakeConnectionImpl implements SnowflakeConnection, Connection {
@@ -57,6 +49,7 @@ public class SnowflakeConnectionImpl implements SnowflakeConnection, Connection 
   private static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeConnectionImpl.class);
   private final String url;
   private final Properties properties;
+  private final CoreDriverApi coreDriverApi;
   private boolean autoCommit = true;
   private final AtomicBoolean closed = new AtomicBoolean(false);
   private String catalog;
@@ -65,55 +58,54 @@ public class SnowflakeConnectionImpl implements SnowflakeConnection, Connection 
   public final ConnectionHandle connectionHandle;
 
   public SnowflakeConnectionImpl(String url, Properties properties) throws SQLException {
+    this(url, properties, ProtobufApis.coreDriverApi);
+  }
+
+  SnowflakeConnectionImpl(String url, Properties properties, CoreDriverApi coreDriverApi)
+      throws SQLException {
     this.url = url;
     this.properties = properties;
-    Properties connectionOptions = ConnectionOptionsResolver.resolve(url, properties);
+    this.coreDriverApi = coreDriverApi;
+
     DatabaseHandle dbHandle = null;
     ConnectionHandle connHandle = null;
     try {
-      dbHandle =
-          ProtobufApis.databaseDriverV1
-              .databaseNew(DatabaseNewRequest.getDefaultInstance())
-              .getDbHandle();
-      DatabaseInitRequest databaseInitRequest =
-          DatabaseInitRequest.newBuilder().setDbHandle(dbHandle).build();
-      ProtobufApis.databaseDriverV1.databaseInit(databaseInitRequest);
-      connHandle =
-          ProtobufApis.databaseDriverV1
-              .connectionNew(ConnectionNewRequest.getDefaultInstance())
-              .getConnHandle();
+      dbHandle = coreDriverApi.databaseNew().getDbHandle();
+      coreDriverApi.databaseInit(dbHandle);
+      connHandle = coreDriverApi.connectionNew().getConnHandle();
 
+      Properties connectionOptions = ConnectionOptionsResolver.resolve(url, properties);
       setOptions(connHandle, connectionOptions);
 
-      WrapperIdentity.Builder identityBuilder =
-          WrapperIdentity.newBuilder()
-              .setDriverName("JDBC")
-              .setDriverVersion(determineClientAppVersion());
-      String runtimeName = System.getProperty("java.vm.name");
-      if (runtimeName != null && !runtimeName.trim().isEmpty()) {
-        identityBuilder.setLanguageRuntime(runtimeName);
-      }
-      String runtimeVersion = System.getProperty("java.version");
-      if (runtimeVersion != null && !runtimeVersion.trim().isEmpty()) {
-        identityBuilder.setLanguageVersion(runtimeVersion);
-      }
-      ConnectionInitRequest connectionInitRequest =
-          ConnectionInitRequest.newBuilder()
-              .setDbHandle(dbHandle)
-              .setConnHandle(connHandle)
-              .setWrapperIdentity(identityBuilder.build())
-              .build();
-      ProtobufApis.databaseDriverV1.connectionInit(connectionInitRequest);
+      WrapperIdentity identity = wrapperIdentity();
+      coreDriverApi.connectionInit(connHandle, dbHandle, identity);
 
       this.databaseHandle = dbHandle;
       this.connectionHandle = connHandle;
-    } catch (DatabaseDriverService.ServiceException | TransportException e) {
-      releaseHandlesQuietly(connHandle, dbHandle);
-      throw new SQLException(e);
+    } catch (SQLException e) {
+      releaseHandlesQuietly(coreDriverApi, connHandle, dbHandle);
+      throw e;
     }
   }
 
-  private void setOptions(ConnectionHandle connHandle, Properties connectionOptions) {
+  private WrapperIdentity wrapperIdentity() {
+    Builder identityBuilder =
+        WrapperIdentity.newBuilder()
+            .setDriverName("JDBC")
+            .setDriverVersion(determineClientAppVersion());
+    String runtimeName = System.getProperty("java.vm.name");
+    if (runtimeName != null && !runtimeName.trim().isEmpty()) {
+      identityBuilder.setLanguageRuntime(runtimeName);
+    }
+    String runtimeVersion = System.getProperty("java.version");
+    if (runtimeVersion != null && !runtimeVersion.trim().isEmpty()) {
+      identityBuilder.setLanguageVersion(runtimeVersion);
+    }
+    return identityBuilder.build();
+  }
+
+  private void setOptions(ConnectionHandle connHandle, Properties connectionOptions)
+      throws SQLException {
     Map<String, ConfigSetting> optionsMap = new HashMap<>();
 
     // JDBC convention: Connection.close() must not throw on logout failure.
@@ -135,11 +127,7 @@ public class SnowflakeConnectionImpl implements SnowflakeConnection, Connection 
 
     if (!optionsMap.isEmpty()) {
       ConnectionSetOptionsResponse response =
-          ProtobufApis.databaseDriverV1.connectionSetOptions(
-              ConnectionSetOptionsRequest.newBuilder()
-                  .setConnHandle(connHandle)
-                  .putAllOptions(optionsMap)
-                  .build());
+          coreDriverApi.connectionSetOptions(connHandle, optionsMap);
       logConnectionOptionWarnings(response);
     }
   }
@@ -230,39 +218,38 @@ public class SnowflakeConnectionImpl implements SnowflakeConnection, Connection 
     throw new NotImplementedException();
   }
 
+  // TODO: track open statements and close them here (+ implement Statement.close() →
+  // statementRelease)
   @Override
   public void close() throws SQLException {
-    // TODO: track open statements and close them here (+ implement stmt close & release)
     if (!closed.compareAndSet(false, true)) {
       return;
     }
     logger.debug("Closing connection");
     try {
-      ProtobufApis.databaseDriverV1.connectionClose(
-          ConnectionCloseRequest.newBuilder().setConnHandle(connectionHandle).build());
-    } catch (DatabaseDriverService.ServiceException | TransportException e) {
+      coreDriverApi.connectionClose(connectionHandle);
+    } catch (SQLException e) {
       logger.warn("Error during connection close: {}", e.getMessage());
       logger.debug("Connection close error details", e);
-      throw new SQLException(e);
+      throw e;
     } finally {
-      releaseHandlesQuietly(connectionHandle, databaseHandle);
+      releaseHandlesQuietly(coreDriverApi, connectionHandle, databaseHandle);
     }
   }
 
-  private static void releaseHandlesQuietly(ConnectionHandle connHandle, DatabaseHandle dbHandle) {
+  private static void releaseHandlesQuietly(
+      CoreDriverApi driver, ConnectionHandle connHandle, DatabaseHandle dbHandle) {
     if (connHandle != null) {
       try {
-        ProtobufApis.databaseDriverV1.connectionRelease(
-            ConnectionReleaseRequest.newBuilder().setConnHandle(connHandle).build());
-      } catch (DatabaseDriverService.ServiceException | TransportException e) {
+        driver.connectionRelease(connHandle);
+      } catch (SQLException e) {
         logger.debug("Error releasing connection handle", e);
       }
     }
     if (dbHandle != null) {
       try {
-        ProtobufApis.databaseDriverV1.databaseRelease(
-            DatabaseReleaseRequest.newBuilder().setDbHandle(dbHandle).build());
-      } catch (DatabaseDriverService.ServiceException | TransportException e) {
+        driver.databaseRelease(dbHandle);
+      } catch (SQLException e) {
         logger.debug("Error releasing database handle", e);
       }
     }

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakeStatementImpl.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakeStatementImpl.java
@@ -19,23 +19,15 @@ import net.snowflake.client.internal.api.implementation.resultset.SnowflakeResul
 import net.snowflake.client.internal.log.SFLogger;
 import net.snowflake.client.internal.log.SFLoggerFactory;
 import net.snowflake.client.internal.unicore.ProtobufApis;
-import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverService;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConfigSetting;
-import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionGetResultSetRequest;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ExecuteQueryResponse;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.MultiStatementResult;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.QueryBindings;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetDescriptor;
-import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetGetStreamRequest;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetGetStreamResponse;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetHandle;
-import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetReleaseRequest;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetResponse;
-import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementExecuteQueryRequest;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementHandle;
-import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementNewRequest;
-import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementSetOptionsRequest;
-import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementSetSqlQueryRequest;
 
 public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
   private static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeStatementImpl.class);
@@ -56,12 +48,10 @@ public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
 
   public SnowflakeStatementImpl(SnowflakeConnectionImpl connection) {
     this.connection = connection;
-    StatementNewRequest statementNewRequest =
-        StatementNewRequest.newBuilder().setConnHandle(connection.connectionHandle).build();
     try {
       this.statementHandle =
-          ProtobufApis.databaseDriverV1.statementNew(statementNewRequest).getStmtHandle();
-    } catch (DatabaseDriverService.ServiceException e) {
+          ProtobufApis.coreDriverApi.statementNew(connection.connectionHandle).getStmtHandle();
+    } catch (SQLException e) {
       throw new RuntimeException(e);
     }
   }
@@ -100,51 +90,15 @@ public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
     boolean hasBindings = bindings != null;
     logger.debug("Statement executeWithBindings start: sql={}, hasBindings={}", sql, hasBindings);
     prepareForExecution();
-    StatementSetSqlQueryRequest statementSetSqlQueryRequest =
-        StatementSetSqlQueryRequest.newBuilder()
-            .setStmtHandle(statementHandle)
-            .setQuery(sql)
-            .build();
-    try {
-      ProtobufApis.databaseDriverV1.statementSetSqlQuery(statementSetSqlQueryRequest);
-    } catch (DatabaseDriverService.ServiceException e) {
-      logger.warn("statementSetSqlQuery failed: sql={}, hasBindings={}", sql, hasBindings, e);
-      throw SnowflakeSQLException.fromServiceException("Failed to set SQL query on statement", e);
-    }
-
-    StatementExecuteQueryRequest.Builder executeQueryRequestBuilder =
-        StatementExecuteQueryRequest.newBuilder().setStmtHandle(statementHandle);
-    if (bindings != null) {
-      executeQueryRequestBuilder.setBindings(bindings);
-    }
-    StatementExecuteQueryRequest executeQueryRequest = executeQueryRequestBuilder.build();
-    logger.debug(
-        "statementExecuteQuery request prepared: hasBindings={}, requestBytes={}",
-        hasBindings,
-        executeQueryRequest.getSerializedSize());
-    try {
-      ExecuteQueryResponse response =
-          ProtobufApis.databaseDriverV1.statementExecuteQuery(executeQueryRequest);
-      logger.debug("statementExecuteQuery succeeded: hasBindings={}", hasBindings);
-      return response;
-    } catch (DatabaseDriverService.ServiceException e) {
-      logger.warn("statementExecuteQuery failed: hasBindings={}", hasBindings, e);
-      throw SnowflakeSQLException.fromServiceException("Failed to execute statement query", e);
-    }
+    ProtobufApis.coreDriverApi.statementSetSqlQuery(statementHandle, sql);
+    ExecuteQueryResponse response =
+        ProtobufApis.coreDriverApi.statementExecuteQuery(statementHandle, bindings);
+    logger.debug("statementExecuteQuery succeeded: hasBindings={}", hasBindings);
+    return response;
   }
 
   private ResultSetResponse fetchResultSetByQueryId(String queryId) throws SQLException {
-    ConnectionGetResultSetRequest request =
-        ConnectionGetResultSetRequest.newBuilder()
-            .setConnHandle(connection.connectionHandle)
-            .setQueryId(queryId)
-            .build();
-    try {
-      return ProtobufApis.databaseDriverV1.connectionGetResultSet(request);
-    } catch (DatabaseDriverService.ServiceException e) {
-      throw SnowflakeSQLException.fromServiceException(
-          "Failed to fetch result set for query ID: " + queryId, e);
-    }
+    return ProtobufApis.coreDriverApi.connectionGetResultSet(connection.connectionHandle, queryId);
   }
 
   /**
@@ -155,24 +109,20 @@ public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
    */
   private ResultSetGetStreamResponse fetchStreamAndRelease(ResultSetHandle handle)
       throws SQLException {
-    ResultSetGetStreamRequest request =
-        ResultSetGetStreamRequest.newBuilder().setResultSetHandle(handle).build();
     try {
-      ResultSetGetStreamResponse response =
-          ProtobufApis.databaseDriverV1.resultSetGetStream(request);
+      ResultSetGetStreamResponse response = ProtobufApis.coreDriverApi.resultSetGetStream(handle);
       releaseResultSet(handle);
       return response;
-    } catch (DatabaseDriverService.ServiceException e) {
+    } catch (SQLException e) {
       releaseResultSet(handle);
-      throw SnowflakeSQLException.fromServiceException("Failed to fetch Arrow stream", e);
+      throw e;
     }
   }
 
   private void releaseResultSet(ResultSetHandle handle) {
     try {
-      ProtobufApis.databaseDriverV1.resultSetRelease(
-          ResultSetReleaseRequest.newBuilder().setResultSetHandle(handle).build());
-    } catch (DatabaseDriverService.ServiceException e) {
+      ProtobufApis.coreDriverApi.resultSetRelease(handle);
+    } catch (SQLException e) {
       logger.warn("Failed to release ResultSet handle", e);
     }
   }
@@ -633,24 +583,14 @@ public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
   @Override
   public void setParameter(String name, Object value) throws SQLException {
     checkClosed();
-    try {
-      ConfigSetting.Builder settingBuilder = ConfigSetting.newBuilder();
-      if (value instanceof Number) {
-        settingBuilder.setIntValue(((Number) value).longValue());
-      } else {
-        settingBuilder.setStringValue(String.valueOf(value));
-      }
-
-      StatementSetOptionsRequest request =
-          StatementSetOptionsRequest.newBuilder()
-              .setStmtHandle(statementHandle)
-              .putOptions(name, settingBuilder.build())
-              .build();
-      ProtobufApis.databaseDriverV1.statementSetOptions(request);
-    } catch (DatabaseDriverService.ServiceException e) {
-      throw SnowflakeSQLException.fromServiceException(
-          "Failed to set statement parameter: " + name, e);
+    ConfigSetting.Builder settingBuilder = ConfigSetting.newBuilder();
+    if (value instanceof Number) {
+      settingBuilder.setIntValue(((Number) value).longValue());
+    } else {
+      settingBuilder.setStringValue(String.valueOf(value));
     }
+    ProtobufApis.coreDriverApi.statementSetOptions(
+        statementHandle, Collections.singletonMap(name, settingBuilder.build()));
   }
 
   @Override

--- a/jdbc/src/main/java/net/snowflake/client/internal/unicore/CoreDriverApi.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/unicore/CoreDriverApi.java
@@ -1,0 +1,145 @@
+package net.snowflake.client.internal.unicore;
+
+import java.sql.SQLException;
+import java.util.Map;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConfigSetting;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionAbortQueryResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionCloseResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionGetAllParametersResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionGetInfoResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionGetParameterResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionGetQueryStatusResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionHandle;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionHeartbeatResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionInitResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionIsClosedResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionNewResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionReleaseResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionSendHttpRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionSendHttpResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionSetOptionsResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionSetSessionParametersResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionTokenResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseHandle;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseInitResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseNewResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseReleaseResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ExecuteQueryResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.QueryBindings;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetGetChunksResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetGetStreamResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetHandle;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetReleaseResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementExecuteAsyncResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementHandle;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementNewResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementPrepareResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementReleaseResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementSetOptionsResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementSetSqlQueryResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.TelemetrySendResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.TokenRequestType;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.WrapperIdentity;
+
+public interface CoreDriverApi {
+
+  // Database lifecycle
+
+  DatabaseNewResponse databaseNew() throws SQLException;
+
+  DatabaseInitResponse databaseInit(DatabaseHandle dbHandle) throws SQLException;
+
+  DatabaseReleaseResponse databaseRelease(DatabaseHandle dbHandle) throws SQLException;
+
+  // Connection lifecycle
+
+  ConnectionNewResponse connectionNew() throws SQLException;
+
+  ConnectionInitResponse connectionInit(
+      ConnectionHandle connHandle, DatabaseHandle dbHandle, WrapperIdentity wrapperIdentity)
+      throws SQLException;
+
+  ConnectionSetOptionsResponse connectionSetOptions(
+      ConnectionHandle connHandle, Map<String, ConfigSetting> options) throws SQLException;
+
+  ConnectionSetSessionParametersResponse connectionSetSessionParameters(
+      ConnectionHandle connHandle, Map<String, String> parameters) throws SQLException;
+
+  ConnectionCloseResponse connectionClose(ConnectionHandle connHandle) throws SQLException;
+
+  ConnectionReleaseResponse connectionRelease(ConnectionHandle connHandle) throws SQLException;
+
+  ConnectionIsClosedResponse connectionIsClosed(ConnectionHandle connHandle) throws SQLException;
+
+  ConnectionHeartbeatResponse connectionHeartbeat(ConnectionHandle connHandle) throws SQLException;
+
+  ConnectionGetInfoResponse connectionGetInfo(
+      ConnectionHandle connHandle, boolean includeMasterToken) throws SQLException;
+
+  ConnectionGetQueryStatusResponse connectionGetQueryStatus(
+      ConnectionHandle connHandle, String queryId) throws SQLException;
+
+  // Connection data & queries
+
+  ResultSetResponse connectionGetResultSet(ConnectionHandle connHandle, String queryId)
+      throws SQLException;
+
+  ExecuteQueryResponse connectionGetQueryResult(ConnectionHandle connHandle, String queryId)
+      throws SQLException;
+
+  ConnectionAbortQueryResponse connectionAbortQuery(ConnectionHandle connHandle, String queryId)
+      throws SQLException;
+
+  ConnectionSendHttpResponse connectionSendHttp(ConnectionSendHttpRequest request)
+      throws SQLException;
+
+  // Connection tokens & parameters
+
+  ConnectionTokenResponse connectionRequestToken(
+      ConnectionHandle connHandle, TokenRequestType requestType) throws SQLException;
+
+  ConnectionGetParameterResponse connectionGetParameter(ConnectionHandle connHandle, String key)
+      throws SQLException;
+
+  ConnectionGetAllParametersResponse connectionGetAllParameters(ConnectionHandle connHandle)
+      throws SQLException;
+
+  // Statement lifecycle
+
+  StatementNewResponse statementNew(ConnectionHandle connHandle) throws SQLException;
+
+  StatementSetSqlQueryResponse statementSetSqlQuery(StatementHandle stmtHandle, String sql)
+      throws SQLException;
+
+  StatementPrepareResponse statementPrepare(StatementHandle stmtHandle) throws SQLException;
+
+  StatementSetOptionsResponse statementSetOptions(
+      StatementHandle stmtHandle, Map<String, ConfigSetting> options) throws SQLException;
+
+  ExecuteQueryResponse statementExecuteQuery(StatementHandle stmtHandle, QueryBindings bindings)
+      throws SQLException;
+
+  StatementExecuteAsyncResponse statementExecuteAsync(
+      StatementHandle stmtHandle, QueryBindings bindings) throws SQLException;
+
+  StatementReleaseResponse statementRelease(StatementHandle stmtHandle) throws SQLException;
+
+  // Result set
+
+  ResultSetGetStreamResponse resultSetGetStream(ResultSetHandle resultSetHandle)
+      throws SQLException;
+
+  ResultSetGetChunksResponse resultSetGetChunks(ResultSetHandle resultSetHandle)
+      throws SQLException;
+
+  ResultSetReleaseResponse resultSetRelease(ResultSetHandle resultSetHandle) throws SQLException;
+
+  // Telemetry
+
+  TelemetrySendResponse telemetrySendApiUsage(ConnectionHandle connHandle, String apiMethod)
+      throws SQLException;
+
+  TelemetrySendResponse telemetrySendWrapperError(
+      ConnectionHandle connHandle, String exceptionType, String errorSource) throws SQLException;
+}

--- a/jdbc/src/main/java/net/snowflake/client/internal/unicore/CoreDriverApiImpl.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/unicore/CoreDriverApiImpl.java
@@ -1,0 +1,395 @@
+package net.snowflake.client.internal.unicore;
+
+import java.sql.SQLException;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import net.snowflake.client.api.exception.SnowflakeSQLException;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverService;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConfigSetting;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionAbortQueryRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionAbortQueryResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionCloseRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionCloseResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionGetAllParametersRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionGetAllParametersResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionGetInfoRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionGetInfoResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionGetParameterRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionGetParameterResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionGetQueryResultRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionGetQueryStatusRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionGetQueryStatusResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionGetResultSetRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionHandle;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionHeartbeatRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionHeartbeatResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionInitRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionInitResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionIsClosedRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionIsClosedResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionNewRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionNewResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionReleaseRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionReleaseResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionSendHttpRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionSendHttpResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionSetOptionsRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionSetOptionsResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionSetSessionParametersRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionSetSessionParametersResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionTokenRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionTokenResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseHandle;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseInitRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseInitResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseNewRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseNewResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseReleaseRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseReleaseResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ExecuteQueryResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.QueryBindings;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetGetChunksRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetGetChunksResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetGetStreamRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetGetStreamResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetHandle;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetReleaseRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetReleaseResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementExecuteAsyncRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementExecuteAsyncResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementExecuteQueryRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementHandle;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementNewRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementNewResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementPrepareRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementPrepareResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementReleaseRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementReleaseResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementSetOptionsRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementSetOptionsResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementSetSqlQueryRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementSetSqlQueryResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.TelemetrySendApiUsageRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.TelemetrySendResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.TelemetrySendWrapperErrorRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.TokenRequestType;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.WrapperIdentity;
+
+/**
+ * Facade over {@link DatabaseDriverService} that encapsulates protobuf request construction and
+ * provides centralized error conversion from core driver exceptions to {@link SQLException}.
+ *
+ * <p>Callers interact with domain-level parameters (handles, strings, maps) and never need to
+ * import or construct {@code *Request} protobuf objects directly.
+ */
+@RequiredArgsConstructor
+class CoreDriverApiImpl implements CoreDriverApi {
+
+  private final DatabaseDriverService client;
+
+  // =========================================================================
+  // Database lifecycle
+  // =========================================================================
+
+  public DatabaseNewResponse databaseNew() throws SQLException {
+    DatabaseNewRequest request = DatabaseNewRequest.getDefaultInstance();
+    return invoke(() -> client.databaseNew(request));
+  }
+
+  public DatabaseInitResponse databaseInit(DatabaseHandle dbHandle) throws SQLException {
+    DatabaseInitRequest request = DatabaseInitRequest.newBuilder().setDbHandle(dbHandle).build();
+    return invoke(() -> client.databaseInit(request));
+  }
+
+  public DatabaseReleaseResponse databaseRelease(DatabaseHandle dbHandle) throws SQLException {
+    DatabaseReleaseRequest request =
+        DatabaseReleaseRequest.newBuilder().setDbHandle(dbHandle).build();
+    return invoke(() -> client.databaseRelease(request));
+  }
+
+  // =========================================================================
+  // Connection lifecycle
+  // =========================================================================
+
+  public ConnectionNewResponse connectionNew() throws SQLException {
+    ConnectionNewRequest request = ConnectionNewRequest.getDefaultInstance();
+    return invoke(() -> client.connectionNew(request));
+  }
+
+  public ConnectionInitResponse connectionInit(
+      ConnectionHandle connHandle, DatabaseHandle dbHandle, WrapperIdentity wrapperIdentity)
+      throws SQLException {
+    ConnectionInitRequest request =
+        ConnectionInitRequest.newBuilder()
+            .setConnHandle(connHandle)
+            .setDbHandle(dbHandle)
+            .setWrapperIdentity(wrapperIdentity)
+            .build();
+    return invoke(() -> client.connectionInit(request));
+  }
+
+  public ConnectionSetOptionsResponse connectionSetOptions(
+      ConnectionHandle connHandle, Map<String, ConfigSetting> options) throws SQLException {
+    ConnectionSetOptionsRequest request =
+        ConnectionSetOptionsRequest.newBuilder()
+            .setConnHandle(connHandle)
+            .putAllOptions(options)
+            .build();
+    return invoke(() -> client.connectionSetOptions(request));
+  }
+
+  public ConnectionSetSessionParametersResponse connectionSetSessionParameters(
+      ConnectionHandle connHandle, Map<String, String> parameters) throws SQLException {
+    ConnectionSetSessionParametersRequest request =
+        ConnectionSetSessionParametersRequest.newBuilder()
+            .setConnHandle(connHandle)
+            .putAllParameters(parameters)
+            .build();
+    return invoke(() -> client.connectionSetSessionParameters(request));
+  }
+
+  public ConnectionCloseResponse connectionClose(ConnectionHandle connHandle) throws SQLException {
+    ConnectionCloseRequest request =
+        ConnectionCloseRequest.newBuilder().setConnHandle(connHandle).build();
+    return invoke(() -> client.connectionClose(request));
+  }
+
+  public ConnectionReleaseResponse connectionRelease(ConnectionHandle connHandle)
+      throws SQLException {
+    ConnectionReleaseRequest request =
+        ConnectionReleaseRequest.newBuilder().setConnHandle(connHandle).build();
+    return invoke(() -> client.connectionRelease(request));
+  }
+
+  public ConnectionIsClosedResponse connectionIsClosed(ConnectionHandle connHandle)
+      throws SQLException {
+    ConnectionIsClosedRequest request =
+        ConnectionIsClosedRequest.newBuilder().setConnHandle(connHandle).build();
+    return invoke(() -> client.connectionIsClosed(request));
+  }
+
+  public ConnectionHeartbeatResponse connectionHeartbeat(ConnectionHandle connHandle)
+      throws SQLException {
+    ConnectionHeartbeatRequest request =
+        ConnectionHeartbeatRequest.newBuilder().setConnHandle(connHandle).build();
+    return invoke(() -> client.connectionHeartbeat(request));
+  }
+
+  public ConnectionGetInfoResponse connectionGetInfo(
+      ConnectionHandle connHandle, boolean includeMasterToken) throws SQLException {
+    ConnectionGetInfoRequest request =
+        ConnectionGetInfoRequest.newBuilder()
+            .setConnHandle(connHandle)
+            .setIncludeMasterToken(includeMasterToken)
+            .build();
+    return invoke(() -> client.connectionGetInfo(request));
+  }
+
+  public ConnectionGetQueryStatusResponse connectionGetQueryStatus(
+      ConnectionHandle connHandle, String queryId) throws SQLException {
+    ConnectionGetQueryStatusRequest request =
+        ConnectionGetQueryStatusRequest.newBuilder()
+            .setConnHandle(connHandle)
+            .setQueryId(queryId)
+            .build();
+    return invoke(() -> client.connectionGetQueryStatus(request));
+  }
+
+  // =========================================================================
+  // Connection data & queries
+  // =========================================================================
+
+  public ResultSetResponse connectionGetResultSet(ConnectionHandle connHandle, String queryId)
+      throws SQLException {
+    ConnectionGetResultSetRequest request =
+        ConnectionGetResultSetRequest.newBuilder()
+            .setConnHandle(connHandle)
+            .setQueryId(queryId)
+            .build();
+    return invoke(() -> client.connectionGetResultSet(request));
+  }
+
+  public ExecuteQueryResponse connectionGetQueryResult(ConnectionHandle connHandle, String queryId)
+      throws SQLException {
+    ConnectionGetQueryResultRequest request =
+        ConnectionGetQueryResultRequest.newBuilder()
+            .setConnHandle(connHandle)
+            .setQueryId(queryId)
+            .build();
+    return invoke(() -> client.connectionGetQueryResult(request));
+  }
+
+  public ConnectionAbortQueryResponse connectionAbortQuery(
+      ConnectionHandle connHandle, String queryId) throws SQLException {
+    ConnectionAbortQueryRequest request =
+        ConnectionAbortQueryRequest.newBuilder()
+            .setConnHandle(connHandle)
+            .setQueryId(queryId)
+            .build();
+    return invoke(() -> client.connectionAbortQuery(request));
+  }
+
+  public ConnectionSendHttpResponse connectionSendHttp(ConnectionSendHttpRequest request)
+      throws SQLException {
+    return invoke(() -> client.connectionSendHttp(request));
+  }
+
+  // =========================================================================
+  // Connection tokens & parameters
+  // =========================================================================
+
+  public ConnectionTokenResponse connectionRequestToken(
+      ConnectionHandle connHandle, TokenRequestType requestType) throws SQLException {
+    ConnectionTokenRequest request =
+        ConnectionTokenRequest.newBuilder()
+            .setConnHandle(connHandle)
+            .setRequestType(requestType)
+            .build();
+    return invoke(() -> client.connectionRequestToken(request));
+  }
+
+  public ConnectionGetParameterResponse connectionGetParameter(
+      ConnectionHandle connHandle, String key) throws SQLException {
+    ConnectionGetParameterRequest request =
+        ConnectionGetParameterRequest.newBuilder().setConnHandle(connHandle).setKey(key).build();
+    return invoke(() -> client.connectionGetParameter(request));
+  }
+
+  public ConnectionGetAllParametersResponse connectionGetAllParameters(ConnectionHandle connHandle)
+      throws SQLException {
+    ConnectionGetAllParametersRequest request =
+        ConnectionGetAllParametersRequest.newBuilder().setConnHandle(connHandle).build();
+    return invoke(() -> client.connectionGetAllParameters(request));
+  }
+
+  // =========================================================================
+  // Statement lifecycle
+  // =========================================================================
+
+  public StatementNewResponse statementNew(ConnectionHandle connHandle) throws SQLException {
+    StatementNewRequest request =
+        StatementNewRequest.newBuilder().setConnHandle(connHandle).build();
+    return invoke(() -> client.statementNew(request));
+  }
+
+  public StatementSetSqlQueryResponse statementSetSqlQuery(StatementHandle stmtHandle, String sql)
+      throws SQLException {
+    StatementSetSqlQueryRequest request =
+        StatementSetSqlQueryRequest.newBuilder().setStmtHandle(stmtHandle).setQuery(sql).build();
+    return invoke(() -> client.statementSetSqlQuery(request));
+  }
+
+  public StatementPrepareResponse statementPrepare(StatementHandle stmtHandle) throws SQLException {
+    StatementPrepareRequest request =
+        StatementPrepareRequest.newBuilder().setStmtHandle(stmtHandle).build();
+    return invoke(() -> client.statementPrepare(request));
+  }
+
+  public StatementSetOptionsResponse statementSetOptions(
+      StatementHandle stmtHandle, Map<String, ConfigSetting> options) throws SQLException {
+    StatementSetOptionsRequest request =
+        StatementSetOptionsRequest.newBuilder()
+            .setStmtHandle(stmtHandle)
+            .putAllOptions(options)
+            .build();
+    return invoke(() -> client.statementSetOptions(request));
+  }
+
+  public ExecuteQueryResponse statementExecuteQuery(
+      StatementHandle stmtHandle, QueryBindings bindings) throws SQLException {
+    StatementExecuteQueryRequest.Builder builder =
+        StatementExecuteQueryRequest.newBuilder().setStmtHandle(stmtHandle);
+    if (bindings != null) {
+      builder.setBindings(bindings);
+    }
+    StatementExecuteQueryRequest request = builder.build();
+    return invoke(() -> client.statementExecuteQuery(request));
+  }
+
+  public StatementExecuteAsyncResponse statementExecuteAsync(
+      StatementHandle stmtHandle, QueryBindings bindings) throws SQLException {
+    StatementExecuteAsyncRequest.Builder builder =
+        StatementExecuteAsyncRequest.newBuilder().setStmtHandle(stmtHandle);
+    if (bindings != null) {
+      builder.setBindings(bindings);
+    }
+    StatementExecuteAsyncRequest request = builder.build();
+    return invoke(() -> client.statementExecuteAsync(request));
+  }
+
+  public StatementReleaseResponse statementRelease(StatementHandle stmtHandle) throws SQLException {
+    StatementReleaseRequest request =
+        StatementReleaseRequest.newBuilder().setStmtHandle(stmtHandle).build();
+    return invoke(() -> client.statementRelease(request));
+  }
+
+  // =========================================================================
+  // Result set
+  // =========================================================================
+
+  public ResultSetGetStreamResponse resultSetGetStream(ResultSetHandle resultSetHandle)
+      throws SQLException {
+    ResultSetGetStreamRequest request =
+        ResultSetGetStreamRequest.newBuilder().setResultSetHandle(resultSetHandle).build();
+    return invoke(() -> client.resultSetGetStream(request));
+  }
+
+  public ResultSetGetChunksResponse resultSetGetChunks(ResultSetHandle resultSetHandle)
+      throws SQLException {
+    ResultSetGetChunksRequest request =
+        ResultSetGetChunksRequest.newBuilder().setResultSetHandle(resultSetHandle).build();
+    return invoke(() -> client.resultSetGetChunks(request));
+  }
+
+  public ResultSetReleaseResponse resultSetRelease(ResultSetHandle resultSetHandle)
+      throws SQLException {
+    ResultSetReleaseRequest request =
+        ResultSetReleaseRequest.newBuilder().setResultSetHandle(resultSetHandle).build();
+    return invoke(() -> client.resultSetRelease(request));
+  }
+
+  // =========================================================================
+  // Telemetry
+  // =========================================================================
+
+  public TelemetrySendResponse telemetrySendApiUsage(ConnectionHandle connHandle, String apiMethod)
+      throws SQLException {
+    TelemetrySendApiUsageRequest request =
+        TelemetrySendApiUsageRequest.newBuilder()
+            .setConnHandle(connHandle)
+            .setApiMethod(apiMethod)
+            .build();
+    return invoke(() -> client.telemetrySendApiUsage(request));
+  }
+
+  public TelemetrySendResponse telemetrySendWrapperError(
+      ConnectionHandle connHandle, String exceptionType, String errorSource) throws SQLException {
+    TelemetrySendWrapperErrorRequest request =
+        TelemetrySendWrapperErrorRequest.newBuilder()
+            .setConnHandle(connHandle)
+            .setExceptionType(exceptionType)
+            .setErrorSource(errorSource)
+            .build();
+    return invoke(() -> client.telemetrySendWrapperError(request));
+  }
+
+  // =========================================================================
+  // Error handling
+  // =========================================================================
+
+  @FunctionalInterface
+  private interface ServiceCall<T> {
+    T call() throws DatabaseDriverService.ServiceException, TransportException;
+  }
+
+  private <T> T invoke(ServiceCall<T> callable) throws SQLException {
+    try {
+      return callable.call();
+    } catch (DatabaseDriverService.ServiceException e) {
+      throw SnowflakeSQLException.fromServiceException(e);
+    } catch (TransportException e) {
+      throw new SQLException("Driver communication error: " + e.getMessage(), e);
+    }
+  }
+}

--- a/jdbc/src/main/java/net/snowflake/client/internal/unicore/ProtobufApis.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/unicore/ProtobufApis.java
@@ -1,9 +1,9 @@
 package net.snowflake.client.internal.unicore;
 
-import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverService;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverServiceClient;
 
 public class ProtobufApis {
-  public static DatabaseDriverService databaseDriverV1 =
-      new DatabaseDriverServiceClient(new JNICoreTransport());
+
+  public static CoreDriverApi coreDriverApi =
+      new CoreDriverApiImpl(new DatabaseDriverServiceClient(new JNICoreTransport()));
 }

--- a/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/connection/SnowflakeConnectionImplTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/connection/SnowflakeConnectionImplTest.java
@@ -6,35 +6,30 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Properties;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.atomic.AtomicInteger;
-import net.snowflake.client.internal.unicore.ProtobufApis;
-import net.snowflake.client.internal.unicore.TransportException;
-import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverService;
+import net.snowflake.client.internal.unicore.CoreDriverApi;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConfigSetting;
-import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionCloseRequest;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionCloseResponse;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionHandle;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionInitResponse;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionNewResponse;
-import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionReleaseRequest;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionReleaseResponse;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionSetOptionsResponse;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseHandle;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseInitResponse;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseNewResponse;
-import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseReleaseRequest;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseReleaseResponse;
-import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DriverException;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -81,48 +76,42 @@ public class SnowflakeConnectionImplTest {
   @Nested
   class Close {
 
-    private DatabaseDriverService originalClient;
-    private DatabaseDriverService mockClient;
+    private final DatabaseHandle dbHandle =
+        DatabaseHandle.newBuilder().setId(1).setMagic(100).build();
+    private final ConnectionHandle connHandle =
+        ConnectionHandle.newBuilder().setId(2).setMagic(200).build();
+
+    private CoreDriverApi mockCoreApi;
 
     @BeforeEach
-    void setUp() {
-      originalClient = ProtobufApis.databaseDriverV1;
-      mockClient = mock(DatabaseDriverService.class);
-      ProtobufApis.databaseDriverV1 = mockClient;
-    }
-
-    @AfterEach
-    void tearDown() {
-      ProtobufApis.databaseDriverV1 = originalClient;
+    void setUp() throws Exception {
+      mockCoreApi = mock(CoreDriverApi.class);
+      when(mockCoreApi.databaseNew())
+          .thenReturn(DatabaseNewResponse.newBuilder().setDbHandle(dbHandle).build());
+      when(mockCoreApi.databaseInit(any())).thenReturn(DatabaseInitResponse.getDefaultInstance());
+      when(mockCoreApi.connectionNew())
+          .thenReturn(ConnectionNewResponse.newBuilder().setConnHandle(connHandle).build());
+      when(mockCoreApi.connectionSetOptions(any(), any()))
+          .thenReturn(ConnectionSetOptionsResponse.getDefaultInstance());
+      when(mockCoreApi.connectionInit(any(), any(), any()))
+          .thenReturn(ConnectionInitResponse.getDefaultInstance());
     }
 
     private SnowflakeConnectionImpl createConnection() throws SQLException {
-      DatabaseHandle dbHandle = DatabaseHandle.newBuilder().setId(1).setMagic(100).build();
-      ConnectionHandle connHandle = ConnectionHandle.newBuilder().setId(2).setMagic(200).build();
-
-      when(mockClient.databaseNew(any()))
-          .thenReturn(DatabaseNewResponse.newBuilder().setDbHandle(dbHandle).build());
-      when(mockClient.databaseInit(any())).thenReturn(DatabaseInitResponse.getDefaultInstance());
-      when(mockClient.connectionNew(any()))
-          .thenReturn(ConnectionNewResponse.newBuilder().setConnHandle(connHandle).build());
-      when(mockClient.connectionSetOptions(any()))
-          .thenReturn(ConnectionSetOptionsResponse.getDefaultInstance());
-      when(mockClient.connectionInit(any()))
-          .thenReturn(ConnectionInitResponse.getDefaultInstance());
-
       Properties props = new Properties();
       props.setProperty("account", "test_account");
       props.setProperty("user", "test_user");
       props.setProperty("password", "test_password");
-      return new SnowflakeConnectionImpl("jdbc:snowflake://test.snowflakecomputing.com", props);
+      return new SnowflakeConnectionImpl(
+          "jdbc:snowflake://test.snowflakecomputing.com", props, mockCoreApi);
     }
 
-    private void stubSuccessfulClose() {
-      when(mockClient.connectionClose(any()))
+    private void stubSuccessfulClose() throws Exception {
+      when(mockCoreApi.connectionClose(any()))
           .thenReturn(ConnectionCloseResponse.getDefaultInstance());
-      when(mockClient.connectionRelease(any()))
+      when(mockCoreApi.connectionRelease(any()))
           .thenReturn(ConnectionReleaseResponse.getDefaultInstance());
-      when(mockClient.databaseRelease(any()))
+      when(mockCoreApi.databaseRelease(any()))
           .thenReturn(DatabaseReleaseResponse.getDefaultInstance());
     }
 
@@ -130,19 +119,19 @@ public class SnowflakeConnectionImplTest {
     void sendsConnectionCloseAndReleasesHandles() throws Exception {
       stubSuccessfulClose();
 
-      SnowflakeConnectionImpl conn = createConnection();
+      Connection conn = createConnection();
       conn.close();
 
-      verify(mockClient).connectionClose(any(ConnectionCloseRequest.class));
-      verify(mockClient).connectionRelease(any(ConnectionReleaseRequest.class));
-      verify(mockClient).databaseRelease(any(DatabaseReleaseRequest.class));
+      verify(mockCoreApi).connectionClose(any());
+      verify(mockCoreApi).connectionRelease(any());
+      verify(mockCoreApi).databaseRelease(any());
     }
 
     @Test
     void isClosedReturnsTrueAfterClose() throws Exception {
       stubSuccessfulClose();
 
-      SnowflakeConnectionImpl conn = createConnection();
+      Connection conn = createConnection();
       assertFalse(conn.isClosed());
 
       conn.close();
@@ -153,54 +142,37 @@ public class SnowflakeConnectionImplTest {
     void isIdempotent() throws Exception {
       stubSuccessfulClose();
 
-      SnowflakeConnectionImpl conn = createConnection();
+      Connection conn = createConnection();
       conn.close();
       conn.close();
       conn.close();
 
-      verify(mockClient, times(1)).connectionClose(any());
-      verify(mockClient, times(1)).connectionRelease(any());
-      verify(mockClient, times(1)).databaseRelease(any());
+      verify(mockCoreApi, times(1)).connectionClose(any());
+      verify(mockCoreApi, times(1)).connectionRelease(any());
+      verify(mockCoreApi, times(1)).databaseRelease(any());
     }
 
     @Test
-    void releasesHandlesEvenWhenConnectionCloseThrowsTransportException() throws Exception {
-      when(mockClient.connectionClose(any())).thenThrow(new TransportException("network error"));
-      when(mockClient.connectionRelease(any()))
+    void releasesHandlesEvenWhenConnectionCloseThrows() throws Exception {
+      when(mockCoreApi.connectionClose(any())).thenThrow(new SQLException("server error"));
+      when(mockCoreApi.connectionRelease(any()))
           .thenReturn(ConnectionReleaseResponse.getDefaultInstance());
-      when(mockClient.databaseRelease(any()))
+      when(mockCoreApi.databaseRelease(any()))
           .thenReturn(DatabaseReleaseResponse.getDefaultInstance());
 
-      SnowflakeConnectionImpl conn = createConnection();
+      Connection conn = createConnection();
       assertThrows(SQLException.class, conn::close);
 
-      verify(mockClient).connectionRelease(any(ConnectionReleaseRequest.class));
-      verify(mockClient).databaseRelease(any(DatabaseReleaseRequest.class));
+      verify(mockCoreApi).connectionRelease(any());
+      verify(mockCoreApi).databaseRelease(any());
       assertTrue(conn.isClosed());
-    }
-
-    @Test
-    void releasesHandlesEvenWhenConnectionCloseThrowsServiceException() throws Exception {
-      when(mockClient.connectionClose(any()))
-          .thenThrow(
-              new DatabaseDriverService.ServiceException(DriverException.getDefaultInstance()));
-      when(mockClient.connectionRelease(any()))
-          .thenReturn(ConnectionReleaseResponse.getDefaultInstance());
-      when(mockClient.databaseRelease(any()))
-          .thenReturn(DatabaseReleaseResponse.getDefaultInstance());
-
-      SnowflakeConnectionImpl conn = createConnection();
-      assertThrows(SQLException.class, conn::close);
-
-      verify(mockClient).connectionRelease(any(ConnectionReleaseRequest.class));
-      verify(mockClient).databaseRelease(any(DatabaseReleaseRequest.class));
     }
 
     @Test
     void operationsThrowAfterClose() throws Exception {
       stubSuccessfulClose();
 
-      SnowflakeConnectionImpl conn = createConnection();
+      Connection conn = createConnection();
       conn.close();
 
       assertThrows(SQLException.class, conn::createStatement);
@@ -211,7 +183,7 @@ public class SnowflakeConnectionImplTest {
     void concurrentCallsResultInSingleLogout() throws Exception {
       stubSuccessfulClose();
 
-      SnowflakeConnectionImpl conn = createConnection();
+      Connection conn = createConnection();
       int threadCount = 5;
       CyclicBarrier barrier = new CyclicBarrier(threadCount);
       AtomicInteger exceptions = new AtomicInteger(0);
@@ -235,7 +207,7 @@ public class SnowflakeConnectionImplTest {
         t.join();
       }
 
-      verify(mockClient, times(1)).connectionClose(any());
+      verify(mockCoreApi, times(1)).connectionClose(any());
       assertTrue(conn.isClosed());
       assertEquals(0, exceptions.get(), "No thread should have thrown an exception");
     }
@@ -244,15 +216,15 @@ public class SnowflakeConnectionImplTest {
     void doesNotCallRpcsWhenAlreadyClosed() throws Exception {
       stubSuccessfulClose();
 
-      SnowflakeConnectionImpl conn = createConnection();
+      Connection conn = createConnection();
       conn.close();
 
-      org.mockito.Mockito.clearInvocations(mockClient);
+      clearInvocations(mockCoreApi);
       conn.close();
 
-      verify(mockClient, never()).connectionClose(any());
-      verify(mockClient, never()).connectionRelease(any());
-      verify(mockClient, never()).databaseRelease(any());
+      verify(mockCoreApi, never()).connectionClose(any());
+      verify(mockCoreApi, never()).connectionRelease(any());
+      verify(mockCoreApi, never()).databaseRelease(any());
     }
   }
 }


### PR DESCRIPTION
## Summary

- Introduces a `CoreDriver` class that encapsulates all protobuf request construction and provides centralized error conversion (`ServiceException`/`TransportException` → `SQLException`)
- Refactors `SnowflakeConnectionImpl` and `SnowflakeStatementImpl` to use `ProtobufApis.coreDriver` singleton instead of constructing protobuf requests inline
- Removes boilerplate try/catch blocks from every call site — error handling is now in one place

## Context

Mirrors the Python `CoreDriver` pattern (`python/src/snowflake/connector/_internal/api_client/client_api.py`) where all core driver calls go through a facade that hides proto request/response details. This gives us:

- A single place to change error mapping logic
- Callers that never import `*Request` types
- Cleaner diffs when adding new core driver methods
- Simpler test mocking (mock `CoreDriver` directly)