### PR TITLE
localhost support as loopback server (#1259)

### DIFF
--- a/sf_core/src/rest/snowflake/oauth/loopback_server.rs
+++ b/sf_core/src/rest/snowflake/oauth/loopback_server.rs
@@ -5,6 +5,18 @@
 //! `0.0.0.0` bind — it widens the OAuth-window attack surface to the
 //! local network.
 //!
+//! The bind decision and the hostname we *advertise* to the IdP in
+//! `redirect_uri` are deliberately split. The listener always sits on
+//! a loopback IP literal (`127.0.0.1` or `::1`), but the advertised
+//! `redirect_uri` round-trips the user-supplied hostname when it is a
+//! loopback equivalent (`localhost`, any `127.0.0.0/8` literal, `::1`).
+//! Several IdPs — Okta among them — perform exact-string matching on
+//! the registered redirect URI per OAuth 2.0 §3.1.2.3, so rewriting
+//! `http://localhost:.../cb` to `http://127.0.0.1:.../cb` would
+//! silently break valid configurations even though the two strings
+//! address the same socket. See [`loopback_host_string_from_hint`] for
+//! the exact policy.
+//!
 //! HTTP parsing and response writing are delegated to `axum`; we keep
 //! ownership of the bind decision and the single-shot semantics
 //! (oneshot channel + graceful shutdown).
@@ -66,6 +78,33 @@ struct RedirectQuery {
     error_description: Option<String>,
 }
 
+/// Returns the host string to round-trip into the advertised
+/// `redirect_uri` when the user supplied a hint, or `None` if the hint
+/// host is not a safe loopback equivalent.
+///
+/// Safe loopback equivalents are:
+///
+/// * the literal `"localhost"` (case-insensitive — RFC 4343);
+/// * any IPv4 loopback literal (the full `127.0.0.0/8` block per
+///   RFC 1122 §3.2.1.3, e.g. `127.0.0.1`, `127.0.0.2`);
+/// * the IPv6 loopback literal `::1`.
+///
+/// Anything else (a non-loopback IP literal that was already coerced
+/// to a loopback bind by [`bind`], or an arbitrary domain name) returns
+/// `None` so the caller falls back to the IP literal of the bound
+/// socket. That fallback is what keeps a misconfigured
+/// `oauth_redirect_uri=http://attacker.example/...` from being
+/// propagated to the IdP — it still gets rewritten to `127.0.0.1`,
+/// just like before this helper existed.
+fn loopback_host_string_from_hint(hint: &Url) -> Option<String> {
+    match hint.host()? {
+        url::Host::Domain(d) if d.eq_ignore_ascii_case("localhost") => Some(d.to_string()),
+        url::Host::Ipv4(v4) if v4.is_loopback() => Some(v4.to_string()),
+        url::Host::Ipv6(v6) if v6.is_loopback() => Some(format!("[{v6}]")),
+        _ => None,
+    }
+}
+
 /// Bind a loopback HTTP listener for the OAuth callback.
 ///
 /// * If `redirect_uri_hint` is `Some`, the listener attempts to bind on
@@ -76,6 +115,12 @@ struct RedirectQuery {
 /// We only ever bind to a loopback interface (gotcha §14 #11): IPv4
 /// `127.0.0.1` by default, IPv6 `::1` only if the caller explicitly
 /// supplied an IPv6 literal in the hint.
+///
+/// The hostname surfaced in the returned `redirect_uri` is computed
+/// separately from the bind decision — see
+/// [`loopback_host_string_from_hint`] — so a `localhost`-based hint
+/// round-trips to the IdP unchanged even though the listener itself
+/// always sits on a loopback IP literal.
 pub(crate) async fn bind(redirect_uri_hint: Option<&Url>) -> Result<LoopbackBinding, OAuthError> {
     let (ip, port, path) = match redirect_uri_hint {
         Some(url) => {
@@ -117,10 +162,19 @@ pub(crate) async fn bind(redirect_uri_hint: Option<&Url>) -> Result<LoopbackBind
         .context(PortBindSnafu)?;
     let local = listener.local_addr().context(PortBindSnafu)?;
 
-    let host_for_url = match local.ip() {
-        IpAddr::V4(_) => "127.0.0.1".to_string(),
-        IpAddr::V6(_) => "[::1]".to_string(),
-    };
+    // Preserve the user-supplied hostname in the advertised redirect URI
+    // when it's a loopback equivalent (see [`loopback_host_string_from_hint`])
+    // so IdPs that do exact-string redirect_uri matching (OAuth 2.0
+    // §3.1.2.3 — e.g. Okta) accept the request. Falling back to the IP
+    // literal of the bound socket keeps the security override above
+    // intact for non-loopback hints — those are still advertised as
+    // `127.0.0.1` / `[::1]` regardless of what the caller passed in.
+    let host_for_url = redirect_uri_hint
+        .and_then(loopback_host_string_from_hint)
+        .unwrap_or_else(|| match local.ip() {
+            IpAddr::V4(_) => "127.0.0.1".to_string(),
+            IpAddr::V6(_) => "[::1]".to_string(),
+        });
     let redirect_uri = Url::parse(&format!("http://{host_for_url}:{}{path}", local.port()))
         .context(RedirectUriParseSnafu)?;
 
@@ -271,8 +325,135 @@ mod tests {
         drop(listener);
         let hint = Url::parse(&format!("http://127.0.0.1:{port}/cb")).unwrap();
         let b = bind(Some(&hint)).await.expect("bind on hint port");
+        assert_eq!(b.redirect_uri.host_str(), Some("127.0.0.1"));
         assert_eq!(b.redirect_uri.port(), Some(port));
         assert_eq!(b.redirect_uri.path(), "/cb");
+    }
+
+    #[tokio::test]
+    async fn bind_with_localhost_and_explicit_port_uses_exact_port() {
+        // The two contract guarantees for `oauth_redirect_uri`:
+        //   1. When a port is given (e.g. `http://localhost:8001/cb`),
+        //      the listener binds that exact port on the loopback
+        //      interface so it can be registered ahead of time with
+        //      the IdP.
+        //   2. When the user supplies `localhost`, the advertised
+        //      `redirect_uri` round-trips that hostname (regression
+        //      fix; previously rewritten to `127.0.0.1`).
+        //
+        // Picks a free port by binding `:0` first, then immediately
+        // releasing — racy in theory but stable enough for unit tests
+        // and faster than a fixed-port collision recovery loop.
+        let probe = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = probe.local_addr().unwrap().port();
+        drop(probe);
+
+        let hint =
+            Url::parse(&format!("http://localhost:{port}/snowflake/oauth-redirect")).unwrap();
+        let b = bind(Some(&hint)).await.expect("bind on localhost:<port>");
+        let bound = b.listener.local_addr().unwrap();
+        assert!(
+            bound.ip().is_loopback(),
+            "listener must bind a loopback interface, got {bound}",
+        );
+        assert_eq!(
+            bound.port(),
+            port,
+            "listener must honor the explicit hint port",
+        );
+        assert_eq!(b.redirect_uri.host_str(), Some("localhost"));
+        assert_eq!(b.redirect_uri.port(), Some(port));
+        assert_eq!(b.redirect_uri.path(), "/snowflake/oauth-redirect");
+    }
+
+    #[tokio::test]
+    async fn bind_without_hint_assigns_ephemeral_loopback_port() {
+        // Explicit contract: when no `oauth_redirect_uri` is configured,
+        // the listener binds `127.0.0.1:0` so the kernel picks any
+        // free ephemeral port. The advertised `redirect_uri` echoes
+        // that assigned port back so the IdP can redirect to it.
+        let b = bind(None).await.expect("bind without hint");
+        let bound = b.listener.local_addr().unwrap();
+        assert!(
+            bound.ip().is_loopback(),
+            "default bind must be on a loopback interface, got {bound}",
+        );
+        assert_ne!(bound.port(), 0, "kernel must have assigned a real port");
+        assert_eq!(b.redirect_uri.host_str(), Some("127.0.0.1"));
+        assert_eq!(b.redirect_uri.port(), Some(bound.port()));
+    }
+
+    #[tokio::test]
+    async fn bind_preserves_localhost_hostname_in_redirect_uri() {
+        // Regression: the listener used to advertise `127.0.0.1` to the
+        // IdP even when the caller supplied `localhost`, which broke
+        // OAuth 2.0 §3.1.2.3 exact-string redirect_uri matching (Okta
+        // and friends). The bind itself stays on a loopback interface;
+        // only the advertised hostname round-trips the user input.
+        let hint = Url::parse("http://localhost:0/snowflake/oauth-redirect").unwrap();
+        let b = bind(Some(&hint)).await.expect("bind on localhost hint");
+        assert_eq!(
+            b.redirect_uri.host_str(),
+            Some("localhost"),
+            "redirect_uri must round-trip the user-supplied localhost hostname",
+        );
+        assert_eq!(b.redirect_uri.path(), "/snowflake/oauth-redirect");
+        let addr = b.listener.local_addr().unwrap();
+        assert!(
+            addr.ip().is_loopback(),
+            "listener must still bind a loopback interface, got {addr}",
+        );
+    }
+
+    #[tokio::test]
+    async fn bind_preserves_localhost_hostname_case_insensitively() {
+        // `url::Url` normalises the host to lowercase already, but
+        // exercise the match arm explicitly so a future change to
+        // `url`'s normalisation behaviour cannot regress us silently.
+        let hint = Url::parse("http://LocalHost:0/cb").unwrap();
+        let b = bind(Some(&hint)).await.expect("bind on LocalHost hint");
+        assert_eq!(b.redirect_uri.host_str(), Some("localhost"));
+    }
+
+    #[tokio::test]
+    async fn bind_preserves_non_canonical_ipv4_loopback_literal() {
+        // The whole `127.0.0.0/8` block is loopback per RFC 1122; users
+        // who registered (say) `127.0.0.2` with their IdP must see the
+        // exact literal echoed back, not the canonical `127.0.0.1`.
+        // Some CI containers refuse the `127.0.0.2` bind — skip rather
+        // than fail in that case so the regression test stays useful
+        // on developer machines without flaking CI.
+        let hint = Url::parse("http://127.0.0.2:0/cb").unwrap();
+        let Ok(b) = bind(Some(&hint)).await else {
+            eprintln!("skipping: 127.0.0.2 bind unavailable on this host");
+            return;
+        };
+        assert_eq!(
+            b.redirect_uri.host_str(),
+            Some("127.0.0.2"),
+            "redirect_uri must round-trip non-canonical IPv4 loopback literal",
+        );
+    }
+
+    #[tokio::test]
+    async fn localhost_hint_end_to_end_redirect_succeeds() {
+        // Belt-and-braces: bind on `localhost`, then send a fake IdP
+        // redirect to the bound loopback socket. The handler must
+        // still pick up the code/state even though `redirect_uri`
+        // advertises `localhost` rather than the IP literal.
+        let hint = Url::parse("http://localhost:0/cb").unwrap();
+        let b = bind(Some(&hint)).await.expect("bind on localhost hint");
+        assert_eq!(b.redirect_uri.host_str(), Some("localhost"));
+        let addr = b.listener.local_addr().unwrap();
+
+        let join = tokio::spawn(async move { b.wait_for_redirect(Duration::from_secs(5)).await });
+        let mut s = TcpStream::connect(addr).await.expect("connect loopback");
+        s.write_all(b"GET /cb?code=LH-CODE&state=LH-STATE HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .await
+            .unwrap();
+        let res = join.await.unwrap().expect("wait_for_redirect");
+        assert_eq!(res.code.reveal(), "LH-CODE");
+        assert_eq!(res.state, "LH-STATE");
     }
 
     #[tokio::test]


### PR DESCRIPTION
cherry-pick oauth loopback server fix https://github.com/snowflakedb/universal-driver/commit/9be7b180e666f7b3bbaafcc188983784211082e9 