### PR TITLE
SNOW-2467786: Add PAT authentication E2E tests and DataSource support for JDBC

### DIFF
--- a/.github/workflows/_build-python-wheels.yml
+++ b/.github/workflows/_build-python-wheels.yml
@@ -168,11 +168,18 @@ jobs:
           SNOWFLAKE_DISABLE_COMPILE_ARROW_EXTENSIONS: "true"
           PROTO_CARGO_TARGET_DIR: ${{ github.workspace }}/proto-target
 
+      # Keep protobuf-gen around long enough that "Re-run this job" on a
+      # downstream build_wheels matrix entry can still fetch it. Cibuildwheel
+      # re-runs are common (esp. manylinux_aarch64), and GitHub's per-job re-run
+      # does NOT re-run upstream `needs: generate_proto`, so the artifact must
+      # outlive the workflow run itself. We previously deleted it eagerly in a
+      # cleanup job, which made any single-job re-run impossible.
       - name: Upload protobuf artifacts
         uses: actions/upload-artifact@v4
         with:
           name: protobuf-gen
           path: python/src/snowflake/connector/_internal/protobuf_gen/
+          retention-days: 7
 
   # ── Build source distribution (platform-independent, runs once) ────
   build_sdist:
@@ -247,36 +254,72 @@ jobs:
       # ── sf_core build: Linux (Docker + manylinux for glibc compat) ──
       # Cannot use job-level container: because cibuildwheel needs Docker.
       # Instead, build sf_core via docker run with the manylinux image.
-      - name: Restore Cargo registry cache (Linux)
+      #
+      # Caching strategy: cargo-cache (registry + target/) runs on the HOST,
+      # and its dirs are volume-mounted into the manylinux container so the
+      # in-container `cargo build` reads/writes them directly. The rustup
+      # toolchain (~/.rustup + ~/.cargo/bin) is cached separately — keyed
+      # only on a version marker so Cargo.lock churn doesn't invalidate it.
+      - name: Restore Rust cache (Linux)
         if: runner.os == 'Linux'
+        id: rust-cache-linux
         continue-on-error: true
-        uses: actions/cache@v5
+        uses: ./.github/actions/cargo-cache
+        with:
+          mode: restore
+          shared-key: sf-core-release-${{ matrix.artifact_id }}
+
+      - name: Restore rustup toolchain cache (Linux)
+        if: runner.os == 'Linux'
+        id: rustup-cache-linux
+        continue-on-error: true
+        uses: actions/cache/restore@v5
         with:
           path: |
-            ~/.cargo/registry/index
-            ~/.cargo/registry/cache
-            ~/.cargo/git/db
-          key: ${{ runner.os }}-${{ matrix.target }}-cargo-registry-v2-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-${{ matrix.target }}-cargo-registry-v2-
+            ~/.rustup
+            ~/.cargo/bin
+          key: ${{ runner.os }}-${{ matrix.artifact_id }}-rustup-stable-minimal-v1
+          restore-keys: ${{ runner.os }}-${{ matrix.artifact_id }}-rustup-stable-minimal-
 
       - name: Build sf_core in manylinux container
         if: runner.os == 'Linux'
         run: |
-          mkdir -p "$HOME/.cargo/registry" "$HOME/.cargo/git"
+          mkdir -p "$HOME/.cargo/registry" "$HOME/.cargo/git" \
+                   "$HOME/.cargo/bin" "$HOME/.rustup"
           docker run --rm \
             -v "$HOME/.cargo/registry:/root/.cargo/registry" \
             -v "$HOME/.cargo/git:/root/.cargo/git" \
+            -v "$HOME/.cargo/bin:/root/.cargo/bin" \
+            -v "$HOME/.rustup:/root/.rustup" \
             -v "$GITHUB_WORKSPACE:/workspace" \
             -w /workspace \
             -e CARGO_TERM_COLOR=always \
+            -e RUSTUP_HOME=/root/.rustup \
+            -e CARGO_HOME=/root/.cargo \
             ${{ matrix.container }} \
             bash -c '
-              curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
-              source "$HOME/.cargo/env"
+              set -e
+              export PATH="/root/.cargo/bin:$PATH"
+              if [ ! -x /root/.cargo/bin/cargo ]; then
+                echo "No cached rustup; installing..."
+                curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs \
+                  | sh -s -- -y --default-toolchain stable --profile minimal
+              else
+                echo "Using cached rustup toolchain"
+              fi
               yum install -y perl-IPC-Cmd perl-Time-Piece
               cargo build --release --package sf_core ${{ matrix.cargo_extra_args }}
             '
-          sudo chown -R "$(id -u):$(id -g)" target/ "$HOME/.cargo/registry" "$HOME/.cargo/git"
+
+      # Chown runs in its own always() step so cache save is possible even
+      # when the build failed (and target/ may be partial or missing).
+      - name: Fix ownership of cached dirs (Linux)
+        if: always() && runner.os == 'Linux'
+        run: |
+          sudo chown -R "$(id -u):$(id -g)" \
+            target/ \
+            "$HOME/.cargo/registry" "$HOME/.cargo/git" \
+            "$HOME/.cargo/bin" "$HOME/.rustup" 2>/dev/null || true
 
       # ── sf_core build: macOS / Windows (direct, no container) ──
       - name: Restore Rust cache
@@ -319,6 +362,32 @@ jobs:
           shared-key: sf-core-release
           registry-cache-hit: ${{ steps.rust-cache.outputs.registry-cache-hit }}
           target-cache-hit: ${{ steps.rust-cache.outputs.target-cache-hit }}
+
+      - name: Save Rust cache (Linux)
+        if: always() && runner.os == 'Linux'
+        timeout-minutes: 20
+        continue-on-error: true
+        uses: ./.github/actions/cargo-cache
+        with:
+          mode: save
+          shared-key: sf-core-release-${{ matrix.artifact_id }}
+          registry-cache-hit: ${{ steps.rust-cache-linux.outputs.registry-cache-hit }}
+          target-cache-hit: ${{ steps.rust-cache-linux.outputs.target-cache-hit }}
+
+      # Gated on cache-hit != 'true' to avoid "Unable to reserve cache" races
+      # when the exact key already exists in the cache service.
+      - name: Save rustup toolchain cache (Linux)
+        if: always() && runner.os == 'Linux' && steps.rustup-cache-linux.outputs.cache-hit != 'true'
+        timeout-minutes: 10
+        continue-on-error: true
+        env:
+          ZSTD_NBTHREADS: '2'
+        uses: actions/cache/save@v5
+        with:
+          path: |
+            ~/.rustup
+            ~/.cargo/bin
+          key: ${{ runner.os }}-${{ matrix.artifact_id }}-rustup-stable-minimal-v1
 
       # ── Download protobuf ──
       - name: Download pre-built protobuf code
@@ -498,20 +567,3 @@ jobs:
         with:
           name: ${{ matrix.artifact_name }}
           path: python/dist/*.whl
-
-  # ── Clean up intermediate build artifacts ──────────────────────────
-  cleanup_build_artifacts:
-    needs: [build_wheels, build_wheel]
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      - name: Delete intermediate artifacts
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts \
-            --paginate -q '.artifacts[] | select(.name == "protobuf-gen") | .id' |
-          while read id; do
-            echo "Deleting artifact $id"
-            gh api -X DELETE repos/${{ github.repository }}/actions/artifacts/$id
-          done

--- a/jdbc/src/main/java/net/snowflake/client/api/datasource/SnowflakeDataSource.java
+++ b/jdbc/src/main/java/net/snowflake/client/api/datasource/SnowflakeDataSource.java
@@ -29,6 +29,10 @@ public interface SnowflakeDataSource extends DataSource {
 
   void setWarehouse(String warehouse);
 
+  void setAuthenticator(String authenticator);
+
+  void setToken(String token);
+
   String getUrl();
 
   Properties getProperties();

--- a/jdbc/src/main/java/net/snowflake/client/api/exception/SnowflakeSQLException.java
+++ b/jdbc/src/main/java/net/snowflake/client/api/exception/SnowflakeSQLException.java
@@ -24,10 +24,10 @@ public class SnowflakeSQLException extends SQLException {
   }
 
   public static SnowflakeSQLException fromServiceException(
-      String fallbackMessage, DatabaseDriverService.ServiceException exception) {
+      DatabaseDriverService.ServiceException exception) {
     DatabaseDriverV1.DriverException error = exception.error;
     if (error == null) {
-      return new SnowflakeSQLException(fallbackMessage, exception);
+      return new SnowflakeSQLException(exception.getMessage(), exception);
     }
     return new SnowflakeSQLException(error, exception);
   }

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/connection/SnowflakeConnectionImpl.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/connection/SnowflakeConnectionImpl.java
@@ -33,23 +33,15 @@ import net.snowflake.client.internal.api.implementation.statement.SnowflakePrepa
 import net.snowflake.client.internal.api.implementation.statement.SnowflakeStatementImpl;
 import net.snowflake.client.internal.log.SFLogger;
 import net.snowflake.client.internal.log.SFLoggerFactory;
+import net.snowflake.client.internal.unicore.CoreDriverApi;
 import net.snowflake.client.internal.unicore.ProtobufApis;
-import net.snowflake.client.internal.unicore.TransportException;
-import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverService;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConfigSetting;
-import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionCloseRequest;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionHandle;
-import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionInitRequest;
-import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionNewRequest;
-import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionReleaseRequest;
-import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionSetOptionsRequest;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionSetOptionsResponse;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseHandle;
-import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseInitRequest;
-import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseNewRequest;
-import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseReleaseRequest;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ValidationIssue;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.WrapperIdentity;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.WrapperIdentity.Builder;
 import net.snowflake.client.internal.util.NotImplementedException;
 
 public class SnowflakeConnectionImpl implements SnowflakeConnection, Connection {
@@ -57,6 +49,7 @@ public class SnowflakeConnectionImpl implements SnowflakeConnection, Connection 
   private static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeConnectionImpl.class);
   private final String url;
   private final Properties properties;
+  private final CoreDriverApi coreDriverApi;
   private boolean autoCommit = true;
   private final AtomicBoolean closed = new AtomicBoolean(false);
   private String catalog;
@@ -65,55 +58,54 @@ public class SnowflakeConnectionImpl implements SnowflakeConnection, Connection 
   public final ConnectionHandle connectionHandle;
 
   public SnowflakeConnectionImpl(String url, Properties properties) throws SQLException {
+    this(url, properties, ProtobufApis.coreDriverApi);
+  }
+
+  SnowflakeConnectionImpl(String url, Properties properties, CoreDriverApi coreDriverApi)
+      throws SQLException {
     this.url = url;
     this.properties = properties;
-    Properties connectionOptions = ConnectionOptionsResolver.resolve(url, properties);
+    this.coreDriverApi = coreDriverApi;
+
     DatabaseHandle dbHandle = null;
     ConnectionHandle connHandle = null;
     try {
-      dbHandle =
-          ProtobufApis.databaseDriverV1
-              .databaseNew(DatabaseNewRequest.getDefaultInstance())
-              .getDbHandle();
-      DatabaseInitRequest databaseInitRequest =
-          DatabaseInitRequest.newBuilder().setDbHandle(dbHandle).build();
-      ProtobufApis.databaseDriverV1.databaseInit(databaseInitRequest);
-      connHandle =
-          ProtobufApis.databaseDriverV1
-              .connectionNew(ConnectionNewRequest.getDefaultInstance())
-              .getConnHandle();
+      dbHandle = coreDriverApi.databaseNew().getDbHandle();
+      coreDriverApi.databaseInit(dbHandle);
+      connHandle = coreDriverApi.connectionNew().getConnHandle();
 
+      Properties connectionOptions = ConnectionOptionsResolver.resolve(url, properties);
       setOptions(connHandle, connectionOptions);
 
-      WrapperIdentity.Builder identityBuilder =
-          WrapperIdentity.newBuilder()
-              .setDriverName("JDBC")
-              .setDriverVersion(determineClientAppVersion());
-      String runtimeName = System.getProperty("java.vm.name");
-      if (runtimeName != null && !runtimeName.trim().isEmpty()) {
-        identityBuilder.setLanguageRuntime(runtimeName);
-      }
-      String runtimeVersion = System.getProperty("java.version");
-      if (runtimeVersion != null && !runtimeVersion.trim().isEmpty()) {
-        identityBuilder.setLanguageVersion(runtimeVersion);
-      }
-      ConnectionInitRequest connectionInitRequest =
-          ConnectionInitRequest.newBuilder()
-              .setDbHandle(dbHandle)
-              .setConnHandle(connHandle)
-              .setWrapperIdentity(identityBuilder.build())
-              .build();
-      ProtobufApis.databaseDriverV1.connectionInit(connectionInitRequest);
+      WrapperIdentity identity = wrapperIdentity();
+      coreDriverApi.connectionInit(connHandle, dbHandle, identity);
 
       this.databaseHandle = dbHandle;
       this.connectionHandle = connHandle;
-    } catch (DatabaseDriverService.ServiceException | TransportException e) {
-      releaseHandlesQuietly(connHandle, dbHandle);
-      throw new SQLException(e);
+    } catch (SQLException e) {
+      releaseHandlesQuietly(coreDriverApi, connHandle, dbHandle);
+      throw e;
     }
   }
 
-  private void setOptions(ConnectionHandle connHandle, Properties connectionOptions) {
+  private WrapperIdentity wrapperIdentity() {
+    Builder identityBuilder =
+        WrapperIdentity.newBuilder()
+            .setDriverName("JDBC")
+            .setDriverVersion(determineClientAppVersion());
+    String runtimeName = System.getProperty("java.vm.name");
+    if (runtimeName != null && !runtimeName.trim().isEmpty()) {
+      identityBuilder.setLanguageRuntime(runtimeName);
+    }
+    String runtimeVersion = System.getProperty("java.version");
+    if (runtimeVersion != null && !runtimeVersion.trim().isEmpty()) {
+      identityBuilder.setLanguageVersion(runtimeVersion);
+    }
+    return identityBuilder.build();
+  }
+
+  private void setOptions(ConnectionHandle connHandle, Properties connectionOptions)
+      throws SQLException {
     Map<String, ConfigSetting> optionsMap = new HashMap<>();
 
     // JDBC convention: Connection.close() must not throw on logout failure.
@@ -135,11 +127,7 @@ public class SnowflakeConnectionImpl implements SnowflakeConnection, Connection 
 
     if (!optionsMap.isEmpty()) {
       ConnectionSetOptionsResponse response =
-          ProtobufApis.databaseDriverV1.connectionSetOptions(
-              ConnectionSetOptionsRequest.newBuilder()
-                  .setConnHandle(connHandle)
-                  .putAllOptions(optionsMap)
-                  .build());
+          coreDriverApi.connectionSetOptions(connHandle, optionsMap);
       logConnectionOptionWarnings(response);
     }
   }
@@ -230,39 +218,38 @@ public class SnowflakeConnectionImpl implements SnowflakeConnection, Connection 
     throw new NotImplementedException();
   }
 
+  // TODO: track open statements and close them here (+ implement Statement.close() →
+  // statementRelease)
   @Override
   public void close() throws SQLException {
-    // TODO: track open statements and close them here (+ implement stmt close & release)
     if (!closed.compareAndSet(false, true)) {
       return;
     }
     logger.debug("Closing connection");
     try {
-      ProtobufApis.databaseDriverV1.connectionClose(
-          ConnectionCloseRequest.newBuilder().setConnHandle(connectionHandle).build());
-    } catch (DatabaseDriverService.ServiceException | TransportException e) {
+      coreDriverApi.connectionClose(connectionHandle);
+    } catch (SQLException e) {
       logger.warn("Error during connection close: {}", e.getMessage());
       logger.debug("Connection close error details", e);
-      throw new SQLException(e);
+      throw e;
     } finally {
-      releaseHandlesQuietly(connectionHandle, databaseHandle);
+      releaseHandlesQuietly(coreDriverApi, connectionHandle, databaseHandle);
     }
   }
 
-  private static void releaseHandlesQuietly(ConnectionHandle connHandle, DatabaseHandle dbHandle) {
+  private static void releaseHandlesQuietly(
+      CoreDriverApi driver, ConnectionHandle connHandle, DatabaseHandle dbHandle) {
     if (connHandle != null) {
       try {
-        ProtobufApis.databaseDriverV1.connectionRelease(
-            ConnectionReleaseRequest.newBuilder().setConnHandle(connHandle).build());
-      } catch (DatabaseDriverService.ServiceException | TransportException e) {
+        driver.connectionRelease(connHandle);
+      } catch (SQLException e) {
         logger.debug("Error releasing connection handle", e);
       }
     }
     if (dbHandle != null) {
       try {
-        ProtobufApis.databaseDriverV1.databaseRelease(
-            DatabaseReleaseRequest.newBuilder().setDbHandle(dbHandle).build());
-      } catch (DatabaseDriverService.ServiceException | TransportException e) {
+        driver.databaseRelease(dbHandle);
+      } catch (SQLException e) {
         logger.debug("Error releasing database handle", e);
       }
     }

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/connection/SnowflakeConnectionImpl.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/connection/SnowflakeConnectionImpl.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
 import net.snowflake.client.api.connection.DownloadStreamConfig;
 import net.snowflake.client.api.connection.SnowflakeConnection;
 import net.snowflake.client.api.connection.UploadStreamConfig;
@@ -33,68 +34,57 @@ import net.snowflake.client.internal.api.implementation.statement.SnowflakeState
 import net.snowflake.client.internal.log.SFLogger;
 import net.snowflake.client.internal.log.SFLoggerFactory;
 import net.snowflake.client.internal.unicore.ProtobufApis;
+import net.snowflake.client.internal.unicore.TransportException;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverService;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConfigSetting;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionCloseRequest;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionHandle;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionInitRequest;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionNewRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionReleaseRequest;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionSetOptionsRequest;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionSetOptionsResponse;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseHandle;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseInitRequest;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseNewRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseReleaseRequest;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ValidationIssue;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.WrapperIdentity;
 import net.snowflake.client.internal.util.NotImplementedException;
 
 public class SnowflakeConnectionImpl implements SnowflakeConnection, Connection {
+
   private static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeConnectionImpl.class);
   private final String url;
   private final Properties properties;
   private boolean autoCommit = true;
-  private boolean closed = false;
+  private final AtomicBoolean closed = new AtomicBoolean(false);
   private String catalog;
   private String schema;
-  private DatabaseHandle databaseHandle;
-  public ConnectionHandle connectionHandle;
+  private final DatabaseHandle databaseHandle;
+  public final ConnectionHandle connectionHandle;
 
   public SnowflakeConnectionImpl(String url, Properties properties) throws SQLException {
     this.url = url;
     this.properties = properties;
     Properties connectionOptions = ConnectionOptionsResolver.resolve(url, properties);
+    DatabaseHandle dbHandle = null;
+    ConnectionHandle connHandle = null;
     try {
-      this.databaseHandle =
+      dbHandle =
           ProtobufApis.databaseDriverV1
               .databaseNew(DatabaseNewRequest.getDefaultInstance())
               .getDbHandle();
       DatabaseInitRequest databaseInitRequest =
-          DatabaseInitRequest.newBuilder().setDbHandle(databaseHandle).build();
+          DatabaseInitRequest.newBuilder().setDbHandle(dbHandle).build();
       ProtobufApis.databaseDriverV1.databaseInit(databaseInitRequest);
-      this.connectionHandle =
+      connHandle =
           ProtobufApis.databaseDriverV1
               .connectionNew(ConnectionNewRequest.getDefaultInstance())
               .getConnHandle();
-      Map<String, ConfigSetting> optionsMap = new HashMap<>();
-      connectionOptions.forEach(
-          (key, value) -> {
-            if (!(key instanceof String)) {
-              return;
-            }
-            String keyStr = (String) key;
-            ConfigSetting configSetting = toConfigSetting(value);
-            if (configSetting != null) {
-              optionsMap.put(keyStr, configSetting);
-            }
-          });
-      if (!optionsMap.isEmpty()) {
-        ConnectionSetOptionsResponse response =
-            ProtobufApis.databaseDriverV1.connectionSetOptions(
-                ConnectionSetOptionsRequest.newBuilder()
-                    .setConnHandle(connectionHandle)
-                    .putAllOptions(optionsMap)
-                    .build());
-        logConnectionOptionWarnings(response);
-      }
+
+      setOptions(connHandle, connectionOptions);
+
       WrapperIdentity.Builder identityBuilder =
           WrapperIdentity.newBuilder()
               .setDriverName("JDBC")
@@ -109,13 +99,48 @@ public class SnowflakeConnectionImpl implements SnowflakeConnection, Connection 
       }
       ConnectionInitRequest connectionInitRequest =
           ConnectionInitRequest.newBuilder()
-              .setDbHandle(databaseHandle)
-              .setConnHandle(connectionHandle)
+              .setDbHandle(dbHandle)
+              .setConnHandle(connHandle)
               .setWrapperIdentity(identityBuilder.build())
               .build();
       ProtobufApis.databaseDriverV1.connectionInit(connectionInitRequest);
-    } catch (DatabaseDriverService.ServiceException e) {
+
+      this.databaseHandle = dbHandle;
+      this.connectionHandle = connHandle;
+    } catch (DatabaseDriverService.ServiceException | TransportException e) {
+      releaseHandlesQuietly(connHandle, dbHandle);
       throw new SQLException(e);
+    }
+  }
+
+  private void setOptions(ConnectionHandle connHandle, Properties connectionOptions) {
+    Map<String, ConfigSetting> optionsMap = new HashMap<>();
+
+    // JDBC convention: Connection.close() must not throw on logout failure.
+    // Users can opt into Strict via the "logout_error_strategy" connection property.
+    optionsMap.put(
+        "logout_error_strategy", ConfigSetting.newBuilder().setStringValue("best_effort").build());
+
+    connectionOptions.forEach(
+        (key, value) -> {
+          if (!(key instanceof String)) {
+            return;
+          }
+          String keyStr = (String) key;
+          ConfigSetting configSetting = toConfigSetting(value);
+          if (configSetting != null) {
+            optionsMap.put(keyStr, configSetting);
+          }
+        });
+
+    if (!optionsMap.isEmpty()) {
+      ConnectionSetOptionsResponse response =
+          ProtobufApis.databaseDriverV1.connectionSetOptions(
+              ConnectionSetOptionsRequest.newBuilder()
+                  .setConnHandle(connHandle)
+                  .putAllOptions(optionsMap)
+                  .build());
+      logConnectionOptionWarnings(response);
     }
   }
 
@@ -207,14 +232,45 @@ public class SnowflakeConnectionImpl implements SnowflakeConnection, Connection 
 
   @Override
   public void close() throws SQLException {
-    if (!closed) {
-      closed = true;
+    // TODO: track open statements and close them here (+ implement stmt close & release)
+    if (!closed.compareAndSet(false, true)) {
+      return;
+    }
+    logger.debug("Closing connection");
+    try {
+      ProtobufApis.databaseDriverV1.connectionClose(
+          ConnectionCloseRequest.newBuilder().setConnHandle(connectionHandle).build());
+    } catch (DatabaseDriverService.ServiceException | TransportException e) {
+      logger.warn("Error during connection close: {}", e.getMessage());
+      logger.debug("Connection close error details", e);
+      throw new SQLException(e);
+    } finally {
+      releaseHandlesQuietly(connectionHandle, databaseHandle);
+    }
+  }
+
+  private static void releaseHandlesQuietly(ConnectionHandle connHandle, DatabaseHandle dbHandle) {
+    if (connHandle != null) {
+      try {
+        ProtobufApis.databaseDriverV1.connectionRelease(
+            ConnectionReleaseRequest.newBuilder().setConnHandle(connHandle).build());
+      } catch (DatabaseDriverService.ServiceException | TransportException e) {
+        logger.debug("Error releasing connection handle", e);
+      }
+    }
+    if (dbHandle != null) {
+      try {
+        ProtobufApis.databaseDriverV1.databaseRelease(
+            DatabaseReleaseRequest.newBuilder().setDbHandle(dbHandle).build());
+      } catch (DatabaseDriverService.ServiceException | TransportException e) {
+        logger.debug("Error releasing database handle", e);
+      }
     }
   }
 
   @Override
   public boolean isClosed() throws SQLException {
-    return closed;
+    return closed.get();
   }
 
   @Override

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/datasource/SnowflakeBasicDataSource.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/datasource/SnowflakeBasicDataSource.java
@@ -168,6 +168,17 @@ public class SnowflakeBasicDataSource implements SnowflakeDataSource {
   }
 
   @Override
+  public void setAuthenticator(String authenticator) {
+    this.properties.setProperty(
+        SnowflakeSessionProperty.AUTHENTICATOR.getPropertyKey(), authenticator);
+  }
+
+  @Override
+  public void setToken(String token) {
+    this.properties.setProperty(SnowflakeSessionProperty.TOKEN.getPropertyKey(), token);
+  }
+
+  @Override
   public String getUrl() {
     return url;
   }

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/datasource/SnowflakeSessionProperty.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/datasource/SnowflakeSessionProperty.java
@@ -14,7 +14,9 @@ enum SnowflakeSessionProperty {
   SCHEMA("schema"),
   ROLE("role"),
   WAREHOUSE("warehouse"),
-  LOGIN_TIMEOUT("loginTimeout");
+  LOGIN_TIMEOUT("loginTimeout"),
+  AUTHENTICATOR("authenticator"),
+  TOKEN("token");
 
   private final String propertyKey;
 }

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakeStatementImpl.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakeStatementImpl.java
@@ -19,23 +19,15 @@ import net.snowflake.client.internal.api.implementation.resultset.SnowflakeResul
 import net.snowflake.client.internal.log.SFLogger;
 import net.snowflake.client.internal.log.SFLoggerFactory;
 import net.snowflake.client.internal.unicore.ProtobufApis;
-import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverService;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConfigSetting;
-import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionGetResultSetRequest;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ExecuteQueryResponse;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.MultiStatementResult;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.QueryBindings;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetDescriptor;
-import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetGetStreamRequest;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetGetStreamResponse;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetHandle;
-import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetReleaseRequest;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetResponse;
-import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementExecuteQueryRequest;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementHandle;
-import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementNewRequest;
-import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementSetOptionsRequest;
-import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementSetSqlQueryRequest;
 
 public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
   private static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeStatementImpl.class);
@@ -56,12 +48,10 @@ public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
 
   public SnowflakeStatementImpl(SnowflakeConnectionImpl connection) {
     this.connection = connection;
-    StatementNewRequest statementNewRequest =
-        StatementNewRequest.newBuilder().setConnHandle(connection.connectionHandle).build();
     try {
       this.statementHandle =
-          ProtobufApis.databaseDriverV1.statementNew(statementNewRequest).getStmtHandle();
-    } catch (DatabaseDriverService.ServiceException e) {
+          ProtobufApis.coreDriverApi.statementNew(connection.connectionHandle).getStmtHandle();
+    } catch (SQLException e) {
       throw new RuntimeException(e);
     }
   }
@@ -100,51 +90,15 @@ public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
     boolean hasBindings = bindings != null;
     logger.debug("Statement executeWithBindings start: sql={}, hasBindings={}", sql, hasBindings);
     prepareForExecution();
-    StatementSetSqlQueryRequest statementSetSqlQueryRequest =
-        StatementSetSqlQueryRequest.newBuilder()
-            .setStmtHandle(statementHandle)
-            .setQuery(sql)
-            .build();
-    try {
-      ProtobufApis.databaseDriverV1.statementSetSqlQuery(statementSetSqlQueryRequest);
-    } catch (DatabaseDriverService.ServiceException e) {
-      logger.warn("statementSetSqlQuery failed: sql={}, hasBindings={}", sql, hasBindings, e);
-      throw SnowflakeSQLException.fromServiceException("Failed to set SQL query on statement", e);
-    }
-
-    StatementExecuteQueryRequest.Builder executeQueryRequestBuilder =
-        StatementExecuteQueryRequest.newBuilder().setStmtHandle(statementHandle);
-    if (bindings != null) {
-      executeQueryRequestBuilder.setBindings(bindings);
-    }
-    StatementExecuteQueryRequest executeQueryRequest = executeQueryRequestBuilder.build();
-    logger.debug(
-        "statementExecuteQuery request prepared: hasBindings={}, requestBytes={}",
-        hasBindings,
-        executeQueryRequest.getSerializedSize());
-    try {
-      ExecuteQueryResponse response =
-          ProtobufApis.databaseDriverV1.statementExecuteQuery(executeQueryRequest);
-      logger.debug("statementExecuteQuery succeeded: hasBindings={}", hasBindings);
-      return response;
-    } catch (DatabaseDriverService.ServiceException e) {
-      logger.warn("statementExecuteQuery failed: hasBindings={}", hasBindings, e);
-      throw SnowflakeSQLException.fromServiceException("Failed to execute statement query", e);
-    }
+    ProtobufApis.coreDriverApi.statementSetSqlQuery(statementHandle, sql);
+    ExecuteQueryResponse response =
+        ProtobufApis.coreDriverApi.statementExecuteQuery(statementHandle, bindings);
+    logger.debug("statementExecuteQuery succeeded: hasBindings={}", hasBindings);
+    return response;
   }
 
   private ResultSetResponse fetchResultSetByQueryId(String queryId) throws SQLException {
-    ConnectionGetResultSetRequest request =
-        ConnectionGetResultSetRequest.newBuilder()
-            .setConnHandle(connection.connectionHandle)
-            .setQueryId(queryId)
-            .build();
-    try {
-      return ProtobufApis.databaseDriverV1.connectionGetResultSet(request);
-    } catch (DatabaseDriverService.ServiceException e) {
-      throw SnowflakeSQLException.fromServiceException(
-          "Failed to fetch result set for query ID: " + queryId, e);
-    }
+    return ProtobufApis.coreDriverApi.connectionGetResultSet(connection.connectionHandle, queryId);
   }
 
   /**
@@ -155,24 +109,20 @@ public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
    */
   private ResultSetGetStreamResponse fetchStreamAndRelease(ResultSetHandle handle)
       throws SQLException {
-    ResultSetGetStreamRequest request =
-        ResultSetGetStreamRequest.newBuilder().setResultSetHandle(handle).build();
     try {
-      ResultSetGetStreamResponse response =
-          ProtobufApis.databaseDriverV1.resultSetGetStream(request);
+      ResultSetGetStreamResponse response = ProtobufApis.coreDriverApi.resultSetGetStream(handle);
       releaseResultSet(handle);
       return response;
-    } catch (DatabaseDriverService.ServiceException e) {
+    } catch (SQLException e) {
       releaseResultSet(handle);
-      throw SnowflakeSQLException.fromServiceException("Failed to fetch Arrow stream", e);
+      throw e;
     }
   }
 
   private void releaseResultSet(ResultSetHandle handle) {
     try {
-      ProtobufApis.databaseDriverV1.resultSetRelease(
-          ResultSetReleaseRequest.newBuilder().setResultSetHandle(handle).build());
-    } catch (DatabaseDriverService.ServiceException e) {
+      ProtobufApis.coreDriverApi.resultSetRelease(handle);
+    } catch (SQLException e) {
       logger.warn("Failed to release ResultSet handle", e);
     }
   }
@@ -633,24 +583,14 @@ public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
   @Override
   public void setParameter(String name, Object value) throws SQLException {
     checkClosed();
-    try {
-      ConfigSetting.Builder settingBuilder = ConfigSetting.newBuilder();
-      if (value instanceof Number) {
-        settingBuilder.setIntValue(((Number) value).longValue());
-      } else {
-        settingBuilder.setStringValue(String.valueOf(value));
-      }
-
-      StatementSetOptionsRequest request =
-          StatementSetOptionsRequest.newBuilder()
-              .setStmtHandle(statementHandle)
-              .putOptions(name, settingBuilder.build())
-              .build();
-      ProtobufApis.databaseDriverV1.statementSetOptions(request);
-    } catch (DatabaseDriverService.ServiceException e) {
-      throw SnowflakeSQLException.fromServiceException(
-          "Failed to set statement parameter: " + name, e);
+    ConfigSetting.Builder settingBuilder = ConfigSetting.newBuilder();
+    if (value instanceof Number) {
+      settingBuilder.setIntValue(((Number) value).longValue());
+    } else {
+      settingBuilder.setStringValue(String.valueOf(value));
     }
+    ProtobufApis.coreDriverApi.statementSetOptions(
+        statementHandle, Collections.singletonMap(name, settingBuilder.build()));
   }
 
   @Override

--- a/jdbc/src/main/java/net/snowflake/client/internal/unicore/CoreDriverApi.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/unicore/CoreDriverApi.java
@@ -1,0 +1,145 @@
+package net.snowflake.client.internal.unicore;
+
+import java.sql.SQLException;
+import java.util.Map;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConfigSetting;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionAbortQueryResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionCloseResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionGetAllParametersResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionGetInfoResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionGetParameterResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionGetQueryStatusResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionHandle;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionHeartbeatResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionInitResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionIsClosedResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionNewResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionReleaseResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionSendHttpRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionSendHttpResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionSetOptionsResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionSetSessionParametersResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionTokenResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseHandle;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseInitResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseNewResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseReleaseResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ExecuteQueryResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.QueryBindings;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetGetChunksResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetGetStreamResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetHandle;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetReleaseResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementExecuteAsyncResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementHandle;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementNewResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementPrepareResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementReleaseResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementSetOptionsResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementSetSqlQueryResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.TelemetrySendResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.TokenRequestType;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.WrapperIdentity;
+
+public interface CoreDriverApi {
+
+  // Database lifecycle
+
+  DatabaseNewResponse databaseNew() throws SQLException;
+
+  DatabaseInitResponse databaseInit(DatabaseHandle dbHandle) throws SQLException;
+
+  DatabaseReleaseResponse databaseRelease(DatabaseHandle dbHandle) throws SQLException;
+
+  // Connection lifecycle
+
+  ConnectionNewResponse connectionNew() throws SQLException;
+
+  ConnectionInitResponse connectionInit(
+      ConnectionHandle connHandle, DatabaseHandle dbHandle, WrapperIdentity wrapperIdentity)
+      throws SQLException;
+
+  ConnectionSetOptionsResponse connectionSetOptions(
+      ConnectionHandle connHandle, Map<String, ConfigSetting> options) throws SQLException;
+
+  ConnectionSetSessionParametersResponse connectionSetSessionParameters(
+      ConnectionHandle connHandle, Map<String, String> parameters) throws SQLException;
+
+  ConnectionCloseResponse connectionClose(ConnectionHandle connHandle) throws SQLException;
+
+  ConnectionReleaseResponse connectionRelease(ConnectionHandle connHandle) throws SQLException;
+
+  ConnectionIsClosedResponse connectionIsClosed(ConnectionHandle connHandle) throws SQLException;
+
+  ConnectionHeartbeatResponse connectionHeartbeat(ConnectionHandle connHandle) throws SQLException;
+
+  ConnectionGetInfoResponse connectionGetInfo(
+      ConnectionHandle connHandle, boolean includeMasterToken) throws SQLException;
+
+  ConnectionGetQueryStatusResponse connectionGetQueryStatus(
+      ConnectionHandle connHandle, String queryId) throws SQLException;
+
+  // Connection data & queries
+
+  ResultSetResponse connectionGetResultSet(ConnectionHandle connHandle, String queryId)
+      throws SQLException;
+
+  ExecuteQueryResponse connectionGetQueryResult(ConnectionHandle connHandle, String queryId)
+      throws SQLException;
+
+  ConnectionAbortQueryResponse connectionAbortQuery(ConnectionHandle connHandle, String queryId)
+      throws SQLException;
+
+  ConnectionSendHttpResponse connectionSendHttp(ConnectionSendHttpRequest request)
+      throws SQLException;
+
+  // Connection tokens & parameters
+
+  ConnectionTokenResponse connectionRequestToken(
+      ConnectionHandle connHandle, TokenRequestType requestType) throws SQLException;
+
+  ConnectionGetParameterResponse connectionGetParameter(ConnectionHandle connHandle, String key)
+      throws SQLException;
+
+  ConnectionGetAllParametersResponse connectionGetAllParameters(ConnectionHandle connHandle)
+      throws SQLException;
+
+  // Statement lifecycle
+
+  StatementNewResponse statementNew(ConnectionHandle connHandle) throws SQLException;
+
+  StatementSetSqlQueryResponse statementSetSqlQuery(StatementHandle stmtHandle, String sql)
+      throws SQLException;
+
+  StatementPrepareResponse statementPrepare(StatementHandle stmtHandle) throws SQLException;
+
+  StatementSetOptionsResponse statementSetOptions(
+      StatementHandle stmtHandle, Map<String, ConfigSetting> options) throws SQLException;
+
+  ExecuteQueryResponse statementExecuteQuery(StatementHandle stmtHandle, QueryBindings bindings)
+      throws SQLException;
+
+  StatementExecuteAsyncResponse statementExecuteAsync(
+      StatementHandle stmtHandle, QueryBindings bindings) throws SQLException;
+
+  StatementReleaseResponse statementRelease(StatementHandle stmtHandle) throws SQLException;
+
+  // Result set
+
+  ResultSetGetStreamResponse resultSetGetStream(ResultSetHandle resultSetHandle)
+      throws SQLException;
+
+  ResultSetGetChunksResponse resultSetGetChunks(ResultSetHandle resultSetHandle)
+      throws SQLException;
+
+  ResultSetReleaseResponse resultSetRelease(ResultSetHandle resultSetHandle) throws SQLException;
+
+  // Telemetry
+
+  TelemetrySendResponse telemetrySendApiUsage(ConnectionHandle connHandle, String apiMethod)
+      throws SQLException;
+
+  TelemetrySendResponse telemetrySendWrapperError(
+      ConnectionHandle connHandle, String exceptionType, String errorSource) throws SQLException;
+}

--- a/jdbc/src/main/java/net/snowflake/client/internal/unicore/CoreDriverApiImpl.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/unicore/CoreDriverApiImpl.java
@@ -1,0 +1,395 @@
+package net.snowflake.client.internal.unicore;
+
+import java.sql.SQLException;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import net.snowflake.client.api.exception.SnowflakeSQLException;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverService;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConfigSetting;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionAbortQueryRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionAbortQueryResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionCloseRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionCloseResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionGetAllParametersRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionGetAllParametersResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionGetInfoRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionGetInfoResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionGetParameterRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionGetParameterResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionGetQueryResultRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionGetQueryStatusRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionGetQueryStatusResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionGetResultSetRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionHandle;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionHeartbeatRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionHeartbeatResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionInitRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionInitResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionIsClosedRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionIsClosedResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionNewRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionNewResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionReleaseRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionReleaseResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionSendHttpRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionSendHttpResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionSetOptionsRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionSetOptionsResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionSetSessionParametersRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionSetSessionParametersResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionTokenRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionTokenResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseHandle;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseInitRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseInitResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseNewRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseNewResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseReleaseRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseReleaseResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ExecuteQueryResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.QueryBindings;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetGetChunksRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetGetChunksResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetGetStreamRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetGetStreamResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetHandle;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetReleaseRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetReleaseResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementExecuteAsyncRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementExecuteAsyncResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementExecuteQueryRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementHandle;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementNewRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementNewResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementPrepareRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementPrepareResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementReleaseRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementReleaseResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementSetOptionsRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementSetOptionsResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementSetSqlQueryRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementSetSqlQueryResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.TelemetrySendApiUsageRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.TelemetrySendResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.TelemetrySendWrapperErrorRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.TokenRequestType;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.WrapperIdentity;
+
+/**
+ * Facade over {@link DatabaseDriverService} that encapsulates protobuf request construction and
+ * provides centralized error conversion from core driver exceptions to {@link SQLException}.
+ *
+ * <p>Callers interact with domain-level parameters (handles, strings, maps) and never need to
+ * import or construct {@code *Request} protobuf objects directly.
+ */
+@RequiredArgsConstructor
+class CoreDriverApiImpl implements CoreDriverApi {
+
+  private final DatabaseDriverService client;
+
+  // =========================================================================
+  // Database lifecycle
+  // =========================================================================
+
+  public DatabaseNewResponse databaseNew() throws SQLException {
+    DatabaseNewRequest request = DatabaseNewRequest.getDefaultInstance();
+    return invoke(() -> client.databaseNew(request));
+  }
+
+  public DatabaseInitResponse databaseInit(DatabaseHandle dbHandle) throws SQLException {
+    DatabaseInitRequest request = DatabaseInitRequest.newBuilder().setDbHandle(dbHandle).build();
+    return invoke(() -> client.databaseInit(request));
+  }
+
+  public DatabaseReleaseResponse databaseRelease(DatabaseHandle dbHandle) throws SQLException {
+    DatabaseReleaseRequest request =
+        DatabaseReleaseRequest.newBuilder().setDbHandle(dbHandle).build();
+    return invoke(() -> client.databaseRelease(request));
+  }
+
+  // =========================================================================
+  // Connection lifecycle
+  // =========================================================================
+
+  public ConnectionNewResponse connectionNew() throws SQLException {
+    ConnectionNewRequest request = ConnectionNewRequest.getDefaultInstance();
+    return invoke(() -> client.connectionNew(request));
+  }
+
+  public ConnectionInitResponse connectionInit(
+      ConnectionHandle connHandle, DatabaseHandle dbHandle, WrapperIdentity wrapperIdentity)
+      throws SQLException {
+    ConnectionInitRequest request =
+        ConnectionInitRequest.newBuilder()
+            .setConnHandle(connHandle)
+            .setDbHandle(dbHandle)
+            .setWrapperIdentity(wrapperIdentity)
+            .build();
+    return invoke(() -> client.connectionInit(request));
+  }
+
+  public ConnectionSetOptionsResponse connectionSetOptions(
+      ConnectionHandle connHandle, Map<String, ConfigSetting> options) throws SQLException {
+    ConnectionSetOptionsRequest request =
+        ConnectionSetOptionsRequest.newBuilder()
+            .setConnHandle(connHandle)
+            .putAllOptions(options)
+            .build();
+    return invoke(() -> client.connectionSetOptions(request));
+  }
+
+  public ConnectionSetSessionParametersResponse connectionSetSessionParameters(
+      ConnectionHandle connHandle, Map<String, String> parameters) throws SQLException {
+    ConnectionSetSessionParametersRequest request =
+        ConnectionSetSessionParametersRequest.newBuilder()
+            .setConnHandle(connHandle)
+            .putAllParameters(parameters)
+            .build();
+    return invoke(() -> client.connectionSetSessionParameters(request));
+  }
+
+  public ConnectionCloseResponse connectionClose(ConnectionHandle connHandle) throws SQLException {
+    ConnectionCloseRequest request =
+        ConnectionCloseRequest.newBuilder().setConnHandle(connHandle).build();
+    return invoke(() -> client.connectionClose(request));
+  }
+
+  public ConnectionReleaseResponse connectionRelease(ConnectionHandle connHandle)
+      throws SQLException {
+    ConnectionReleaseRequest request =
+        ConnectionReleaseRequest.newBuilder().setConnHandle(connHandle).build();
+    return invoke(() -> client.connectionRelease(request));
+  }
+
+  public ConnectionIsClosedResponse connectionIsClosed(ConnectionHandle connHandle)
+      throws SQLException {
+    ConnectionIsClosedRequest request =
+        ConnectionIsClosedRequest.newBuilder().setConnHandle(connHandle).build();
+    return invoke(() -> client.connectionIsClosed(request));
+  }
+
+  public ConnectionHeartbeatResponse connectionHeartbeat(ConnectionHandle connHandle)
+      throws SQLException {
+    ConnectionHeartbeatRequest request =
+        ConnectionHeartbeatRequest.newBuilder().setConnHandle(connHandle).build();
+    return invoke(() -> client.connectionHeartbeat(request));
+  }
+
+  public ConnectionGetInfoResponse connectionGetInfo(
+      ConnectionHandle connHandle, boolean includeMasterToken) throws SQLException {
+    ConnectionGetInfoRequest request =
+        ConnectionGetInfoRequest.newBuilder()
+            .setConnHandle(connHandle)
+            .setIncludeMasterToken(includeMasterToken)
+            .build();
+    return invoke(() -> client.connectionGetInfo(request));
+  }
+
+  public ConnectionGetQueryStatusResponse connectionGetQueryStatus(
+      ConnectionHandle connHandle, String queryId) throws SQLException {
+    ConnectionGetQueryStatusRequest request =
+        ConnectionGetQueryStatusRequest.newBuilder()
+            .setConnHandle(connHandle)
+            .setQueryId(queryId)
+            .build();
+    return invoke(() -> client.connectionGetQueryStatus(request));
+  }
+
+  // =========================================================================
+  // Connection data & queries
+  // =========================================================================
+
+  public ResultSetResponse connectionGetResultSet(ConnectionHandle connHandle, String queryId)
+      throws SQLException {
+    ConnectionGetResultSetRequest request =
+        ConnectionGetResultSetRequest.newBuilder()
+            .setConnHandle(connHandle)
+            .setQueryId(queryId)
+            .build();
+    return invoke(() -> client.connectionGetResultSet(request));
+  }
+
+  public ExecuteQueryResponse connectionGetQueryResult(ConnectionHandle connHandle, String queryId)
+      throws SQLException {
+    ConnectionGetQueryResultRequest request =
+        ConnectionGetQueryResultRequest.newBuilder()
+            .setConnHandle(connHandle)
+            .setQueryId(queryId)
+            .build();
+    return invoke(() -> client.connectionGetQueryResult(request));
+  }
+
+  public ConnectionAbortQueryResponse connectionAbortQuery(
+      ConnectionHandle connHandle, String queryId) throws SQLException {
+    ConnectionAbortQueryRequest request =
+        ConnectionAbortQueryRequest.newBuilder()
+            .setConnHandle(connHandle)
+            .setQueryId(queryId)
+            .build();
+    return invoke(() -> client.connectionAbortQuery(request));
+  }
+
+  public ConnectionSendHttpResponse connectionSendHttp(ConnectionSendHttpRequest request)
+      throws SQLException {
+    return invoke(() -> client.connectionSendHttp(request));
+  }
+
+  // =========================================================================
+  // Connection tokens & parameters
+  // =========================================================================
+
+  public ConnectionTokenResponse connectionRequestToken(
+      ConnectionHandle connHandle, TokenRequestType requestType) throws SQLException {
+    ConnectionTokenRequest request =
+        ConnectionTokenRequest.newBuilder()
+            .setConnHandle(connHandle)
+            .setRequestType(requestType)
+            .build();
+    return invoke(() -> client.connectionRequestToken(request));
+  }
+
+  public ConnectionGetParameterResponse connectionGetParameter(
+      ConnectionHandle connHandle, String key) throws SQLException {
+    ConnectionGetParameterRequest request =
+        ConnectionGetParameterRequest.newBuilder().setConnHandle(connHandle).setKey(key).build();
+    return invoke(() -> client.connectionGetParameter(request));
+  }
+
+  public ConnectionGetAllParametersResponse connectionGetAllParameters(ConnectionHandle connHandle)
+      throws SQLException {
+    ConnectionGetAllParametersRequest request =
+        ConnectionGetAllParametersRequest.newBuilder().setConnHandle(connHandle).build();
+    return invoke(() -> client.connectionGetAllParameters(request));
+  }
+
+  // =========================================================================
+  // Statement lifecycle
+  // =========================================================================
+
+  public StatementNewResponse statementNew(ConnectionHandle connHandle) throws SQLException {
+    StatementNewRequest request =
+        StatementNewRequest.newBuilder().setConnHandle(connHandle).build();
+    return invoke(() -> client.statementNew(request));
+  }
+
+  public StatementSetSqlQueryResponse statementSetSqlQuery(StatementHandle stmtHandle, String sql)
+      throws SQLException {
+    StatementSetSqlQueryRequest request =
+        StatementSetSqlQueryRequest.newBuilder().setStmtHandle(stmtHandle).setQuery(sql).build();
+    return invoke(() -> client.statementSetSqlQuery(request));
+  }
+
+  public StatementPrepareResponse statementPrepare(StatementHandle stmtHandle) throws SQLException {
+    StatementPrepareRequest request =
+        StatementPrepareRequest.newBuilder().setStmtHandle(stmtHandle).build();
+    return invoke(() -> client.statementPrepare(request));
+  }
+
+  public StatementSetOptionsResponse statementSetOptions(
+      StatementHandle stmtHandle, Map<String, ConfigSetting> options) throws SQLException {
+    StatementSetOptionsRequest request =
+        StatementSetOptionsRequest.newBuilder()
+            .setStmtHandle(stmtHandle)
+            .putAllOptions(options)
+            .build();
+    return invoke(() -> client.statementSetOptions(request));
+  }
+
+  public ExecuteQueryResponse statementExecuteQuery(
+      StatementHandle stmtHandle, QueryBindings bindings) throws SQLException {
+    StatementExecuteQueryRequest.Builder builder =
+        StatementExecuteQueryRequest.newBuilder().setStmtHandle(stmtHandle);
+    if (bindings != null) {
+      builder.setBindings(bindings);
+    }
+    StatementExecuteQueryRequest request = builder.build();
+    return invoke(() -> client.statementExecuteQuery(request));
+  }
+
+  public StatementExecuteAsyncResponse statementExecuteAsync(
+      StatementHandle stmtHandle, QueryBindings bindings) throws SQLException {
+    StatementExecuteAsyncRequest.Builder builder =
+        StatementExecuteAsyncRequest.newBuilder().setStmtHandle(stmtHandle);
+    if (bindings != null) {
+      builder.setBindings(bindings);
+    }
+    StatementExecuteAsyncRequest request = builder.build();
+    return invoke(() -> client.statementExecuteAsync(request));
+  }
+
+  public StatementReleaseResponse statementRelease(StatementHandle stmtHandle) throws SQLException {
+    StatementReleaseRequest request =
+        StatementReleaseRequest.newBuilder().setStmtHandle(stmtHandle).build();
+    return invoke(() -> client.statementRelease(request));
+  }
+
+  // =========================================================================
+  // Result set
+  // =========================================================================
+
+  public ResultSetGetStreamResponse resultSetGetStream(ResultSetHandle resultSetHandle)
+      throws SQLException {
+    ResultSetGetStreamRequest request =
+        ResultSetGetStreamRequest.newBuilder().setResultSetHandle(resultSetHandle).build();
+    return invoke(() -> client.resultSetGetStream(request));
+  }
+
+  public ResultSetGetChunksResponse resultSetGetChunks(ResultSetHandle resultSetHandle)
+      throws SQLException {
+    ResultSetGetChunksRequest request =
+        ResultSetGetChunksRequest.newBuilder().setResultSetHandle(resultSetHandle).build();
+    return invoke(() -> client.resultSetGetChunks(request));
+  }
+
+  public ResultSetReleaseResponse resultSetRelease(ResultSetHandle resultSetHandle)
+      throws SQLException {
+    ResultSetReleaseRequest request =
+        ResultSetReleaseRequest.newBuilder().setResultSetHandle(resultSetHandle).build();
+    return invoke(() -> client.resultSetRelease(request));
+  }
+
+  // =========================================================================
+  // Telemetry
+  // =========================================================================
+
+  public TelemetrySendResponse telemetrySendApiUsage(ConnectionHandle connHandle, String apiMethod)
+      throws SQLException {
+    TelemetrySendApiUsageRequest request =
+        TelemetrySendApiUsageRequest.newBuilder()
+            .setConnHandle(connHandle)
+            .setApiMethod(apiMethod)
+            .build();
+    return invoke(() -> client.telemetrySendApiUsage(request));
+  }
+
+  public TelemetrySendResponse telemetrySendWrapperError(
+      ConnectionHandle connHandle, String exceptionType, String errorSource) throws SQLException {
+    TelemetrySendWrapperErrorRequest request =
+        TelemetrySendWrapperErrorRequest.newBuilder()
+            .setConnHandle(connHandle)
+            .setExceptionType(exceptionType)
+            .setErrorSource(errorSource)
+            .build();
+    return invoke(() -> client.telemetrySendWrapperError(request));
+  }
+
+  // =========================================================================
+  // Error handling
+  // =========================================================================
+
+  @FunctionalInterface
+  private interface ServiceCall<T> {
+    T call() throws DatabaseDriverService.ServiceException, TransportException;
+  }
+
+  private <T> T invoke(ServiceCall<T> callable) throws SQLException {
+    try {
+      return callable.call();
+    } catch (DatabaseDriverService.ServiceException e) {
+      throw SnowflakeSQLException.fromServiceException(e);
+    } catch (TransportException e) {
+      throw new SQLException("Driver communication error: " + e.getMessage(), e);
+    }
+  }
+}

--- a/jdbc/src/main/java/net/snowflake/client/internal/unicore/ProtobufApis.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/unicore/ProtobufApis.java
@@ -1,9 +1,9 @@
 package net.snowflake.client.internal.unicore;
 
-import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverService;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverServiceClient;
 
 public class ProtobufApis {
-  public static DatabaseDriverService databaseDriverV1 =
-      new DatabaseDriverServiceClient(new JNICoreTransport());
+
+  public static CoreDriverApi coreDriverApi =
+      new CoreDriverApiImpl(new DatabaseDriverServiceClient(new JNICoreTransport()));
 }

--- a/jdbc/src/main/java/net/snowflake/client/internal/unicore/ProtobufApis.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/unicore/ProtobufApis.java
@@ -1,8 +1,9 @@
 package net.snowflake.client.internal.unicore;
 
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverService;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverServiceClient;
 
 public class ProtobufApis {
-  public static DatabaseDriverServiceClient databaseDriverV1 =
+  public static DatabaseDriverService databaseDriverV1 =
       new DatabaseDriverServiceClient(new JNICoreTransport());
 }

--- a/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/connection/SnowflakeConnectionImplTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/connection/SnowflakeConnectionImplTest.java
@@ -1,9 +1,42 @@
 package net.snowflake.client.internal.api.implementation.connection;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import java.sql.SQLException;
+import java.util.Properties;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.atomic.AtomicInteger;
+import net.snowflake.client.internal.unicore.ProtobufApis;
+import net.snowflake.client.internal.unicore.TransportException;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverService;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConfigSetting;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionCloseRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionCloseResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionHandle;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionInitResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionNewResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionReleaseRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionReleaseResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionSetOptionsResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseHandle;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseInitResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseNewResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseReleaseRequest;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseReleaseResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DriverException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 public class SnowflakeConnectionImplTest {
@@ -43,5 +76,183 @@ public class SnowflakeConnectionImplTest {
   @Test
   public void toConfigSettingReturnsNullForUnsupportedValues() {
     assertNull(SnowflakeConnectionImpl.toConfigSetting(new Object()));
+  }
+
+  @Nested
+  class Close {
+
+    private DatabaseDriverService originalClient;
+    private DatabaseDriverService mockClient;
+
+    @BeforeEach
+    void setUp() {
+      originalClient = ProtobufApis.databaseDriverV1;
+      mockClient = mock(DatabaseDriverService.class);
+      ProtobufApis.databaseDriverV1 = mockClient;
+    }
+
+    @AfterEach
+    void tearDown() {
+      ProtobufApis.databaseDriverV1 = originalClient;
+    }
+
+    private SnowflakeConnectionImpl createConnection() throws SQLException {
+      DatabaseHandle dbHandle = DatabaseHandle.newBuilder().setId(1).setMagic(100).build();
+      ConnectionHandle connHandle = ConnectionHandle.newBuilder().setId(2).setMagic(200).build();
+
+      when(mockClient.databaseNew(any()))
+          .thenReturn(DatabaseNewResponse.newBuilder().setDbHandle(dbHandle).build());
+      when(mockClient.databaseInit(any())).thenReturn(DatabaseInitResponse.getDefaultInstance());
+      when(mockClient.connectionNew(any()))
+          .thenReturn(ConnectionNewResponse.newBuilder().setConnHandle(connHandle).build());
+      when(mockClient.connectionSetOptions(any()))
+          .thenReturn(ConnectionSetOptionsResponse.getDefaultInstance());
+      when(mockClient.connectionInit(any()))
+          .thenReturn(ConnectionInitResponse.getDefaultInstance());
+
+      Properties props = new Properties();
+      props.setProperty("account", "test_account");
+      props.setProperty("user", "test_user");
+      props.setProperty("password", "test_password");
+      return new SnowflakeConnectionImpl("jdbc:snowflake://test.snowflakecomputing.com", props);
+    }
+
+    private void stubSuccessfulClose() {
+      when(mockClient.connectionClose(any()))
+          .thenReturn(ConnectionCloseResponse.getDefaultInstance());
+      when(mockClient.connectionRelease(any()))
+          .thenReturn(ConnectionReleaseResponse.getDefaultInstance());
+      when(mockClient.databaseRelease(any()))
+          .thenReturn(DatabaseReleaseResponse.getDefaultInstance());
+    }
+
+    @Test
+    void sendsConnectionCloseAndReleasesHandles() throws Exception {
+      stubSuccessfulClose();
+
+      SnowflakeConnectionImpl conn = createConnection();
+      conn.close();
+
+      verify(mockClient).connectionClose(any(ConnectionCloseRequest.class));
+      verify(mockClient).connectionRelease(any(ConnectionReleaseRequest.class));
+      verify(mockClient).databaseRelease(any(DatabaseReleaseRequest.class));
+    }
+
+    @Test
+    void isClosedReturnsTrueAfterClose() throws Exception {
+      stubSuccessfulClose();
+
+      SnowflakeConnectionImpl conn = createConnection();
+      assertFalse(conn.isClosed());
+
+      conn.close();
+      assertTrue(conn.isClosed());
+    }
+
+    @Test
+    void isIdempotent() throws Exception {
+      stubSuccessfulClose();
+
+      SnowflakeConnectionImpl conn = createConnection();
+      conn.close();
+      conn.close();
+      conn.close();
+
+      verify(mockClient, times(1)).connectionClose(any());
+      verify(mockClient, times(1)).connectionRelease(any());
+      verify(mockClient, times(1)).databaseRelease(any());
+    }
+
+    @Test
+    void releasesHandlesEvenWhenConnectionCloseThrowsTransportException() throws Exception {
+      when(mockClient.connectionClose(any())).thenThrow(new TransportException("network error"));
+      when(mockClient.connectionRelease(any()))
+          .thenReturn(ConnectionReleaseResponse.getDefaultInstance());
+      when(mockClient.databaseRelease(any()))
+          .thenReturn(DatabaseReleaseResponse.getDefaultInstance());
+
+      SnowflakeConnectionImpl conn = createConnection();
+      assertThrows(SQLException.class, conn::close);
+
+      verify(mockClient).connectionRelease(any(ConnectionReleaseRequest.class));
+      verify(mockClient).databaseRelease(any(DatabaseReleaseRequest.class));
+      assertTrue(conn.isClosed());
+    }
+
+    @Test
+    void releasesHandlesEvenWhenConnectionCloseThrowsServiceException() throws Exception {
+      when(mockClient.connectionClose(any()))
+          .thenThrow(
+              new DatabaseDriverService.ServiceException(DriverException.getDefaultInstance()));
+      when(mockClient.connectionRelease(any()))
+          .thenReturn(ConnectionReleaseResponse.getDefaultInstance());
+      when(mockClient.databaseRelease(any()))
+          .thenReturn(DatabaseReleaseResponse.getDefaultInstance());
+
+      SnowflakeConnectionImpl conn = createConnection();
+      assertThrows(SQLException.class, conn::close);
+
+      verify(mockClient).connectionRelease(any(ConnectionReleaseRequest.class));
+      verify(mockClient).databaseRelease(any(DatabaseReleaseRequest.class));
+    }
+
+    @Test
+    void operationsThrowAfterClose() throws Exception {
+      stubSuccessfulClose();
+
+      SnowflakeConnectionImpl conn = createConnection();
+      conn.close();
+
+      assertThrows(SQLException.class, conn::createStatement);
+      assertThrows(SQLException.class, () -> conn.prepareStatement("SELECT 1"));
+    }
+
+    @Test
+    void concurrentCallsResultInSingleLogout() throws Exception {
+      stubSuccessfulClose();
+
+      SnowflakeConnectionImpl conn = createConnection();
+      int threadCount = 5;
+      CyclicBarrier barrier = new CyclicBarrier(threadCount);
+      AtomicInteger exceptions = new AtomicInteger(0);
+
+      Thread[] threads = new Thread[threadCount];
+      for (int i = 0; i < threadCount; i++) {
+        threads[i] =
+            new Thread(
+                () -> {
+                  try {
+                    barrier.await();
+                    conn.close();
+                  } catch (Exception e) {
+                    exceptions.incrementAndGet();
+                  }
+                });
+        threads[i].start();
+      }
+
+      for (Thread t : threads) {
+        t.join();
+      }
+
+      verify(mockClient, times(1)).connectionClose(any());
+      assertTrue(conn.isClosed());
+      assertEquals(0, exceptions.get(), "No thread should have thrown an exception");
+    }
+
+    @Test
+    void doesNotCallRpcsWhenAlreadyClosed() throws Exception {
+      stubSuccessfulClose();
+
+      SnowflakeConnectionImpl conn = createConnection();
+      conn.close();
+
+      org.mockito.Mockito.clearInvocations(mockClient);
+      conn.close();
+
+      verify(mockClient, never()).connectionClose(any());
+      verify(mockClient, never()).connectionRelease(any());
+      verify(mockClient, never()).databaseRelease(any());
+    }
   }
 }

--- a/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/connection/SnowflakeConnectionImplTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/connection/SnowflakeConnectionImplTest.java
@@ -6,35 +6,30 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Properties;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.atomic.AtomicInteger;
-import net.snowflake.client.internal.unicore.ProtobufApis;
-import net.snowflake.client.internal.unicore.TransportException;
-import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverService;
+import net.snowflake.client.internal.unicore.CoreDriverApi;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConfigSetting;
-import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionCloseRequest;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionCloseResponse;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionHandle;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionInitResponse;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionNewResponse;
-import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionReleaseRequest;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionReleaseResponse;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionSetOptionsResponse;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseHandle;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseInitResponse;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseNewResponse;
-import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseReleaseRequest;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DatabaseReleaseResponse;
-import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DriverException;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -81,48 +76,42 @@ public class SnowflakeConnectionImplTest {
   @Nested
   class Close {
 
-    private DatabaseDriverService originalClient;
-    private DatabaseDriverService mockClient;
+    private final DatabaseHandle dbHandle =
+        DatabaseHandle.newBuilder().setId(1).setMagic(100).build();
+    private final ConnectionHandle connHandle =
+        ConnectionHandle.newBuilder().setId(2).setMagic(200).build();
+
+    private CoreDriverApi mockCoreApi;
 
     @BeforeEach
-    void setUp() {
-      originalClient = ProtobufApis.databaseDriverV1;
-      mockClient = mock(DatabaseDriverService.class);
-      ProtobufApis.databaseDriverV1 = mockClient;
-    }
-
-    @AfterEach
-    void tearDown() {
-      ProtobufApis.databaseDriverV1 = originalClient;
+    void setUp() throws Exception {
+      mockCoreApi = mock(CoreDriverApi.class);
+      when(mockCoreApi.databaseNew())
+          .thenReturn(DatabaseNewResponse.newBuilder().setDbHandle(dbHandle).build());
+      when(mockCoreApi.databaseInit(any())).thenReturn(DatabaseInitResponse.getDefaultInstance());
+      when(mockCoreApi.connectionNew())
+          .thenReturn(ConnectionNewResponse.newBuilder().setConnHandle(connHandle).build());
+      when(mockCoreApi.connectionSetOptions(any(), any()))
+          .thenReturn(ConnectionSetOptionsResponse.getDefaultInstance());
+      when(mockCoreApi.connectionInit(any(), any(), any()))
+          .thenReturn(ConnectionInitResponse.getDefaultInstance());
     }
 
     private SnowflakeConnectionImpl createConnection() throws SQLException {
-      DatabaseHandle dbHandle = DatabaseHandle.newBuilder().setId(1).setMagic(100).build();
-      ConnectionHandle connHandle = ConnectionHandle.newBuilder().setId(2).setMagic(200).build();
-
-      when(mockClient.databaseNew(any()))
-          .thenReturn(DatabaseNewResponse.newBuilder().setDbHandle(dbHandle).build());
-      when(mockClient.databaseInit(any())).thenReturn(DatabaseInitResponse.getDefaultInstance());
-      when(mockClient.connectionNew(any()))
-          .thenReturn(ConnectionNewResponse.newBuilder().setConnHandle(connHandle).build());
-      when(mockClient.connectionSetOptions(any()))
-          .thenReturn(ConnectionSetOptionsResponse.getDefaultInstance());
-      when(mockClient.connectionInit(any()))
-          .thenReturn(ConnectionInitResponse.getDefaultInstance());
-
       Properties props = new Properties();
       props.setProperty("account", "test_account");
       props.setProperty("user", "test_user");
       props.setProperty("password", "test_password");
-      return new SnowflakeConnectionImpl("jdbc:snowflake://test.snowflakecomputing.com", props);
+      return new SnowflakeConnectionImpl(
+          "jdbc:snowflake://test.snowflakecomputing.com", props, mockCoreApi);
     }
 
-    private void stubSuccessfulClose() {
-      when(mockClient.connectionClose(any()))
+    private void stubSuccessfulClose() throws Exception {
+      when(mockCoreApi.connectionClose(any()))
           .thenReturn(ConnectionCloseResponse.getDefaultInstance());
-      when(mockClient.connectionRelease(any()))
+      when(mockCoreApi.connectionRelease(any()))
           .thenReturn(ConnectionReleaseResponse.getDefaultInstance());
-      when(mockClient.databaseRelease(any()))
+      when(mockCoreApi.databaseRelease(any()))
           .thenReturn(DatabaseReleaseResponse.getDefaultInstance());
     }
 
@@ -130,19 +119,19 @@ public class SnowflakeConnectionImplTest {
     void sendsConnectionCloseAndReleasesHandles() throws Exception {
       stubSuccessfulClose();
 
-      SnowflakeConnectionImpl conn = createConnection();
+      Connection conn = createConnection();
       conn.close();
 
-      verify(mockClient).connectionClose(any(ConnectionCloseRequest.class));
-      verify(mockClient).connectionRelease(any(ConnectionReleaseRequest.class));
-      verify(mockClient).databaseRelease(any(DatabaseReleaseRequest.class));
+      verify(mockCoreApi).connectionClose(any());
+      verify(mockCoreApi).connectionRelease(any());
+      verify(mockCoreApi).databaseRelease(any());
     }
 
     @Test
     void isClosedReturnsTrueAfterClose() throws Exception {
       stubSuccessfulClose();
 
-      SnowflakeConnectionImpl conn = createConnection();
+      Connection conn = createConnection();
       assertFalse(conn.isClosed());
 
       conn.close();
@@ -153,54 +142,37 @@ public class SnowflakeConnectionImplTest {
     void isIdempotent() throws Exception {
       stubSuccessfulClose();
 
-      SnowflakeConnectionImpl conn = createConnection();
+      Connection conn = createConnection();
       conn.close();
       conn.close();
       conn.close();
 
-      verify(mockClient, times(1)).connectionClose(any());
-      verify(mockClient, times(1)).connectionRelease(any());
-      verify(mockClient, times(1)).databaseRelease(any());
+      verify(mockCoreApi, times(1)).connectionClose(any());
+      verify(mockCoreApi, times(1)).connectionRelease(any());
+      verify(mockCoreApi, times(1)).databaseRelease(any());
     }
 
     @Test
-    void releasesHandlesEvenWhenConnectionCloseThrowsTransportException() throws Exception {
-      when(mockClient.connectionClose(any())).thenThrow(new TransportException("network error"));
-      when(mockClient.connectionRelease(any()))
+    void releasesHandlesEvenWhenConnectionCloseThrows() throws Exception {
+      when(mockCoreApi.connectionClose(any())).thenThrow(new SQLException("server error"));
+      when(mockCoreApi.connectionRelease(any()))
           .thenReturn(ConnectionReleaseResponse.getDefaultInstance());
-      when(mockClient.databaseRelease(any()))
+      when(mockCoreApi.databaseRelease(any()))
           .thenReturn(DatabaseReleaseResponse.getDefaultInstance());
 
-      SnowflakeConnectionImpl conn = createConnection();
+      Connection conn = createConnection();
       assertThrows(SQLException.class, conn::close);
 
-      verify(mockClient).connectionRelease(any(ConnectionReleaseRequest.class));
-      verify(mockClient).databaseRelease(any(DatabaseReleaseRequest.class));
+      verify(mockCoreApi).connectionRelease(any());
+      verify(mockCoreApi).databaseRelease(any());
       assertTrue(conn.isClosed());
-    }
-
-    @Test
-    void releasesHandlesEvenWhenConnectionCloseThrowsServiceException() throws Exception {
-      when(mockClient.connectionClose(any()))
-          .thenThrow(
-              new DatabaseDriverService.ServiceException(DriverException.getDefaultInstance()));
-      when(mockClient.connectionRelease(any()))
-          .thenReturn(ConnectionReleaseResponse.getDefaultInstance());
-      when(mockClient.databaseRelease(any()))
-          .thenReturn(DatabaseReleaseResponse.getDefaultInstance());
-
-      SnowflakeConnectionImpl conn = createConnection();
-      assertThrows(SQLException.class, conn::close);
-
-      verify(mockClient).connectionRelease(any(ConnectionReleaseRequest.class));
-      verify(mockClient).databaseRelease(any(DatabaseReleaseRequest.class));
     }
 
     @Test
     void operationsThrowAfterClose() throws Exception {
       stubSuccessfulClose();
 
-      SnowflakeConnectionImpl conn = createConnection();
+      Connection conn = createConnection();
       conn.close();
 
       assertThrows(SQLException.class, conn::createStatement);
@@ -211,7 +183,7 @@ public class SnowflakeConnectionImplTest {
     void concurrentCallsResultInSingleLogout() throws Exception {
       stubSuccessfulClose();
 
-      SnowflakeConnectionImpl conn = createConnection();
+      Connection conn = createConnection();
       int threadCount = 5;
       CyclicBarrier barrier = new CyclicBarrier(threadCount);
       AtomicInteger exceptions = new AtomicInteger(0);
@@ -235,7 +207,7 @@ public class SnowflakeConnectionImplTest {
         t.join();
       }
 
-      verify(mockClient, times(1)).connectionClose(any());
+      verify(mockCoreApi, times(1)).connectionClose(any());
       assertTrue(conn.isClosed());
       assertEquals(0, exceptions.get(), "No thread should have thrown an exception");
     }
@@ -244,15 +216,15 @@ public class SnowflakeConnectionImplTest {
     void doesNotCallRpcsWhenAlreadyClosed() throws Exception {
       stubSuccessfulClose();
 
-      SnowflakeConnectionImpl conn = createConnection();
+      Connection conn = createConnection();
       conn.close();
 
-      org.mockito.Mockito.clearInvocations(mockClient);
+      clearInvocations(mockCoreApi);
       conn.close();
 
-      verify(mockClient, never()).connectionClose(any());
-      verify(mockClient, never()).connectionRelease(any());
-      verify(mockClient, never()).databaseRelease(any());
+      verify(mockCoreApi, never()).connectionClose(any());
+      verify(mockCoreApi, never()).connectionRelease(any());
+      verify(mockCoreApi, never()).databaseRelease(any());
     }
   }
 }

--- a/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/datasource/SnowflakeBasicDataSourceTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/datasource/SnowflakeBasicDataSourceTest.java
@@ -220,4 +220,20 @@ public class SnowflakeBasicDataSourceTest {
     assertEquals("myaccount", freshProps.getProperty("account"));
     assertNull(freshProps.getProperty("injected"));
   }
+
+  @Test
+  public void testSetAuthenticatorStoresProperty() {
+    dataSource.setAuthenticator("PROGRAMMATIC_ACCESS_TOKEN");
+
+    Properties props = dataSource.getProperties();
+    assertEquals("PROGRAMMATIC_ACCESS_TOKEN", props.getProperty("authenticator"));
+  }
+
+  @Test
+  public void testSetTokenStoresProperty() {
+    dataSource.setToken("my_pat_token_value");
+
+    Properties props = dataSource.getProperties();
+    assertEquals("my_pat_token_value", props.getProperty("token"));
+  }
 }

--- a/jdbc/src/test/java/net/snowflake/jdbc/e2e/authentication/PatTests.java
+++ b/jdbc/src/test/java/net/snowflake/jdbc/e2e/authentication/PatTests.java
@@ -1,0 +1,153 @@
+package net.snowflake.jdbc.e2e.authentication;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+import java.util.Random;
+import net.snowflake.client.SnowflakeIntegrationTestBase;
+import net.snowflake.client.api.datasource.SnowflakeDataSource;
+import net.snowflake.client.api.datasource.SnowflakeDataSourceFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class PatTests extends SnowflakeIntegrationTestBase {
+
+  private String patToken;
+  private String patTokenName;
+
+  @BeforeAll
+  void createPATToken() throws Exception {
+    Properties props = loadConnectionProperties();
+    String user = props.getProperty("user");
+    String role = props.getProperty("role");
+    patTokenName = "UD_JDBC_E2E_" + String.format("%08x", new Random().nextInt());
+
+    try (Connection conn = openConnection();
+        Statement stmt = conn.createStatement();
+        ResultSet rs =
+            stmt.executeQuery(
+                "ALTER USER IF EXISTS "
+                    + user
+                    + " ADD PROGRAMMATIC ACCESS TOKEN "
+                    + patTokenName
+                    + " ROLE_RESTRICTION = "
+                    + role)) {
+      assertTrue(rs.next(), "ALTER USER should return a result");
+      patToken = rs.getString(2);
+      assertNotNull(patToken, "PAT token secret should not be null");
+      assertFalse(patToken.isEmpty(), "PAT token secret should not be empty");
+    }
+  }
+
+  @AfterAll
+  void cleanupPATToken() throws Exception {
+    if (patTokenName != null) {
+      try (Connection conn = openConnection();
+          Statement stmt = conn.createStatement()) {
+        Properties props = loadConnectionProperties();
+        String user = props.getProperty("user");
+        stmt.execute(
+            "ALTER USER IF EXISTS " + user + " REMOVE PROGRAMMATIC ACCESS TOKEN " + patTokenName);
+      } catch (Exception e) {
+        System.err.println("Failed to cleanup PAT token " + patTokenName + ": " + e.getMessage());
+      }
+    }
+  }
+
+  @Test
+  void shouldAuthenticateUsingPATAsPassword() throws Exception {
+    // Given Authentication is set to password and valid PAT token is provided
+    Properties props = loadConnectionProperties();
+    props.setProperty("password", patToken);
+
+    // When Trying to Connect
+    String url = buildJdbcUrl(props);
+    try (Connection conn = DriverManager.getConnection(url, props)) {
+      // Then Login is successful and simple query can be executed
+      assertSimpleQuerySucceeds(conn);
+    }
+  }
+
+  @Test
+  void shouldAuthenticateUsingPATAsToken() throws Exception {
+    // Given Authentication is set to Programmatic Access Token and valid PAT token is provided
+    Properties props = loadConnectionProperties();
+    props.remove("password");
+    props.setProperty("authenticator", "PROGRAMMATIC_ACCESS_TOKEN");
+    props.setProperty("token", patToken);
+
+    // When Trying to Connect
+    String url = buildJdbcUrl(props);
+    try (Connection conn = DriverManager.getConnection(url, props)) {
+      // Then Login is successful and simple query can be executed
+      assertSimpleQuerySucceeds(conn);
+    }
+  }
+
+  @Test
+  void shouldAuthenticateUsingPATAsTokenWithLowercaseAuthenticator() throws Exception {
+    // Given Authentication is set to lowercase programmatic_access_token and valid PAT token is
+    // provided
+    Properties props = loadConnectionProperties();
+    props.remove("password");
+    props.setProperty("authenticator", "programmatic_access_token");
+    props.setProperty("token", patToken);
+
+    // When Trying to Connect
+    String url = buildJdbcUrl(props);
+    try (Connection conn = DriverManager.getConnection(url, props)) {
+      // Then Login is successful and simple query can be executed
+      assertSimpleQuerySucceeds(conn);
+    }
+  }
+
+  @Test
+  void shouldFailPATAuthenticationWhenInvalidTokenProvided() throws Exception {
+    // Given Authentication is set to Programmatic Access Token and invalid PAT token is provided
+    Properties props = loadConnectionProperties();
+    props.remove("password");
+    props.setProperty("authenticator", "PROGRAMMATIC_ACCESS_TOKEN");
+    props.setProperty("token", "invalid_token_12345");
+
+    // When Trying to Connect
+    String url = buildJdbcUrl(props);
+
+    // Then There is error returned
+    assertThrows(SQLException.class, () -> DriverManager.getConnection(url, props));
+  }
+
+  @Test
+  void shouldAuthenticateUsingPATViaDataSource() throws Exception {
+    // Given DataSource is configured with PAT authentication
+    Properties props = loadConnectionProperties();
+    SnowflakeDataSource ds = SnowflakeDataSourceFactory.createDataSource();
+    ds.setUrl(buildJdbcUrl(props));
+    ds.setUser(props.getProperty("user"));
+    ds.setAccount(props.getProperty("account"));
+    ds.setAuthenticator("PROGRAMMATIC_ACCESS_TOKEN");
+    ds.setToken(patToken);
+
+    // When Trying to Connect via DataSource
+    try (Connection conn = ds.getConnection()) {
+      // Then Login is successful and simple query can be executed
+      assertSimpleQuerySucceeds(conn);
+    }
+  }
+
+  private void assertSimpleQuerySucceeds(Connection conn) throws SQLException {
+    try (Statement stmt = conn.createStatement();
+        ResultSet rs = stmt.executeQuery("SELECT 1")) {
+      assertTrue(rs.next(), "Result set should have at least one row");
+      assertTrue(rs.getInt(1) == 1, "SELECT 1 should return 1");
+    }
+  }
+}

--- a/jdbc/src/test/java/net/snowflake/jdbc/wiremock/connection/LogoutTest.java
+++ b/jdbc/src/test/java/net/snowflake/jdbc/wiremock/connection/LogoutTest.java
@@ -1,0 +1,80 @@
+package net.snowflake.jdbc.wiremock.connection;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Properties;
+import net.snowflake.client.api.driver.SnowflakeDriver;
+import net.snowflake.jdbc.wiremock.BaseWiremockTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class LogoutTest extends BaseWiremockTest {
+
+  @BeforeAll
+  void loadDriver() throws Exception {
+    Class.forName(SnowflakeDriver.class.getName());
+  }
+
+  private Properties connectionProps() {
+    Properties props = new Properties();
+    props.setProperty("account", "test_account");
+    props.setProperty("user", "test_user");
+    props.setProperty("password", "test_password");
+    props.setProperty("protocol", "http");
+    return props;
+  }
+
+  @Test
+  void closeSendsLogoutRequest() throws Exception {
+    wiremock.addMapping("auth/login_success_any.json");
+    wiremock.addMapping("session/logout_success.json");
+
+    Connection conn = DriverManager.getConnection(wiremockJdbcUrl(), connectionProps());
+    conn.close();
+
+    wiremock.verifyRequestCount(1, "/session$");
+    assertTrue(conn.isClosed());
+  }
+
+  @Test
+  void closeDoesNotThrowWhenServerReturns500() throws Exception {
+    wiremock.addMapping("auth/login_success_any.json");
+    wiremock.addMapping("session/logout_500_always.json");
+
+    Connection conn = DriverManager.getConnection(wiremockJdbcUrl(), connectionProps());
+    assertDoesNotThrow(conn::close);
+    assertTrue(conn.isClosed());
+  }
+
+  @Test
+  void closeThrowsWhenStrictModeAndServerReturns500() throws Exception {
+    wiremock.addMapping("auth/login_success_any.json");
+    wiremock.addMapping("session/logout_500_always.json");
+
+    Properties props = connectionProps();
+    props.setProperty("logout_error_strategy", "strict");
+
+    Connection conn = DriverManager.getConnection(wiremockJdbcUrl(), props);
+    assertThrows(SQLException.class, conn::close);
+    assertTrue(conn.isClosed());
+  }
+
+  @Test
+  void closeRetriesOn503() throws Exception {
+    wiremock.addMapping("auth/login_success_any.json");
+    wiremock.addMapping("session/logout_503_then_success.json");
+
+    Connection conn = DriverManager.getConnection(wiremockJdbcUrl(), connectionProps());
+    conn.close();
+
+    int logoutRequests = wiremock.getRequests("/session$").size();
+    assertTrue(
+        logoutRequests >= 2, "Expected at least 2 logout attempts (retry), got " + logoutRequests);
+    assertTrue(conn.isClosed());
+  }
+}

--- a/odbc_tests/BehaviorDifferences.yaml
+++ b/odbc_tests/BehaviorDifferences.yaml
@@ -236,7 +236,7 @@ behavior_differences:
 
   17:
     name: "On Windows, PUT source column returns filename only instead of full absolute path"
-    status: unknown
+    status: fixed
     type: bug
     reviewed: false
     old_driver_behavior: |

--- a/odbc_tests/common/include/put_get_utils.hpp
+++ b/odbc_tests/common/include/put_get_utils.hpp
@@ -133,20 +133,15 @@ inline std::filesystem::path write_text_file(const std::filesystem::path& dir, c
   return p;
 }
 
-// BD#17: On Windows, the old driver returns a full absolute path for the PUT source column;
-// the new driver returns just the filename (same as Linux).
+// On Windows, both drivers return the full absolute file path verbatim in the PUT source column.
 inline std::string expected_put_source(const std::filesystem::path& file_path) {
   WINDOWS_ONLY {
-    OLD_DRIVER_ONLY("BD#17") {
-      std::string s = std::filesystem::absolute(file_path).string();
-      std::replace(s.begin(), s.end(), '\\', '/');
-      return s;
-    }
-    NEW_DRIVER_ONLY("BD#17") { return file_path.filename().string(); }
+    std::string s = std::filesystem::absolute(file_path).string();
+    std::replace(s.begin(), s.end(), '\\', '/');
+    return s;
   }
   UNIX_ONLY { return file_path.filename().string(); }
   throw std::logic_error("expected_put_source: unsupported platform");
-  ;
 }
 
 // Convert a path into a URI-safe string for Snowflake file:// usage

--- a/python/src/snowflake/connector/connection.py
+++ b/python/src/snowflake/connector/connection.py
@@ -761,7 +761,7 @@ class Connection(ErrorHandlerMixin):
     @property
     def validate_default_parameters(self) -> bool:
         """Whether to validate default connection parameters at connect time."""
-        raise NotImplementedError("validate_default_parameters is not yet implemented")
+        return bool(self.config.validate_default_parameters)
 
     @property
     def insecure_mode(self) -> bool:

--- a/python/src/snowflake/connector/connection_config.py
+++ b/python/src/snowflake/connector/connection_config.py
@@ -195,6 +195,9 @@ class ConnectionConfig(ConnectionConfigMixin):
     user: str | None = None
     """Login username. Required"""
 
+    validate_default_parameters: bool | None = False
+    """Validate that the default database, schema, and warehouse exist on the server at connect time. Default: False"""
+
     verify_certificates: bool | None = True
     """Whether to verify TLS certificates. Default: True"""
 

--- a/sf_core/src/apis/database_driver_v1/connection.rs
+++ b/sf_core/src/apis/database_driver_v1/connection.rs
@@ -1196,22 +1196,117 @@ impl RefreshContext {
 
     /// Execute an async operation with automatic token refresh on session expiry.
     ///
-    /// Canonical implementation of the refresh-retry loop. On `SessionExpired`,
-    /// refreshes the session token via master token and retries exactly once.
-    /// Named to parallel [`execute_with_retry`](crate::http::retry::execute_with_retry).
+    /// On `SessionExpired`, refreshes the session token via master token and
+    /// retries exactly once. Implemented on top of the generic
+    /// [`refresh::execute_with_refresh`](crate::refresh::execute_with_refresh)
+    /// helper. Named to parallel
+    /// [`execute_with_retry`](crate::http::retry::execute_with_retry).
     pub async fn execute_with_refresh<F, Fut, T>(&mut self, f: F) -> Result<T, ApiError>
     where
         F: Fn(SensitiveString) -> Fut,
         Fut: Future<Output = Result<T, RestError>>,
     {
-        let mut last_error: Option<RestError> = None;
-        loop {
-            let token = self.refresh_token(last_error).await?;
-            match f(token).await {
-                Ok(result) => return Ok(result),
-                Err(e) => last_error = Some(e),
+        use snafu::IntoError;
+        crate::refresh::execute_with_refresh(self, |token| {
+            let fut = f(token);
+            async move { fut.await.map_err(|e| QuerySnafu.into_error(e)) }
+        })
+        .await
+    }
+}
+
+impl crate::refresh::Refresher<SensitiveString, ApiError> for RefreshContext {
+    fn current(&mut self) -> crate::refresh::RefreshFuture<'_, Result<SensitiveString, ApiError>> {
+        Box::pin(async move {
+            let tokens_guard = self.tokens_lock.read().await;
+            let token = tokens_guard
+                .as_ref()
+                .map(|t| t.session_token.clone())
+                .context(ConnectionNotInitializedSnafu)?;
+            // Stamp the token into the state machine on first read so
+            // that `refresh()` can detect — by comparing this token
+            // against the cache after acquiring the write lock — whether
+            // another request already rotated while we were waiting.
+            if matches!(self.state, RefreshState::Initial) {
+                self.state = RefreshState::FirstToken(token.clone());
             }
-        }
+            Ok(token)
+        })
+    }
+
+    fn should_refresh(&self, err: &ApiError) -> bool {
+        let ApiError::Query { source, .. } = err else {
+            return false;
+        };
+        matches!(
+            source.as_ref(),
+            RestError::InvalidSnowflakeResponse {
+                source: SnowflakeResponseError::SessionExpired { .. },
+                ..
+            },
+        )
+    }
+
+    fn refresh(&mut self) -> crate::refresh::RefreshFuture<'_, Result<bool, ApiError>> {
+        Box::pin(async move {
+            // One-shot state machine: the first refresh call does the
+            // work, subsequent calls return Ok(false) so the generic
+            // helper propagates the original error. `Initial` is
+            // unreachable in practice — `execute_with_refresh` always
+            // calls `current()` first, which transitions Initial →
+            // FirstToken — but we keep a safe fallback rather than
+            // panicking on a misuse from a future caller.
+            let failed_token = match &self.state {
+                RefreshState::FirstToken(t) => t.clone(),
+                RefreshState::Refreshed => return Ok(false),
+                RefreshState::Initial => {
+                    debug_assert!(
+                        false,
+                        "RefreshContext::refresh() called before current(); \
+                         execute_with_refresh always calls current() first"
+                    );
+                    return Ok(false);
+                }
+            };
+            self.state = RefreshState::Refreshed;
+
+            // Acquire the write lock — blocks other readers/writers during
+            // refresh.
+            let mut tokens_guard = self.tokens_lock.write().await;
+            let tokens = tokens_guard
+                .as_ref()
+                .cloned()
+                .context(ConnectionNotInitializedSnafu)?;
+
+            // If another request already refreshed while we waited, the
+            // current token is fresh — treat as a successful rotation
+            // without hitting GS.
+            if tokens.session_token.reveal() != failed_token.reveal() {
+                tracing::debug!("Session already refreshed by another request");
+                return Ok(true);
+            }
+
+            if tokens.is_master_expired() {
+                tracing::error!("Master token expired, full re-authentication required");
+                return MasterTokenExpiredSnafu.fail();
+            }
+
+            tracing::info!("Session expired, attempting refresh");
+            let new_tokens = snowflake::refresh_session(
+                &self.http_client,
+                &self.server_url,
+                &self.client_info,
+                &tokens,
+            )
+            .await
+            .context(SessionRefreshSnafu)?;
+
+            *tokens_guard = Some(new_tokens);
+            drop(tokens_guard);
+
+            tracing::info!("Session refreshed, retrying operation");
+            Ok(true)
+        })
     }
 }
 

--- a/sf_core/src/apis/database_driver_v1/connection.rs
+++ b/sf_core/src/apis/database_driver_v1/connection.rs
@@ -256,9 +256,12 @@ impl DatabaseDriverV1 {
                     read_spcs_token(self.fs_adapter().as_ref()),
                 );
 
-                let mfa_caching_requested = matches!(
+                let token_caching_requested = matches!(
                     &login_parameters.login_method,
                     LoginMethod::UserPasswordMfa {
+                        client_store_temporary_credential: true,
+                        ..
+                    } | LoginMethod::ExternalBrowser {
                         client_store_temporary_credential: true,
                         ..
                     }
@@ -279,7 +282,7 @@ impl DatabaseDriverV1 {
                         if cfg.client_store_temporary_credential
                 );
 
-                let token_cache = if mfa_caching_requested || oauth_caching_requested {
+                let token_cache = if token_caching_requested || oauth_caching_requested {
                     Some(self.token_cache().context(TokenCacheInitializationSnafu)?)
                 } else {
                     None

--- a/sf_core/src/apis/database_driver_v1/connection.rs
+++ b/sf_core/src/apis/database_driver_v1/connection.rs
@@ -210,6 +210,15 @@ impl DatabaseDriverV1 {
                             v.to_string(),
                         );
                     }
+                    if resolved
+                        .get_bool(param_names::VALIDATE_DEFAULT_PARAMETERS)
+                        .unwrap_or(false)
+                    {
+                        unknown_settings.insert(
+                            "CLIENT_VALIDATE_DEFAULT_PARAMETERS".to_string(),
+                            "true".to_string(),
+                        );
+                    }
                     let init_params = match init_params {
                         Some(explicit) => {
                             // Normalize explicit keys to uppercase so precedence

--- a/sf_core/src/auth.rs
+++ b/sf_core/src/auth.rs
@@ -25,6 +25,8 @@ pub enum Credentials {
     Password {
         username: String,
         password: SensitiveString,
+        passcode_in_password: bool,
+        passcode: Option<SensitiveString>,
     },
     Jwt {
         username: String,
@@ -130,9 +132,16 @@ fn generate_jwt_token(
 
 pub fn create_credentials(login_parameters: &LoginParameters) -> Result<Credentials, AuthError> {
     match &login_parameters.login_method {
-        LoginMethod::Password { username, password } => Ok(Credentials::Password {
+        LoginMethod::Password {
+            username,
+            password,
+            passcode_in_password,
+            passcode,
+        } => Ok(Credentials::Password {
             username: username.clone(),
             password: password.clone(),
+            passcode_in_password: *passcode_in_password,
+            passcode: passcode.clone(),
         }),
         // NativeOkta and ExternalBrowser perform their own multi-step flows in
         // auth_request_data() and never reach create_credentials(). Return an error

--- a/sf_core/src/bin/collect_chunk_data.rs
+++ b/sf_core/src/bin/collect_chunk_data.rs
@@ -318,6 +318,8 @@ fn build_login_params(
         LoginMethod::Password {
             username: user,
             password: SensitiveString::from(password.clone()),
+            passcode_in_password: false,
+            passcode: None,
         }
     } else {
         return Err("No authentication method available: set private_key_file, private_key_contents, or password in parameters".into());

--- a/sf_core/src/config/connection_config.rs
+++ b/sf_core/src/config/connection_config.rs
@@ -48,6 +48,8 @@ pub enum AuthConfig {
     Password {
         user: String,
         password: SensitiveString,
+        passcode_in_password: bool,
+        passcode: Option<SensitiveString>,
     },
     Mfa {
         user: String,
@@ -377,6 +379,8 @@ fn build_auth_config(settings: &ParamStore) -> Result<AuthConfig, ConfigError> {
                 .context(MissingParameterSnafu {
                     parameter: String::from(PASSWORD),
                 })?,
+            passcode_in_password: settings.get_bool(PASSCODE_IN_PASSWORD).unwrap_or(false),
+            passcode: settings.get_sensitive_string(PASSCODE),
         }),
         "USERNAME_PASSWORD_MFA" => Ok(AuthConfig::Mfa {
             user: non_empty_string(settings, USER).context(MissingParameterSnafu {
@@ -526,9 +530,16 @@ impl ConnectionConfig {
 
 fn login_method_from_auth_config(auth: &AuthConfig) -> LoginMethod {
     match auth {
-        AuthConfig::Password { user, password } => LoginMethod::Password {
+        AuthConfig::Password {
+            user,
+            password,
+            passcode_in_password,
+            passcode,
+        } => LoginMethod::Password {
             username: user.clone(),
             password: password.clone(),
+            passcode_in_password: *passcode_in_password,
+            passcode: passcode.clone(),
         },
         AuthConfig::Mfa {
             user,
@@ -1014,7 +1025,7 @@ mod tests {
                 .contains("myaccount.snowflakecomputing.com")
         );
         match &config.auth {
-            AuthConfig::Password { user, password } => {
+            AuthConfig::Password { user, password, .. } => {
                 assert_eq!(user, "myuser");
                 assert_eq!(password.reveal(), "mypassword");
             }
@@ -1193,7 +1204,7 @@ mod tests {
         ]);
         let config = ConnectionConfig::build(&settings).unwrap();
         match &config.auth {
-            AuthConfig::Password { user, password } => {
+            AuthConfig::Password { user, password, .. } => {
                 assert_eq!(user, "u");
                 assert_eq!(password.reveal(), "p");
             }

--- a/sf_core/src/config/connection_config.rs
+++ b/sf_core/src/config/connection_config.rs
@@ -69,6 +69,7 @@ pub enum AuthConfig {
     ExternalBrowser {
         user: String,
         authentication_timeout_secs: u64,
+        client_store_temporary_credential: bool,
     },
     /// Legacy pre-acquired OAuth access token (`AUTHENTICATOR=OAUTH` +
     /// raw `token=`). Forwarded unchanged to Snowflake
@@ -460,6 +461,9 @@ fn build_auth_config(settings: &ParamStore) -> Result<AuthConfig, ConfigError> {
                 parameter: String::from(USER),
             })?,
             authentication_timeout_secs: parse_authentication_timeout(settings),
+            client_store_temporary_credential: settings
+                .get_bool(CLIENT_STORE_TEMPORARY_CREDENTIAL)
+                .unwrap_or(false),
         }),
         _ => InvalidParameterValueSnafu {
             parameter: String::from(AUTHENTICATOR),
@@ -563,9 +567,11 @@ fn login_method_from_auth_config(auth: &AuthConfig) -> LoginMethod {
         AuthConfig::ExternalBrowser {
             user,
             authentication_timeout_secs,
+            client_store_temporary_credential,
         } => LoginMethod::ExternalBrowser {
             username: user.clone(),
             authentication_timeout_secs: *authentication_timeout_secs,
+            client_store_temporary_credential: *client_store_temporary_credential,
         },
         AuthConfig::OAuthAccessToken { user, token } => LoginMethod::OAuthAccessToken {
             username: user.clone(),

--- a/sf_core/src/config/param_registry.rs
+++ b/sf_core/src/config/param_registry.rs
@@ -124,6 +124,7 @@ pub mod param_names {
     // canonical name matches the field on `StageInfo` (and libsfclient's
     // `use_s3_regional_url` connection attribute).
     pub const USE_S3_REGIONAL_URL: ParamKey = ParamKey("use_s3_regional_url");
+    pub const VALIDATE_DEFAULT_PARAMETERS: ParamKey = ParamKey("validate_default_parameters");
 }
 
 /// Which API layer owns writes for a parameter.
@@ -1133,6 +1134,20 @@ static PARAM_DEFS: &[ParamDef] = &[
         scope: ParamScope::Session,
         used_at_connect: false,
         mutable_after_connect: true,
+    },
+    ParamDef {
+        canonical_name: param_names::VALIDATE_DEFAULT_PARAMETERS.as_str(),
+        aliases: &["VALIDATE_DEFAULT_PARAMETERS"],
+        value_type: ValueType::Bool,
+        additional_value_type: None,
+        required: Required::Never,
+        default: Some(|| Setting::Bool(false)),
+        sensitive: false,
+        description: "Validate that the default database, schema, and warehouse exist on the server at connect time",
+        deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: true,
+        mutable_after_connect: false,
     },
 ];
 

--- a/sf_core/src/config/rest_parameters.rs
+++ b/sf_core/src/config/rest_parameters.rs
@@ -388,6 +388,8 @@ pub enum LoginMethod {
     Password {
         username: String,
         password: SensitiveString,
+        passcode_in_password: bool,
+        passcode: Option<SensitiveString>,
     },
     NativeOkta(NativeOktaConfig),
     PrivateKey {
@@ -709,6 +711,16 @@ impl LoginMethod {
                         parameter: "password",
                     })?
                     .into(),
+                passcode_in_password: settings
+                    .get_bool("passcodeInPassword")
+                    .or_else(|| {
+                        settings
+                            .get_string("passcodeInPassword")
+                            .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
+                    })
+                    .or_else(|| settings.get_int("passcodeInPassword").map(|v| v != 0))
+                    .unwrap_or(false),
+                passcode: settings.get_string("passcode").map(SensitiveString::from),
             }),
             "PROGRAMMATIC_ACCESS_TOKEN" => Ok(Self::Pat {
                 username: non_empty_string(settings, "user")
@@ -967,7 +979,9 @@ mod tests {
         let result = LoginMethod::from_settings(&settings);
         assert!(result.is_ok());
         match result.unwrap() {
-            LoginMethod::Password { username, password } => {
+            LoginMethod::Password {
+                username, password, ..
+            } => {
                 assert_eq!(username, "test_user");
                 assert_eq!(password.reveal(), "test_password");
             }
@@ -986,7 +1000,9 @@ mod tests {
         let result = LoginMethod::from_settings(&settings);
         assert!(result.is_ok());
         match result.unwrap() {
-            LoginMethod::Password { username, password } => {
+            LoginMethod::Password {
+                username, password, ..
+            } => {
                 assert_eq!(username, "test_user");
                 assert_eq!(password.reveal(), "test_password");
             }

--- a/sf_core/src/config/rest_parameters.rs
+++ b/sf_core/src/config/rest_parameters.rs
@@ -409,6 +409,7 @@ pub enum LoginMethod {
     ExternalBrowser {
         username: String,
         authentication_timeout_secs: u64,
+        client_store_temporary_credential: bool,
     },
     /// Pre-acquired OAuth access token (legacy `AUTHENTICATOR=OAUTH` with
     /// raw `token=`). The driver forwards the token to Snowflake unchanged.
@@ -794,19 +795,10 @@ impl LoginMethod {
                     .or_else(|| settings.get_int("passcodeInPassword").map(|v| v != 0))
                     .unwrap_or(false),
                 passcode: settings.get_string("passcode").map(SensitiveString::from),
-                client_store_temporary_credential: settings
-                    .get_bool("client_store_temporary_credential")
-                    .or_else(|| {
-                        settings
-                            .get_string("client_store_temporary_credential")
-                            .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
-                    })
-                    .or_else(|| {
-                        settings
-                            .get_int("client_store_temporary_credential")
-                            .map(|v| v != 0)
-                    })
-                    .unwrap_or(false),
+                client_store_temporary_credential: get_flexible_bool(
+                    settings,
+                    "client_store_temporary_credential",
+                ),
             }),
             "EXTERNALBROWSER" => {
                 let authentication_timeout_secs = settings
@@ -817,6 +809,10 @@ impl LoginMethod {
                     username: non_empty_string(settings, "user")
                         .context(MissingParameterSnafu { parameter: "user" })?,
                     authentication_timeout_secs,
+                    client_store_temporary_credential: get_flexible_bool(
+                        settings,
+                        "client_store_temporary_credential",
+                    ),
                 })
             }
             _ => InvalidParameterValueSnafu {
@@ -1524,7 +1520,7 @@ mod tests {
 
     // ─── External Browser config tests ───────────────────────────────────
 
-    fn external_browser_config(extras: Vec<(&str, Setting)>) -> (String, u64) {
+    fn external_browser_config(extras: Vec<(&str, Setting)>) -> (String, u64, bool) {
         let mut base = vec![
             ("user", Setting::String("browser_user".to_string())),
             (
@@ -1543,21 +1539,27 @@ mod tests {
             LoginMethod::ExternalBrowser {
                 username,
                 authentication_timeout_secs,
-            } => (username, authentication_timeout_secs),
+                client_store_temporary_credential,
+            } => (
+                username,
+                authentication_timeout_secs,
+                client_store_temporary_credential,
+            ),
             other => panic!("Expected ExternalBrowser, got {other:?}"),
         }
     }
 
     #[test]
     fn test_external_browser_happy_path() {
-        let (user, timeout) = external_browser_config(vec![]);
+        let (user, timeout, store_cred) = external_browser_config(vec![]);
         assert_eq!(user, "browser_user");
         assert_eq!(timeout, DEFAULT_AUTHENTICATION_TIMEOUT_SECS);
+        assert!(!store_cred);
     }
 
     #[test]
     fn test_external_browser_custom_timeout() {
-        let (_, timeout) = external_browser_config(vec![(
+        let (_, timeout, _) = external_browser_config(vec![(
             "authentication_timeout",
             Setting::String("30".to_string()),
         )]);
@@ -1566,11 +1568,20 @@ mod tests {
 
     #[test]
     fn test_external_browser_invalid_timeout_uses_default() {
-        let (_, timeout) = external_browser_config(vec![(
+        let (_, timeout, _) = external_browser_config(vec![(
             "authentication_timeout",
             Setting::String("abc".to_string()),
         )]);
         assert_eq!(timeout, DEFAULT_AUTHENTICATION_TIMEOUT_SECS);
+    }
+
+    #[test]
+    fn test_external_browser_with_credential_caching_enabled() {
+        let (_, _, store_cred) = external_browser_config(vec![(
+            "client_store_temporary_credential",
+            Setting::String("true".to_string()),
+        )]);
+        assert!(store_cred);
     }
 
     #[test]

--- a/sf_core/src/crl/integration_test.rs
+++ b/sf_core/src/crl/integration_test.rs
@@ -81,7 +81,7 @@ mod integration_tests {
         );
 
         match &config.auth {
-            AuthConfig::Password { user, password } => {
+            AuthConfig::Password { user, password, .. } => {
                 assert_eq!(user, "test_user");
                 assert_eq!(password.reveal(), "test_password");
             }

--- a/sf_core/src/file_manager/mod.rs
+++ b/sf_core/src/file_manager/mod.rs
@@ -161,6 +161,27 @@ fn upload_result_message(status: UploadStatus, flavor: &PutGetResultsetFlavor) -
     }
 }
 
+/// Returns the `source` column value for a completed upload, gated on the
+/// active wrapper flavor and host platform. Legacy driver provides full path
+/// verbatim on Windows, the `Odbc` flavor restores that behaviour; every other
+/// combination keeps the `Path::file_name()` basename that UD-Python has always
+/// reported.
+///
+/// `is_windows` is parameterized rather than read from `cfg!(windows)`
+/// inside the helper so the unit tests can exercise both branches on
+/// any host.
+fn upload_result_source(
+    file_path: &str,
+    filename: &str,
+    flavor: &PutGetResultsetFlavor,
+    is_windows: bool,
+) -> String {
+    match (is_windows, flavor) {
+        (true, PutGetResultsetFlavor::Odbc) => file_path.replace('\\', "/"),
+        _ => filename.to_string(),
+    }
+}
+
 /// Sets file metadata, compresses the file if needed, and optionally encrypts the data.
 /// For SSE stages (no encryption material), the data is uploaded without client-side encryption.
 fn preprocess_file_before_upload(
@@ -177,7 +198,12 @@ fn preprocess_file_before_upload(
     )
     .context(CompressionTypeSnafu)?;
 
-    let source = data.filename.clone();
+    let source = upload_result_source(
+        data.file_path.as_str(),
+        data.filename.as_str(),
+        &data.flavor,
+        cfg!(windows),
+    );
     let mut target = data.filename.clone();
 
     let target_compression = if data.auto_compress && source_compression == CompressionType::None {
@@ -506,6 +532,103 @@ mod tests {
             ODBC_PUT_MESSAGE_SKIPPED,
             "File with same name already exists. SKIPPED",
         );
+    }
+
+    // BD#17 — `upload_result_source` must return the full source path
+    // under `Odbc` on Windows with `\` normalised to `/` (matching the
+    // legacy libsnowflakeclient wire-level value, whose `srcFileName`
+    // came from the file:// URI parser and was therefore already
+    // all-forward-slash), and the basename everywhere else (matching
+    // the historical UD-Python behaviour).
+    const WINDOWS_BACKSLASH_PATH: &str = r"C:\Users\test\test_data.csv";
+    const WINDOWS_MIXED_PATH: &str = r"D:/a\universal-driver\tests\test_data.csv";
+    const WINDOWS_FORWARD_SLASH_PATH: &str = "C:/Users/test/test_data.csv";
+    const WINDOWS_BACKSLASH_PATH_NORMALISED: &str = "C:/Users/test/test_data.csv";
+    const WINDOWS_MIXED_PATH_NORMALISED: &str = "D:/a/universal-driver/tests/test_data.csv";
+    const UNIX_FULL_PATH: &str = "/home/test/test_data.csv";
+    const BASENAME: &str = "test_data.csv";
+
+    #[test]
+    fn upload_result_source_windows_odbc_returns_full_path_with_forward_slashes() {
+        // Pure backslash input — the form a path-like API surface might
+        // produce; must be normalised to forward slashes to match legacy.
+        assert_eq!(
+            upload_result_source(
+                WINDOWS_BACKSLASH_PATH,
+                BASENAME,
+                &PutGetResultsetFlavor::Odbc,
+                true,
+            ),
+            WINDOWS_BACKSLASH_PATH_NORMALISED,
+        );
+        // Mixed-separator input — the actual shape `glob` produces on
+        // Windows when fed a file:// URI pattern (drive letter and first
+        // segment as `/`, deeper segments rewritten to `\` during
+        // filesystem traversal). This is the case that broke PR4 in CI.
+        assert_eq!(
+            upload_result_source(
+                WINDOWS_MIXED_PATH,
+                BASENAME,
+                &PutGetResultsetFlavor::Odbc,
+                true,
+            ),
+            WINDOWS_MIXED_PATH_NORMALISED,
+        );
+        // Already-normalised input must be returned unchanged.
+        assert_eq!(
+            upload_result_source(
+                WINDOWS_FORWARD_SLASH_PATH,
+                BASENAME,
+                &PutGetResultsetFlavor::Odbc,
+                true,
+            ),
+            WINDOWS_FORWARD_SLASH_PATH,
+        );
+    }
+
+    #[test]
+    fn upload_result_source_windows_python_returns_basename() {
+        for full_path in [
+            WINDOWS_BACKSLASH_PATH,
+            WINDOWS_MIXED_PATH,
+            WINDOWS_FORWARD_SLASH_PATH,
+        ] {
+            assert_eq!(
+                upload_result_source(full_path, BASENAME, &PutGetResultsetFlavor::Python, true),
+                BASENAME,
+                "Python on Windows must continue stripping directories from `{full_path}`",
+            );
+        }
+    }
+
+    #[test]
+    fn upload_result_source_non_windows_returns_basename_for_both_flavors() {
+        for flavor in [PutGetResultsetFlavor::Python, PutGetResultsetFlavor::Odbc] {
+            assert_eq!(
+                upload_result_source(UNIX_FULL_PATH, BASENAME, &flavor, false),
+                BASENAME,
+                "{flavor:?} on non-Windows must always return the basename — \
+                 legacy ODBC's `find_last_of('/')` worked correctly on Unix paths",
+            );
+        }
+    }
+
+    #[test]
+    fn upload_result_source_basename_only_input_unchanged_for_all_combinations() {
+        // When `file_path` already equals the basename (e.g. the user
+        // passed a relative single-segment path) the two branches must
+        // collapse to the same value regardless of host or flavor.
+        // Backslash-free input guarantees the Odbc-on-Windows
+        // normalisation is a no-op here.
+        for is_windows in [false, true] {
+            for flavor in [PutGetResultsetFlavor::Python, PutGetResultsetFlavor::Odbc] {
+                assert_eq!(
+                    upload_result_source(BASENAME, BASENAME, &flavor, is_windows),
+                    BASENAME,
+                    "is_windows={is_windows}, flavor={flavor:?} must return {BASENAME}",
+                );
+            }
+        }
     }
 
     // BD#4 — `download_single_file` must report the on-cloud

--- a/sf_core/src/file_manager/s3_transfer.rs
+++ b/sf_core/src/file_manager/s3_transfer.rs
@@ -3,7 +3,9 @@ use super::types::{
     StageCredsRefreshError, StageCredsRefresher, StageInfo, UploadStatus,
 };
 use crate::config::retry::{BackoffConfig, Jitter, RetryPolicy};
-use snafu::{Location, ResultExt, Snafu};
+use crate::refresh::{Refresher, execute_with_refresh};
+use snafu::{IntoError, Location, ResultExt, Snafu};
+use std::marker::PhantomData;
 use std::time::Duration;
 
 // AWS SDK imports
@@ -36,6 +38,10 @@ const REQUEST_TIMEOUT_SECS: u64 = 300;
 /// successful refresh for 10 minutes, matching ODBC's `m_lastRefreshTokenSec`
 /// gate). The refreshed credentials are visible to other files in the batch
 /// via the shared cache — no return-value plumbing required.
+///
+/// When `refresher` is `Some`, the retry loop is driven by
+/// [`crate::refresh::execute_with_refresh`] via the [`S3StsRefresher`]
+/// implementation in this module.
 pub async fn upload_to_s3_or_skip(
     prepared: PreparedUpload,
     stage_info: &StageInfo,
@@ -44,73 +50,180 @@ pub async fn upload_to_s3_or_skip(
     refresher: &mut Option<&mut dyn StageCredsRefresher>,
 ) -> Result<UploadStatus, UploadFileError> {
     let s3_key = format!("{}{filename}", stage_info.key_prefix);
-    // Working copy of stage_info — `creds` may be replaced with refreshed
-    // values pulled from the refresher's cache; bucket/region/key_prefix are
-    // immutable for the lifetime of one PUT/GET command.
-    let mut stage_info = stage_info.clone();
 
-    loop {
-        let s3_client = create_s3_client(&stage_info, SNOWFLAKE_UPLOAD_PROVIDER).await?;
+    let attempt = |creds: CloudCredentials| {
+        let prepared = prepared.clone();
+        let stage_info = with_creds(stage_info, creds);
+        let s3_key = s3_key.clone();
+        async move {
+            let s3_client = create_s3_client(&stage_info, SNOWFLAKE_UPLOAD_PROVIDER)
+                .await
+                .map_err(|e| S3AttemptError::Other(UploadFileError::from(e)))?;
 
-        if !overwrite && check_if_file_exists(&s3_client, &stage_info, &s3_key).await? {
-            tracing::info!("File already exists in S3: {}", s3_key);
-            return Ok(UploadStatus::Skipped);
-        }
-
-        match upload_to_s3(prepared.clone(), &s3_client, &stage_info, &s3_key).await? {
-            S3Outcome::Ok(()) => return Ok(UploadStatus::Uploaded),
-            S3Outcome::StsExpired(aws_err) => {
-                let rotated = try_refresh_creds(refresher, &mut stage_info)
+            if !overwrite
+                && check_if_file_exists(&s3_client, &stage_info, &s3_key)
                     .await
-                    .context(upload_file_error::StageCredsRefreshSnafu)?;
-                if !rotated {
-                    // No refresher, or refresher returned the same creds —
-                    // surface the original AWS error as a normal upload
-                    // failure, the same shape callers see for any other S3
-                    // PUT error.
-                    return Err(aws_err).context(upload_file_error::S3UploadSnafu);
-                }
+                    .map_err(S3AttemptError::Other)?
+            {
+                tracing::info!("File already exists in S3: {}", s3_key);
+                return Ok(UploadStatus::Skipped);
             }
+
+            put_object(prepared, &s3_client, &stage_info, &s3_key).await?;
+            Ok(UploadStatus::Uploaded)
+        }
+    };
+
+    run_s3_with_sts_refresh(
+        refresher,
+        &stage_info.creds,
+        |e| upload_file_error::StageCredsRefreshSnafu.into_error(e),
+        // Refresher declined to rotate (or there was none). Surface the
+        // original AWS error as a normal upload failure — same shape as
+        // any other S3 PUT error.
+        |aws_err| upload_file_error::S3UploadSnafu.into_error(aws_err),
+        attempt,
+    )
+    .await
+}
+
+/// Internal error type for one attempt of an S3 operation. The `StsExpired`
+/// arm is the recoverable signal `should_refresh` matches on; everything
+/// else lives in `Other`. This stays internal — `UploadFileError` /
+/// `DownloadFileError` have no `StsExpiredToken` variant, so callers cannot
+/// observe a refresh-internal state.
+#[derive(Debug)]
+enum S3AttemptError<E> {
+    StsExpired(aws_sdk_s3::Error),
+    Other(E),
+}
+
+/// S3 STS implementation of the generic [`Refresher`] trait. Drives the
+/// retry loop in `execute_with_refresh` by reading credentials from a
+/// `StageCredsRefresher`'s shared cache and asking it to rotate when the
+/// AWS SDK reports `ExpiredToken`.
+///
+/// `map_refresh_err` keeps snafu's source-location stamping at the call
+/// site: each operation translates `StageCredsRefreshError` into its own
+/// error variant locally rather than via a blanket
+/// `From<StageCredsRefreshError>` impl on `UploadFileError` /
+/// `DownloadFileError`, which would lose location info.
+///
+/// Tracks the last AWS key id handed out so a refresh that doesn't
+/// actually rotate (refresher inside its coalescing window) reports
+/// `Ok(false)` and the helper propagates the original error rather than
+/// spinning.
+struct S3StsRefresher<'a, E, W> {
+    refresher: &'a mut dyn StageCredsRefresher,
+    last_seen_key: Option<String>,
+    map_refresh_err: W,
+    _marker: PhantomData<fn() -> E>,
+}
+
+impl<'a, E, W> S3StsRefresher<'a, E, W>
+where
+    W: Fn(StageCredsRefreshError) -> E,
+{
+    fn new(
+        refresher: &'a mut dyn StageCredsRefresher,
+        initial: &CloudCredentials,
+        map_refresh_err: W,
+    ) -> Self {
+        Self {
+            refresher,
+            last_seen_key: aws_key_id(initial).map(str::to_string),
+            map_refresh_err,
+            _marker: PhantomData,
         }
     }
 }
 
-/// Outcome of a single S3 attempt (PUT or GET). `StsExpired` is an
-/// internal-only signal that drives the credential-refresh retry inside this
-/// module — `UploadFileError` / `DownloadFileError` deliberately have no
-/// `StsExpiredToken` variant, so callers cannot observe (or pattern-match on)
-/// a refresh-internal state.
-#[derive(Debug)]
-enum S3Outcome<T> {
-    Ok(T),
-    StsExpired(aws_sdk_s3::Error),
+impl<'a, E, W> Refresher<CloudCredentials, S3AttemptError<E>> for S3StsRefresher<'a, E, W>
+where
+    E: Send,
+    W: Fn(StageCredsRefreshError) -> E + Send,
+{
+    fn current(
+        &mut self,
+    ) -> crate::refresh::RefreshFuture<'_, Result<CloudCredentials, S3AttemptError<E>>> {
+        let creds = self.refresher.cache().snapshot();
+        Box::pin(async move { Ok(creds) })
+    }
+
+    fn should_refresh(&self, err: &S3AttemptError<E>) -> bool {
+        matches!(err, S3AttemptError::StsExpired(_))
+    }
+
+    fn refresh(&mut self) -> crate::refresh::RefreshFuture<'_, Result<bool, S3AttemptError<E>>> {
+        Box::pin(async move {
+            tracing::info!("S3 hit ExpiredToken; refreshing stage credentials");
+            self.refresher
+                .refresh()
+                .await
+                .map_err(|e| S3AttemptError::Other((self.map_refresh_err)(e)))?;
+            let new = self.refresher.cache().snapshot();
+            let new_key = aws_key_id(&new).map(str::to_string);
+            if new_key == self.last_seen_key {
+                // Refresher coalesced or returned the same creds — retrying
+                // would loop, so decline further rotations.
+                return Ok(false);
+            }
+            self.last_seen_key = new_key;
+            Ok(true)
+        })
+    }
 }
 
-/// Asks the refresher (if any) to fetch new stage credentials and updates
-/// `stage_info.creds` from the refresher's cache. Returns:
-/// - `Ok(true)` — credentials rotated; the caller should retry.
-/// - `Ok(false)` — no refresher, or the refresher returned the same creds
-///   (e.g. inside its coalescing window). The caller should propagate the
-///   original AWS error rather than loop.
-/// - `Err(e)` — the refresh itself failed; the caller wraps with
-///   `.context(...)` to attach the upload/download error path's snafu
-///   instrumentation.
-async fn try_refresh_creds(
+/// Runs `attempt` once (no refresher) or in a refresh-retry loop (with
+/// refresher), folding `S3AttemptError<E>` back to `E` at the boundary so
+/// callers see a uniform error type. With no refresher, an `StsExpired`
+/// outcome surfaces as the caller-supplied AWS error path — same shape as
+/// any other S3 PUT/GET error.
+///
+/// `map_refresh_err` / `map_sts_err` keep the call sites' snafu
+/// instrumentation at the boundary so source locations land on the
+/// operation's own error variants rather than on this helper.
+async fn run_s3_with_sts_refresh<F, Fut, T, E>(
     refresher: &mut Option<&mut dyn StageCredsRefresher>,
-    stage_info: &mut StageInfo,
-) -> Result<bool, StageCredsRefreshError> {
-    let Some(r) = refresher.as_deref_mut() else {
-        return Ok(false);
+    initial_creds: &CloudCredentials,
+    map_refresh_err: impl Fn(StageCredsRefreshError) -> E + Send,
+    map_sts_err: impl FnOnce(aws_sdk_s3::Error) -> E,
+    attempt: F,
+) -> Result<T, E>
+where
+    F: Fn(CloudCredentials) -> Fut,
+    Fut: Future<Output = Result<T, S3AttemptError<E>>>,
+    E: Send,
+{
+    let outcome = match refresher.as_deref_mut() {
+        Some(r) => {
+            let mut sts_refresher = S3StsRefresher::new(r, initial_creds, map_refresh_err);
+            execute_with_refresh(&mut sts_refresher, attempt).await
+        }
+        None => attempt(initial_creds.clone()).await,
     };
-    tracing::info!("S3 hit ExpiredToken; refreshing stage credentials");
-    r.refresh().await?;
-    let new_creds = r.cache().snapshot();
-    if creds_unchanged(&stage_info.creds, &new_creds) {
-        Ok(false)
-    } else {
-        stage_info.creds = new_creds;
-        Ok(true)
+    outcome.map_err(|e| match e {
+        S3AttemptError::Other(err) => err,
+        S3AttemptError::StsExpired(aws_err) => map_sts_err(aws_err),
+    })
+}
+
+/// Returns the AWS key id from S3 credentials, or None for non-S3 variants.
+/// Used as the rotation marker; a different key id implies a fresh STS
+/// rotation from GS.
+fn aws_key_id(creds: &CloudCredentials) -> Option<&str> {
+    match creds {
+        CloudCredentials::S3 { aws_key_id, .. } => Some(aws_key_id.as_str()),
+        _ => None,
     }
+}
+
+/// Returns a copy of `stage_info` with `creds` replaced. Bucket/region/
+/// key_prefix are immutable for the lifetime of one PUT/GET command.
+fn with_creds(stage_info: &StageInfo, creds: CloudCredentials) -> StageInfo {
+    let mut info = stage_info.clone();
+    info.creds = creds;
+    info
 }
 
 /// Returns true if the file exists in S3, false if it does not.
@@ -149,31 +262,14 @@ fn is_expired_token_error(err: &aws_sdk_s3::Error) -> bool {
     err.code() == Some("ExpiredToken")
 }
 
-/// Checks whether a refresh returned the same credentials we already had — for
-/// example because the refresher is inside its coalescing window. Compared on
-/// the non-sensitive `aws_key_id`; `SensitiveString` has no `PartialEq`
-/// (equality on secrets is its own footgun) and a new key id implies a fresh
-/// STS rotation from GS.
-fn creds_unchanged(a: &CloudCredentials, b: &CloudCredentials) -> bool {
-    match (a, b) {
-        (
-            CloudCredentials::S3 {
-                aws_key_id: a_key, ..
-            },
-            CloudCredentials::S3 {
-                aws_key_id: b_key, ..
-            },
-        ) => a_key == b_key,
-        _ => false,
-    }
-}
-
-async fn upload_to_s3(
+/// Issues the S3 `PutObject` call and folds `ExpiredToken` into the
+/// `S3AttemptError::StsExpired` arm so the generic refresh helper can catch it.
+async fn put_object(
     prepared: PreparedUpload,
     s3_client: &S3Client,
     stage_info: &StageInfo,
     s3_key: &str,
-) -> Result<S3Outcome<()>, UploadFileError> {
+) -> Result<(), S3AttemptError<UploadFileError>> {
     let mut put_object_request = s3_client
         .put_object()
         .bucket(stage_info.bucket.clone())
@@ -184,7 +280,8 @@ async fn upload_to_s3(
 
     if let Some(ref enc_meta) = prepared.encryption_metadata {
         let mat_desc = serde_json::to_string(&enc_meta.material_desc)
-            .context(upload_file_error::SerializationSnafu)?;
+            .map_err(|e| upload_file_error::SerializationSnafu.into_error(e))
+            .map_err(S3AttemptError::Other)?;
         put_object_request = put_object_request
             .metadata("x-amz-iv", &enc_meta.iv)
             .metadata("x-amz-key", &enc_meta.encrypted_key)
@@ -196,15 +293,17 @@ async fn upload_to_s3(
     match put_object_request.send().await {
         Ok(res) => {
             tracing::debug!("S3 upload result: {:?}", res);
-            Ok(S3Outcome::Ok(()))
+            Ok(())
         }
         Err(sdk_err) => {
             let aws_err = aws_sdk_s3::Error::from(sdk_err);
             if is_expired_token_error(&aws_err) {
                 tracing::warn!("S3 upload failed with ExpiredToken");
-                Ok(S3Outcome::StsExpired(aws_err))
+                Err(S3AttemptError::StsExpired(aws_err))
             } else {
-                Err(aws_err).context(upload_file_error::S3UploadSnafu)
+                Err(S3AttemptError::Other(
+                    upload_file_error::S3UploadSnafu.into_error(aws_err),
+                ))
             }
         }
     }
@@ -225,22 +324,26 @@ pub async fn download_from_s3(
     refresher: &mut Option<&mut dyn StageCredsRefresher>,
 ) -> Result<DownloadResponse, DownloadFileError> {
     let s3_key = format!("{}{filename}", stage_info.key_prefix);
-    let mut stage_info = stage_info.clone();
 
-    let response = loop {
-        let s3_client = create_s3_client(&stage_info, SNOWFLAKE_DOWNLOAD_PROVIDER).await?;
-        match do_get_object(&s3_client, &stage_info, &s3_key).await? {
-            S3Outcome::Ok(r) => break *r,
-            S3Outcome::StsExpired(aws_err) => {
-                let rotated = try_refresh_creds(refresher, &mut stage_info)
-                    .await
-                    .context(download_file_error::StageCredsRefreshSnafu)?;
-                if !rotated {
-                    return Err(aws_err).context(download_file_error::S3DownloadSnafu);
-                }
-            }
+    let attempt = |creds: CloudCredentials| {
+        let stage_info = with_creds(stage_info, creds);
+        let s3_key = s3_key.clone();
+        async move {
+            let s3_client = create_s3_client(&stage_info, SNOWFLAKE_DOWNLOAD_PROVIDER)
+                .await
+                .map_err(|e| S3AttemptError::Other(DownloadFileError::from(e)))?;
+            get_object(&s3_client, &stage_info, &s3_key).await
         }
     };
+
+    let response = run_s3_with_sts_refresh(
+        refresher,
+        &stage_info.creds,
+        |e| download_file_error::StageCredsRefreshSnafu.into_error(e),
+        |aws_err| download_file_error::S3DownloadSnafu.into_error(aws_err),
+        attempt,
+    )
+    .await?;
 
     let metadata_map = response.metadata().cloned().unwrap_or_default();
 
@@ -288,14 +391,12 @@ pub async fn download_from_s3(
 }
 
 /// Issues the S3 `GetObject` call and folds `ExpiredToken` into the
-/// `S3Outcome::StsExpired` arm so the retry loop can catch it. The `Ok`
-/// payload is boxed because `GetObjectOutput` is ~800 bytes — far larger
-/// than the `aws_sdk_s3::Error` in `StsExpired`.
-async fn do_get_object(
+/// `S3AttemptError::StsExpired` arm so the generic refresh helper can catch it.
+async fn get_object(
     s3_client: &S3Client,
     stage_info: &StageInfo,
     s3_key: &str,
-) -> Result<S3Outcome<Box<aws_sdk_s3::operation::get_object::GetObjectOutput>>, DownloadFileError> {
+) -> Result<aws_sdk_s3::operation::get_object::GetObjectOutput, S3AttemptError<DownloadFileError>> {
     match s3_client
         .get_object()
         .bucket(stage_info.bucket.clone())
@@ -303,14 +404,16 @@ async fn do_get_object(
         .send()
         .await
     {
-        Ok(out) => Ok(S3Outcome::Ok(Box::new(out))),
+        Ok(out) => Ok(out),
         Err(sdk_err) => {
             let aws_err = aws_sdk_s3::Error::from(sdk_err);
             if is_expired_token_error(&aws_err) {
                 tracing::warn!("S3 download failed with ExpiredToken");
-                Ok(S3Outcome::StsExpired(aws_err))
+                Err(S3AttemptError::StsExpired(aws_err))
             } else {
-                Err(aws_err).context(download_file_error::S3DownloadSnafu)
+                Err(S3AttemptError::Other(
+                    download_file_error::S3DownloadSnafu.into_error(aws_err),
+                ))
             }
         }
     }
@@ -800,39 +903,39 @@ mod tests {
         }
     }
 
+    // --- aws_key_id helper used by S3StsRefresher's rotation check ---
+    //
+    // S3StsRefresher compares AWS key ids before/after refresh: a different
+    // key id implies a fresh STS rotation from GS, the same key id means
+    // we're inside the refresher's coalescing window and retrying would
+    // loop. Non-S3 variants intentionally return None so the comparison
+    // never deadlocks the retry on Gcs/Azure stages.
+
     #[test]
-    fn creds_unchanged_returns_true_when_aws_key_id_matches() {
-        assert!(creds_unchanged(&s3_creds("AKIA1"), &s3_creds("AKIA1")));
+    fn aws_key_id_returns_some_for_s3_creds() {
+        assert_eq!(aws_key_id(&s3_creds("AKIA1")), Some("AKIA1"));
     }
 
     #[test]
-    fn creds_unchanged_returns_false_when_aws_key_id_differs() {
-        assert!(!creds_unchanged(&s3_creds("AKIA1"), &s3_creds("AKIA2")));
-    }
-
-    #[test]
-    fn creds_unchanged_returns_false_for_non_s3_variants() {
-        // GCS/Azure can't expire mid-S3-transfer, so the comparison is
-        // S3-only by construction. Other variants always report "changed"
-        // so the retry loop never gets stuck on them.
+    fn aws_key_id_returns_none_for_non_s3_variants() {
         let gcs = CloudCredentials::Gcs {
             gcs_access_token: Some("g".to_string().into()),
         };
         let azure = CloudCredentials::Azure {
             sas_token: "a".to_string().into(),
         };
-        assert!(!creds_unchanged(&gcs, &gcs));
-        assert!(!creds_unchanged(&azure, &azure));
-        assert!(!creds_unchanged(&gcs, &azure));
+        assert_eq!(aws_key_id(&gcs), None);
+        assert_eq!(aws_key_id(&azure), None);
     }
 
-    // --- try_refresh_creds drives the refresher correctly ---
+    // --- S3StsRefresher::refresh ---
     //
-    // A fake StageCredsRefresher records call counts and exposes a
-    // mutable cache so tests can simulate "refresh rotated the creds"
-    // vs "refresh coalesced and returned the same creds".
+    // A fake StageCredsRefresher records call counts and exposes a mutable
+    // cache so tests can simulate "refresh rotated the creds" vs "refresh
+    // coalesced and returned the same creds".
 
     use super::super::types::{StageCredsCache, StageCredsRefreshError};
+    use crate::refresh::Refresher;
     use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
 
     struct FakeRefresher {
@@ -863,8 +966,6 @@ mod tests {
             if let Some(c) = next {
                 self.cache.store(c);
             }
-            // No-op rotation when not armed: the cache keeps the same creds,
-            // so try_refresh_creds will see "unchanged" and return Ok(false).
             Box::pin(async { Ok::<(), StageCredsRefreshError>(()) })
         }
 
@@ -873,61 +974,64 @@ mod tests {
         }
     }
 
-    fn stage_info_with(creds: CloudCredentials) -> StageInfo {
-        StageInfo {
-            location_type: super::super::types::LocationType::S3,
-            bucket: "bucket".into(),
-            key_prefix: "prefix/".into(),
-            region: "us-east-1".into(),
-            creds,
-            endpoint: None,
-            presigned_url: None,
-            use_virtual_url: false,
-            use_regional_url: false,
-            use_s3_regional_url: false,
-            storage_account: None,
-        }
+    /// Identity `map_refresh_err` for tests that don't care about error
+    /// translation — keeps the `StageCredsRefreshError` as-is.
+    fn identity_map(e: StageCredsRefreshError) -> StageCredsRefreshError {
+        e
     }
 
     #[tokio::test]
-    async fn try_refresh_creds_returns_false_without_refresher() {
-        let mut none: Option<&mut dyn StageCredsRefresher> = None;
-        let mut info = stage_info_with(s3_creds("AKIA1"));
-        let rotated = try_refresh_creds(&mut none, &mut info).await.unwrap();
-        assert!(!rotated, "no refresher → no rotation");
-    }
-
-    #[tokio::test]
-    async fn try_refresh_creds_returns_true_when_creds_rotate() {
+    async fn s3_sts_refresher_refresh_returns_true_when_creds_rotate() {
         let mut fake = FakeRefresher::new(s3_creds("AKIA1"));
         fake.arm(s3_creds("AKIA2"));
-        let mut info = stage_info_with(s3_creds("AKIA1"));
+        let initial = s3_creds("AKIA1");
+        let mut sts_refresher = S3StsRefresher::new(&mut fake, &initial, identity_map);
 
-        let mut handle: Option<&mut dyn StageCredsRefresher> = Some(&mut fake);
-        let rotated = try_refresh_creds(&mut handle, &mut info).await.unwrap();
+        let rotated = sts_refresher.refresh().await.unwrap();
 
         assert!(rotated);
         assert_eq!(fake.refresh_calls.load(AtomicOrdering::SeqCst), 1);
-        // The caller's stage_info now holds the rotated key.
-        match &info.creds {
-            CloudCredentials::S3 { aws_key_id, .. } => assert_eq!(aws_key_id, "AKIA2"),
-            _ => panic!("expected S3 creds"),
-        }
+        assert_eq!(
+            aws_key_id(&fake.cache().snapshot()),
+            Some("AKIA2"),
+            "cache holds rotated creds"
+        );
     }
 
     #[tokio::test]
-    async fn try_refresh_creds_returns_false_when_refresher_coalesces() {
-        // Refresher leaves the cache untouched (simulating a hit inside its
-        // coalescing window). try_refresh_creds must report Ok(false) so the
-        // caller propagates the original AWS error rather than spinning.
+    async fn s3_sts_refresher_refresh_returns_false_when_creds_unchanged() {
+        // FakeRefresher with no `arm()` leaves the cache holding the
+        // initial creds — simulating a hit inside the refresher's
+        // coalescing window. The S3StsRefresher must report Ok(false) so
+        // the generic helper propagates the original error rather than
+        // spinning.
         let mut fake = FakeRefresher::new(s3_creds("AKIA1"));
-        // Not armed → refresh() is a no-op, cache still holds AKIA1.
-        let mut info = stage_info_with(s3_creds("AKIA1"));
+        let initial = s3_creds("AKIA1");
+        let mut sts_refresher = S3StsRefresher::new(&mut fake, &initial, identity_map);
 
-        let mut handle: Option<&mut dyn StageCredsRefresher> = Some(&mut fake);
-        let rotated = try_refresh_creds(&mut handle, &mut info).await.unwrap();
+        let rotated = sts_refresher.refresh().await.unwrap();
 
-        assert!(!rotated, "unchanged creds → caller should propagate");
+        assert!(
+            !rotated,
+            "unchanged creds → S3StsRefresher declines further rotations"
+        );
         assert_eq!(fake.refresh_calls.load(AtomicOrdering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn s3_sts_refresher_refresh_tracks_last_seen_key_across_rotations() {
+        // After a successful rotation, last_seen_key is updated. A
+        // subsequent unchanged refresh against the new key should still
+        // report Ok(false) — confirming the marker followed the rotation.
+        let mut fake = FakeRefresher::new(s3_creds("AKIA1"));
+        fake.arm(s3_creds("AKIA2"));
+        let initial = s3_creds("AKIA1");
+        let mut sts_refresher = S3StsRefresher::new(&mut fake, &initial, identity_map);
+
+        assert!(sts_refresher.refresh().await.unwrap()); // AKIA1 -> AKIA2
+        // Cache still holds AKIA2; arming nothing means refresh() leaves
+        // it as-is. S3StsRefresher must see "no rotation" against AKIA2
+        // (not AKIA1).
+        assert!(!sts_refresher.refresh().await.unwrap());
     }
 }

--- a/sf_core/src/lib.rs
+++ b/sf_core/src/lib.rs
@@ -19,6 +19,7 @@ pub mod http;
 pub mod logging;
 pub mod perf_timing;
 pub mod query_types;
+pub mod refresh;
 pub mod rest;
 pub mod sensitive;
 pub mod telemetry;

--- a/sf_core/src/refresh.rs
+++ b/sf_core/src/refresh.rs
@@ -1,0 +1,212 @@
+//! Generic refresh-and-retry pattern for refreshable resources (auth tokens,
+//! cloud-stage credentials, etc.).
+//!
+//! Consumers follow the same shape:
+//!
+//! 1. read the current resource,
+//! 2. run an operation that consumes it,
+//! 3. on a recoverable error, rotate the resource and retry.
+//!
+//! What varies per consumer — which error is recoverable, where the resource
+//! is cached, how rapid-fire refreshes are *coalesced* (collapsed into one
+//! upstream call when they arrive close together) — lives entirely in the
+//! `Refresher` impl. The loop itself is shared.
+//!
+//! # Termination
+//!
+//! `execute_with_refresh` retries at most as many times as the refresher
+//! agrees to rotate. A refresher returns `Ok(false)` from `refresh` when it
+//! declines further rotation (e.g. recent refresh still considered valid, or
+//! retry budget exhausted), and the helper then propagates the original
+//! error. Callers that want a stricter cap can encode it inside `refresh`.
+//!
+//! # Object safety
+//!
+//! The trait carries `Resource` and `Err` as type parameters (rather than
+//! associated types) so that `dyn Refresher<Resource, Err>` works for paths
+//! that need to thread a refresher through a heterogeneous call stack (the
+//! S3 file-transfer path does this).
+
+use std::future::Future;
+use std::pin::Pin;
+
+/// A future returned by `Refresher` methods. Boxed so the trait is dyn-safe.
+pub type RefreshFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+/// Owns a refreshable resource and rotates it on demand.
+///
+/// `Resource` is what the operation consumes per attempt — the implementation
+/// chooses between handing out a clone of a cached value or fetching freshly
+/// each call. `Err` is the error type the operation returns; `should_refresh`
+/// inspects it to decide whether a retry is warranted.
+pub trait Refresher<Resource, Err>: Send
+where
+    Resource: Send,
+    Err: Send,
+{
+    /// Read the current resource for the next attempt. Called once per
+    /// iteration of `execute_with_refresh`.
+    fn current(&mut self) -> RefreshFuture<'_, Result<Resource, Err>>;
+
+    /// Whether `err` is the recoverable kind that warrants a refresh +
+    /// retry. Non-recoverable errors propagate up immediately.
+    fn should_refresh(&self, err: &Err) -> bool;
+
+    /// Rotate the resource. Returns:
+    ///
+    /// - `Ok(true)` — rotation happened; the next `current()` will return a
+    ///   fresh value and the helper will retry.
+    /// - `Ok(false)` — the refresher coalesced or has exhausted its retry
+    ///   budget. The helper propagates the original error.
+    /// - `Err(e)` — the refresh itself failed; this is terminal.
+    fn refresh(&mut self) -> RefreshFuture<'_, Result<bool, Err>>;
+}
+
+/// Run `operation` against `refresher`'s resource, refreshing once on
+/// recoverable errors. Loops until either `operation` succeeds, the error
+/// is non-recoverable, or the refresher declines to rotate again.
+pub async fn execute_with_refresh<R, Resource, Err, Op, Fut, T>(
+    refresher: &mut R,
+    operation: Op,
+) -> Result<T, Err>
+where
+    R: Refresher<Resource, Err> + ?Sized,
+    Resource: Send,
+    Err: Send,
+    Op: Fn(Resource) -> Fut,
+    Fut: Future<Output = Result<T, Err>>,
+{
+    loop {
+        let resource = refresher.current().await?;
+        let err = match operation(resource).await {
+            Ok(value) => return Ok(value),
+            Err(e) => e,
+        };
+        if !refresher.should_refresh(&err) {
+            return Err(err);
+        }
+        if !refresher.refresh().await? {
+            // Retrying without a fresh resource would loop, so propagate.
+            // Refresher declined to rotate: coalescing window or exhausted
+            // budget.
+            return Err(err);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    #[derive(Debug, PartialEq)]
+    enum TestErr {
+        Recoverable,
+        Fatal,
+    }
+
+    /// A minimal refresher used by the unit tests below. Holds a single
+    /// integer resource that increments each time `refresh` rotates.
+    struct CountingRefresher {
+        value: i32,
+        refresh_calls: i32,
+        max_refreshes: i32,
+        recoverable_errors: bool,
+    }
+
+    impl CountingRefresher {
+        fn new(max_refreshes: i32) -> Self {
+            Self {
+                value: 0,
+                refresh_calls: 0,
+                max_refreshes,
+                recoverable_errors: true,
+            }
+        }
+    }
+
+    impl Refresher<i32, TestErr> for CountingRefresher {
+        fn current(&mut self) -> RefreshFuture<'_, Result<i32, TestErr>> {
+            let v = self.value;
+            Box::pin(async move { Ok(v) })
+        }
+
+        fn should_refresh(&self, err: &TestErr) -> bool {
+            self.recoverable_errors && matches!(err, TestErr::Recoverable)
+        }
+
+        fn refresh(&mut self) -> RefreshFuture<'_, Result<bool, TestErr>> {
+            Box::pin(async move {
+                if self.refresh_calls >= self.max_refreshes {
+                    return Ok(false);
+                }
+                self.refresh_calls += 1;
+                self.value += 1;
+                Ok(true)
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn returns_first_success_without_refresh() {
+        let mut r = CountingRefresher::new(1);
+        let calls = Mutex::new(0);
+        let result: Result<i32, TestErr> = execute_with_refresh(&mut r, |v| {
+            *calls.lock().unwrap() += 1;
+            async move { Ok(v + 100) }
+        })
+        .await;
+        assert_eq!(result.unwrap(), 100);
+        assert_eq!(*calls.lock().unwrap(), 1);
+        assert_eq!(r.refresh_calls, 0);
+    }
+
+    #[tokio::test]
+    async fn refreshes_once_then_succeeds() {
+        let mut r = CountingRefresher::new(1);
+        let calls = Mutex::new(0);
+        let result: Result<i32, TestErr> = execute_with_refresh(&mut r, |v| {
+            let n = {
+                let mut g = calls.lock().unwrap();
+                *g += 1;
+                *g
+            };
+            async move {
+                if n == 1 {
+                    Err(TestErr::Recoverable)
+                } else {
+                    Ok(v + 100)
+                }
+            }
+        })
+        .await;
+        assert_eq!(result.unwrap(), 101); // resource was rotated to 1
+        assert_eq!(*calls.lock().unwrap(), 2);
+        assert_eq!(r.refresh_calls, 1);
+    }
+
+    #[tokio::test]
+    async fn propagates_when_refresher_declines_second_rotation() {
+        let mut r = CountingRefresher::new(1); // only one refresh allowed
+        let calls = Mutex::new(0);
+        let result: Result<i32, TestErr> = execute_with_refresh(&mut r, |_v| {
+            *calls.lock().unwrap() += 1;
+            async { Err(TestErr::Recoverable) }
+        })
+        .await;
+        assert_eq!(result.unwrap_err(), TestErr::Recoverable);
+        // First op fails → refresh #1 → retry op fails → refresh attempt #2
+        // returns Ok(false) → propagate.
+        assert_eq!(*calls.lock().unwrap(), 2);
+        assert_eq!(r.refresh_calls, 1);
+    }
+
+    #[tokio::test]
+    async fn propagates_non_recoverable_error_without_refresh() {
+        let mut r = CountingRefresher::new(5);
+        let result: Result<i32, TestErr> =
+            execute_with_refresh(&mut r, |_v| async { Err(TestErr::Fatal) }).await;
+        assert_eq!(result.unwrap_err(), TestErr::Fatal);
+        assert_eq!(r.refresh_calls, 0);
+    }
+}

--- a/sf_core/src/rest/snowflake/auth.rs
+++ b/sf_core/src/rest/snowflake/auth.rs
@@ -14,6 +14,16 @@ where
     Ok(secs.map(Duration::from_secs))
 }
 
+/// Wire-format authenticator values sent in the `AUTHENTICATOR` field of the login-request body.
+pub mod authenticator {
+    pub const EXTERNAL_BROWSER: &str = "EXTERNALBROWSER";
+    pub const ID_TOKEN: &str = "ID_TOKEN";
+    pub const OAUTH: &str = "OAUTH";
+    pub const SNOWFLAKE_JWT: &str = "SNOWFLAKE_JWT";
+    pub const PROGRAMMATIC_ACCESS_TOKEN: &str = "PROGRAMMATIC_ACCESS_TOKEN";
+    pub const USERNAME_PASSWORD_MFA: &str = "USERNAME_PASSWORD_MFA";
+}
+
 // TODO: Delete all unused fields when we are sure they are not needed
 
 #[derive(Debug, Serialize, Default)]
@@ -104,6 +114,16 @@ pub struct AuthRequestData {
     /// (matching JDBC's `DPoPUtil` pattern).
     #[serde(skip)]
     pub dpop_jwk_json: Option<String>,
+    /// Whether this request uses a cached token (ID token or MFA token).
+    /// Guards the evict-and-retry path so we don't retry pointlessly when
+    /// the original login didn't use a cached token.
+    #[serde(skip)]
+    pub token_from_cache_used: bool,
+    /// Transient flag (not serialized): whether the IdP consented to ID
+    /// token caching. `None` when the browser flow was skipped (cache hit)
+    /// or when the callback was a plain GET redirect without consent info.
+    #[serde(skip)]
+    pub consent_cache_id_token: Option<bool>,
 }
 
 #[derive(Debug, Serialize)]
@@ -155,7 +175,7 @@ pub struct AuthResponseMain {
     #[serde(rename = "mfaToken")]
     pub mfa_token: Option<SensitiveString>,
     #[serde(rename = "idToken")]
-    pub _id_token: Option<SensitiveString>,
+    pub id_token: Option<SensitiveString>,
     #[serde(rename = "idTokenValidityInSeconds")]
     pub _id_token_validity: Option<u64>,
     #[serde(rename = "displayUserName")]

--- a/sf_core/src/rest/snowflake/mod.rs
+++ b/sf_core/src/rest/snowflake/mod.rs
@@ -32,7 +32,7 @@ use crate::config::retry::RetryPolicy;
 use crate::http::retry::{HttpContext, HttpError, execute_with_retry};
 use crate::rest::snowflake::auth::{
     AuthRequest, AuthRequestClientCapabilities, AuthRequestClientEnvironment, AuthRequestData,
-    AuthResponse,
+    AuthResponse, authenticator,
 };
 use crate::rest::snowflake::error::SfError;
 use crate::rest::snowflake::external_browser::{
@@ -336,12 +336,15 @@ fn base_auth_request_data(login_parameters: &LoginParameters) -> AuthRequestData
     }
 }
 
-const EXT_AUTHN_ERROR_CODES: [i32; 5] = [
+const EXT_AUTHN_ERROR_CODES: [i32; 8] = [
     390120, // EXT_AUTHN_DENIED
+    390122, // EXT_AUTHN_NOT_ENROLLED
     390123, // EXT_AUTHN_LOCKED
     390126, // EXT_AUTHN_TIMEOUT
     390127, // EXT_AUTHN_INVALID
     390129, // EXT_AUTHN_EXCEPTION
+    390132, // EXT_AUTHN_DUO_PUSH_DISABLED
+    390195, // ID_TOKEN_INVALID
 ];
 
 fn extract_host_from_url(server_url: &str) -> Option<String> {
@@ -351,64 +354,66 @@ fn extract_host_from_url(server_url: &str) -> Option<String> {
         .map(|h| h.to_string())
 }
 
-fn try_get_cached_mfa_token(
+fn try_get_cached_token(
     server_url: &str,
     username: &str,
+    token_type: TokenType,
     token_cache: Option<&dyn TokenCache>,
 ) -> Option<SensitiveString> {
     let host = extract_host_from_url(server_url)?;
     let cache = token_cache?;
-    match cache.get_token(&host, username, TokenType::MfaToken) {
+    match cache.get_token(&host, username, token_type) {
         Ok(Some(token)) if !token.is_empty() => {
-            tracing::info!("Found cached MFA token");
+            tracing::info!(%token_type, "Found cached token");
             Some(token.into())
         }
         Ok(_) => None,
         Err(e) => {
-            tracing::warn!(error = %e, "Failed to retrieve cached MFA token");
+            tracing::warn!(%token_type, error = %e, "Failed to retrieve cached token");
             None
         }
     }
 }
 
-fn store_mfa_token_in_cache(
+fn store_token_in_cache(
     server_url: &str,
     username: &str,
-    mfa_token: &str,
+    token_type: TokenType,
+    token_value: &str,
     token_cache: Option<&dyn TokenCache>,
 ) {
     let Some(host) = extract_host_from_url(server_url) else {
-        tracing::warn!("Cannot cache MFA token: unable to extract host from server URL");
+        tracing::warn!(%token_type, "Cannot cache token: unable to extract host from server URL");
         return;
     };
     let Some(cache) = token_cache else {
-        tracing::debug!("No token cache available for MFA token storage");
+        tracing::debug!(%token_type, "No token cache available");
         return;
     };
-    if let Err(e) = cache.add_token(&host, username, TokenType::MfaToken, mfa_token) {
-        tracing::warn!(error = %e, "Failed to cache MFA token");
+    if let Err(e) = cache.add_token(&host, username, token_type, token_value) {
+        tracing::warn!(%token_type, error = %e, "Failed to cache token");
     } else {
-        tracing::info!("Cached MFA token for future use");
+        tracing::info!(%token_type, "Cached token for future use");
     }
 }
 
-fn remove_mfa_token_from_cache(
+fn remove_token_from_cache(
     server_url: &str,
     username: &str,
+    token_type: TokenType,
     token_cache: Option<&dyn TokenCache>,
 ) {
     let Some(host) = extract_host_from_url(server_url) else {
-        tracing::warn!("Cannot remove cached MFA token: unable to extract host from server URL");
+        tracing::warn!(%token_type, "Cannot remove cached token: unable to extract host");
         return;
     };
     let Some(cache) = token_cache else {
-        tracing::debug!("No token cache available for MFA token removal");
         return;
     };
-    if let Err(e) = cache.remove_token(&host, username, TokenType::MfaToken) {
-        tracing::warn!(error = %e, "Failed to remove cached MFA token");
+    if let Err(e) = cache.remove_token(&host, username, token_type) {
+        tracing::warn!(%token_type, error = %e, "Failed to remove cached token");
     } else {
-        tracing::info!("Removed cached MFA token due to authentication error");
+        tracing::info!(%token_type, "Removed cached token");
     }
 }
 
@@ -478,27 +483,56 @@ pub async fn auth_request_data(
         LoginMethod::ExternalBrowser {
             username,
             authentication_timeout_secs,
+            client_store_temporary_credential,
         } => {
-            // TODO: cache SSO tokens (same approach as MFA tokens)
-            let result = external_browser_authenticate(
-                client,
-                login_parameters,
-                username,
-                *authentication_timeout_secs,
-                &DefaultBrowserOpener,
-            )
-            .await
-            .context(ExternalBrowserSnafu)?;
-
             data.login_name = Some(username.clone());
-            data.authenticator = Some("EXTERNALBROWSER".to_string());
-            data.token = Some(result.token);
-            data.proof_key = Some(result.proof_key);
+            data.authenticator = Some(authenticator::EXTERNAL_BROWSER.to_string());
+
+            if *client_store_temporary_credential {
+                data.session_parameters
+                    .get_or_insert_with(HashMap::new)
+                    .insert(
+                        "CLIENT_STORE_TEMPORARY_CREDENTIAL".to_string(),
+                        serde_json::Value::Bool(true),
+                    );
+            }
+
+            let cached_id_token = if *client_store_temporary_credential {
+                try_get_cached_token(
+                    &login_parameters.server_url,
+                    username,
+                    TokenType::IdToken,
+                    token_cache,
+                )
+            } else {
+                None
+            };
+
+            if let Some(cached_token) = cached_id_token {
+                tracing::info!("Using cached SSO ID token for external browser login");
+                data.authenticator = Some(authenticator::ID_TOKEN.to_string());
+                data.token = Some(cached_token);
+                data.token_from_cache_used = true;
+            } else {
+                let result = external_browser_authenticate(
+                    client,
+                    login_parameters,
+                    username,
+                    *authentication_timeout_secs,
+                    &DefaultBrowserOpener,
+                )
+                .await
+                .context(ExternalBrowserSnafu)?;
+
+                data.token = Some(result.token);
+                data.proof_key = Some(result.proof_key);
+                data.consent_cache_id_token = result.consent_cache_id_token;
+            }
         }
         // Authorization Code orchestration runs the PKCE/state/loopback flow
         // (and any cache hits / refresh-token exchange) before forwarding the
         // resulting access token to Snowflake under AUTHENTICATOR=OAUTH.
-        // The body always uses uppercase "OAUTH" — never the user-supplied
+        // The body always uses uppercase OAUTH — never the user-supplied
         // authenticator string verbatim — and tags the request with
         // OAUTH_TYPE=OAUTH_AUTHORIZATION_CODE so GS knows which flow
         // produced the token. LOGIN_NAME is always set.
@@ -514,7 +548,7 @@ pub async fn auth_request_data(
                     .context(OAuthFlowSnafu)?;
             data.login_name = Some(cfg.username.clone());
             data.token = Some(acquired.access_token);
-            data.authenticator = Some("OAUTH".to_string());
+            data.authenticator = Some(authenticator::OAUTH.to_string());
             data.oauth_type = Some("OAUTH_AUTHORIZATION_CODE".to_string());
             // `dpop_jwk_json` is `Option<String>`: `Some` when DPoP was
             // enabled, `None` otherwise, so the assignment is implicitly
@@ -536,7 +570,7 @@ pub async fn auth_request_data(
                 .context(OAuthFlowSnafu)?;
             data.login_name = Some(cfg.username.clone());
             data.token = Some(acquired.access_token);
-            data.authenticator = Some("OAUTH".to_string());
+            data.authenticator = Some(authenticator::OAUTH.to_string());
             data.oauth_type = Some("OAUTH_CLIENT_CREDENTIALS".to_string());
             // See AC branch above for why dpop_jwk_json is carried here.
             data.dpop_jwk_json = acquired.dpop_jwk_json;
@@ -549,12 +583,12 @@ pub async fn auth_request_data(
             Credentials::Jwt { username, token } => {
                 data.login_name = Some(username);
                 data.token = Some(token);
-                data.authenticator = Some("SNOWFLAKE_JWT".to_string());
+                data.authenticator = Some(authenticator::SNOWFLAKE_JWT.to_string());
             }
             Credentials::Pat { username, token } => {
                 data.login_name = Some(username);
                 data.token = Some(token);
-                data.authenticator = Some("PROGRAMMATIC_ACCESS_TOKEN".to_string());
+                data.authenticator = Some(authenticator::PROGRAMMATIC_ACCESS_TOKEN.to_string());
             }
             // Legacy pre-acquired access token: forward unchanged (analysis
             // §6 / §10.1). LOGIN_NAME is always set (§14 #10) — never the
@@ -566,7 +600,7 @@ pub async fn auth_request_data(
             } => {
                 data.login_name = Some(username);
                 data.token = Some(access_token);
-                data.authenticator = Some("OAUTH".to_string());
+                data.authenticator = Some(authenticator::OAUTH.to_string());
             }
             Credentials::UserPasswordMfa {
                 username,
@@ -583,17 +617,23 @@ pub async fn auth_request_data(
                 );
 
                 let cached_mfa_token = if store_temp_cred {
-                    try_get_cached_mfa_token(&login_parameters.server_url, &username, token_cache)
+                    try_get_cached_token(
+                        &login_parameters.server_url,
+                        &username,
+                        TokenType::MfaToken,
+                        token_cache,
+                    )
                 } else {
                     None
                 };
 
                 data.login_name = Some(username);
                 data.password = Some(password);
-                data.authenticator = Some("USERNAME_PASSWORD_MFA".to_string());
+                data.authenticator = Some(authenticator::USERNAME_PASSWORD_MFA.to_string());
 
                 if let Some(cached_token) = cached_mfa_token {
                     data.token = Some(cached_token);
+                    data.token_from_cache_used = true;
                 } else {
                     data.ext_authn_duo_method =
                         Some(if passcode.is_some() || passcode_in_password {
@@ -749,10 +789,6 @@ pub async fn snowflake_login_with_client(
     let login_request_data =
         auth_request_data(client, login_parameters, session_parameters, token_cache).await?;
     tracing::Span::current().record("login_name", &login_request_data.login_name);
-    let used_cached_mfa_token = matches!(
-        &login_parameters.login_method,
-        LoginMethod::UserPasswordMfa { .. }
-    ) && login_request_data.token.is_some();
     let login_request = AuthRequest {
         data: login_request_data,
     };
@@ -763,50 +799,58 @@ pub async fn snowflake_login_with_client(
         "Login request prepared (secrets redacted)"
     );
 
+    // Send the actual login request
     let mut auth_response = send_login_request(client, login_parameters, &login_request).await?;
 
-    // TODO: cache SSO tokens (same approach as MFA tokens)
-    // When a cached MFA token caused an EXT_AUTHN error, evict it and retry
-    // via the normal DUO push/passcode flow.
-    if !auth_response.success && used_cached_mfa_token {
-        let code = auth_response
-            .code
-            .as_deref()
-            .and_then(|c| c.parse::<i32>().ok())
-            .unwrap_or(-1);
-        if EXT_AUTHN_ERROR_CODES.contains(&code)
-            && let LoginMethod::UserPasswordMfa { username, .. } = &login_parameters.login_method
-        {
-            tracing::warn!(
-                code = code,
-                "MFA authentication error detected, removing cached MFA token"
-            );
-            remove_mfa_token_from_cache(&login_parameters.server_url, username, token_cache);
-            tracing::info!("Retrying login without cached MFA token");
-            let retry_data =
-                auth_request_data(client, login_parameters, session_parameters, token_cache)
-                    .await?;
-            let retry_request = AuthRequest { data: retry_data };
-            auth_response = send_login_request(client, login_parameters, &retry_request).await?;
-        }
-    }
-
-    // OAuth refresh-on-failure: when GS rejects the OAuth access token
-    // with 390303 / 390318, replay the login once. For Authorization Code
-    // we first evict the cached access token (and any DPoP-bundled entry)
-    // so the replay exercises the refresh-token leg or, failing that, the
-    // interactive flow. For Client Credentials there is no cache to evict
-    // (CC tokens are not persisted), so the replay re-hits the IdP token
-    // endpoint to fetch a fresh access token. Cross-driver consensus:
-    // JDBC, ODBC, .NET, Go all retry both flows. Legacy `OAuthAccessToken`
-    // bubbles the error since the caller supplies the token directly.
+    // Revoke cached token and retry if cached token caused failure
     if !auth_response.success {
         let code = auth_response
             .code
             .as_deref()
             .and_then(|c| c.parse::<i32>().ok())
             .unwrap_or(-1);
-        if OAUTH_REFRESH_ERROR_CODES.contains(&code) {
+
+        // Cached token (ID token or MFA) rejected with an EXT_AUTHN error:
+        // evict it and retry via the normal interactive flow.
+        if login_request.data.token_from_cache_used && EXT_AUTHN_ERROR_CODES.contains(&code) {
+            if let Some((username, token_type)) = match &login_parameters.login_method {
+                LoginMethod::ExternalBrowser { username, .. } => {
+                    Some((username.as_str(), TokenType::IdToken))
+                }
+                LoginMethod::UserPasswordMfa { username, .. } => {
+                    Some((username.as_str(), TokenType::MfaToken))
+                }
+                _ => None,
+            } {
+                tracing::warn!(
+                    code,
+                    %token_type,
+                    "Cached token rejected, evicting and retrying"
+                );
+                remove_token_from_cache(
+                    &login_parameters.server_url,
+                    username,
+                    token_type,
+                    token_cache,
+                );
+                let retry_data =
+                    auth_request_data(client, login_parameters, session_parameters, token_cache)
+                        .await?;
+                let retry_request = AuthRequest { data: retry_data };
+                auth_response =
+                    send_login_request(client, login_parameters, &retry_request).await?;
+            }
+        }
+        // OAuth refresh-on-failure: when GS rejects the OAuth access token
+        // with 390303 / 390318, replay the login once. For Authorization Code
+        // we first evict the cached access token (and any DPoP-bundled entry)
+        // so the replay exercises the refresh-token leg or, failing that, the
+        // interactive flow. For Client Credentials there is no cache to evict
+        // (CC tokens are not persisted), so the replay re-hits the IdP token
+        // endpoint to fetch a fresh access token. Cross-driver consensus:
+        // JDBC, ODBC, .NET, Go all retry both flows. Legacy `OAuthAccessToken`
+        // bubbles the error since the caller supplies the token directly.
+        else if OAUTH_REFRESH_ERROR_CODES.contains(&code) {
             let mut should_retry = false;
             match &login_parameters.login_method {
                 LoginMethod::OAuthAuthorizationCode(cfg) => {
@@ -846,6 +890,7 @@ pub async fn snowflake_login_with_client(
         }
     }
 
+    // If retry failed or unrecoverable, evict tokens from cache and fail
     if !auth_response.success {
         let message = auth_response
             .message
@@ -856,37 +901,66 @@ pub async fn snowflake_login_with_client(
             .as_deref()
             .and_then(|c| c.parse::<i32>().ok())
             .unwrap_or(-1);
-        if EXT_AUTHN_ERROR_CODES.contains(&code)
-            && let LoginMethod::UserPasswordMfa { username, .. } = &login_parameters.login_method
-        {
-            tracing::warn!(
-                code = code,
-                "MFA authentication error detected, removing cached MFA token"
-            );
-            remove_mfa_token_from_cache(&login_parameters.server_url, username, token_cache);
+        if EXT_AUTHN_ERROR_CODES.contains(&code) {
+            let evictable = match &login_parameters.login_method {
+                LoginMethod::UserPasswordMfa { username, .. } => {
+                    Some((username.as_str(), TokenType::MfaToken))
+                }
+                LoginMethod::ExternalBrowser { username, .. } => {
+                    Some((username.as_str(), TokenType::IdToken))
+                }
+                _ => None,
+            };
+            if let Some((username, token_type)) = evictable {
+                tracing::warn!(code, %token_type, "Evicting cached token after terminal login failure");
+                remove_token_from_cache(
+                    &login_parameters.server_url,
+                    username,
+                    token_type,
+                    token_cache,
+                );
+            }
         }
         LoginSnafu { message, code }.fail()?;
     }
 
     tracing::debug!("Login successful, extracting session tokens");
 
-    // TODO: cache SSO tokens (same approach as MFA tokens)
-    // Cache MFA token from response if caching is enabled
-    if let LoginMethod::UserPasswordMfa {
-        username,
-        client_store_temporary_credential: true,
-        ..
-    } = &login_parameters.login_method
-        && let Some(mfa_token) = &auth_response.data.mfa_token
-    {
-        store_mfa_token_in_cache(
+    // If success - cache response tokens (MFA or ID token) when caching is enabled.
+    // Also, for IdToken, respect IdP consent: skip caching when explicitly denied.
+    let cacheable_token: Option<(&str, TokenType, &SensitiveString)> =
+        match &login_parameters.login_method {
+            LoginMethod::UserPasswordMfa {
+                username,
+                client_store_temporary_credential: true,
+                ..
+            } => auth_response
+                .data
+                .mfa_token
+                .as_ref()
+                .map(|t| (username.as_str(), TokenType::MfaToken, t)),
+            LoginMethod::ExternalBrowser {
+                username,
+                client_store_temporary_credential: true,
+                ..
+            } if login_request.data.consent_cache_id_token != Some(false) => auth_response
+                .data
+                .id_token
+                .as_ref()
+                .map(|t| (username.as_str(), TokenType::IdToken, t)),
+            _ => None,
+        };
+    if let Some((username, token_type, token)) = cacheable_token {
+        store_token_in_cache(
             &login_parameters.server_url,
             username,
-            mfa_token.reveal(),
+            token_type,
+            token.reveal(),
             token_cache,
         );
     }
 
+    // Extract tokens and session id from response
     let session_token = auth_response
         .data
         .token
@@ -2121,105 +2195,116 @@ mod tests {
         }
     }
 
-    mod try_get_cached_mfa_token_tests {
+    mod token_cache_helpers_tests {
         use super::*;
 
-        #[test]
-        fn returns_cached_token_on_hit() {
-            let cache = StubTokenCache::with_token(
-                "host.example.com",
-                "alice",
-                TokenType::MfaToken,
-                "tok123",
-            );
-            let result =
-                try_get_cached_mfa_token("https://host.example.com", "alice", Some(&cache));
-            assert_eq!(result.unwrap().reveal(), "tok123");
-        }
-
-        #[test]
-        fn returns_none_on_cache_miss() {
-            let cache = StubTokenCache::new();
-            let result =
-                try_get_cached_mfa_token("https://host.example.com", "alice", Some(&cache));
-            assert!(result.is_none());
-        }
-
-        #[test]
-        fn returns_none_when_no_cache_provided() {
-            let result = try_get_cached_mfa_token("https://host.example.com", "alice", None);
-            assert!(result.is_none());
-        }
-
-        #[test]
-        fn returns_none_for_invalid_url() {
-            let cache = StubTokenCache::new();
-            let result = try_get_cached_mfa_token("not-a-url", "alice", Some(&cache));
-            assert!(result.is_none());
-        }
-
-        #[test]
-        fn returns_none_for_empty_cached_token() {
+        fn assert_get_store_remove_for(token_type: TokenType) {
+            // try_get: returns cached token on hit
             let cache =
-                StubTokenCache::with_token("host.example.com", "alice", TokenType::MfaToken, "");
-            let result =
-                try_get_cached_mfa_token("https://host.example.com", "alice", Some(&cache));
-            assert!(result.is_none());
-        }
-    }
+                StubTokenCache::with_token("host.example.com", "alice", token_type, "tok_val");
+            let result = try_get_cached_token(
+                "https://host.example.com",
+                "alice",
+                token_type,
+                Some(&cache),
+            );
+            assert_eq!(result.unwrap().reveal(), "tok_val");
 
-    mod store_mfa_token_in_cache_tests {
-        use super::*;
+            // try_get: returns None on cache miss
+            let empty = StubTokenCache::new();
+            assert!(
+                try_get_cached_token(
+                    "https://host.example.com",
+                    "alice",
+                    token_type,
+                    Some(&empty),
+                )
+                .is_none()
+            );
 
-        #[test]
-        fn stores_token_successfully() {
+            // try_get: returns None when no cache provided
+            assert!(
+                try_get_cached_token("https://host.example.com", "alice", token_type, None)
+                    .is_none()
+            );
+
+            // try_get: returns None for invalid URL
+            assert!(try_get_cached_token("not-a-url", "alice", token_type, Some(&empty)).is_none());
+
+            // try_get: returns None for empty cached value
+            let empty_val = StubTokenCache::with_token("host.example.com", "alice", token_type, "");
+            assert!(
+                try_get_cached_token(
+                    "https://host.example.com",
+                    "alice",
+                    token_type,
+                    Some(&empty_val),
+                )
+                .is_none()
+            );
+
+            // store + get round-trip
             let cache = StubTokenCache::new();
-            store_mfa_token_in_cache("https://host.example.com", "alice", "new_tok", Some(&cache));
+            store_token_in_cache(
+                "https://host.example.com",
+                "alice",
+                token_type,
+                "new_tok",
+                Some(&cache),
+            );
             let stored = cache
-                .get_token("host.example.com", "alice", TokenType::MfaToken)
+                .get_token("host.example.com", "alice", token_type)
                 .unwrap();
             assert_eq!(stored.as_deref(), Some("new_tok"));
-        }
 
-        #[test]
-        fn no_panic_when_no_cache() {
-            store_mfa_token_in_cache("https://host.example.com", "alice", "tok", None);
-        }
+            // store: no panic when no cache
+            store_token_in_cache("https://host.example.com", "alice", token_type, "tok", None);
 
-        #[test]
-        fn no_panic_for_invalid_url() {
-            let cache = StubTokenCache::new();
-            store_mfa_token_in_cache("not-a-url", "alice", "tok", Some(&cache));
-        }
-    }
-
-    mod remove_mfa_token_from_cache_tests {
-        use super::*;
-
-        #[test]
-        fn removes_existing_token() {
-            let cache = StubTokenCache::with_token(
-                "host.example.com",
+            // store: no panic for invalid URL
+            store_token_in_cache(
+                "not-a-url",
                 "alice",
-                TokenType::MfaToken,
-                "tok_to_remove",
+                token_type,
+                "tok",
+                Some(&StubTokenCache::new()),
             );
-            remove_mfa_token_from_cache("https://host.example.com", "alice", Some(&cache));
-            let stored = cache
-                .get_token("host.example.com", "alice", TokenType::MfaToken)
-                .unwrap();
-            assert!(stored.is_none());
+
+            // remove evicts token
+            let cache =
+                StubTokenCache::with_token("host.example.com", "alice", token_type, "to_remove");
+            remove_token_from_cache(
+                "https://host.example.com",
+                "alice",
+                token_type,
+                Some(&cache),
+            );
+            assert!(
+                cache
+                    .get_token("host.example.com", "alice", token_type)
+                    .unwrap()
+                    .is_none()
+            );
+
+            // remove: no panic when no cache
+            remove_token_from_cache("https://host.example.com", "alice", token_type, None);
+
+            // remove: no panic for invalid URL
+            remove_token_from_cache(
+                "not-a-url",
+                "alice",
+                token_type,
+                Some(&StubTokenCache::new()),
+            );
         }
 
         #[test]
-        fn no_panic_when_no_cache() {
-            remove_mfa_token_from_cache("https://host.example.com", "alice", None);
+        fn mfa_token_cache_operations() {
+            assert_get_store_remove_for(TokenType::MfaToken);
         }
 
         #[test]
-        fn no_panic_for_invalid_url() {
-            let cache = StubTokenCache::new();
-            remove_mfa_token_from_cache("not-a-url", "alice", Some(&cache));
+        fn id_token_cache_operations() {
+            assert_get_store_remove_for(TokenType::IdToken);
         }
     }
 

--- a/sf_core/src/rest/snowflake/mod.rs
+++ b/sf_core/src/rest/snowflake/mod.rs
@@ -347,6 +347,25 @@ const EXT_AUTHN_ERROR_CODES: [i32; 8] = [
     390195, // ID_TOKEN_INVALID
 ];
 
+/// Sets the DUO second-factor fields on the login request.
+/// Matches the behavior of the old JDBC, .NET, and ODBC drivers:
+/// always sends `EXT_AUTHN_DUO_METHOD`, defaulting to `"push"` when
+/// no passcode is provided.
+fn set_duo_authn_fields(
+    data: &mut AuthRequestData,
+    passcode_in_password: bool,
+    passcode: Option<SensitiveString>,
+) {
+    data.ext_authn_duo_method = Some(if passcode.is_some() || passcode_in_password {
+        "passcode".to_string()
+    } else {
+        "push".to_string()
+    });
+    if !passcode_in_password {
+        data.passcode = passcode;
+    }
+}
+
 fn extract_host_from_url(server_url: &str) -> Option<String> {
     Url::parse(server_url)
         .ok()?
@@ -576,9 +595,15 @@ pub async fn auth_request_data(
             data.dpop_jwk_json = acquired.dpop_jwk_json;
         }
         _ => match create_credentials(login_parameters).context(AuthenticationSnafu)? {
-            Credentials::Password { username, password } => {
+            Credentials::Password {
+                username,
+                password,
+                passcode_in_password,
+                passcode,
+            } => {
                 data.login_name = Some(username);
                 data.password = Some(password);
+                set_duo_authn_fields(&mut data, passcode_in_password, passcode);
             }
             Credentials::Jwt { username, token } => {
                 data.login_name = Some(username);
@@ -635,15 +660,7 @@ pub async fn auth_request_data(
                     data.token = Some(cached_token);
                     data.token_from_cache_used = true;
                 } else {
-                    data.ext_authn_duo_method =
-                        Some(if passcode.is_some() || passcode_in_password {
-                            "passcode".to_string()
-                        } else {
-                            "push".to_string()
-                        });
-                    if !passcode_in_password {
-                        data.passcode = passcode.clone();
-                    }
+                    set_duo_authn_fields(&mut data, passcode_in_password, passcode.clone());
                     if store_temp_cred {
                         data.client_request_mfa_token = Some(store_temp_cred);
                     }
@@ -2183,6 +2200,8 @@ mod tests {
             login_method: LoginMethod::Password {
                 username: "testuser".to_string(),
                 password: "testpass".into(),
+                passcode_in_password: false,
+                passcode: None,
             },
             server_url: "https://testaccount.snowflakecomputing.com".to_string(),
             database: None,

--- a/sf_core/tests/common/mocks/external_browser.rs
+++ b/sf_core/tests/common/mocks/external_browser.rs
@@ -107,3 +107,108 @@ pub fn login_failure() -> Mock {
             "message": "Invalid credentials"
         })))
 }
+
+// ─── Cached ID Token Login ──────────────────────────────────────────────────
+
+/// Successful login using a cached SSO ID token (no PROOF_KEY in request).
+pub fn login_success_with_cached_id_token() -> Mock {
+    Mock::given(method("POST"))
+        .and(path_regex(r"/session/v1/login-request"))
+        .and(body_partial_json(json!({
+            "data": {
+                "AUTHENTICATOR": "ID_TOKEN",
+                "TOKEN": "cached_id_token"
+            }
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "success": true,
+            "data": {
+                "token": "mock_session_token",
+                "masterToken": "mock_master_token",
+                "sessionId": 12345,
+                "validityInSeconds": 3600,
+                "masterValidityInSeconds": 14400,
+                "parameters": [],
+                "sessionInfo": {
+                    "databaseName": "test_database",
+                    "schemaName": "test_schema",
+                    "warehouseName": "test_warehouse",
+                    "roleName": "test_role"
+                }
+            }
+        })))
+}
+
+/// Successful login that returns an idToken (for caching after browser flow).
+pub fn login_success_with_id_token_in_response() -> Mock {
+    Mock::given(method("POST"))
+        .and(path_regex(r"/session/v1/login-request"))
+        .and(body_partial_json(json!({
+            "data": {
+                "AUTHENTICATOR": "EXTERNALBROWSER"
+            }
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "success": true,
+            "data": {
+                "token": "mock_session_token",
+                "masterToken": "mock_master_token",
+                "sessionId": 12345,
+                "idToken": "server_issued_id_token",
+                "idTokenValidityInSeconds": 3600,
+                "validityInSeconds": 3600,
+                "masterValidityInSeconds": 14400,
+                "parameters": [],
+                "sessionInfo": {
+                    "databaseName": "test_database",
+                    "schemaName": "test_schema",
+                    "warehouseName": "test_warehouse",
+                    "roleName": "test_role"
+                }
+            }
+        })))
+}
+
+// ─── EXT_AUTHN Failure with Cached ID Token ─────────────────────────────────
+
+fn login_failure_ext_authn_with_cached_id_token(code: &str, message: &str) -> Mock {
+    Mock::given(method("POST"))
+        .and(path_regex(r"/session/v1/login-request"))
+        .and(body_partial_json(json!({
+            "data": {
+                "AUTHENTICATOR": "ID_TOKEN",
+                "TOKEN": "cached_id_token"
+            }
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "success": false,
+            "code": code,
+            "message": message
+        })))
+}
+
+pub fn login_failure_ext_authn_denied_cached_id() -> Mock {
+    login_failure_ext_authn_with_cached_id_token(
+        "390120",
+        "Authentication denied by external provider",
+    )
+}
+
+pub fn login_failure_ext_authn_locked_cached_id() -> Mock {
+    login_failure_ext_authn_with_cached_id_token("390123", "Account locked by external provider")
+}
+
+pub fn login_failure_ext_authn_timeout_cached_id() -> Mock {
+    login_failure_ext_authn_with_cached_id_token("390126", "External authentication timed out")
+}
+
+pub fn login_failure_ext_authn_invalid_cached_id() -> Mock {
+    login_failure_ext_authn_with_cached_id_token(
+        "390127",
+        "External authentication token is invalid",
+    )
+}
+
+pub fn login_failure_ext_authn_exception_cached_id() -> Mock {
+    login_failure_ext_authn_with_cached_id_token("390129", "External authentication exception")
+}

--- a/sf_core/tests/common/mocks/password.rs
+++ b/sf_core/tests/common/mocks/password.rs
@@ -42,15 +42,17 @@ pub fn success_login_response() -> ResponseTemplate {
     }))
 }
 
-/// Successful password login — matches a POST to login-request with LOGIN_NAME and PASSWORD
-/// and verifies the AUTHENTICATOR field is absent (matching old driver behavior).
+/// Successful password login — matches a POST to login-request with LOGIN_NAME, PASSWORD,
+/// and EXT_AUTHN_DUO_METHOD="push" (implicit MFA hint matching old driver behavior).
+/// Also verifies the AUTHENTICATOR field is absent.
 pub fn login_success() -> Mock {
     Mock::given(method("POST"))
         .and(path_regex(r"/session/v1/login-request"))
         .and(body_partial_json(json!({
             "data": {
                 "LOGIN_NAME": "test_user",
-                "PASSWORD": "test_password"
+                "PASSWORD": "test_password",
+                "EXT_AUTHN_DUO_METHOD": "push"
             }
         })))
         .and(AuthenticatorFieldAbsent)
@@ -64,7 +66,8 @@ pub fn login_failure_wrong_credentials() -> Mock {
         .and(body_partial_json(json!({
             "data": {
                 "LOGIN_NAME": "test_user",
-                "PASSWORD": "wrong_password"
+                "PASSWORD": "wrong_password",
+                "EXT_AUTHN_DUO_METHOD": "push"
             }
         })))
         .and(AuthenticatorFieldAbsent)

--- a/sf_core/tests/integration/authentication/external_browser_id_token_cache.rs
+++ b/sf_core/tests/integration/authentication/external_browser_id_token_cache.rs
@@ -1,0 +1,402 @@
+use std::io::{Read, Write};
+
+use crate::common::mocks::external_browser;
+use crate::common::snowflake_test_client::SnowflakeTestClient;
+use crate::common::tls_proxy::MockServerWithTls;
+use sf_core::token_cache::{KeyringTokenCache, TokenCache, TokenType};
+
+// =============================================================================
+// Test Fixture
+// =============================================================================
+
+struct IdTokenCacheFixture {
+    mock: MockServerWithTls,
+    client: SnowflakeTestClient,
+    cache: KeyringTokenCache,
+    host: String,
+    user: String,
+}
+
+impl IdTokenCacheFixture {
+    fn new(user: &str) -> Self {
+        unsafe { std::env::set_var("SF_TEST_BROWSER_OPENER", "noop") };
+
+        let mock = MockServerWithTls::start();
+        let client = SnowflakeTestClient::with_int_tests_params(Some(&mock.http_url()));
+        client.set_connection_option("authenticator", "EXTERNALBROWSER");
+        client.set_connection_option("user", user);
+        client.set_connection_option("authentication_timeout", "10");
+        client.set_connection_option("client_store_temporary_credential", "true");
+
+        let cache = KeyringTokenCache::new().expect("token cache should be available");
+        let host = url::Url::parse(&mock.http_url())
+            .expect("mock URL should be valid")
+            .host_str()
+            .expect("mock URL should have a host")
+            .to_string();
+
+        Self {
+            mock,
+            client,
+            cache,
+            host,
+            user: user.to_string(),
+        }
+    }
+
+    fn seed_cached_id_token(&self) {
+        self.cache
+            .add_token(
+                &self.host,
+                &self.user,
+                TokenType::IdToken,
+                "cached_id_token",
+            )
+            .expect("failed to seed ID token in cache");
+    }
+
+    fn connect(&self) -> Result<(), String> {
+        self.client.connect()
+    }
+
+    fn cached_id_token(&self) -> Option<String> {
+        self.cache
+            .get_token(&self.host, &self.user, TokenType::IdToken)
+            .expect("get_token should not fail")
+    }
+}
+
+impl Drop for IdTokenCacheFixture {
+    fn drop(&mut self) {
+        let _ = self
+            .cache
+            .remove_token(&self.host, &self.user, TokenType::IdToken);
+    }
+}
+
+fn assert_success(result: Result<(), String>, context: &str) {
+    assert!(result.is_ok(), "Expected {context}, got: {result:?}");
+}
+
+fn assert_error(result: Result<(), String>, patterns: &[&str], context: &str) {
+    let error = result.expect_err(&format!("Expected {context} to fail"));
+    let matches = patterns.iter().any(|p| error.contains(p));
+    assert!(matches, "Expected {context}, got: {error}");
+}
+
+/// Simulate a browser callback delivering a token to the loopback server.
+fn simulate_browser_callback(mock: &MockServerWithTls, token: &str) {
+    let requests = mock.received_requests();
+    let authn_req = requests
+        .iter()
+        .find(|r| r.url.path().contains("authenticator-request"))
+        .expect("No authenticator-request was captured");
+
+    let body: serde_json::Value =
+        serde_json::from_slice(&authn_req.body).expect("Request body is not valid JSON");
+    let port_str = body["data"]["BROWSER_MODE_REDIRECT_PORT"]
+        .as_str()
+        .expect("BROWSER_MODE_REDIRECT_PORT not found in request body");
+    let port: u16 = port_str
+        .parse()
+        .expect("BROWSER_MODE_REDIRECT_PORT is not a valid port number");
+
+    let mut stream = std::net::TcpStream::connect(format!("127.0.0.1:{port}"))
+        .expect("Failed to connect to callback listener");
+    let request = format!("GET /?token={token} HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    stream
+        .write_all(request.as_bytes())
+        .expect("Failed to write to callback listener");
+
+    let mut response = Vec::new();
+    stream
+        .read_to_end(&mut response)
+        .expect("Failed to read response from callback listener");
+    let response_str = String::from_utf8_lossy(&response);
+    assert!(
+        response_str.contains("200 OK"),
+        "Expected 200 OK response, got: {response_str}"
+    );
+}
+
+// =============================================================================
+// Cached ID Token - Happy Path
+// =============================================================================
+
+#[test]
+fn should_authenticate_with_cached_id_token() {
+    let fixture = IdTokenCacheFixture::new("eb_cache_hit");
+    fixture.seed_cached_id_token();
+    fixture
+        .mock
+        .mount(external_browser::login_success_with_cached_id_token());
+
+    let result = fixture.connect();
+
+    assert_success(result, "login with cached ID token to succeed");
+
+    let requests = fixture.mock.received_requests();
+    assert!(
+        !requests
+            .iter()
+            .any(|r| r.url.path().contains("authenticator-request")),
+        "Should skip authenticator-request when using cached ID token"
+    );
+    let login_req = requests
+        .iter()
+        .find(|r| r.url.path().contains("login-request"))
+        .expect("No login-request was captured");
+    let body: serde_json::Value = serde_json::from_slice(&login_req.body).unwrap();
+    assert_eq!(body["data"]["AUTHENTICATOR"], "ID_TOKEN");
+    assert_eq!(body["data"]["TOKEN"], "cached_id_token");
+    assert!(
+        body["data"]["PROOF_KEY"].is_null(),
+        "PROOF_KEY should not be sent when using cached ID token"
+    );
+}
+
+// =============================================================================
+// ID Token Stored After Successful Browser Flow
+// =============================================================================
+
+#[test]
+fn should_store_id_token_after_successful_browser_login() {
+    let fixture = IdTokenCacheFixture::new("eb_cache_store");
+    fixture.mock.mount(external_browser::authenticator_request(
+        "https://idp.example.com/sso",
+        "proof_key_store_test",
+    ));
+    fixture
+        .mock
+        .mount(external_browser::login_success_with_id_token_in_response());
+
+    let mock_ref = &fixture.mock;
+    let result = std::thread::scope(|s| {
+        s.spawn(|| {
+            for _ in 0..50 {
+                std::thread::sleep(std::time::Duration::from_millis(100));
+                let requests = mock_ref.received_requests();
+                if requests
+                    .iter()
+                    .any(|r| r.url.path().contains("authenticator-request"))
+                {
+                    simulate_browser_callback(mock_ref, "browser_token_xyz");
+                    return;
+                }
+            }
+            panic!("Timed out waiting for authenticator-request");
+        });
+        fixture.connect()
+    });
+
+    assert_success(result, "browser login to succeed");
+
+    let cached = fixture.cached_id_token();
+    assert_eq!(
+        cached.as_deref(),
+        Some("server_issued_id_token"),
+        "ID token from login response should be stored in cache"
+    );
+}
+
+// =============================================================================
+// EXT_AUTHN Error Evicts Cached ID Token
+// =============================================================================
+
+fn assert_ext_authn_error_evicts_cached_id_token(
+    mount_failure: fn() -> wiremock::Mock,
+    code: &str,
+    user: &str,
+) {
+    let fixture = IdTokenCacheFixture::new(user);
+    fixture.seed_cached_id_token();
+
+    // First request with cached token fails with EXT_AUTHN error.
+    fixture.mock.mount(mount_failure());
+    // Retry goes through browser flow, which also fails (no callback → timeout).
+    // We set a short timeout so the test doesn't hang.
+    fixture
+        .client
+        .set_connection_option("authentication_timeout", "2");
+    fixture.mock.mount(external_browser::authenticator_request(
+        "https://idp.example.com/sso",
+        "retry_proof_key",
+    ));
+
+    let result = fixture.connect();
+
+    assert_error(
+        result,
+        &[
+            "timeout",
+            "Timeout",
+            "browser",
+            "Browser",
+            "ExternalBrowser",
+            "login",
+            "Login",
+        ],
+        &format!("login to fail after evict-and-retry for EXT_AUTHN code {code}"),
+    );
+
+    let cached = fixture.cached_id_token();
+    assert!(
+        cached.is_none(),
+        "Expected cached ID token to be removed after EXT_AUTHN error {code}, but it still exists"
+    );
+}
+
+#[test]
+fn should_evict_cached_id_token_on_ext_authn_denied() {
+    assert_ext_authn_error_evicts_cached_id_token(
+        external_browser::login_failure_ext_authn_denied_cached_id,
+        "390120",
+        "eb_evict_denied",
+    );
+}
+
+#[test]
+fn should_evict_cached_id_token_on_ext_authn_locked() {
+    assert_ext_authn_error_evicts_cached_id_token(
+        external_browser::login_failure_ext_authn_locked_cached_id,
+        "390123",
+        "eb_evict_locked",
+    );
+}
+
+#[test]
+fn should_evict_cached_id_token_on_ext_authn_timeout() {
+    assert_ext_authn_error_evicts_cached_id_token(
+        external_browser::login_failure_ext_authn_timeout_cached_id,
+        "390126",
+        "eb_evict_timeout",
+    );
+}
+
+#[test]
+fn should_evict_cached_id_token_on_ext_authn_invalid() {
+    assert_ext_authn_error_evicts_cached_id_token(
+        external_browser::login_failure_ext_authn_invalid_cached_id,
+        "390127",
+        "eb_evict_invalid",
+    );
+}
+
+#[test]
+fn should_evict_cached_id_token_on_ext_authn_exception() {
+    assert_ext_authn_error_evicts_cached_id_token(
+        external_browser::login_failure_ext_authn_exception_cached_id,
+        "390129",
+        "eb_evict_exception",
+    );
+}
+
+// =============================================================================
+// EXT_AUTHN Retry Succeeds After Eviction
+// =============================================================================
+
+#[test]
+fn should_retry_with_browser_flow_when_cached_id_token_fails() {
+    let fixture = IdTokenCacheFixture::new("eb_retry_ok");
+    fixture.seed_cached_id_token();
+
+    // First request with cached token → EXT_AUTHN denied.
+    fixture
+        .mock
+        .mount(external_browser::login_failure_ext_authn_denied_cached_id());
+    // Retry → browser flow → success with a fresh ID token in response.
+    fixture.mock.mount(external_browser::authenticator_request(
+        "https://idp.example.com/sso",
+        "retry_proof_key",
+    ));
+    fixture
+        .mock
+        .mount(external_browser::login_success_with_id_token_in_response());
+
+    let mock_ref = &fixture.mock;
+    let result = std::thread::scope(|s| {
+        s.spawn(|| {
+            // Wait for the retry's authenticator-request (the second one).
+            // The first login-request uses the cached token (no authenticator-request).
+            for _ in 0..80 {
+                std::thread::sleep(std::time::Duration::from_millis(100));
+                let requests = mock_ref.received_requests();
+                if requests
+                    .iter()
+                    .any(|r| r.url.path().contains("authenticator-request"))
+                {
+                    simulate_browser_callback(mock_ref, "retry_browser_token");
+                    return;
+                }
+            }
+            panic!("Timed out waiting for authenticator-request on retry");
+        });
+        fixture.connect()
+    });
+
+    assert_success(result, "login retry via browser flow to succeed");
+
+    let cached = fixture.cached_id_token();
+    assert_eq!(
+        cached.as_deref(),
+        Some("server_issued_id_token"),
+        "New ID token should be cached after successful retry"
+    );
+}
+
+// =============================================================================
+// Caching Disabled — Token Not Stored
+// =============================================================================
+
+#[test]
+fn should_not_cache_id_token_when_caching_disabled() {
+    unsafe { std::env::set_var("SF_TEST_BROWSER_OPENER", "noop") };
+
+    let mock = MockServerWithTls::start();
+    let client = SnowflakeTestClient::with_int_tests_params(Some(&mock.http_url()));
+    client.set_connection_option("authenticator", "EXTERNALBROWSER");
+    client.set_connection_option("user", "eb_no_cache");
+    client.set_connection_option("authentication_timeout", "10");
+    // client_store_temporary_credential is NOT set (defaults to false)
+
+    mock.mount(external_browser::authenticator_request(
+        "https://idp.example.com/sso",
+        "proof_key_no_cache",
+    ));
+    mock.mount(external_browser::login_success_with_id_token_in_response());
+
+    let mock_ref = &mock;
+    let result = std::thread::scope(|s| {
+        s.spawn(|| {
+            for _ in 0..50 {
+                std::thread::sleep(std::time::Duration::from_millis(100));
+                let requests = mock_ref.received_requests();
+                if requests
+                    .iter()
+                    .any(|r| r.url.path().contains("authenticator-request"))
+                {
+                    simulate_browser_callback(mock_ref, "token_no_cache");
+                    return;
+                }
+            }
+            panic!("Timed out waiting for authenticator-request");
+        });
+        client.connect()
+    });
+
+    assert_success(result, "browser login to succeed without caching");
+
+    let cache = KeyringTokenCache::new().expect("token cache should be available");
+    let host = url::Url::parse(&mock.http_url())
+        .expect("mock URL should be valid")
+        .host_str()
+        .expect("mock URL should have a host")
+        .to_string();
+    let cached = cache
+        .get_token(&host, "eb_no_cache", TokenType::IdToken)
+        .expect("get_token should not fail");
+    assert!(
+        cached.is_none(),
+        "ID token should NOT be cached when client_store_temporary_credential is false"
+    );
+}

--- a/sf_core/tests/integration/authentication/mod.rs
+++ b/sf_core/tests/integration/authentication/mod.rs
@@ -1,4 +1,5 @@
 pub mod external_browser;
+pub mod external_browser_id_token_cache;
 pub mod native_okta;
 pub mod oauth;
 pub mod odbc_client_identity;

--- a/tests/definitions/shared/authentication/PAT.feature
+++ b/tests/definitions/shared/authentication/PAT.feature
@@ -1,26 +1,32 @@
-@core @python @odbc
+@core @python @odbc @jdbc
 Feature: Personal Access Token Authentication
 
-  @core_e2e @python_e2e @odbc_e2e
+  @core_e2e @python_e2e @odbc_e2e @jdbc_e2e
   Scenario: should authenticate using PAT as password
     Given Authentication is set to password and valid PAT token is provided
     When Trying to Connect
     Then Login is successful and simple query can be executed
 
-  @core_e2e @python_e2e @odbc_e2e
+  @core_e2e @python_e2e @odbc_e2e @jdbc_e2e
   Scenario: should authenticate using PAT as token
     Given Authentication is set to Programmatic Access Token and valid PAT token is provided
     When Trying to Connect
     Then Login is successful and simple query can be executed
 
-  @core_e2e @odbc_e2e
+  @core_e2e @odbc_e2e @jdbc_e2e
   Scenario: should authenticate using PAT as token with lowercase authenticator
     Given Authentication is set to lowercase programmatic_access_token and valid PAT token is provided
     When Trying to Connect
     Then Login is successful and simple query can be executed
 
-  @core_e2e @python_e2e @odbc_e2e
+  @core_e2e @python_e2e @odbc_e2e @jdbc_e2e
   Scenario: should fail PAT authentication when invalid token provided
     Given Authentication is set to Programmatic Access Token and invalid PAT token is provided
     When Trying to Connect
     Then There is error returned
+
+  @jdbc_e2e
+  Scenario: should authenticate using PAT via DataSource
+    Given DataSource is configured with PAT authentication
+    When Trying to Connect via DataSource
+    Then Login is successful and simple query can be executed


### PR DESCRIPTION
## Summary
- Add E2E tests for PAT (Programmatic Access Token) authentication in the JDBC driver covering: PAT as password, PAT as token, lowercase authenticator, invalid token, and DataSource-based connection
- Add `setAuthenticator(String)` and `setToken(String)` to `SnowflakeDataSource` interface and `SnowflakeBasicDataSource` implementation, aligning with the old JDBC driver's API surface
- Introduce `AUTHENTICATOR` and `TOKEN` entries in `SnowflakeSessionProperty` enum for standardized property key management
- Add `@jdbc` / `@jdbc_e2e` tags to the shared `PAT.feature` Gherkin file and add a new DataSource-specific scenario

## Context
Part of bringing feature parity for authentication methods in the new universal-driver JDBC wrapper. PAT authentication functionally works through `sf_core`, but lacked dedicated E2E test coverage and ergonomic DataSource setters for programmatic configuration.

## Test plan
- All 5 PAT E2E tests executed and passing against a live Snowflake environment:
  - `shouldAuthenticateUsingPATAsPassword` — PASSED
  - `shouldAuthenticateUsingPATAsToken` — PASSED
  - `shouldAuthenticateUsingPATAsTokenWithLowercaseAuthenticator` — PASSED
  - `shouldFailPATAuthenticationWhenInvalidTokenProvided` — PASSED
  - `shouldAuthenticateUsingPATViaDataSource` — PASSED
- Unit tests for `SnowflakeBasicDataSource` setters pass
- Pre-commit hooks (Spotless, tests format validator) pass

Made with [Cursor](https://cursor.com)