### PR TITLE
NO-SNOW: Fix PyPI development status classifier (Alpha -> Beta) and shorten PrPr disclaimer

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -1,6 +1,7 @@
 # ⚠️ PRIVATE PREVIEW DISCLAIMER ⚠️
 
-This is a beta version of our Universal Driver intended for Snowflake customers who are subject to Snowflake's Preview Terms.
+**This is a beta version of our Universal Driver intended for Snowflake customers who are subject to Snowflake's Preview Terms.**
+
 This driver is not ready for use with production data and may be unstable. Please only use it if you are actively participating in the Universal Driver Private Preview.
 
 ## Development

--- a/python/README.md
+++ b/python/README.md
@@ -1,10 +1,7 @@
 # ⚠️ PRIVATE PREVIEW DISCLAIMER ⚠️
 
-**IMPORTANT:** This release contains a **Private Preview** version of the Snowflake DB driver. By downloading or using this software, you acknowledge and agree to the following conditions:
-
-- **Restricted Access:** Usage of this driver is strictly limited to participants who are actively enrolled in the official Private Preview program for this specific driver. If you have not been explicitly invited and authorized to participate in this preview, do not download, install, or use this software.
-- **Testing Environments Only:** For authorized Private Preview partners, this driver is provided solely for evaluation, feedback, and testing purposes. It must be deployed exclusively in isolated, non-production environments.
-- **"As-Is" Software:** As a preview release, this driver is still under active development. It may contain bugs, lack features, or undergo significant breaking changes before general availability. It is provided "as-is" without any warranties, service level agreements (SLAs), or official support commitments.
+This is a beta version of our Universal Driver intended for Snowflake customers who are subject to Snowflake's Preview Terms.
+This driver is not ready for use with production data and may be unstable. Please only use it if you are actively participating in the Universal Driver Private Preview.
 
 ## Development
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 license = { text = "Apache-2.0" }
 keywords = ["database", "api", "pep249", "dbapi", "python", "snowflake"]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Topic :: Database",
     "Topic :: Software Development :: Libraries :: Python Modules",


### PR DESCRIPTION
- Update [PyPi-posted](https://pypi.org/project/snowflake-connector-python/5.0.0b2/) project description to match [ODBC one](https://github.com/snowflakedb/universal-driver/releases)
- Update [PyPi Development status](https://pypi.org/search/?c=Development+Status+%3A%3A+3+-+Alpha) from "alpha" to "beta"