### PR TITLE
SNOW-3235557 Attribute Error Handling & Conformance

### DIFF
--- a/odbc/src/api/connection.rs
+++ b/odbc/src/api/connection.rs
@@ -684,8 +684,11 @@ pub fn set_connect_attr<E: OdbcEncoding>(
         None if ConnectionAttribute::is_snowflake_custom(attribute) => {
             return UnknownAttributeSnafu { attribute }.fail();
         }
+        None if ConnectionAttribute::is_odbc_range(attribute) => {
+            return UnsupportedAttributeSnafu { attribute }.fail();
+        }
         None => {
-            tracing::debug!("set_connect_attr: ignoring standard attribute {attribute}");
+            tracing::debug!("set_connect_attr: ignoring unknown attribute {attribute}");
             return Ok(());
         }
     };
@@ -896,6 +899,9 @@ pub fn get_connect_attr<E: OdbcEncoding>(
 
     let attr = match ConnectionAttribute::from_raw(attribute) {
         Some(a) => a,
+        None if ConnectionAttribute::is_odbc_range(attribute) => {
+            return UnsupportedAttributeSnafu { attribute }.fail();
+        }
         None => {
             tracing::warn!("get_connect_attr: unknown attribute {attribute}");
             return UnknownAttributeSnafu { attribute }.fail();
@@ -1152,6 +1158,12 @@ pub fn get_connect_attr<E: OdbcEncoding>(
         | ConnectionAttribute::PrivKeyPassword
         | ConnectionAttribute::PrivKeyBase64
         | ConnectionAttribute::Application => {
+            if buffer_length < 0 {
+                return InvalidBufferLengthSnafu {
+                    length: buffer_length as i64,
+                }
+                .fail();
+            }
             let value = connection
                 .pre_connection_attrs
                 .get(&attr)

--- a/odbc/src/api/types/odbc_types.rs
+++ b/odbc/src/api/types/odbc_types.rs
@@ -112,6 +112,15 @@ pub enum ConnectionAttribute {
 }
 
 impl ConnectionAttribute {
+    /// Returns true if `raw` is a standard ODBC-defined connection attribute ID.
+    /// ODBC spec (sql.h / sqlext.h) defines connection attributes in the ranges
+    /// 101–117, 1209, 10001, and 10014.  IDs in these ranges that the driver does
+    /// not handle should return HYC00 (optional feature not implemented) rather
+    /// than HY092 (invalid attribute identifier).
+    pub fn is_odbc_range(raw: i32) -> bool {
+        matches!(raw, 101..=117 | 1209 | 10001 | 10014)
+    }
+
     /// Convert a raw ODBC attribute ID to a `ConnectionAttribute`.
     /// Returns `None` for unrecognized attributes.
     pub fn from_raw(value: i32) -> Option<Self> {
@@ -415,10 +424,20 @@ impl TryFrom<i32> for StmtAttr {
             16648 => Ok(StmtAttr::SnowflakeMultiStatementCount),
             _ => {
                 tracing::warn!("Unknown statement attribute: {}", value);
-                Err(OdbcError::UnknownAttribute {
-                    attribute: value,
-                    location: snafu::location!(),
-                })
+                // ODBC-defined range (spec IDs -2..=27 and 10010..=10014): the driver
+                // doesn't support it but it's a valid ODBC ID → HYC00.
+                // Everything else is completely invalid → HY092.
+                if matches!(value, -2..=27 | 10010..=10014) {
+                    Err(OdbcError::UnsupportedAttribute {
+                        attribute: value,
+                        location: snafu::location!(),
+                    })
+                } else {
+                    Err(OdbcError::UnknownAttribute {
+                        attribute: value,
+                        location: snafu::location!(),
+                    })
+                }
             }
         }
     }

--- a/odbc_tests/BehaviorDifferences.yaml
+++ b/odbc_tests/BehaviorDifferences.yaml
@@ -862,3 +862,30 @@ behavior_differences:
       SQLCancel on an async statement sends a cancel request to the server, and subsequent polling returns SQL_ERROR with SQLSTATE HY008 ("Operation canceled") once the cancellation is acknowledged.
     impact: |
       Applications that rely on SQLCancel to abort long-running async queries will not get timely cancellation on the old driver. The query may run to completion despite the cancel request.
+
+  61:
+    name: "Unknown ODBC-range connection attribute returns HYC00; old driver silently ignores on set and returns HY092 on get"
+    status: unknown
+    type: api_incompatibility
+    reviewed: false
+    old_driver_behavior: |
+      SQLSetConnectAttr with an unrecognised standard ODBC connection attribute (e.g. SQL_ATTR_TRACE = 114) returns SQL_SUCCESS silently.
+      SQLGetConnectAttr with the same attribute returns SQL_ERROR with SQLSTATE HY092 (Invalid attribute/option identifier).
+    new_driver_behavior: |
+      Both SQLSetConnectAttr and SQLGetConnectAttr return SQL_ERROR with SQLSTATE HYC00 (Optional feature not implemented) for standard ODBC-defined connection attribute IDs (101–117, 1209, 10001, 10014) that the driver does not support.
+      Completely unrecognised attribute IDs outside the ODBC-defined ranges are still silently ignored on set and return HY092 on get.
+    impact: |
+      Applications that set ODBC-range connection attributes not supported by the driver (e.g. SQL_ATTR_TRACE) will now receive an error instead of silent success. Applications that specifically check for HY092 on get of these attributes will now see HYC00.
+
+  62:
+    name: "Unknown ODBC-range statement attribute returns HYC00; old driver returns HY092"
+    status: unknown
+    type: api_incompatibility
+    reviewed: false
+    old_driver_behavior: |
+      SQLSetStmtAttr and SQLGetStmtAttr with any unrecognised attribute ID return SQL_ERROR with SQLSTATE HY092 (Invalid attribute/option identifier), regardless of whether the ID falls within the ODBC-defined range.
+    new_driver_behavior: |
+      Standard ODBC-defined statement attribute IDs (-2 to 27, 10010–10014) that the driver does not implement return SQL_ERROR with SQLSTATE HYC00 (Optional feature not implemented).
+      Completely invalid attribute IDs outside those ranges return SQL_ERROR with SQLSTATE HY092.
+    impact: |
+      Applications checking for HY092 on unimplemented but valid ODBC statement attribute IDs (e.g. SQL_ATTR_FETCH_BOOKMARK_PTR = 16) will now see HYC00 instead.

--- a/odbc_tests/tests/e2e/query/attr_error_handling.cpp
+++ b/odbc_tests/tests/e2e/query/attr_error_handling.cpp
@@ -76,3 +76,144 @@ TEST_CASE("SQLGetConnectAttr with negative buffer length returns HY090.") {
   REQUIRE(ret == SQL_ERROR);
   NEW_DRIVER_ONLY("BD#53") { CHECK(get_sqlstate(conn.handleWrapper()) == "HY090"); }
 }
+
+// ============================================================================
+// Unknown attribute handling (BD#61, BD#62)
+// ============================================================================
+
+TEST_CASE("SQLSetConnectAttr with unknown ODBC-range attribute returns error (BD#61).") {
+  // Given Snowflake client is logged in
+  Connection conn;
+
+  // When SQLSetConnectAttr is called with SQL_ATTR_TRACE (114) — a valid ODBC attr not supported by the driver
+  SQLRETURN ret = SQLSetConnectAttr(conn.handleWrapper().getHandle(), 114 /* SQL_ATTR_TRACE */, nullptr, 0);
+
+  // Then new driver returns SQL_ERROR with HYC00; old driver silently ignores it (BD#61)
+  NEW_DRIVER_ONLY("BD#61") {
+    REQUIRE(ret == SQL_ERROR);
+    CHECK(get_sqlstate(conn.handleWrapper()) == "HYC00");
+  }
+  OLD_DRIVER_ONLY("BD#61") { REQUIRE(ret == SQL_SUCCESS); }
+}
+
+TEST_CASE("SQLGetConnectAttr with unknown ODBC-range attribute returns error (BD#61).") {
+  // Given Snowflake client is logged in
+  Connection conn;
+
+  // When SQLGetConnectAttr is called with SQL_ATTR_TRACE (114)
+  SQLINTEGER value = 0;
+  SQLRETURN ret = SQLGetConnectAttr(conn.handleWrapper().getHandle(), 114 /* SQL_ATTR_TRACE */, &value, 0, nullptr);
+
+  // Then both drivers return SQL_ERROR; new driver returns HYC00, old driver returns HY092 (BD#61)
+  REQUIRE(ret == SQL_ERROR);
+  NEW_DRIVER_ONLY("BD#61") { CHECK(get_sqlstate(conn.handleWrapper()) == "HYC00"); }
+  OLD_DRIVER_ONLY("BD#61") { CHECK(get_sqlstate(conn.handleWrapper()) == "HY092"); }
+}
+
+TEST_CASE("SQLSetStmtAttr with unimplemented ODBC-range attribute returns HYC00 (BD#62).") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQLSetStmtAttr is called with SQL_ATTR_FETCH_BOOKMARK_PTR (16) — valid ODBC attr not implemented
+  SQLRETURN ret = SQLSetStmtAttr(stmt.getHandle(), 16 /* SQL_ATTR_FETCH_BOOKMARK_PTR */, nullptr, 0);
+
+  // Then new driver returns SQL_ERROR with HYC00; old driver returns HY092 (BD#62)
+  REQUIRE(ret == SQL_ERROR);
+  NEW_DRIVER_ONLY("BD#62") { CHECK(get_sqlstate(stmt) == "HYC00"); }
+  OLD_DRIVER_ONLY("BD#62") { CHECK(get_sqlstate(stmt) == "HY092"); }
+}
+
+TEST_CASE("SQLGetStmtAttr with unimplemented ODBC-range attribute returns HYC00 (BD#62).") {
+  // Given Snowflake client is logged in
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  // When SQLGetStmtAttr is called with SQL_ATTR_FETCH_BOOKMARK_PTR (16)
+  SQLPOINTER value = nullptr;
+  SQLINTEGER len = 0;
+  SQLRETURN ret = SQLGetStmtAttr(stmt.getHandle(), 16 /* SQL_ATTR_FETCH_BOOKMARK_PTR */, &value, 0, &len);
+
+  // Then new driver returns SQL_ERROR with HYC00; old driver returns HY092 (BD#62)
+  REQUIRE(ret == SQL_ERROR);
+  NEW_DRIVER_ONLY("BD#62") { CHECK(get_sqlstate(stmt) == "HYC00"); }
+  OLD_DRIVER_ONLY("BD#62") { CHECK(get_sqlstate(stmt) == "HY092"); }
+}
+
+// ============================================================================
+// Read-only connection attributes on set
+// ============================================================================
+
+TEST_CASE("SQLSetConnectAttr on read-only SQL_ATTR_CONNECTION_DEAD returns HY092.") {
+  // Given Snowflake client is logged in
+  Connection conn;
+
+  // When SQLSetConnectAttr is called for SQL_ATTR_CONNECTION_DEAD (1209), which is read-only
+  SQLRETURN ret = SQLSetConnectAttr(conn.handleWrapper().getHandle(), SQL_ATTR_CONNECTION_DEAD,
+                                    reinterpret_cast<SQLPOINTER>(SQL_CD_FALSE), 0);
+
+  // Then it should return SQL_ERROR with HY092
+  REQUIRE(ret == SQL_ERROR);
+  CHECK(get_sqlstate(conn.handleWrapper()) == "HY092");
+}
+
+TEST_CASE("SQLSetConnectAttr on read-only SQL_ATTR_AUTO_IPD returns HY092.") {
+  // Given Snowflake client is logged in
+  Connection conn;
+
+  // When SQLSetConnectAttr is called for SQL_ATTR_AUTO_IPD (10001), which is read-only
+  SQLRETURN ret = SQLSetConnectAttr(conn.handleWrapper().getHandle(), SQL_ATTR_AUTO_IPD,
+                                    reinterpret_cast<SQLPOINTER>(SQL_FALSE), 0);
+
+  // Then it should return SQL_ERROR with HY092
+  REQUIRE(ret == SQL_ERROR);
+  CHECK(get_sqlstate(conn.handleWrapper()) == "HY092");
+}
+
+// ============================================================================
+// Connection-state-dependent attributes (HY011)
+// ============================================================================
+
+TEST_CASE("SQLSetConnectAttr for SQL_ATTR_LOGIN_TIMEOUT after connect returns HY011.") {
+  // Given Snowflake client is logged in (connected state)
+  Connection conn;
+
+  // When SQL_ATTR_LOGIN_TIMEOUT is set while already connected
+  SQLRETURN ret =
+      SQLSetConnectAttr(conn.handleWrapper().getHandle(), SQL_ATTR_LOGIN_TIMEOUT, reinterpret_cast<SQLPOINTER>(30), 0);
+
+  // Then it should return SQL_ERROR with HY011 (attribute cannot be set now)
+  REQUIRE(ret == SQL_ERROR);
+  CHECK(get_sqlstate(conn.handleWrapper()) == "HY011");
+}
+
+TEST_CASE("SQLSetConnectAttr for SQL_ATTR_PACKET_SIZE after connect returns HY011.") {
+  // Given Snowflake client is logged in (connected state)
+  Connection conn;
+
+  // When SQL_ATTR_PACKET_SIZE is set while already connected
+  SQLRETURN ret =
+      SQLSetConnectAttr(conn.handleWrapper().getHandle(), SQL_ATTR_PACKET_SIZE, reinterpret_cast<SQLPOINTER>(4096), 0);
+
+  // Then it should return SQL_ERROR with HY011 (attribute cannot be set now)
+  REQUIRE(ret == SQL_ERROR);
+  CHECK(get_sqlstate(conn.handleWrapper()) == "HY011");
+}
+
+// ============================================================================
+// Negative buffer length on non-catalog string connection attributes
+// ============================================================================
+
+TEST_CASE("SQLGetConnectAttr for SF private key attribute with negative buffer returns HY090.") {
+  // Given Snowflake client is logged in
+  Connection conn;
+
+  // When SQLGetConnectAttr is called with buffer_length = -1 for a Snowflake string attribute
+  char buf[256] = {};
+  SQLINTEGER len = 0;
+  SQLRETURN ret = SQLGetConnectAttr(conn.handleWrapper().getHandle(), SQL_SF_CONN_ATTR_PRIV_KEY_CONTENT, buf, -1, &len);
+
+  // Then new driver returns SQL_ERROR with HY090; old driver may return HY000 (BD#53)
+  REQUIRE(ret == SQL_ERROR);
+  NEW_DRIVER_ONLY("BD#53") { CHECK(get_sqlstate(conn.handleWrapper()) == "HY090"); }
+}


### PR DESCRIPTION
- Distinguish HYC00 vs HY092 for unknown statement attributes:
  ODBC-range IDs (-2..=27, 10010..=10014) now return UnsupportedAttribute
  (HYC00); completely invalid IDs still return UnknownAttribute (HY092)
- Add ConnectionAttribute::is_odbc_range() and apply it in
  get_connect_attr / set_connect_attr so ODBC-range unknowns return HYC00
  instead of silently succeeding (set) or returning HY092 (get)
- Add buffer_length < 0 guard (HY090) to PrivKey* and Application string
  attrs in get_connect_attr
- Add BD#61 and BD#62 entries to BehaviorDifferences.yaml
- Expand attr_error_handling.cpp with 9 new e2e tests covering unknown
  ODBC-range attrs, read-only conn attrs, HY011 state-dependent attrs,
  and negative buffer on Snowflake string conn attrs

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>