### PR TITLE
SNOW-2872352: jdbc - implement statement release and connection-level statement tracking

### DIFF
--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/connection/InternalSnowflakeConnection.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/connection/InternalSnowflakeConnection.java
@@ -1,0 +1,14 @@
+package net.snowflake.client.internal.api.implementation.connection;
+
+import java.sql.Connection;
+import java.sql.Statement;
+import net.snowflake.client.api.connection.SnowflakeConnection;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionHandle;
+
+/** Internal interface combining JDBC Connection and SnowflakeConnection with handle access. */
+public interface InternalSnowflakeConnection extends Connection, SnowflakeConnection {
+
+  ConnectionHandle getHandle();
+
+  void removeStatement(Statement stmt);
+}

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/connection/SnowflakeConnectionImpl.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/connection/SnowflakeConnectionImpl.java
@@ -5,7 +5,6 @@ import java.sql.Array;
 import java.sql.Blob;
 import java.sql.CallableStatement;
 import java.sql.Clob;
-import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.NClob;
 import java.sql.PreparedStatement;
@@ -22,10 +21,11 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import net.snowflake.client.api.connection.DownloadStreamConfig;
-import net.snowflake.client.api.connection.SnowflakeConnection;
 import net.snowflake.client.api.connection.UploadStreamConfig;
 import net.snowflake.client.api.driver.SnowflakeDriver;
 import net.snowflake.client.api.resultset.QueryStatus;
@@ -45,18 +45,21 @@ import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.Wrapp
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.WrapperIdentity.Builder;
 import net.snowflake.client.internal.util.NotImplementedException;
 
-public class SnowflakeConnectionImpl implements SnowflakeConnection, Connection {
+public class SnowflakeConnectionImpl implements InternalSnowflakeConnection {
 
   private static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeConnectionImpl.class);
+
+  private final AtomicBoolean closed = new AtomicBoolean(false);
+  private final Set<Statement> openStatements = ConcurrentHashMap.newKeySet();
+  private final CoreDriverApi coreDriverApi;
+  private final DatabaseHandle databaseHandle;
+  private final ConnectionHandle connectionHandle;
   private final String url;
   private final Properties properties;
-  private final CoreDriverApi coreDriverApi;
+
   private boolean autoCommit = true;
-  private final AtomicBoolean closed = new AtomicBoolean(false);
   private String catalog;
   private String schema;
-  private final DatabaseHandle databaseHandle;
-  public final ConnectionHandle connectionHandle;
 
   private volatile String cachedDatabaseVersion;
   private final Object databaseVersionLock = new Object();
@@ -137,15 +140,24 @@ public class SnowflakeConnectionImpl implements SnowflakeConnection, Connection 
   }
 
   @Override
+  public ConnectionHandle getHandle() {
+    return connectionHandle;
+  }
+
+  @Override
   public Statement createStatement() throws SQLException {
     checkClosed();
-    return new SnowflakeStatementImpl(this);
+    Statement stmt = new SnowflakeStatementImpl(this, coreDriverApi);
+    openStatements.add(stmt);
+    return stmt;
   }
 
   @Override
   public PreparedStatement prepareStatement(String sql) throws SQLException {
     checkClosed();
-    return new SnowflakePreparedStatementImpl(this, sql);
+    PreparedStatement stmt = new SnowflakePreparedStatementImpl(this, sql, coreDriverApi);
+    openStatements.add(stmt);
+    return stmt;
   }
 
   @Override
@@ -211,14 +223,15 @@ public class SnowflakeConnectionImpl implements SnowflakeConnection, Connection 
     throw new NotImplementedException();
   }
 
-  // TODO: track open statements and close them here (+ implement Statement.close() →
-  // statementRelease)
   @Override
   public void close() throws SQLException {
     if (!closed.compareAndSet(false, true)) {
       return;
     }
+
     logger.debug("Closing connection");
+    closeOpenStatements();
+
     try {
       coreDriverApi.connectionClose(connectionHandle);
     } catch (SQLException e) {
@@ -228,6 +241,24 @@ public class SnowflakeConnectionImpl implements SnowflakeConnection, Connection 
     } finally {
       releaseHandlesQuietly(coreDriverApi, connectionHandle, databaseHandle);
     }
+  }
+
+  @Override
+  public void removeStatement(Statement stmt) {
+    openStatements.remove(stmt);
+  }
+
+  private void closeOpenStatements() {
+    for (Statement stmt : openStatements) {
+      try {
+        if (!stmt.isClosed()) {
+          stmt.close();
+        }
+      } catch (SQLException e) {
+        logger.debug("Error closing statement during connection close", e);
+      }
+    }
+    openStatements.clear();
   }
 
   private static void releaseHandlesQuietly(

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakePreparedStatementImpl.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakePreparedStatementImpl.java
@@ -27,9 +27,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 import net.snowflake.client.api.statement.SnowflakePreparedStatement;
-import net.snowflake.client.internal.api.implementation.connection.SnowflakeConnectionImpl;
+import net.snowflake.client.internal.api.implementation.connection.InternalSnowflakeConnection;
 import net.snowflake.client.internal.log.SFLogger;
 import net.snowflake.client.internal.log.SFLoggerFactory;
+import net.snowflake.client.internal.unicore.CoreDriverApi;
 import net.snowflake.client.internal.util.HexUtil;
 
 public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
@@ -41,8 +42,9 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
   private final SqlPlaceholderMetadata placeholderMetadata;
   private final Map<Integer, PreparedStatementBindingSerializer.ParameterValue> parameterValues;
 
-  public SnowflakePreparedStatementImpl(SnowflakeConnectionImpl connection, String sql) {
-    super(connection);
+  public SnowflakePreparedStatementImpl(
+      InternalSnowflakeConnection connection, String sql, CoreDriverApi coreDriverApi) {
+    super(connection, coreDriverApi);
     this.sql = sql;
     this.placeholderMetadata = SqlPlaceholderMetadata.analyze(sql);
     this.parameterValues = new HashMap<>();

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakeStatementImpl.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakeStatementImpl.java
@@ -12,13 +12,14 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import net.snowflake.client.api.exception.SnowflakeSQLException;
 import net.snowflake.client.api.statement.SnowflakeStatement;
-import net.snowflake.client.internal.api.implementation.connection.SnowflakeConnectionImpl;
+import net.snowflake.client.internal.api.implementation.connection.InternalSnowflakeConnection;
 import net.snowflake.client.internal.api.implementation.resultset.SnowflakeResultSetImpl;
 import net.snowflake.client.internal.log.SFLogger;
 import net.snowflake.client.internal.log.SFLoggerFactory;
-import net.snowflake.client.internal.unicore.ProtobufApis;
+import net.snowflake.client.internal.unicore.CoreDriverApi;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConfigSetting;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ExecuteQueryResponse;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.MultiStatementResult;
@@ -32,8 +33,10 @@ import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.State
 public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
   private static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeStatementImpl.class);
 
-  protected final SnowflakeConnectionImpl connection;
-  protected boolean closed = false;
+  protected final InternalSnowflakeConnection connection;
+  protected final CoreDriverApi coreDriverApi;
+
+  private final AtomicBoolean closed = new AtomicBoolean(false);
   protected int maxRows = 0;
   protected int queryTimeout = 0;
   protected int fetchSize = 0;
@@ -45,11 +48,12 @@ public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
   /** Non-null only while navigating a multi-statement result set sequence. */
   private MultiStatementState multiState;
 
-  public SnowflakeStatementImpl(SnowflakeConnectionImpl connection) {
+  public SnowflakeStatementImpl(
+      InternalSnowflakeConnection connection, CoreDriverApi coreDriverApi) {
     this.connection = connection;
+    this.coreDriverApi = coreDriverApi;
     try {
-      this.statementHandle =
-          ProtobufApis.coreDriverApi.statementNew(connection.connectionHandle).getStmtHandle();
+      this.statementHandle = coreDriverApi.statementNew(connection.getHandle()).getStmtHandle();
     } catch (SQLException e) {
       throw new RuntimeException(e);
     }
@@ -89,15 +93,14 @@ public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
     boolean hasBindings = bindings != null;
     logger.debug("Statement executeWithBindings start: sql={}, hasBindings={}", sql, hasBindings);
     prepareForExecution();
-    ProtobufApis.coreDriverApi.statementSetSqlQuery(statementHandle, sql);
-    ExecuteQueryResponse response =
-        ProtobufApis.coreDriverApi.statementExecuteQuery(statementHandle, bindings);
+    coreDriverApi.statementSetSqlQuery(statementHandle, sql);
+    ExecuteQueryResponse response = coreDriverApi.statementExecuteQuery(statementHandle, bindings);
     logger.debug("statementExecuteQuery succeeded: hasBindings={}", hasBindings);
     return response;
   }
 
   private ResultSetResponse fetchResultSetByQueryId(String queryId) throws SQLException {
-    return ProtobufApis.coreDriverApi.connectionGetResultSet(connection.connectionHandle, queryId);
+    return coreDriverApi.connectionGetResultSet(connection.getHandle(), queryId);
   }
 
   /**
@@ -109,7 +112,7 @@ public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
   private ResultSetGetStreamResponse fetchStreamAndRelease(ResultSetHandle handle)
       throws SQLException {
     try {
-      ResultSetGetStreamResponse response = ProtobufApis.coreDriverApi.resultSetGetStream(handle);
+      ResultSetGetStreamResponse response = coreDriverApi.resultSetGetStream(handle);
       releaseResultSet(handle);
       return response;
     } catch (SQLException e) {
@@ -120,7 +123,7 @@ public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
 
   private void releaseResultSet(ResultSetHandle handle) {
     try {
-      ProtobufApis.coreDriverApi.resultSetRelease(handle);
+      coreDriverApi.resultSetRelease(handle);
     } catch (SQLException e) {
       logger.warn("Failed to release ResultSet handle", e);
     }
@@ -277,11 +280,16 @@ public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
 
   @Override
   public void close() throws SQLException {
-    if (closed) {
+    if (!closed.compareAndSet(false, true)) {
       return;
     }
     clearExecutionState();
-    closed = true;
+    try {
+      coreDriverApi.statementRelease(statementHandle);
+    } catch (SQLException e) {
+      logger.debug("Error releasing statement handle", e);
+    }
+    connection.removeStatement(this);
   }
 
   @Override
@@ -508,7 +516,7 @@ public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
 
   @Override
   public boolean isClosed() throws SQLException {
-    return closed;
+    return closed.get();
   }
 
   @Override
@@ -549,7 +557,7 @@ public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
   }
 
   protected void checkClosed() throws SQLException {
-    if (closed) {
+    if (isClosed()) {
       throw new SQLException("Statement is closed");
     }
     if (connection.isClosed()) {
@@ -577,7 +585,7 @@ public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
     } else {
       settingBuilder.setStringValue(String.valueOf(value));
     }
-    ProtobufApis.coreDriverApi.statementSetOptions(
+    coreDriverApi.statementSetOptions(
         statementHandle, Collections.singletonMap(name, settingBuilder.build()));
   }
 

--- a/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/connection/SnowflakeConnectionImplTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/connection/SnowflakeConnectionImplTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.when;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.Properties;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -30,6 +31,9 @@ import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.Datab
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseInitResponse;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseNewResponse;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseReleaseResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementHandle;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementNewResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementReleaseResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -57,7 +61,7 @@ public class SnowflakeConnectionImplTest {
     ConfigSetting configSetting = SnowflakeConnectionImpl.toConfigSetting(Boolean.TRUE);
 
     assertEquals(ConfigSetting.ValueCase.BOOL_VALUE, configSetting.getValueCase());
-    assertEquals(true, configSetting.getBoolValue());
+    assertTrue(configSetting.getBoolValue());
   }
 
   @Test
@@ -250,6 +254,45 @@ public class SnowflakeConnectionImplTest {
       verify(mockCoreApi, never()).connectionClose(any());
       verify(mockCoreApi, never()).connectionRelease(any());
       verify(mockCoreApi, never()).databaseRelease(any());
+    }
+
+    @Test
+    void closesOpenStatementsBeforeConnectionClose() throws Exception {
+      stubSuccessfulClose();
+      StatementHandle stmtHandle = StatementHandle.newBuilder().setId(10).setMagic(1000).build();
+      when(mockCoreApi.statementNew(any()))
+          .thenReturn(StatementNewResponse.newBuilder().setStmtHandle(stmtHandle).build());
+      when(mockCoreApi.statementRelease(any()))
+          .thenReturn(StatementReleaseResponse.getDefaultInstance());
+
+      Connection conn = createConnection();
+      Statement stmt = conn.createStatement();
+      assertFalse(stmt.isClosed());
+
+      conn.close();
+
+      assertTrue(stmt.isClosed());
+      verify(mockCoreApi).statementRelease(any());
+    }
+
+    @Test
+    void manuallyClosedStatementIsNotDoubleClosedOnConnectionClose() throws Exception {
+      stubSuccessfulClose();
+      StatementHandle stmtHandle = StatementHandle.newBuilder().setId(10).setMagic(1000).build();
+      when(mockCoreApi.statementNew(any()))
+          .thenReturn(StatementNewResponse.newBuilder().setStmtHandle(stmtHandle).build());
+      when(mockCoreApi.statementRelease(any()))
+          .thenReturn(StatementReleaseResponse.getDefaultInstance());
+
+      Connection conn = createConnection();
+      Statement stmt = conn.createStatement();
+      stmt.close();
+
+      clearInvocations(mockCoreApi);
+      stubSuccessfulClose();
+      conn.close();
+
+      verify(mockCoreApi, never()).statementRelease(any());
     }
   }
 }

--- a/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/statement/SnowflakeStatementImplTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/statement/SnowflakeStatementImplTest.java
@@ -1,0 +1,96 @@
+package net.snowflake.client.internal.api.implementation.statement;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.SQLException;
+import java.sql.Statement;
+import net.snowflake.client.internal.api.implementation.connection.InternalSnowflakeConnection;
+import net.snowflake.client.internal.unicore.CoreDriverApi;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionHandle;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementHandle;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementNewResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementReleaseResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class SnowflakeStatementImplTest {
+
+  private final ConnectionHandle connHandle =
+      ConnectionHandle.newBuilder().setId(1).setMagic(100).build();
+  private final StatementHandle stmtHandle =
+      StatementHandle.newBuilder().setId(10).setMagic(1000).build();
+
+  private CoreDriverApi mockCoreApi;
+  private InternalSnowflakeConnection mockConnection;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    mockCoreApi = mock(CoreDriverApi.class);
+    mockConnection = mock(InternalSnowflakeConnection.class);
+    when(mockConnection.getHandle()).thenReturn(connHandle);
+    when(mockCoreApi.statementNew(any()))
+        .thenReturn(StatementNewResponse.newBuilder().setStmtHandle(stmtHandle).build());
+    when(mockCoreApi.statementRelease(any()))
+        .thenReturn(StatementReleaseResponse.getDefaultInstance());
+  }
+
+  private Statement createStatement() {
+    return new SnowflakeStatementImpl(mockConnection, mockCoreApi);
+  }
+
+  @Test
+  void closeReleasesStatementHandle() throws Exception {
+    Statement stmt = createStatement();
+
+    stmt.close();
+
+    verify(mockCoreApi).statementRelease(any());
+    assertTrue(stmt.isClosed());
+  }
+
+  @Test
+  void closeDeregistersFromConnection() throws Exception {
+    Statement stmt = createStatement();
+
+    stmt.close();
+
+    verify(mockConnection).removeStatement(stmt);
+  }
+
+  @Test
+  void doubleCloseDoesNotReleaseHandleTwice() throws Exception {
+    Statement stmt = createStatement();
+
+    stmt.close();
+    stmt.close();
+
+    verify(mockCoreApi, times(1)).statementRelease(any());
+    verify(mockConnection, times(1)).removeStatement(stmt);
+  }
+
+  @Test
+  void closeSucceedsEvenWhenReleaseThrows() throws Exception {
+    when(mockCoreApi.statementRelease(any())).thenThrow(new SQLException("release failed"));
+
+    Statement stmt = createStatement();
+    stmt.close();
+
+    assertTrue(stmt.isClosed());
+    verify(mockConnection).removeStatement(stmt);
+  }
+
+  @Test
+  void operationsThrowAfterClose() throws Exception {
+    Statement stmt = createStatement();
+    stmt.close();
+
+    assertThrows(SQLException.class, () -> stmt.execute("SELECT 1"));
+    assertThrows(SQLException.class, () -> stmt.executeQuery("SELECT 1"));
+  }
+}


### PR DESCRIPTION
## Summary

- Implement `Statement.close()` to release native statement handles via `statementRelease` RPC
- Track open statements on `Connection` using strong references (`Set<Statement>`) for reliable cleanup on connection close
- Statements deregister themselves from the connection on `close()` via `InternalSnowflakeConnection.removeStatement()`, preventing double-close and allowing immediate GC
- Inject `CoreDriverApi` into `SnowflakeStatementImpl` and `SnowflakePreparedStatementImpl` via constructor for testability

## Context

This is a follow-up to the CoreDriver facade PR (#1262). With the `CoreDriverApi` interface in place, statements can now properly manage their lifecycle by releasing native handles through the core driver.

We use strong references (not `WeakReference`) for statement tracking because statements own native handles that require an explicit RPC (`statementRelease`) to free. With weak references, a user dropping a `Statement` reference without calling `close()` would allow GC to collect the Java object while the native handle leaks — `statementRelease` would never be called. Strong references ensure the native handle stays reachable until either `Statement.close()` (which deregisters from the connection) or `Connection.close()` (which closes all remaining statements). This matches the approach taken by PostgreSQL and MySQL JDBC drivers.