### PR TITLE
SNOW-2872469: Send EXT_AUTHN_DUO_METHOD in password login request

### DIFF
--- a/sf_core/src/auth.rs
+++ b/sf_core/src/auth.rs
@@ -25,6 +25,8 @@ pub enum Credentials {
     Password {
         username: String,
         password: SensitiveString,
+        passcode_in_password: bool,
+        passcode: Option<SensitiveString>,
     },
     Jwt {
         username: String,
@@ -130,9 +132,16 @@ fn generate_jwt_token(
 
 pub fn create_credentials(login_parameters: &LoginParameters) -> Result<Credentials, AuthError> {
     match &login_parameters.login_method {
-        LoginMethod::Password { username, password } => Ok(Credentials::Password {
+        LoginMethod::Password {
+            username,
+            password,
+            passcode_in_password,
+            passcode,
+        } => Ok(Credentials::Password {
             username: username.clone(),
             password: password.clone(),
+            passcode_in_password: *passcode_in_password,
+            passcode: passcode.clone(),
         }),
         // NativeOkta and ExternalBrowser perform their own multi-step flows in
         // auth_request_data() and never reach create_credentials(). Return an error

--- a/sf_core/src/bin/collect_chunk_data.rs
+++ b/sf_core/src/bin/collect_chunk_data.rs
@@ -318,6 +318,8 @@ fn build_login_params(
         LoginMethod::Password {
             username: user,
             password: SensitiveString::from(password.clone()),
+            passcode_in_password: false,
+            passcode: None,
         }
     } else {
         return Err("No authentication method available: set private_key_file, private_key_contents, or password in parameters".into());

--- a/sf_core/src/config/connection_config.rs
+++ b/sf_core/src/config/connection_config.rs
@@ -48,6 +48,8 @@ pub enum AuthConfig {
     Password {
         user: String,
         password: SensitiveString,
+        passcode_in_password: bool,
+        passcode: Option<SensitiveString>,
     },
     Mfa {
         user: String,
@@ -376,6 +378,8 @@ fn build_auth_config(settings: &ParamStore) -> Result<AuthConfig, ConfigError> {
                 .context(MissingParameterSnafu {
                     parameter: String::from(PASSWORD),
                 })?,
+            passcode_in_password: settings.get_bool(PASSCODE_IN_PASSWORD).unwrap_or(false),
+            passcode: settings.get_sensitive_string(PASSCODE),
         }),
         "USERNAME_PASSWORD_MFA" => Ok(AuthConfig::Mfa {
             user: non_empty_string(settings, USER).context(MissingParameterSnafu {
@@ -522,9 +526,16 @@ impl ConnectionConfig {
 
 fn login_method_from_auth_config(auth: &AuthConfig) -> LoginMethod {
     match auth {
-        AuthConfig::Password { user, password } => LoginMethod::Password {
+        AuthConfig::Password {
+            user,
+            password,
+            passcode_in_password,
+            passcode,
+        } => LoginMethod::Password {
             username: user.clone(),
             password: password.clone(),
+            passcode_in_password: *passcode_in_password,
+            passcode: passcode.clone(),
         },
         AuthConfig::Mfa {
             user,
@@ -1008,7 +1019,7 @@ mod tests {
                 .contains("myaccount.snowflakecomputing.com")
         );
         match &config.auth {
-            AuthConfig::Password { user, password } => {
+            AuthConfig::Password { user, password, .. } => {
                 assert_eq!(user, "myuser");
                 assert_eq!(password.reveal(), "mypassword");
             }
@@ -1187,7 +1198,7 @@ mod tests {
         ]);
         let config = ConnectionConfig::build(&settings).unwrap();
         match &config.auth {
-            AuthConfig::Password { user, password } => {
+            AuthConfig::Password { user, password, .. } => {
                 assert_eq!(user, "u");
                 assert_eq!(password.reveal(), "p");
             }

--- a/sf_core/src/config/rest_parameters.rs
+++ b/sf_core/src/config/rest_parameters.rs
@@ -388,6 +388,8 @@ pub enum LoginMethod {
     Password {
         username: String,
         password: SensitiveString,
+        passcode_in_password: bool,
+        passcode: Option<SensitiveString>,
     },
     NativeOkta(NativeOktaConfig),
     PrivateKey {
@@ -708,6 +710,16 @@ impl LoginMethod {
                         parameter: "password",
                     })?
                     .into(),
+                passcode_in_password: settings
+                    .get_bool("passcodeInPassword")
+                    .or_else(|| {
+                        settings
+                            .get_string("passcodeInPassword")
+                            .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
+                    })
+                    .or_else(|| settings.get_int("passcodeInPassword").map(|v| v != 0))
+                    .unwrap_or(false),
+                passcode: settings.get_string("passcode").map(SensitiveString::from),
             }),
             "PROGRAMMATIC_ACCESS_TOKEN" => Ok(Self::Pat {
                 username: non_empty_string(settings, "user")
@@ -971,7 +983,9 @@ mod tests {
         let result = LoginMethod::from_settings(&settings);
         assert!(result.is_ok());
         match result.unwrap() {
-            LoginMethod::Password { username, password } => {
+            LoginMethod::Password {
+                username, password, ..
+            } => {
                 assert_eq!(username, "test_user");
                 assert_eq!(password.reveal(), "test_password");
             }
@@ -990,7 +1004,9 @@ mod tests {
         let result = LoginMethod::from_settings(&settings);
         assert!(result.is_ok());
         match result.unwrap() {
-            LoginMethod::Password { username, password } => {
+            LoginMethod::Password {
+                username, password, ..
+            } => {
                 assert_eq!(username, "test_user");
                 assert_eq!(password.reveal(), "test_password");
             }

--- a/sf_core/src/crl/integration_test.rs
+++ b/sf_core/src/crl/integration_test.rs
@@ -81,7 +81,7 @@ mod integration_tests {
         );
 
         match &config.auth {
-            AuthConfig::Password { user, password } => {
+            AuthConfig::Password { user, password, .. } => {
                 assert_eq!(user, "test_user");
                 assert_eq!(password.reveal(), "test_password");
             }

--- a/sf_core/src/rest/snowflake/mod.rs
+++ b/sf_core/src/rest/snowflake/mod.rs
@@ -344,6 +344,25 @@ const EXT_AUTHN_ERROR_CODES: [i32; 5] = [
     390129, // EXT_AUTHN_EXCEPTION
 ];
 
+/// Sets the DUO second-factor fields on the login request.
+/// Matches the behavior of the old JDBC, .NET, and ODBC drivers:
+/// always sends `EXT_AUTHN_DUO_METHOD`, defaulting to `"push"` when
+/// no passcode is provided.
+fn set_duo_authn_fields(
+    data: &mut AuthRequestData,
+    passcode_in_password: bool,
+    passcode: Option<SensitiveString>,
+) {
+    data.ext_authn_duo_method = Some(if passcode.is_some() || passcode_in_password {
+        "passcode".to_string()
+    } else {
+        "push".to_string()
+    });
+    if !passcode_in_password {
+        data.passcode = passcode;
+    }
+}
+
 fn extract_host_from_url(server_url: &str) -> Option<String> {
     Url::parse(server_url)
         .ok()?
@@ -542,9 +561,15 @@ pub async fn auth_request_data(
             data.dpop_jwk_json = acquired.dpop_jwk_json;
         }
         _ => match create_credentials(login_parameters).context(AuthenticationSnafu)? {
-            Credentials::Password { username, password } => {
+            Credentials::Password {
+                username,
+                password,
+                passcode_in_password,
+                passcode,
+            } => {
                 data.login_name = Some(username);
                 data.password = Some(password);
+                set_duo_authn_fields(&mut data, passcode_in_password, passcode);
             }
             Credentials::Jwt { username, token } => {
                 data.login_name = Some(username);
@@ -595,15 +620,7 @@ pub async fn auth_request_data(
                 if let Some(cached_token) = cached_mfa_token {
                     data.token = Some(cached_token);
                 } else {
-                    data.ext_authn_duo_method =
-                        Some(if passcode.is_some() || passcode_in_password {
-                            "passcode".to_string()
-                        } else {
-                            "push".to_string()
-                        });
-                    if !passcode_in_password {
-                        data.passcode = passcode.clone();
-                    }
+                    set_duo_authn_fields(&mut data, passcode_in_password, passcode.clone());
                     if store_temp_cred {
                         data.client_request_mfa_token = Some(store_temp_cred);
                     }
@@ -2109,6 +2126,8 @@ mod tests {
             login_method: LoginMethod::Password {
                 username: "testuser".to_string(),
                 password: "testpass".into(),
+                passcode_in_password: false,
+                passcode: None,
             },
             server_url: "https://testaccount.snowflakecomputing.com".to_string(),
             database: None,

--- a/sf_core/tests/common/mocks/password.rs
+++ b/sf_core/tests/common/mocks/password.rs
@@ -42,15 +42,17 @@ pub fn success_login_response() -> ResponseTemplate {
     }))
 }
 
-/// Successful password login — matches a POST to login-request with LOGIN_NAME and PASSWORD
-/// and verifies the AUTHENTICATOR field is absent (matching old driver behavior).
+/// Successful password login — matches a POST to login-request with LOGIN_NAME, PASSWORD,
+/// and EXT_AUTHN_DUO_METHOD="push" (implicit MFA hint matching old driver behavior).
+/// Also verifies the AUTHENTICATOR field is absent.
 pub fn login_success() -> Mock {
     Mock::given(method("POST"))
         .and(path_regex(r"/session/v1/login-request"))
         .and(body_partial_json(json!({
             "data": {
                 "LOGIN_NAME": "test_user",
-                "PASSWORD": "test_password"
+                "PASSWORD": "test_password",
+                "EXT_AUTHN_DUO_METHOD": "push"
             }
         })))
         .and(AuthenticatorFieldAbsent)
@@ -64,7 +66,8 @@ pub fn login_failure_wrong_credentials() -> Mock {
         .and(body_partial_json(json!({
             "data": {
                 "LOGIN_NAME": "test_user",
-                "PASSWORD": "wrong_password"
+                "PASSWORD": "wrong_password",
+                "EXT_AUTHN_DUO_METHOD": "push"
             }
         })))
         .and(AuthenticatorFieldAbsent)


### PR DESCRIPTION
## Summary

- Always send `EXT_AUTHN_DUO_METHOD` in the login request for SNOWFLAKE/SNOWFLAKE_PASSWORD authenticator, matching the behavior of the old JDBC, .NET, and ODBC drivers
- Default to `"push"` when no passcode is provided; use `"passcode"` when `passcode` or `passcodeInPassword` is set
- Extract `set_duo_authn_fields()` helper to deduplicate the logic shared with the `USERNAME_PASSWORD_MFA` branch

## Context

The new universal driver (sf_core) was not sending any `EXT_AUTHN_DUO_METHOD` hint for plain password auth (`LoginMethod::Password`). This is a breaking change from the old drivers — users on MFA-enforced accounts who use `authenticator=snowflake` (or no authenticator) would get authentication failures.

Per [Snowflake documentation](https://docs.snowflake.com/en/user-guide/security-mfa): _"By default, the Duo Push authentication mechanism is used when a user is enrolled in MFA; no changes to the connection string are required."_

### Complete Driver Comparison

| Driver | Sends DUO hint on plain password? | Default (no passcode) | With passcode provided | nextAction/inFlightCtx? |
| --- | --- | --- | --- | --- |
| **Old JDBC** | Always | `"push"` | `"passcode"` + `PASSCODE` field | No |
| **Old .NET** | Always | `"push"` | `"passcode"` + `PASSCODE` field | No |
| **Old ODBC/libsnowflakeclient** | Always | `"push"` | `"passcode"` + `PASSCODE` field | No |
| **Old Go** | Only with passcode | N/A | `"passcode"` + `PASSCODE` field | No |
| **Old Node.js** | Only with MFA signals | N/A (auto-upgrades to USERNAME_PASSWORD_MFA) | `"passcode"` + `PASSCODE` field | inFlightCtx passthrough |
| **Old Python** | Only with passcode | N/A | `"passcode"` + `PASSCODE` field | Yes (full reactive multi-roundtrip) |
| **sf_core (before this PR)** | Never | N/A | N/A (only via USERNAME_PASSWORD_MFA) | No |
| **sf_core (this PR)** | Always | `"push"` | `"passcode"` + `PASSCODE` field | No |

This PR aligns with the majority pattern (JDBC, .NET, ODBC) which is also the simplest and most compatible: always send the hint, let the server ignore it for non-MFA accounts.