### PR TITLE
Add e2e tests for ODBC async execution

### DIFF
--- a/odbc_tests/BehaviorDifferences.yaml
+++ b/odbc_tests/BehaviorDifferences.yaml
@@ -751,3 +751,15 @@ behavior_differences:
       The new driver sends CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY to the server as a session parameter during login, making it queryable via SHOW PARAMETERS. The value is also used client-side to configure the heartbeat interval.
     impact: |
       Applications that query SHOW PARAMETERS to verify the heartbeat frequency will now see the value they configured in the connection string.
+
+  58:
+    name: "Async SQLCancel does not interrupt in-progress operations on reference driver"
+    status: unknown
+    type: bug
+    reviewed: false
+    old_driver_behavior: |
+      When SQLCancel is called on a statement that has an in-progress async operation (SQL_STILL_EXECUTING), the cancel does not actually interrupt the server-side query. Subsequent polling continues to return SQL_STILL_EXECUTING indefinitely or until the query completes naturally, rather than returning SQL_ERROR with HY008.
+    new_driver_behavior: |
+      SQLCancel on an async statement sends a cancel request to the server, and subsequent polling returns SQL_ERROR with SQLSTATE HY008 ("Operation canceled") once the cancellation is acknowledged.
+    impact: |
+      Applications that rely on SQLCancel to abort long-running async queries will not get timely cancellation on the old driver. The query may run to completion despite the cancel request.

--- a/odbc_tests/tests/e2e/CMakeLists.txt
+++ b/odbc_tests/tests/e2e/CMakeLists.txt
@@ -41,6 +41,7 @@ add_odbc_test(e2e_query_sql_bulk_operations query/sql_bulk_operations.cpp)
 add_odbc_test(e2e_query_attr_error_handling query/attr_error_handling.cpp)
 add_odbc_test(e2e_query_last_query_id query/last_query_id.cpp)
 add_odbc_test(e2e_query_sf_stmt_attrs query/sf_stmt_attrs.cpp)
+add_odbc_test(e2e_query_async_execution query/async_execution.cpp)
 
 # tls
 add_odbc_test(e2e_tls_crl_enabled tls/crl_enabled.cpp)

--- a/odbc_tests/tests/e2e/query/async_execution.cpp
+++ b/odbc_tests/tests/e2e/query/async_execution.cpp
@@ -1,0 +1,369 @@
+#include <sql.h>
+#include <sqlext.h>
+
+#include <chrono>
+#include <string>
+#include <thread>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "Connection.hpp"
+#include "compatibility.hpp"
+#include "cross_thread_cancel.hpp"
+#include "get_data.hpp"
+#include "get_diag_rec.hpp"
+#include "odbc_matchers.hpp"
+
+namespace {
+
+constexpr int kMaxPollIterations = 300;
+constexpr auto kPollInterval = std::chrono::milliseconds(100);
+
+// Long-running query that gives enough time to observe SQL_STILL_EXECUTING.
+constexpr const char* kLongQuery = "SELECT COUNT(*) FROM TABLE(GENERATOR(TIMELIMIT => 30))";
+
+// Fast query that should complete nearly instantly.
+constexpr const char* kFastQuery = "SELECT 42 AS value";
+
+SQLRETURN poll_until_complete(SQLHSTMT stmt, const char* query) {
+  int polls = 0;
+  SQLRETURN ret = SQL_STILL_EXECUTING;
+  while (ret == SQL_STILL_EXECUTING && ++polls < kMaxPollIterations) {
+    std::this_thread::sleep_for(kPollInterval);
+    ret = SQLExecDirect(stmt, (SQLCHAR*)query, SQL_NTS);
+  }
+  return ret;
+}
+
+// SQLFetch is also async-capable: with async ON it returns SQL_STILL_EXECUTING.
+// Poll by re-calling SQLFetch until it completes.
+SQLRETURN poll_fetch(SQLHSTMT stmt) {
+  int polls = 0;
+  SQLRETURN ret = SQLFetch(stmt);
+  while (ret == SQL_STILL_EXECUTING && ++polls < kMaxPollIterations) {
+    std::this_thread::sleep_for(kPollInterval);
+    ret = SQLFetch(stmt);
+  }
+  return ret;
+}
+
+}  // namespace
+
+// =============================================================================
+// ATTRIBUTE SETUP
+// =============================================================================
+
+TEST_CASE("should enable async execution on statement", "[query][async]") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_ASYNC_ENABLE is set to ON
+  SQLRETURN ret =
+      SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_ASYNC_ENABLE, reinterpret_cast<SQLPOINTER>(SQL_ASYNC_ENABLE_ON), 0);
+
+  // Then the attribute is accepted
+  REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
+}
+
+TEST_CASE("should disable async execution on statement", "[query][async]") {
+  // Given Snowflake client is logged in with async enabled
+  Connection conn;
+  auto stmt = conn.createStatement();
+  SQLRETURN ret =
+      SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_ASYNC_ENABLE, reinterpret_cast<SQLPOINTER>(SQL_ASYNC_ENABLE_ON), 0);
+  REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
+
+  // When SQL_ATTR_ASYNC_ENABLE is set to OFF
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_ASYNC_ENABLE, SQL_ASYNC_ENABLE_OFF, 0);
+
+  // Then the attribute is accepted
+  REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
+}
+
+TEST_CASE("should get async enable attribute value after setting it", "[query][async]") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQL_ATTR_ASYNC_ENABLE is set to ON and then read back
+  SQLRETURN ret =
+      SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_ASYNC_ENABLE, reinterpret_cast<SQLPOINTER>(SQL_ASYNC_ENABLE_ON), 0);
+  REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
+
+  SQLULEN value = 0;
+  ret = SQLGetStmtAttr(stmt.getHandle(), SQL_ATTR_ASYNC_ENABLE, &value, 0, nullptr);
+
+  // Then the value should be SQL_ASYNC_ENABLE_ON
+  REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
+  CHECK(value == SQL_ASYNC_ENABLE_ON);
+}
+
+TEST_CASE("should reject connection-level async with HY092", "[query][async]") {
+  // Given Snowflake client is logged in
+  Connection conn;
+
+  // When SQL_ATTR_ASYNC_DBC_FUNCTIONS_ENABLE is set on the connection handle
+  const SQLRETURN ret = SQLSetConnectAttr(conn.handleWrapper().getHandle(), SQL_ATTR_ASYNC_DBC_FUNCTIONS_ENABLE,
+                                          reinterpret_cast<SQLPOINTER>(SQL_ASYNC_DBC_ENABLE_ON), 0);
+
+  // Then the driver should reject it
+  REQUIRE(ret == SQL_ERROR);
+  CHECK(get_sqlstate(conn.handleWrapper()) == "HY092");
+}
+
+// =============================================================================
+// ASYNC EXECUTION (POLLING)
+// =============================================================================
+
+TEST_CASE("should return SQL_STILL_EXECUTING for long query", "[query][async]") {
+  // Given Snowflake client is logged in with async enabled
+  Connection conn;
+  auto stmt = conn.createStatement();
+  SQLRETURN ret =
+      SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_ASYNC_ENABLE, reinterpret_cast<SQLPOINTER>(SQL_ASYNC_ENABLE_ON), 0);
+  REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
+
+  // When a long-running query is executed
+  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)kLongQuery, SQL_NTS);
+
+  // Then the first call should return SQL_STILL_EXECUTING
+  REQUIRE(ret == SQL_STILL_EXECUTING);
+
+  // Cleanup: poll to completion so the statement is usable for teardown
+  poll_until_complete(stmt.getHandle(), kLongQuery);
+}
+
+TEST_CASE("should complete async execution via polling", "[query][async]") {
+  // Given Snowflake client is logged in with async enabled
+  Connection conn;
+  auto stmt = conn.createStatement();
+  SQLRETURN ret =
+      SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_ASYNC_ENABLE, reinterpret_cast<SQLPOINTER>(SQL_ASYNC_ENABLE_ON), 0);
+  REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
+
+  // When a query is executed and polled to completion
+  // Use a shorter query so the test doesn't take 30 seconds
+  const char* query = "SELECT COUNT(*) FROM TABLE(GENERATOR(ROWCOUNT => 1000000))";
+  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)query, SQL_NTS);
+
+  if (ret == SQL_STILL_EXECUTING) {
+    ret = poll_until_complete(stmt.getHandle(), query);
+  }
+
+  // Then the final result should indicate success
+  REQUIRE(ret != SQL_STILL_EXECUTING);
+  REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
+}
+
+TEST_CASE("should allow immediate completion with async enabled", "[query][async]") {
+  // Given Snowflake client is logged in with async enabled
+  Connection conn;
+  auto stmt = conn.createStatement();
+  SQLRETURN ret =
+      SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_ASYNC_ENABLE, reinterpret_cast<SQLPOINTER>(SQL_ASYNC_ENABLE_ON), 0);
+  REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
+
+  // When a fast query is executed
+  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)kFastQuery, SQL_NTS);
+
+  // Then the driver may return SQL_SUCCESS directly or SQL_STILL_EXECUTING
+  // (both are spec-valid — the spec says "the first call MAY complete immediately")
+  if (ret == SQL_STILL_EXECUTING) {
+    ret = poll_until_complete(stmt.getHandle(), kFastQuery);
+  }
+  REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
+
+  // And data should be retrievable (SQLFetch is also async-capable)
+  SQLRETURN fetch_ret = poll_fetch(stmt.getHandle());
+  REQUIRE_THAT(OdbcResult(fetch_ret, stmt), OdbcMatchers::Succeeded());
+
+  auto value = get_data<SQL_C_LONG>(stmt, 1);
+  CHECK(value == 42);
+}
+
+TEST_CASE("should execute and retrieve result set asynchronously", "[query][async]") {
+  // Given Snowflake client is logged in with async enabled
+  Connection conn;
+  auto stmt = conn.createStatement();
+  SQLRETURN ret =
+      SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_ASYNC_ENABLE, reinterpret_cast<SQLPOINTER>(SQL_ASYNC_ENABLE_ON), 0);
+  REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
+
+  // When a query returning multiple rows is executed asynchronously
+  const char* query = "SELECT seq4() AS id FROM TABLE(GENERATOR(ROWCOUNT => 5)) ORDER BY id";
+  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)query, SQL_NTS);
+
+  if (ret == SQL_STILL_EXECUTING) {
+    ret = poll_until_complete(stmt.getHandle(), query);
+  }
+  REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
+
+  // Then all rows should be fetchable after async completion
+  // (SQLFetch is also async-capable, so we must poll it too)
+  int row_count = 0;
+  while (true) {
+    SQLRETURN fetch_ret = poll_fetch(stmt.getHandle());
+    if (fetch_ret == SQL_NO_DATA) break;
+    REQUIRE_THAT(OdbcResult(fetch_ret, stmt), OdbcMatchers::Succeeded());
+
+    auto id = get_data<SQL_C_LONG>(stmt, 1);
+    CHECK(id == row_count);
+    row_count++;
+  }
+  CHECK(row_count == 5);
+}
+
+// =============================================================================
+// ASYNC + STATEMENT REUSE
+// =============================================================================
+
+TEST_CASE("should allow re-execution after async completion", "[query][async]") {
+  // Given Snowflake client is logged in with async enabled
+  Connection conn;
+  auto stmt = conn.createStatement();
+  SQLRETURN ret =
+      SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_ASYNC_ENABLE, reinterpret_cast<SQLPOINTER>(SQL_ASYNC_ENABLE_ON), 0);
+  REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
+
+  // When first async query completes
+  const char* query1 = "SELECT 1 AS val";
+  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)query1, SQL_NTS);
+  if (ret == SQL_STILL_EXECUTING) {
+    ret = poll_until_complete(stmt.getHandle(), query1);
+  }
+  REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
+
+  // And we close the cursor and execute a second query
+  SQLCloseCursor(stmt.getHandle());
+
+  const char* query2 = "SELECT 99 AS val";
+  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)query2, SQL_NTS);
+  if (ret == SQL_STILL_EXECUTING) {
+    ret = poll_until_complete(stmt.getHandle(), query2);
+  }
+  REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
+
+  // Then the second query should produce correct results
+  SQLRETURN fetch_ret = poll_fetch(stmt.getHandle());
+  REQUIRE_THAT(OdbcResult(fetch_ret, stmt), OdbcMatchers::Succeeded());
+  CHECK(get_data<SQL_C_LONG>(stmt, 1) == 99);
+}
+
+TEST_CASE("should allow disabling async after completion", "[query][async]") {
+  // Given Snowflake client is logged in with async enabled
+  Connection conn;
+  auto stmt = conn.createStatement();
+  SQLRETURN ret =
+      SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_ASYNC_ENABLE, reinterpret_cast<SQLPOINTER>(SQL_ASYNC_ENABLE_ON), 0);
+  REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
+
+  // When an async query completes
+  const char* query = "SELECT 1";
+  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)query, SQL_NTS);
+  if (ret == SQL_STILL_EXECUTING) {
+    ret = poll_until_complete(stmt.getHandle(), query);
+  }
+  REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
+  SQLCloseCursor(stmt.getHandle());
+
+  // And async is disabled
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_ASYNC_ENABLE, SQL_ASYNC_ENABLE_OFF, 0);
+  REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
+
+  // Then synchronous execution should work normally
+  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT 77 AS val", SQL_NTS);
+  REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
+  REQUIRE(ret != SQL_STILL_EXECUTING);
+
+  SQLRETURN fetch_ret = SQLFetch(stmt.getHandle());
+  REQUIRE_THAT(OdbcResult(fetch_ret, stmt), OdbcMatchers::Succeeded());
+  CHECK(get_data<SQL_C_LONG>(stmt, 1) == 77);
+}
+
+// =============================================================================
+// ASYNC CANCEL
+// =============================================================================
+
+TEST_CASE("should cancel async execution with HY008", "[query][async][cancel]") {
+  SKIP_OLD_DRIVER("BD#34", "Async cancel does not interrupt in-progress operations on reference driver");
+
+  // Given Snowflake client is logged in with async enabled
+  Connection conn;
+  auto stmt = conn.createStatement();
+  SQLRETURN ret =
+      SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_ASYNC_ENABLE, reinterpret_cast<SQLPOINTER>(SQL_ASYNC_ENABLE_ON), 0);
+  REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
+
+  // When a long query is started and then cancelled
+  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)kLongQuery, SQL_NTS);
+  REQUIRE(ret == SQL_STILL_EXECUTING);
+
+  SQLRETURN cancel_ret = SQLCancel(stmt.getHandle());
+  REQUIRE_THAT(OdbcResult(cancel_ret, stmt), OdbcMatchers::Succeeded());
+
+  // Then polling should eventually return HY008
+  SQLRETURN poll_ret = poll_until_complete(stmt.getHandle(), kLongQuery);
+  REQUIRE(poll_ret != SQL_STILL_EXECUTING);
+  REQUIRE(poll_ret == SQL_ERROR);
+  CHECK(get_sqlstate(stmt) == "HY008");
+}
+
+// =============================================================================
+// CROSS-THREAD CANCEL
+// =============================================================================
+
+TEST_CASE("should cancel from another thread with HY008", "[query][async][cross_thread]") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When a long query is executed on one thread and cancelled from another
+  odbc_test::CrossThreadCancel ctx;
+  ctx.run(stmt.getHandle(), "SELECT COUNT(*) FROM TABLE(GENERATOR(TIMELIMIT => 60))", std::chrono::seconds(5));
+
+  // Then the execution result should be HY008
+  SQLRETURN exec_ret = ctx.exec_result.load();
+
+  OLD_DRIVER_ONLY("BD#47") {
+    // Old driver: cancel may return SQL_ERROR with HY008 (non-spec-compliant)
+    REQUIRE((ctx.cancel_result == SQL_SUCCESS || ctx.cancel_result == SQL_ERROR));
+  }
+  NEW_DRIVER_ONLY("BD#47") { REQUIRE_THAT(OdbcResult(ctx.cancel_result, stmt), OdbcMatchers::Succeeded()); }
+
+  REQUIRE(exec_ret == SQL_ERROR);
+  CHECK(get_sqlstate(stmt) == "HY008");
+}
+
+// =============================================================================
+// SQLGETINFO REPORTING
+// =============================================================================
+
+TEST_CASE("should report SQL_AM_STATEMENT for SQL_ASYNC_MODE", "[query][async]") {
+  // Given Snowflake client is logged in
+  Connection conn;
+
+  // When SQLGetInfo is called for SQL_ASYNC_MODE
+  SQLUINTEGER mode = 0;
+  SQLSMALLINT len = 0;
+  SQLRETURN ret = SQLGetInfo(conn.handleWrapper().getHandle(), SQL_ASYNC_MODE, &mode, sizeof(mode), &len);
+
+  // Then it should report statement-level async
+  REQUIRE_THAT(OdbcResult(ret, conn.handleWrapper()), OdbcMatchers::Succeeded());
+  CHECK(mode == SQL_AM_STATEMENT);
+}
+
+TEST_CASE("should report no limit for SQL_MAX_ASYNC_CONCURRENT_STATEMENTS", "[query][async]") {
+  // Given Snowflake client is logged in
+  Connection conn;
+
+  // When SQLGetInfo is called for SQL_MAX_ASYNC_CONCURRENT_STATEMENTS
+  SQLUINTEGER max_stmts = 999;
+  SQLSMALLINT len = 0;
+  SQLRETURN ret = SQLGetInfo(conn.handleWrapper().getHandle(), SQL_MAX_ASYNC_CONCURRENT_STATEMENTS, &max_stmts,
+                             sizeof(max_stmts), &len);
+
+  // Then the call should succeed and report 0 (no driver-imposed limit)
+  REQUIRE_THAT(OdbcResult(ret, conn.handleWrapper()), OdbcMatchers::Succeeded());
+  CHECK(max_stmts == 0);
+}

--- a/odbc_tests/tests/e2e/query/async_execution.cpp
+++ b/odbc_tests/tests/e2e/query/async_execution.cpp
@@ -311,6 +311,8 @@ TEST_CASE("should execute prepared statement asynchronously", "[query][async]") 
       SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_ASYNC_ENABLE, reinterpret_cast<SQLPOINTER>(SQL_ASYNC_ENABLE_ON), 0);
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
 
+  ret = SQLPrepare(stmt.getHandle(), sqlchar("SELECT 123 AS val"), SQL_NTS);
+  REQUIRE(ret == SQL_STILL_EXECUTING);
   ret = poll_prepare(stmt.getHandle(), "SELECT 123 AS val");
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
 
@@ -400,7 +402,7 @@ TEST_CASE("should re-execute prepared statement multiple times asynchronously", 
 
 TEST_CASE("should cancel async execution with HY008", "[query][async][cancel]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SKIP_OLD_DRIVER("BD#34", "Async cancel does not interrupt in-progress operations on reference driver");
+  SKIP_OLD_DRIVER("BD#58", "Async cancel does not interrupt in-progress operations on reference driver");
 
   // Given Snowflake client is logged in with async enabled
   Connection conn;
@@ -525,11 +527,20 @@ TEST_CASE("should clear diagnostic records between async polls", "[query][async]
       SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_ASYNC_ENABLE, reinterpret_cast<SQLPOINTER>(SQL_ASYNC_ENABLE_ON), 0);
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
 
-  // When a query is executing asynchronously
+  // And a prior query has failed, leaving diagnostics populated
+  const char* bad_query = "SELCT INVALID";
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar(bad_query), SQL_NTS);
+  REQUIRE(ret == SQL_STILL_EXECUTING);
+  ret = poll_until_complete(stmt.getHandle(), bad_query);
+  REQUIRE(ret == SQL_ERROR);
+  auto error_records = get_diag_rec(SQL_HANDLE_STMT, stmt.getHandle());
+  REQUIRE_FALSE(error_records.empty());
+
+  // When a new async query is started
   ret = SQLExecDirect(stmt.getHandle(), sqlchar(kFastQuery), SQL_NTS);
   REQUIRE(ret == SQL_STILL_EXECUTING);
 
-  // Then diagnostic records should be empty during SQL_STILL_EXECUTING
+  // Then diagnostic records should be cleared during SQL_STILL_EXECUTING
   auto records = get_diag_rec(SQL_HANDLE_STMT, stmt.getHandle());
   CHECK(records.empty());
 
@@ -571,4 +582,19 @@ TEST_CASE("should report no limit for SQL_MAX_ASYNC_CONCURRENT_STATEMENTS", "[qu
   // Then the call should succeed and report 0 (no driver-imposed limit)
   REQUIRE_THAT(OdbcResult(ret, conn.handleWrapper()), OdbcMatchers::Succeeded());
   CHECK(max_stmts == 0);
+}
+
+TEST_CASE("should report SQL_ASYNC_NOTIFICATION_NOT_CAPABLE", "[query][async]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+  // Given Snowflake client is logged in
+  Connection conn;
+
+  // When SQLGetInfo is called for SQL_ASYNC_NOTIFICATION
+  SQLUINTEGER notif = 999;
+  SQLSMALLINT len = 0;
+  SQLRETURN ret = SQLGetInfo(conn.handleWrapper().getHandle(), SQL_ASYNC_NOTIFICATION, &notif, sizeof(notif), &len);
+
+  // Then it should report not capable (polling only, no notification support)
+  REQUIRE_THAT(OdbcResult(ret, conn.handleWrapper()), OdbcMatchers::Succeeded());
+  CHECK(notif == SQL_ASYNC_NOTIFICATION_NOT_CAPABLE);
 }

--- a/odbc_tests/tests/e2e/query/async_execution.cpp
+++ b/odbc_tests/tests/e2e/query/async_execution.cpp
@@ -292,6 +292,173 @@ TEST_CASE("should allow disabling async after completion", "[query][async]") {
 }
 
 // =============================================================================
+// ASYNC PREPARE + EXECUTE
+// =============================================================================
+
+TEST_CASE("should prepare asynchronously and poll to completion", "[query][async]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+  // Given Snowflake client is logged in with async enabled
+  Connection conn;
+  auto stmt = conn.createStatement();
+  SQLRETURN ret =
+      SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_ASYNC_ENABLE, reinterpret_cast<SQLPOINTER>(SQL_ASYNC_ENABLE_ON), 0);
+  REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
+
+  // When SQLPrepare is called asynchronously
+  const char* query = "SELECT ? AS val";
+  ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)query, SQL_NTS);
+
+  // Then it may return SQL_STILL_EXECUTING or complete immediately
+  if (ret == SQL_STILL_EXECUTING) {
+    int polls = 0;
+    while (ret == SQL_STILL_EXECUTING && ++polls < kMaxPollIterations) {
+      std::this_thread::sleep_for(kPollInterval);
+      ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)query, SQL_NTS);
+    }
+  }
+  REQUIRE(ret != SQL_STILL_EXECUTING);
+  REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
+}
+
+TEST_CASE("should execute prepared statement asynchronously", "[query][async]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+  // Given Snowflake client is logged in with async enabled and a prepared statement
+  Connection conn;
+  auto stmt = conn.createStatement();
+  SQLRETURN ret =
+      SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_ASYNC_ENABLE, reinterpret_cast<SQLPOINTER>(SQL_ASYNC_ENABLE_ON), 0);
+  REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
+
+  // Prepare (poll if needed)
+  const char* query = "SELECT 123 AS val";
+  ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)query, SQL_NTS);
+  if (ret == SQL_STILL_EXECUTING) {
+    int polls = 0;
+    while (ret == SQL_STILL_EXECUTING && ++polls < kMaxPollIterations) {
+      std::this_thread::sleep_for(kPollInterval);
+      ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)query, SQL_NTS);
+    }
+  }
+  REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
+
+  // When SQLExecute is called asynchronously
+  ret = SQLExecute(stmt.getHandle());
+  if (ret == SQL_STILL_EXECUTING) {
+    int polls = 0;
+    while (ret == SQL_STILL_EXECUTING && ++polls < kMaxPollIterations) {
+      std::this_thread::sleep_for(kPollInterval);
+      ret = SQLExecute(stmt.getHandle());
+    }
+  }
+
+  // Then it should complete successfully
+  REQUIRE(ret != SQL_STILL_EXECUTING);
+  REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
+
+  // And results should be retrievable
+  SQLRETURN fetch_ret = poll_fetch(stmt.getHandle());
+  REQUIRE_THAT(OdbcResult(fetch_ret, stmt), OdbcMatchers::Succeeded());
+  CHECK(get_data<SQL_C_LONG>(stmt, 1) == 123);
+}
+
+TEST_CASE("should prepare and execute with bound parameters asynchronously", "[query][async]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+  // Given Snowflake client is logged in with async enabled
+  Connection conn;
+  auto stmt = conn.createStatement();
+  SQLRETURN ret =
+      SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_ASYNC_ENABLE, reinterpret_cast<SQLPOINTER>(SQL_ASYNC_ENABLE_ON), 0);
+  REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
+
+  // Prepare with parameter marker (poll if needed)
+  const char* query = "SELECT ? AS val";
+  ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)query, SQL_NTS);
+  if (ret == SQL_STILL_EXECUTING) {
+    int polls = 0;
+    while (ret == SQL_STILL_EXECUTING && ++polls < kMaxPollIterations) {
+      std::this_thread::sleep_for(kPollInterval);
+      ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)query, SQL_NTS);
+    }
+  }
+  REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
+
+  // Bind a parameter
+  SQLINTEGER param_val = 456;
+  SQLLEN ind = 0;
+  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, &param_val, 0, &ind);
+  REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
+
+  // When SQLExecute is called asynchronously
+  ret = SQLExecute(stmt.getHandle());
+  if (ret == SQL_STILL_EXECUTING) {
+    int polls = 0;
+    while (ret == SQL_STILL_EXECUTING && ++polls < kMaxPollIterations) {
+      std::this_thread::sleep_for(kPollInterval);
+      ret = SQLExecute(stmt.getHandle());
+    }
+  }
+
+  // Then it should complete and return the bound value
+  REQUIRE(ret != SQL_STILL_EXECUTING);
+  REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
+
+  SQLRETURN fetch_ret = poll_fetch(stmt.getHandle());
+  REQUIRE_THAT(OdbcResult(fetch_ret, stmt), OdbcMatchers::Succeeded());
+  CHECK(get_data<SQL_C_LONG>(stmt, 1) == 456);
+}
+
+TEST_CASE("should re-execute prepared statement multiple times asynchronously", "[query][async]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+  // Given Snowflake client is logged in with async enabled and a prepared statement
+  Connection conn;
+  auto stmt = conn.createStatement();
+  SQLRETURN ret =
+      SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_ASYNC_ENABLE, reinterpret_cast<SQLPOINTER>(SQL_ASYNC_ENABLE_ON), 0);
+  REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
+
+  // Prepare once (poll if needed)
+  const char* query = "SELECT ? AS val";
+  ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)query, SQL_NTS);
+  if (ret == SQL_STILL_EXECUTING) {
+    int polls = 0;
+    while (ret == SQL_STILL_EXECUTING && ++polls < kMaxPollIterations) {
+      std::this_thread::sleep_for(kPollInterval);
+      ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)query, SQL_NTS);
+    }
+  }
+  REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
+
+  SQLINTEGER param_val = 0;
+  SQLLEN ind = 0;
+  ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, &param_val, 0, &ind);
+  REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
+
+  // When the prepared statement is executed multiple times with different values
+  for (int i = 1; i <= 3; i++) {
+    param_val = i * 10;
+
+    ret = SQLExecute(stmt.getHandle());
+    if (ret == SQL_STILL_EXECUTING) {
+      int polls = 0;
+      while (ret == SQL_STILL_EXECUTING && ++polls < kMaxPollIterations) {
+        std::this_thread::sleep_for(kPollInterval);
+        ret = SQLExecute(stmt.getHandle());
+      }
+    }
+    REQUIRE(ret != SQL_STILL_EXECUTING);
+    REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
+
+    SQLRETURN fetch_ret = poll_fetch(stmt.getHandle());
+    REQUIRE_THAT(OdbcResult(fetch_ret, stmt), OdbcMatchers::Succeeded());
+
+    // Then each execution should return the correct bound value
+    CHECK(get_data<SQL_C_LONG>(stmt, 1) == i * 10);
+
+    SQLCloseCursor(stmt.getHandle());
+  }
+}
+
+// =============================================================================
 // ASYNC CANCEL
 // =============================================================================
 

--- a/odbc_tests/tests/e2e/query/async_execution.cpp
+++ b/odbc_tests/tests/e2e/query/async_execution.cpp
@@ -54,6 +54,7 @@ SQLRETURN poll_fetch(SQLHSTMT stmt) {
 // =============================================================================
 
 TEST_CASE("should enable async execution on statement", "[query][async]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in
   Connection conn;
   auto stmt = conn.createStatement();
@@ -67,6 +68,7 @@ TEST_CASE("should enable async execution on statement", "[query][async]") {
 }
 
 TEST_CASE("should disable async execution on statement", "[query][async]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in with async enabled
   Connection conn;
   auto stmt = conn.createStatement();
@@ -82,6 +84,7 @@ TEST_CASE("should disable async execution on statement", "[query][async]") {
 }
 
 TEST_CASE("should get async enable attribute value after setting it", "[query][async]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in
   Connection conn;
   auto stmt = conn.createStatement();
@@ -100,6 +103,7 @@ TEST_CASE("should get async enable attribute value after setting it", "[query][a
 }
 
 TEST_CASE("should reject connection-level async with HY092", "[query][async]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in
   Connection conn;
 
@@ -117,6 +121,7 @@ TEST_CASE("should reject connection-level async with HY092", "[query][async]") {
 // =============================================================================
 
 TEST_CASE("should return SQL_STILL_EXECUTING for long query", "[query][async]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in with async enabled
   Connection conn;
   auto stmt = conn.createStatement();
@@ -135,6 +140,7 @@ TEST_CASE("should return SQL_STILL_EXECUTING for long query", "[query][async]") 
 }
 
 TEST_CASE("should complete async execution via polling", "[query][async]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in with async enabled
   Connection conn;
   auto stmt = conn.createStatement();
@@ -157,6 +163,7 @@ TEST_CASE("should complete async execution via polling", "[query][async]") {
 }
 
 TEST_CASE("should allow immediate completion with async enabled", "[query][async]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in with async enabled
   Connection conn;
   auto stmt = conn.createStatement();
@@ -183,6 +190,7 @@ TEST_CASE("should allow immediate completion with async enabled", "[query][async
 }
 
 TEST_CASE("should execute and retrieve result set asynchronously", "[query][async]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in with async enabled
   Connection conn;
   auto stmt = conn.createStatement();
@@ -219,6 +227,7 @@ TEST_CASE("should execute and retrieve result set asynchronously", "[query][asyn
 // =============================================================================
 
 TEST_CASE("should allow re-execution after async completion", "[query][async]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in with async enabled
   Connection conn;
   auto stmt = conn.createStatement();
@@ -251,6 +260,7 @@ TEST_CASE("should allow re-execution after async completion", "[query][async]") 
 }
 
 TEST_CASE("should allow disabling async after completion", "[query][async]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in with async enabled
   Connection conn;
   auto stmt = conn.createStatement();
@@ -286,6 +296,7 @@ TEST_CASE("should allow disabling async after completion", "[query][async]") {
 // =============================================================================
 
 TEST_CASE("should cancel async execution with HY008", "[query][async][cancel]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   SKIP_OLD_DRIVER("BD#34", "Async cancel does not interrupt in-progress operations on reference driver");
 
   // Given Snowflake client is logged in with async enabled
@@ -314,6 +325,7 @@ TEST_CASE("should cancel async execution with HY008", "[query][async][cancel]") 
 // =============================================================================
 
 TEST_CASE("should cancel from another thread with HY008", "[query][async][cross_thread]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in
   Connection conn;
   auto stmt = conn.createStatement();
@@ -340,6 +352,7 @@ TEST_CASE("should cancel from another thread with HY008", "[query][async][cross_
 // =============================================================================
 
 TEST_CASE("should report SQL_AM_STATEMENT for SQL_ASYNC_MODE", "[query][async]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in
   Connection conn;
 
@@ -354,6 +367,7 @@ TEST_CASE("should report SQL_AM_STATEMENT for SQL_ASYNC_MODE", "[query][async]")
 }
 
 TEST_CASE("should report no limit for SQL_MAX_ASYNC_CONCURRENT_STATEMENTS", "[query][async]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in
   Connection conn;
 

--- a/odbc_tests/tests/e2e/query/async_execution.cpp
+++ b/odbc_tests/tests/e2e/query/async_execution.cpp
@@ -148,14 +148,14 @@ TEST_CASE("should complete async execution via polling and retrieve data", "[que
       SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_ASYNC_ENABLE, reinterpret_cast<SQLPOINTER>(SQL_ASYNC_ENABLE_ON), 0);
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
 
-  // When a fast query is executed (may complete immediately or go async)
+  // When a query is executed asynchronously
   ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)kFastQuery, SQL_NTS);
-  if (ret == SQL_STILL_EXECUTING) {
-    ret = poll_until_complete(stmt.getHandle(), kFastQuery);
-  }
 
-  // Then the final result should indicate success
-  REQUIRE(ret != SQL_STILL_EXECUTING);
+  // Then the first call must return SQL_STILL_EXECUTING
+  REQUIRE(ret == SQL_STILL_EXECUTING);
+
+  // And polling eventually completes
+  ret = poll_until_complete(stmt.getHandle(), kFastQuery);
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
 
   // And data should be retrievable (SQLFetch is also async-capable)
@@ -176,10 +176,9 @@ TEST_CASE("should execute and retrieve result set asynchronously", "[query][asyn
   // When a query returning multiple rows is executed asynchronously
   const char* query = "SELECT seq4() AS id FROM TABLE(GENERATOR(ROWCOUNT => 5)) ORDER BY id";
   ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)query, SQL_NTS);
+  REQUIRE(ret == SQL_STILL_EXECUTING);
 
-  if (ret == SQL_STILL_EXECUTING) {
-    ret = poll_until_complete(stmt.getHandle(), query);
-  }
+  ret = poll_until_complete(stmt.getHandle(), query);
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
 
   // Then all rows should be fetchable after async completion
@@ -213,9 +212,8 @@ TEST_CASE("should allow re-execution after async completion", "[query][async]") 
   // When first async query completes
   const char* query1 = "SELECT 1 AS val";
   ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)query1, SQL_NTS);
-  if (ret == SQL_STILL_EXECUTING) {
-    ret = poll_until_complete(stmt.getHandle(), query1);
-  }
+  REQUIRE(ret == SQL_STILL_EXECUTING);
+  ret = poll_until_complete(stmt.getHandle(), query1);
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
 
   // And we close the cursor and execute a second query
@@ -223,9 +221,8 @@ TEST_CASE("should allow re-execution after async completion", "[query][async]") 
 
   const char* query2 = "SELECT 99 AS val";
   ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)query2, SQL_NTS);
-  if (ret == SQL_STILL_EXECUTING) {
-    ret = poll_until_complete(stmt.getHandle(), query2);
-  }
+  REQUIRE(ret == SQL_STILL_EXECUTING);
+  ret = poll_until_complete(stmt.getHandle(), query2);
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
 
   // Then the second query should produce correct results
@@ -246,9 +243,8 @@ TEST_CASE("should allow disabling async after completion", "[query][async]") {
   // When an async query completes
   const char* query = "SELECT 1";
   ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)query, SQL_NTS);
-  if (ret == SQL_STILL_EXECUTING) {
-    ret = poll_until_complete(stmt.getHandle(), query);
-  }
+  REQUIRE(ret == SQL_STILL_EXECUTING);
+  ret = poll_until_complete(stmt.getHandle(), query);
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
   SQLCloseCursor(stmt.getHandle());
 
@@ -280,10 +276,10 @@ TEST_CASE("should prepare asynchronously and poll to completion", "[query][async
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
 
   // When SQLPrepare is called asynchronously
+  // Note: SQLPrepare may complete immediately (spec-valid) since the driver
+  // can resolve metadata without a server round-trip for simple queries.
   const char* query = "SELECT ? AS val";
   ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)query, SQL_NTS);
-
-  // Then it may return SQL_STILL_EXECUTING or complete immediately
   if (ret == SQL_STILL_EXECUTING) {
     int polls = 0;
     while (ret == SQL_STILL_EXECUTING && ++polls < kMaxPollIterations) {
@@ -291,7 +287,8 @@ TEST_CASE("should prepare asynchronously and poll to completion", "[query][async
       ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)query, SQL_NTS);
     }
   }
-  REQUIRE(ret != SQL_STILL_EXECUTING);
+
+  // Then the prepare completes successfully
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
 }
 
@@ -304,7 +301,7 @@ TEST_CASE("should execute prepared statement asynchronously", "[query][async]") 
       SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_ASYNC_ENABLE, reinterpret_cast<SQLPOINTER>(SQL_ASYNC_ENABLE_ON), 0);
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
 
-  // Prepare (poll if needed)
+  // Prepare (may complete immediately — spec-valid for simple queries)
   const char* query = "SELECT 123 AS val";
   ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)query, SQL_NTS);
   if (ret == SQL_STILL_EXECUTING) {
@@ -316,9 +313,10 @@ TEST_CASE("should execute prepared statement asynchronously", "[query][async]") 
   }
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
 
-  // When SQLExecute is called asynchronously
+  // When SQLExecute is called asynchronously — must go async
   ret = SQLExecute(stmt.getHandle());
-  if (ret == SQL_STILL_EXECUTING) {
+  REQUIRE(ret == SQL_STILL_EXECUTING);
+  {
     int polls = 0;
     while (ret == SQL_STILL_EXECUTING && ++polls < kMaxPollIterations) {
       std::this_thread::sleep_for(kPollInterval);
@@ -326,11 +324,8 @@ TEST_CASE("should execute prepared statement asynchronously", "[query][async]") 
     }
   }
 
-  // Then it should complete successfully
-  REQUIRE(ret != SQL_STILL_EXECUTING);
+  // Then execution completes and results are retrievable
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
-
-  // And results should be retrievable
   SQLRETURN fetch_ret = poll_fetch(stmt.getHandle());
   REQUIRE_THAT(OdbcResult(fetch_ret, stmt), OdbcMatchers::Succeeded());
   CHECK(get_data<SQL_C_LONG>(stmt, 1) == 123);
@@ -345,7 +340,7 @@ TEST_CASE("should prepare and execute with bound parameters asynchronously", "[q
       SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_ASYNC_ENABLE, reinterpret_cast<SQLPOINTER>(SQL_ASYNC_ENABLE_ON), 0);
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
 
-  // Prepare with parameter marker (poll if needed)
+  // Prepare (may complete immediately)
   const char* query = "SELECT ? AS val";
   ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)query, SQL_NTS);
   if (ret == SQL_STILL_EXECUTING) {
@@ -363,20 +358,19 @@ TEST_CASE("should prepare and execute with bound parameters asynchronously", "[q
   ret = SQLBindParameter(stmt.getHandle(), 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, &param_val, 0, &ind);
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
 
-  // When SQLExecute is called asynchronously
+  // When SQLExecute is called asynchronously — must go async
   ret = SQLExecute(stmt.getHandle());
-  if (ret == SQL_STILL_EXECUTING) {
+  REQUIRE(ret == SQL_STILL_EXECUTING);
+  {
     int polls = 0;
     while (ret == SQL_STILL_EXECUTING && ++polls < kMaxPollIterations) {
       std::this_thread::sleep_for(kPollInterval);
       ret = SQLExecute(stmt.getHandle());
     }
   }
-
-  // Then it should complete and return the bound value
-  REQUIRE(ret != SQL_STILL_EXECUTING);
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
 
+  // Then it should return the bound value
   SQLRETURN fetch_ret = poll_fetch(stmt.getHandle());
   REQUIRE_THAT(OdbcResult(fetch_ret, stmt), OdbcMatchers::Succeeded());
   CHECK(get_data<SQL_C_LONG>(stmt, 1) == 456);
@@ -391,7 +385,7 @@ TEST_CASE("should re-execute prepared statement multiple times asynchronously", 
       SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_ASYNC_ENABLE, reinterpret_cast<SQLPOINTER>(SQL_ASYNC_ENABLE_ON), 0);
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
 
-  // Prepare once (poll if needed)
+  // Prepare once (may complete immediately)
   const char* query = "SELECT ? AS val";
   ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)query, SQL_NTS);
   if (ret == SQL_STILL_EXECUTING) {
@@ -412,15 +406,16 @@ TEST_CASE("should re-execute prepared statement multiple times asynchronously", 
   for (int i = 1; i <= 3; i++) {
     param_val = i * 10;
 
+    // SQLExecute must go async
     ret = SQLExecute(stmt.getHandle());
-    if (ret == SQL_STILL_EXECUTING) {
+    REQUIRE(ret == SQL_STILL_EXECUTING);
+    {
       int polls = 0;
       while (ret == SQL_STILL_EXECUTING && ++polls < kMaxPollIterations) {
         std::this_thread::sleep_for(kPollInterval);
         ret = SQLExecute(stmt.getHandle());
       }
     }
-    REQUIRE(ret != SQL_STILL_EXECUTING);
     REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
 
     SQLRETURN fetch_ret = poll_fetch(stmt.getHandle());

--- a/odbc_tests/tests/e2e/query/async_execution.cpp
+++ b/odbc_tests/tests/e2e/query/async_execution.cpp
@@ -12,6 +12,7 @@
 #include "cross_thread_cancel.hpp"
 #include "get_data.hpp"
 #include "get_diag_rec.hpp"
+#include "odbc_cast.hpp"
 #include "odbc_matchers.hpp"
 
 namespace {
@@ -30,19 +31,37 @@ SQLRETURN poll_until_complete(SQLHSTMT stmt, const char* query) {
   SQLRETURN ret = SQL_STILL_EXECUTING;
   while (ret == SQL_STILL_EXECUTING && ++polls < kMaxPollIterations) {
     std::this_thread::sleep_for(kPollInterval);
-    ret = SQLExecDirect(stmt, (SQLCHAR*)query, SQL_NTS);
+    ret = SQLExecDirect(stmt, sqlchar(query), SQL_NTS);
   }
   return ret;
 }
 
-// SQLFetch is also async-capable: with async ON it returns SQL_STILL_EXECUTING.
-// Poll by re-calling SQLFetch until it completes.
 SQLRETURN poll_fetch(SQLHSTMT stmt) {
   int polls = 0;
   SQLRETURN ret = SQLFetch(stmt);
   while (ret == SQL_STILL_EXECUTING && ++polls < kMaxPollIterations) {
     std::this_thread::sleep_for(kPollInterval);
     ret = SQLFetch(stmt);
+  }
+  return ret;
+}
+
+SQLRETURN poll_prepare(SQLHSTMT stmt, const char* query) {
+  SQLRETURN ret = SQLPrepare(stmt, sqlchar(query), SQL_NTS);
+  int polls = 0;
+  while (ret == SQL_STILL_EXECUTING && ++polls < kMaxPollIterations) {
+    std::this_thread::sleep_for(kPollInterval);
+    ret = SQLPrepare(stmt, sqlchar(query), SQL_NTS);
+  }
+  return ret;
+}
+
+SQLRETURN poll_execute(SQLHSTMT stmt) {
+  SQLRETURN ret = SQLExecute(stmt);
+  int polls = 0;
+  while (ret == SQL_STILL_EXECUTING && ++polls < kMaxPollIterations) {
+    std::this_thread::sleep_for(kPollInterval);
+    ret = SQLExecute(stmt);
   }
   return ret;
 }
@@ -77,7 +96,7 @@ TEST_CASE("should disable async execution on statement", "[query][async]") {
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
 
   // When SQL_ATTR_ASYNC_ENABLE is set to OFF
-  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_ASYNC_ENABLE, SQL_ASYNC_ENABLE_OFF, 0);
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_ASYNC_ENABLE, reinterpret_cast<SQLPOINTER>(SQL_ASYNC_ENABLE_OFF), 0);
 
   // Then the attribute is accepted
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
@@ -112,8 +131,7 @@ TEST_CASE("should reject connection-level async with HY092", "[query][async]") {
                                           reinterpret_cast<SQLPOINTER>(SQL_ASYNC_DBC_ENABLE_ON), 0);
 
   // Then the driver should reject it
-  REQUIRE(ret == SQL_ERROR);
-  CHECK(get_sqlstate(conn.handleWrapper()) == "HY092");
+  REQUIRE_THAT(OdbcResult(ret, conn.handleWrapper()), OdbcMatchers::IsError() && OdbcMatchers::HasSqlState("HY092"));
 }
 
 // =============================================================================
@@ -130,7 +148,7 @@ TEST_CASE("should return SQL_STILL_EXECUTING for long query", "[query][async]") 
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
 
   // When a long-running query is executed
-  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)kLongQuery, SQL_NTS);
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar(kLongQuery), SQL_NTS);
 
   // Then the first call should return SQL_STILL_EXECUTING
   REQUIRE(ret == SQL_STILL_EXECUTING);
@@ -149,7 +167,7 @@ TEST_CASE("should complete async execution via polling and retrieve data", "[que
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
 
   // When a query is executed asynchronously
-  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)kFastQuery, SQL_NTS);
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar(kFastQuery), SQL_NTS);
 
   // Then the first call must return SQL_STILL_EXECUTING
   REQUIRE(ret == SQL_STILL_EXECUTING);
@@ -175,19 +193,18 @@ TEST_CASE("should execute and retrieve result set asynchronously", "[query][asyn
 
   // When a query returning multiple rows is executed asynchronously
   const char* query = "SELECT seq4() AS id FROM TABLE(GENERATOR(ROWCOUNT => 5)) ORDER BY id";
-  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)query, SQL_NTS);
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar(query), SQL_NTS);
   REQUIRE(ret == SQL_STILL_EXECUTING);
 
   ret = poll_until_complete(stmt.getHandle(), query);
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
 
   // Then all rows should be fetchable after async completion
-  // (SQLFetch is also async-capable, so we must poll it too)
   int row_count = 0;
   while (true) {
     SQLRETURN fetch_ret = poll_fetch(stmt.getHandle());
     if (fetch_ret == SQL_NO_DATA) break;
-    REQUIRE_THAT(OdbcResult(fetch_ret, stmt), OdbcMatchers::Succeeded());
+    CHECK_THAT(OdbcResult(fetch_ret, stmt), OdbcMatchers::Succeeded());
 
     auto id = get_data<SQL_C_LONG>(stmt, 1);
     CHECK(id == row_count);
@@ -211,16 +228,17 @@ TEST_CASE("should allow re-execution after async completion", "[query][async]") 
 
   // When first async query completes
   const char* query1 = "SELECT 1 AS val";
-  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)query1, SQL_NTS);
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar(query1), SQL_NTS);
   REQUIRE(ret == SQL_STILL_EXECUTING);
   ret = poll_until_complete(stmt.getHandle(), query1);
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
 
   // And we close the cursor and execute a second query
-  SQLCloseCursor(stmt.getHandle());
+  ret = SQLCloseCursor(stmt.getHandle());
+  REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
 
   const char* query2 = "SELECT 99 AS val";
-  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)query2, SQL_NTS);
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar(query2), SQL_NTS);
   REQUIRE(ret == SQL_STILL_EXECUTING);
   ret = poll_until_complete(stmt.getHandle(), query2);
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
@@ -242,20 +260,20 @@ TEST_CASE("should allow disabling async after completion", "[query][async]") {
 
   // When an async query completes
   const char* query = "SELECT 1";
-  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)query, SQL_NTS);
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar(query), SQL_NTS);
   REQUIRE(ret == SQL_STILL_EXECUTING);
   ret = poll_until_complete(stmt.getHandle(), query);
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
-  SQLCloseCursor(stmt.getHandle());
+  ret = SQLCloseCursor(stmt.getHandle());
+  REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
 
   // And async is disabled
-  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_ASYNC_ENABLE, SQL_ASYNC_ENABLE_OFF, 0);
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_ASYNC_ENABLE, reinterpret_cast<SQLPOINTER>(SQL_ASYNC_ENABLE_OFF), 0);
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
 
   // Then synchronous execution should work normally
-  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)"SELECT 77 AS val", SQL_NTS);
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar("SELECT 77 AS val"), SQL_NTS);
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
-  REQUIRE(ret != SQL_STILL_EXECUTING);
 
   SQLRETURN fetch_ret = SQLFetch(stmt.getHandle());
   REQUIRE_THAT(OdbcResult(fetch_ret, stmt), OdbcMatchers::Succeeded());
@@ -275,18 +293,10 @@ TEST_CASE("should prepare asynchronously and poll to completion", "[query][async
       SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_ASYNC_ENABLE, reinterpret_cast<SQLPOINTER>(SQL_ASYNC_ENABLE_ON), 0);
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
 
-  // When SQLPrepare is called asynchronously
+  // When SQLPrepare is called with async enabled
   // Note: SQLPrepare may complete immediately (spec-valid) since the driver
   // can resolve metadata without a server round-trip for simple queries.
-  const char* query = "SELECT ? AS val";
-  ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)query, SQL_NTS);
-  if (ret == SQL_STILL_EXECUTING) {
-    int polls = 0;
-    while (ret == SQL_STILL_EXECUTING && ++polls < kMaxPollIterations) {
-      std::this_thread::sleep_for(kPollInterval);
-      ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)query, SQL_NTS);
-    }
-  }
+  ret = poll_prepare(stmt.getHandle(), "SELECT ? AS val");
 
   // Then the prepare completes successfully
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
@@ -301,28 +311,13 @@ TEST_CASE("should execute prepared statement asynchronously", "[query][async]") 
       SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_ASYNC_ENABLE, reinterpret_cast<SQLPOINTER>(SQL_ASYNC_ENABLE_ON), 0);
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
 
-  // Prepare (may complete immediately — spec-valid for simple queries)
-  const char* query = "SELECT 123 AS val";
-  ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)query, SQL_NTS);
-  if (ret == SQL_STILL_EXECUTING) {
-    int polls = 0;
-    while (ret == SQL_STILL_EXECUTING && ++polls < kMaxPollIterations) {
-      std::this_thread::sleep_for(kPollInterval);
-      ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)query, SQL_NTS);
-    }
-  }
+  ret = poll_prepare(stmt.getHandle(), "SELECT 123 AS val");
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
 
   // When SQLExecute is called asynchronously — must go async
   ret = SQLExecute(stmt.getHandle());
   REQUIRE(ret == SQL_STILL_EXECUTING);
-  {
-    int polls = 0;
-    while (ret == SQL_STILL_EXECUTING && ++polls < kMaxPollIterations) {
-      std::this_thread::sleep_for(kPollInterval);
-      ret = SQLExecute(stmt.getHandle());
-    }
-  }
+  ret = poll_execute(stmt.getHandle());
 
   // Then execution completes and results are retrievable
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
@@ -340,16 +335,7 @@ TEST_CASE("should prepare and execute with bound parameters asynchronously", "[q
       SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_ASYNC_ENABLE, reinterpret_cast<SQLPOINTER>(SQL_ASYNC_ENABLE_ON), 0);
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
 
-  // Prepare (may complete immediately)
-  const char* query = "SELECT ? AS val";
-  ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)query, SQL_NTS);
-  if (ret == SQL_STILL_EXECUTING) {
-    int polls = 0;
-    while (ret == SQL_STILL_EXECUTING && ++polls < kMaxPollIterations) {
-      std::this_thread::sleep_for(kPollInterval);
-      ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)query, SQL_NTS);
-    }
-  }
+  ret = poll_prepare(stmt.getHandle(), "SELECT ? AS val");
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
 
   // Bind a parameter
@@ -361,13 +347,7 @@ TEST_CASE("should prepare and execute with bound parameters asynchronously", "[q
   // When SQLExecute is called asynchronously — must go async
   ret = SQLExecute(stmt.getHandle());
   REQUIRE(ret == SQL_STILL_EXECUTING);
-  {
-    int polls = 0;
-    while (ret == SQL_STILL_EXECUTING && ++polls < kMaxPollIterations) {
-      std::this_thread::sleep_for(kPollInterval);
-      ret = SQLExecute(stmt.getHandle());
-    }
-  }
+  ret = poll_execute(stmt.getHandle());
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
 
   // Then it should return the bound value
@@ -385,16 +365,7 @@ TEST_CASE("should re-execute prepared statement multiple times asynchronously", 
       SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_ASYNC_ENABLE, reinterpret_cast<SQLPOINTER>(SQL_ASYNC_ENABLE_ON), 0);
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
 
-  // Prepare once (may complete immediately)
-  const char* query = "SELECT ? AS val";
-  ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)query, SQL_NTS);
-  if (ret == SQL_STILL_EXECUTING) {
-    int polls = 0;
-    while (ret == SQL_STILL_EXECUTING && ++polls < kMaxPollIterations) {
-      std::this_thread::sleep_for(kPollInterval);
-      ret = SQLPrepare(stmt.getHandle(), (SQLCHAR*)query, SQL_NTS);
-    }
-  }
+  ret = poll_prepare(stmt.getHandle(), "SELECT ? AS val");
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
 
   SQLINTEGER param_val = 0;
@@ -409,22 +380,17 @@ TEST_CASE("should re-execute prepared statement multiple times asynchronously", 
     // SQLExecute must go async
     ret = SQLExecute(stmt.getHandle());
     REQUIRE(ret == SQL_STILL_EXECUTING);
-    {
-      int polls = 0;
-      while (ret == SQL_STILL_EXECUTING && ++polls < kMaxPollIterations) {
-        std::this_thread::sleep_for(kPollInterval);
-        ret = SQLExecute(stmt.getHandle());
-      }
-    }
+    ret = poll_execute(stmt.getHandle());
     REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
 
     SQLRETURN fetch_ret = poll_fetch(stmt.getHandle());
-    REQUIRE_THAT(OdbcResult(fetch_ret, stmt), OdbcMatchers::Succeeded());
+    CHECK_THAT(OdbcResult(fetch_ret, stmt), OdbcMatchers::Succeeded());
 
     // Then each execution should return the correct bound value
     CHECK(get_data<SQL_C_LONG>(stmt, 1) == i * 10);
 
-    SQLCloseCursor(stmt.getHandle());
+    ret = SQLCloseCursor(stmt.getHandle());
+    REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
   }
 }
 
@@ -444,7 +410,7 @@ TEST_CASE("should cancel async execution with HY008", "[query][async][cancel]") 
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
 
   // When a long query is started and then cancelled
-  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)kLongQuery, SQL_NTS);
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar(kLongQuery), SQL_NTS);
   REQUIRE(ret == SQL_STILL_EXECUTING);
 
   SQLRETURN cancel_ret = SQLCancel(stmt.getHandle());
@@ -452,9 +418,30 @@ TEST_CASE("should cancel async execution with HY008", "[query][async][cancel]") 
 
   // Then polling should eventually return HY008
   SQLRETURN poll_ret = poll_until_complete(stmt.getHandle(), kLongQuery);
-  REQUIRE(poll_ret != SQL_STILL_EXECUTING);
   REQUIRE(poll_ret == SQL_ERROR);
   CHECK(get_sqlstate(stmt) == "HY008");
+}
+
+TEST_CASE("should treat SQLCancel on idle async-enabled statement as no-op", "[query][async][cancel]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+  // Given Snowflake client is logged in with async enabled but no query in progress
+  Connection conn;
+  auto stmt = conn.createStatement();
+  SQLRETURN ret =
+      SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_ASYNC_ENABLE, reinterpret_cast<SQLPOINTER>(SQL_ASYNC_ENABLE_ON), 0);
+  REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
+
+  // When SQLCancel is called on an idle statement
+  ret = SQLCancel(stmt.getHandle());
+
+  // Then it should succeed with no side effects (ODBC 3.5+ no-op semantics)
+  REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
+
+  // And the statement should still be usable for execution
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar(kFastQuery), SQL_NTS);
+  REQUIRE(ret == SQL_STILL_EXECUTING);
+  ret = poll_until_complete(stmt.getHandle(), kFastQuery);
+  REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
 }
 
 // =============================================================================
@@ -474,14 +461,81 @@ TEST_CASE("should cancel from another thread with HY008", "[query][async][cross_
   // Then the execution result should be HY008
   SQLRETURN exec_ret = ctx.exec_result.load();
 
-  OLD_DRIVER_ONLY("BD#47") {
-    // Old driver: cancel may return SQL_ERROR with HY008 (non-spec-compliant)
-    REQUIRE((ctx.cancel_result == SQL_SUCCESS || ctx.cancel_result == SQL_ERROR));
-  }
+  OLD_DRIVER_ONLY("BD#47") { REQUIRE((ctx.cancel_result == SQL_SUCCESS || ctx.cancel_result == SQL_ERROR)); }
   NEW_DRIVER_ONLY("BD#47") { REQUIRE_THAT(OdbcResult(ctx.cancel_result, stmt), OdbcMatchers::Succeeded()); }
 
   REQUIRE(exec_ret == SQL_ERROR);
   CHECK(get_sqlstate(stmt) == "HY008");
+}
+
+// =============================================================================
+// ASYNC ERROR PATHS
+// =============================================================================
+
+TEST_CASE("should return SQL_ERROR asynchronously for invalid SQL", "[query][async]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+  // Given Snowflake client is logged in with async enabled
+  Connection conn;
+  auto stmt = conn.createStatement();
+  SQLRETURN ret =
+      SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_ASYNC_ENABLE, reinterpret_cast<SQLPOINTER>(SQL_ASYNC_ENABLE_ON), 0);
+  REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
+
+  // When an invalid query is executed asynchronously
+  const char* bad_query = "SELCT INVALID SYNTAX GIBBERISH";
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar(bad_query), SQL_NTS);
+  REQUIRE(ret == SQL_STILL_EXECUTING);
+
+  // Then polling should eventually return SQL_ERROR with a syntax error SQLSTATE
+  ret = poll_until_complete(stmt.getHandle(), bad_query);
+  REQUIRE(ret == SQL_ERROR);
+  CHECK(get_sqlstate(stmt) == "42000");
+}
+
+TEST_CASE("should reject non-permitted function call during async execution", "[query][async]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+  // Given Snowflake client is logged in with async enabled and a query in progress
+  Connection conn;
+  auto stmt = conn.createStatement();
+  SQLRETURN ret =
+      SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_ASYNC_ENABLE, reinterpret_cast<SQLPOINTER>(SQL_ASYNC_ENABLE_ON), 0);
+  REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
+
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar(kLongQuery), SQL_NTS);
+  REQUIRE(ret == SQL_STILL_EXECUTING);
+
+  // When a non-permitted function is called on the busy statement
+  SQLSMALLINT num_cols = 0;
+  SQLRETURN bad_ret = SQLNumResultCols(stmt.getHandle(), &num_cols);
+
+  // Then it should return HY010 (function sequence error)
+  CHECK(bad_ret == SQL_ERROR);
+  CHECK(get_sqlstate(stmt) == "HY010");
+
+  // Cleanup: poll to completion
+  poll_until_complete(stmt.getHandle(), kLongQuery);
+}
+
+TEST_CASE("should clear diagnostic records between async polls", "[query][async]") {
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
+  // Given Snowflake client is logged in with async enabled
+  Connection conn;
+  auto stmt = conn.createStatement();
+  SQLRETURN ret =
+      SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_ASYNC_ENABLE, reinterpret_cast<SQLPOINTER>(SQL_ASYNC_ENABLE_ON), 0);
+  REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
+
+  // When a query is executing asynchronously
+  ret = SQLExecDirect(stmt.getHandle(), sqlchar(kFastQuery), SQL_NTS);
+  REQUIRE(ret == SQL_STILL_EXECUTING);
+
+  // Then diagnostic records should be empty during SQL_STILL_EXECUTING
+  auto records = get_diag_rec(SQL_HANDLE_STMT, stmt.getHandle());
+  CHECK(records.empty());
+
+  // And after polling to completion, diagnostics reflect the final state
+  ret = poll_until_complete(stmt.getHandle(), kFastQuery);
+  REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
 }
 
 // =============================================================================

--- a/odbc_tests/tests/e2e/query/async_execution.cpp
+++ b/odbc_tests/tests/e2e/query/async_execution.cpp
@@ -139,7 +139,7 @@ TEST_CASE("should return SQL_STILL_EXECUTING for long query", "[query][async]") 
   poll_until_complete(stmt.getHandle(), kLongQuery);
 }
 
-TEST_CASE("should complete async execution via polling", "[query][async]") {
+TEST_CASE("should complete async execution via polling and retrieve data", "[query][async]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   // Given Snowflake client is logged in with async enabled
   Connection conn;
@@ -148,45 +148,20 @@ TEST_CASE("should complete async execution via polling", "[query][async]") {
       SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_ASYNC_ENABLE, reinterpret_cast<SQLPOINTER>(SQL_ASYNC_ENABLE_ON), 0);
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
 
-  // When a query is executed and polled to completion
-  // Use a shorter query so the test doesn't take 30 seconds
-  const char* query = "SELECT COUNT(*) FROM TABLE(GENERATOR(ROWCOUNT => 1000000))";
-  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)query, SQL_NTS);
-
+  // When a fast query is executed (may complete immediately or go async)
+  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)kFastQuery, SQL_NTS);
   if (ret == SQL_STILL_EXECUTING) {
-    ret = poll_until_complete(stmt.getHandle(), query);
+    ret = poll_until_complete(stmt.getHandle(), kFastQuery);
   }
 
   // Then the final result should indicate success
   REQUIRE(ret != SQL_STILL_EXECUTING);
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
-}
-
-TEST_CASE("should allow immediate completion with async enabled", "[query][async]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  // Given Snowflake client is logged in with async enabled
-  Connection conn;
-  auto stmt = conn.createStatement();
-  SQLRETURN ret =
-      SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_ASYNC_ENABLE, reinterpret_cast<SQLPOINTER>(SQL_ASYNC_ENABLE_ON), 0);
-  REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
-
-  // When a fast query is executed
-  ret = SQLExecDirect(stmt.getHandle(), (SQLCHAR*)kFastQuery, SQL_NTS);
-
-  // Then the driver may return SQL_SUCCESS directly or SQL_STILL_EXECUTING
-  // (both are spec-valid — the spec says "the first call MAY complete immediately")
-  if (ret == SQL_STILL_EXECUTING) {
-    ret = poll_until_complete(stmt.getHandle(), kFastQuery);
-  }
-  REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
 
   // And data should be retrievable (SQLFetch is also async-capable)
   SQLRETURN fetch_ret = poll_fetch(stmt.getHandle());
   REQUIRE_THAT(OdbcResult(fetch_ret, stmt), OdbcMatchers::Succeeded());
-
-  auto value = get_data<SQL_C_LONG>(stmt, 1);
-  CHECK(value == 42);
+  CHECK(get_data<SQL_C_LONG>(stmt, 1) == 42);
 }
 
 TEST_CASE("should execute and retrieve result set asynchronously", "[query][async]") {

--- a/odbc_tests/tests/e2e/query/async_execution.cpp
+++ b/odbc_tests/tests/e2e/query/async_execution.cpp
@@ -26,7 +26,7 @@ constexpr const char* kLongQuery = "SELECT COUNT(*) FROM TABLE(GENERATOR(TIMELIM
 // Fast query that should complete nearly instantly.
 constexpr const char* kFastQuery = "SELECT 42 AS value";
 
-SQLRETURN poll_until_complete(SQLHSTMT stmt, const char* query) {
+SQLRETURN poll_exec_direct(SQLHSTMT stmt, const char* query) {
   int polls = 0;
   SQLRETURN ret = SQL_STILL_EXECUTING;
   while (ret == SQL_STILL_EXECUTING && ++polls < kMaxPollIterations) {
@@ -154,7 +154,7 @@ TEST_CASE("should return SQL_STILL_EXECUTING for long query", "[query][async]") 
   REQUIRE(ret == SQL_STILL_EXECUTING);
 
   // Cleanup: poll to completion so the statement is usable for teardown
-  poll_until_complete(stmt.getHandle(), kLongQuery);
+  poll_exec_direct(stmt.getHandle(), kLongQuery);
 }
 
 TEST_CASE("should complete async execution via polling and retrieve data", "[query][async]") {
@@ -173,7 +173,7 @@ TEST_CASE("should complete async execution via polling and retrieve data", "[que
   REQUIRE(ret == SQL_STILL_EXECUTING);
 
   // And polling eventually completes
-  ret = poll_until_complete(stmt.getHandle(), kFastQuery);
+  ret = poll_exec_direct(stmt.getHandle(), kFastQuery);
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
 
   // And data should be retrievable (SQLFetch is also async-capable)
@@ -196,7 +196,7 @@ TEST_CASE("should execute and retrieve result set asynchronously", "[query][asyn
   ret = SQLExecDirect(stmt.getHandle(), sqlchar(query), SQL_NTS);
   REQUIRE(ret == SQL_STILL_EXECUTING);
 
-  ret = poll_until_complete(stmt.getHandle(), query);
+  ret = poll_exec_direct(stmt.getHandle(), query);
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
 
   // Then all rows should be fetchable after async completion
@@ -230,7 +230,7 @@ TEST_CASE("should allow re-execution after async completion", "[query][async]") 
   const char* query1 = "SELECT 1 AS val";
   ret = SQLExecDirect(stmt.getHandle(), sqlchar(query1), SQL_NTS);
   REQUIRE(ret == SQL_STILL_EXECUTING);
-  ret = poll_until_complete(stmt.getHandle(), query1);
+  ret = poll_exec_direct(stmt.getHandle(), query1);
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
 
   // And we close the cursor and execute a second query
@@ -240,7 +240,7 @@ TEST_CASE("should allow re-execution after async completion", "[query][async]") 
   const char* query2 = "SELECT 99 AS val";
   ret = SQLExecDirect(stmt.getHandle(), sqlchar(query2), SQL_NTS);
   REQUIRE(ret == SQL_STILL_EXECUTING);
-  ret = poll_until_complete(stmt.getHandle(), query2);
+  ret = poll_exec_direct(stmt.getHandle(), query2);
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
 
   // Then the second query should produce correct results
@@ -262,7 +262,7 @@ TEST_CASE("should allow disabling async after completion", "[query][async]") {
   const char* query = "SELECT 1";
   ret = SQLExecDirect(stmt.getHandle(), sqlchar(query), SQL_NTS);
   REQUIRE(ret == SQL_STILL_EXECUTING);
-  ret = poll_until_complete(stmt.getHandle(), query);
+  ret = poll_exec_direct(stmt.getHandle(), query);
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
   ret = SQLCloseCursor(stmt.getHandle());
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
@@ -311,8 +311,6 @@ TEST_CASE("should execute prepared statement asynchronously", "[query][async]") 
       SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_ASYNC_ENABLE, reinterpret_cast<SQLPOINTER>(SQL_ASYNC_ENABLE_ON), 0);
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
 
-  ret = SQLPrepare(stmt.getHandle(), sqlchar("SELECT 123 AS val"), SQL_NTS);
-  REQUIRE(ret == SQL_STILL_EXECUTING);
   ret = poll_prepare(stmt.getHandle(), "SELECT 123 AS val");
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
 
@@ -419,7 +417,7 @@ TEST_CASE("should cancel async execution with HY008", "[query][async][cancel]") 
   REQUIRE_THAT(OdbcResult(cancel_ret, stmt), OdbcMatchers::Succeeded());
 
   // Then polling should eventually return HY008
-  SQLRETURN poll_ret = poll_until_complete(stmt.getHandle(), kLongQuery);
+  SQLRETURN poll_ret = poll_exec_direct(stmt.getHandle(), kLongQuery);
   REQUIRE(poll_ret == SQL_ERROR);
   CHECK(get_sqlstate(stmt) == "HY008");
 }
@@ -442,7 +440,7 @@ TEST_CASE("should treat SQLCancel on idle async-enabled statement as no-op", "[q
   // And the statement should still be usable for execution
   ret = SQLExecDirect(stmt.getHandle(), sqlchar(kFastQuery), SQL_NTS);
   REQUIRE(ret == SQL_STILL_EXECUTING);
-  ret = poll_until_complete(stmt.getHandle(), kFastQuery);
+  ret = poll_exec_direct(stmt.getHandle(), kFastQuery);
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
 }
 
@@ -489,7 +487,7 @@ TEST_CASE("should return SQL_ERROR asynchronously for invalid SQL", "[query][asy
   REQUIRE(ret == SQL_STILL_EXECUTING);
 
   // Then polling should eventually return SQL_ERROR with a syntax error SQLSTATE
-  ret = poll_until_complete(stmt.getHandle(), bad_query);
+  ret = poll_exec_direct(stmt.getHandle(), bad_query);
   REQUIRE(ret == SQL_ERROR);
   CHECK(get_sqlstate(stmt) == "42000");
 }
@@ -515,7 +513,7 @@ TEST_CASE("should reject non-permitted function call during async execution", "[
   CHECK(get_sqlstate(stmt) == "HY010");
 
   // Cleanup: poll to completion
-  poll_until_complete(stmt.getHandle(), kLongQuery);
+  poll_exec_direct(stmt.getHandle(), kLongQuery);
 }
 
 TEST_CASE("should clear diagnostic records between async polls", "[query][async]") {
@@ -531,7 +529,7 @@ TEST_CASE("should clear diagnostic records between async polls", "[query][async]
   const char* bad_query = "SELCT INVALID";
   ret = SQLExecDirect(stmt.getHandle(), sqlchar(bad_query), SQL_NTS);
   REQUIRE(ret == SQL_STILL_EXECUTING);
-  ret = poll_until_complete(stmt.getHandle(), bad_query);
+  ret = poll_exec_direct(stmt.getHandle(), bad_query);
   REQUIRE(ret == SQL_ERROR);
   auto error_records = get_diag_rec(SQL_HANDLE_STMT, stmt.getHandle());
   REQUIRE_FALSE(error_records.empty());
@@ -545,7 +543,7 @@ TEST_CASE("should clear diagnostic records between async polls", "[query][async]
   CHECK(records.empty());
 
   // And after polling to completion, diagnostics reflect the final state
-  ret = poll_until_complete(stmt.getHandle(), kFastQuery);
+  ret = poll_exec_direct(stmt.getHandle(), kFastQuery);
   REQUIRE_THAT(OdbcResult(ret, stmt), OdbcMatchers::Succeeded());
 }
 

--- a/odbc_tests/tests/odbc-api/terminating_statement/cancel_tests.cpp
+++ b/odbc_tests/tests/odbc-api/terminating_statement/cancel_tests.cpp
@@ -668,7 +668,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancel: Does not post diagnostic rec
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancel: Async cancel interrupts execution with HY008",
                  "[odbc-api][cancel][terminating_statement][async]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SKIP_OLD_DRIVER("BD#34", "Async cancel does not interrupt in-progress operations on reference driver");
+  SKIP_OLD_DRIVER("BD#58", "Async cancel does not interrupt in-progress operations on reference driver");
 
   SQLRETURN ret =
       SQLSetStmtAttr(stmt_handle(), SQL_ATTR_ASYNC_ENABLE, reinterpret_cast<SQLPOINTER>(SQL_ASYNC_ENABLE_ON), 0);
@@ -699,7 +699,7 @@ TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancel: Async cancel interrupts exec
 TEST_CASE_METHOD(StmtDefaultDSNFixture, "SQLCancel: Async cancel clears diagnostics and posts its own",
                  "[odbc-api][cancel][terminating_statement][async]") {
   SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-  SKIP_OLD_DRIVER("BD#34", "Async cancel does not interrupt in-progress operations on reference driver");
+  SKIP_OLD_DRIVER("BD#58", "Async cancel does not interrupt in-progress operations on reference driver");
 
   SQLRETURN ret =
       SQLSetStmtAttr(stmt_handle(), SQL_ATTR_ASYNC_ENABLE, reinterpret_cast<SQLPOINTER>(SQL_ASYNC_ENABLE_ON), 0);


### PR DESCRIPTION
## Summary

- Add `odbc_tests/tests/e2e/query/async_execution.cpp` with 21 e2e tests covering the full ODBC async execution lifecycle
- Tests validate: attribute setup, async polling (`SQL_STILL_EXECUTING`), result set retrieval with async fetch, statement reuse, prepare+execute with parameters, cancel (BD#34 skip), cross-thread cancel, SQLGetInfo reporting, error paths (invalid SQL, sequence errors, diagnostics)
- All tests pass on reference driver (1 skipped for BD#34: async cancel doesn't interrupt on old driver)
- All tests skip on new driver via `SKIP_NEW_DRIVER_NOT_IMPLEMENTED()` until async is implemented

## Test Categories

| Category | Tests |
|----------|-------|
| Attribute setup (set/get/disable/reject) | 4 |
| Async polling + data retrieval | 3 |
| Statement reuse after async | 2 |
| Async prepare + execute | 4 |
| Cancel (async + idle + cross-thread) | 3 |
| Error paths (invalid SQL, HY010, diagnostics) | 3 |
| SQLGetInfo reporting | 2 |

## Test Results (reference driver)

```
100% tests passed, 0 tests failed out of 21
Total Test time (real) = 32.63 sec

Skipped:
  433 - should cancel async execution with HY008 (BD#34)
```

## References

- Jira: [SNOW-2872509](https://snowflakecomputing.atlassian.net/browse/SNOW-2872509)
- Milestone: ODBC PrPr Milestone 3 (deadline 2026-06-03)
- This is the test-first step before implementing the async state machine in Rust

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SNOW-2872509]: https://snowflakecomputing.atlassian.net/browse/SNOW-2872509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ