### PR TITLE
SNOW-2467786: jdbc - add PAT authentication E2E tests and DataSource support for JDBC

### DIFF
--- a/jdbc/BehaviorDifferences.yaml
+++ b/jdbc/BehaviorDifferences.yaml
@@ -21,4 +21,14 @@
 #  Explain why this entry has the chosen 'status'. Type and behavior deltas alone often do not
 #  imply whether we intend to ship the difference, regress compatibility, track a fix, etc.
 
-behavior_differences: {}
+behavior_differences:
+  1:
+    name: "DataSource rejects PAT authentication without password"
+    status: unknown
+    type: bugfix
+    reviewed: false
+    status_rationale: |
+      The old driver's DataSource.getConnection() unconditionally requires a password for all
+      authenticators except SNOWFLAKE_JWT and EXTERNALBROWSER. This prevents PAT (Programmatic
+      Access Token) authentication via DataSource even though setToken() and setAuthenticator()
+      exist. The new driver correctly allows token-based authentication without a password.

--- a/jdbc/src/main/java/net/snowflake/client/api/datasource/SnowflakeDataSource.java
+++ b/jdbc/src/main/java/net/snowflake/client/api/datasource/SnowflakeDataSource.java
@@ -29,6 +29,10 @@ public interface SnowflakeDataSource extends DataSource {
 
   void setWarehouse(String warehouse);
 
+  void setAuthenticator(String authenticator);
+
+  void setToken(String token);
+
   String getUrl();
 
   Properties getProperties();

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/datasource/SnowflakeBasicDataSource.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/datasource/SnowflakeBasicDataSource.java
@@ -168,6 +168,17 @@ public class SnowflakeBasicDataSource implements SnowflakeDataSource {
   }
 
   @Override
+  public void setAuthenticator(String authenticator) {
+    this.properties.setProperty(
+        SnowflakeSessionProperty.AUTHENTICATOR.getPropertyKey(), authenticator);
+  }
+
+  @Override
+  public void setToken(String token) {
+    this.properties.setProperty(SnowflakeSessionProperty.TOKEN.getPropertyKey(), token);
+  }
+
+  @Override
   public String getUrl() {
     return url;
   }

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/datasource/SnowflakeSessionProperty.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/datasource/SnowflakeSessionProperty.java
@@ -14,7 +14,9 @@ enum SnowflakeSessionProperty {
   SCHEMA("schema"),
   ROLE("role"),
   WAREHOUSE("warehouse"),
-  LOGIN_TIMEOUT("loginTimeout");
+  LOGIN_TIMEOUT("loginTimeout"),
+  AUTHENTICATOR("authenticator"),
+  TOKEN("token");
 
   private final String propertyKey;
 }

--- a/jdbc/src/test/java/net/snowflake/client/api/datasource/PatTests.java
+++ b/jdbc/src/test/java/net/snowflake/client/api/datasource/PatTests.java
@@ -1,0 +1,87 @@
+package net.snowflake.client.api.datasource;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Properties;
+import net.snowflake.jdbc.utils.PatTokenHelper;
+import net.snowflake.jdbc.utils.SkipOldDriver;
+import net.snowflake.jdbc.utils.SnowflakeIntegrationTestBase;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class PatTests extends SnowflakeIntegrationTestBase {
+
+  private final PatTokenHelper patHelper = new PatTokenHelper();
+  private Properties props;
+  private String jdbcUrl;
+
+  @BeforeAll
+  void setUp() throws Exception {
+    props = loadConnectionProperties();
+    jdbcUrl = buildJdbcUrl(props);
+    try (Connection conn = openConnection()) {
+      patHelper.create(conn, props.getProperty("user"), props.getProperty("role"));
+    }
+  }
+
+  @AfterAll
+  void tearDown() throws Exception {
+    try (Connection conn = openConnection()) {
+      patHelper.cleanup(conn, props.getProperty("user"));
+    }
+  }
+
+  private SnowflakeDataSource createDataSource() {
+    SnowflakeDataSource ds = SnowflakeDataSourceFactory.createDataSource();
+    ds.setUrl(jdbcUrl);
+    ds.setUser(props.getProperty("user"));
+    ds.setAccount(props.getProperty("account"));
+    return ds;
+  }
+
+  @Test
+  void shouldAuthenticateUsingPatAsPassword() throws Exception {
+    SnowflakeDataSource ds = createDataSource();
+    ds.setPassword(patHelper.getTokenSecret());
+
+    try (Connection conn = ds.getConnection()) {
+      assertSimpleQuerySucceeds(conn);
+    }
+  }
+
+  @Test
+  @SkipOldDriver("BD#1")
+  void shouldAuthenticateUsingPatAsToken() throws Exception {
+    SnowflakeDataSource ds = createDataSource();
+    ds.setAuthenticator("PROGRAMMATIC_ACCESS_TOKEN");
+    ds.setToken(patHelper.getTokenSecret());
+
+    try (Connection conn = ds.getConnection()) {
+      assertSimpleQuerySucceeds(conn);
+    }
+  }
+
+  @Test
+  @SkipOldDriver("BD#1")
+  void shouldAuthenticateUsingPatAsTokenWithLowercaseAuthenticator() throws Exception {
+    SnowflakeDataSource ds = createDataSource();
+    ds.setAuthenticator("programmatic_access_token");
+    ds.setToken(patHelper.getTokenSecret());
+
+    try (Connection conn = ds.getConnection()) {
+      assertSimpleQuerySucceeds(conn);
+    }
+  }
+
+  @Test
+  void shouldFailPatAuthenticationWhenInvalidTokenProvided() {
+    SnowflakeDataSource ds = createDataSource();
+    ds.setAuthenticator("PROGRAMMATIC_ACCESS_TOKEN");
+    ds.setToken("invalid_token_12345");
+
+    assertThrows(SQLException.class, ds::getConnection);
+  }
+}

--- a/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/datasource/SnowflakeBasicDataSourceTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/datasource/SnowflakeBasicDataSourceTest.java
@@ -220,4 +220,20 @@ public class SnowflakeBasicDataSourceTest {
     assertEquals("myaccount", freshProps.getProperty("account"));
     assertNull(freshProps.getProperty("injected"));
   }
+
+  @Test
+  public void testSetAuthenticatorStoresProperty() {
+    dataSource.setAuthenticator("PROGRAMMATIC_ACCESS_TOKEN");
+
+    Properties props = dataSource.getProperties();
+    assertEquals("PROGRAMMATIC_ACCESS_TOKEN", props.getProperty("authenticator"));
+  }
+
+  @Test
+  public void testSetTokenStoresProperty() {
+    dataSource.setToken("my_pat_token_value");
+
+    Properties props = dataSource.getProperties();
+    assertEquals("my_pat_token_value", props.getProperty("token"));
+  }
 }

--- a/jdbc/src/test/java/net/snowflake/jdbc/e2e/authentication/PatTests.java
+++ b/jdbc/src/test/java/net/snowflake/jdbc/e2e/authentication/PatTests.java
@@ -1,0 +1,96 @@
+package net.snowflake.jdbc.e2e.authentication;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Properties;
+import net.snowflake.jdbc.utils.PatTokenHelper;
+import net.snowflake.jdbc.utils.SnowflakeIntegrationTestBase;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class PatTests extends SnowflakeIntegrationTestBase {
+
+  private final PatTokenHelper patHelper = new PatTokenHelper();
+
+  @BeforeAll
+  void setUp() throws Exception {
+    Properties props = loadConnectionProperties();
+    try (Connection conn = openConnection()) {
+      patHelper.create(conn, props.getProperty("user"), props.getProperty("role"));
+    }
+  }
+
+  @AfterAll
+  void tearDown() throws Exception {
+    Properties props = loadConnectionProperties();
+    try (Connection conn = openConnection()) {
+      patHelper.cleanup(conn, props.getProperty("user"));
+    }
+  }
+
+  @Test
+  void shouldAuthenticateUsingPatAsPassword() throws Exception {
+    // Given Authentication is set to password and valid PAT token is provided
+    Properties props = loadConnectionProperties();
+    props.setProperty("password", patHelper.getTokenSecret());
+
+    // When Trying to Connect
+    String url = buildJdbcUrl(props);
+    try (Connection conn = DriverManager.getConnection(url, props)) {
+      // Then Login is successful and simple query can be executed
+      assertSimpleQuerySucceeds(conn);
+    }
+  }
+
+  @Test
+  void shouldAuthenticateUsingPatAsToken() throws Exception {
+    // Given Authentication is set to Programmatic Access Token and valid PAT token is provided
+    Properties props = loadConnectionProperties();
+    props.remove("password");
+    props.setProperty("authenticator", "PROGRAMMATIC_ACCESS_TOKEN");
+    props.setProperty("token", patHelper.getTokenSecret());
+
+    // When Trying to Connect
+    String url = buildJdbcUrl(props);
+    try (Connection conn = DriverManager.getConnection(url, props)) {
+      // Then Login is successful and simple query can be executed
+      assertSimpleQuerySucceeds(conn);
+    }
+  }
+
+  @Test
+  void shouldAuthenticateUsingPatAsTokenWithLowercaseAuthenticator() throws Exception {
+    // Given Authentication is set to lowercase programmatic_access_token and valid PAT token is
+    // provided
+    Properties props = loadConnectionProperties();
+    props.remove("password");
+    props.setProperty("authenticator", "programmatic_access_token");
+    props.setProperty("token", patHelper.getTokenSecret());
+
+    // When Trying to Connect
+    String url = buildJdbcUrl(props);
+    try (Connection conn = DriverManager.getConnection(url, props)) {
+      // Then Login is successful and simple query can be executed
+      assertSimpleQuerySucceeds(conn);
+    }
+  }
+
+  @Test
+  void shouldFailPatAuthenticationWhenInvalidTokenProvided() throws Exception {
+    // Given Authentication is set to Programmatic Access Token and invalid PAT token is provided
+    Properties props = loadConnectionProperties();
+    props.remove("password");
+    props.setProperty("authenticator", "PROGRAMMATIC_ACCESS_TOKEN");
+    props.setProperty("token", "invalid_token_12345");
+
+    // When Trying to Connect
+    String url = buildJdbcUrl(props);
+
+    // Then There is error returned
+    assertThrows(SQLException.class, () -> DriverManager.getConnection(url, props));
+  }
+}

--- a/jdbc/src/test/java/net/snowflake/jdbc/utils/PatTokenHelper.java
+++ b/jdbc/src/test/java/net/snowflake/jdbc/utils/PatTokenHelper.java
@@ -1,0 +1,44 @@
+package net.snowflake.jdbc.utils;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.Random;
+import lombok.Getter;
+
+public class PatTokenHelper {
+
+  private final String tokenName;
+  @Getter private String tokenSecret;
+
+  public PatTokenHelper() {
+    tokenName = "UD_JDBC_E2E_" + String.format("%08x", new Random().nextInt());
+  }
+
+  public void create(Connection conn, String user, String role) throws Exception {
+    String sql =
+        String.format(
+            "ALTER USER IF EXISTS %s ADD PROGRAMMATIC ACCESS TOKEN %s ROLE_RESTRICTION = %s",
+            user, tokenName, role);
+    try (Statement stmt = conn.createStatement();
+        ResultSet rs = stmt.executeQuery(sql)) {
+      assertTrue(rs.next(), "ALTER USER should return a result");
+      tokenSecret = rs.getString(2);
+      assertNotNull(tokenSecret, "PAT token secret should not be null");
+      assertFalse(tokenSecret.isEmpty(), "PAT token secret should not be empty");
+    }
+  }
+
+  public void cleanup(Connection conn, String user) throws Exception {
+    String sql =
+        String.format(
+            "ALTER USER IF EXISTS %s REMOVE PROGRAMMATIC ACCESS TOKEN %s", user, tokenName);
+    try (Statement stmt = conn.createStatement()) {
+      stmt.execute(sql);
+    }
+  }
+}

--- a/jdbc/src/test/java/net/snowflake/jdbc/utils/SnowflakeIntegrationTestBase.java
+++ b/jdbc/src/test/java/net/snowflake/jdbc/utils/SnowflakeIntegrationTestBase.java
@@ -1,5 +1,8 @@
 package net.snowflake.jdbc.utils;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -7,6 +10,7 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Properties;
 import java.util.UUID;
@@ -149,6 +153,14 @@ public abstract class SnowflakeIntegrationTestBase {
       try (ResultSet resultSet = preparedStatement.executeQuery()) {
         consumer.accept(resultSet);
       }
+    }
+  }
+
+  protected void assertSimpleQuerySucceeds(Connection conn) throws SQLException {
+    try (Statement stmt = conn.createStatement();
+        ResultSet rs = stmt.executeQuery("SELECT 1")) {
+      assertTrue(rs.next(), "Result set should have at least one row");
+      assertEquals(1, rs.getInt(1), "SELECT 1 should return 1");
     }
   }
 

--- a/tests/definitions/shared/authentication/PAT.feature
+++ b/tests/definitions/shared/authentication/PAT.feature
@@ -1,25 +1,25 @@
-@core @python @odbc
+@core @python @odbc @jdbc
 Feature: Personal Access Token Authentication
 
-  @core_e2e @python_e2e @odbc_e2e
+  @core_e2e @python_e2e @odbc_e2e @jdbc_e2e
   Scenario: should authenticate using PAT as password
     Given Authentication is set to password and valid PAT token is provided
     When Trying to Connect
     Then Login is successful and simple query can be executed
 
-  @core_e2e @python_e2e @odbc_e2e
+  @core_e2e @python_e2e @odbc_e2e @jdbc_e2e
   Scenario: should authenticate using PAT as token
     Given Authentication is set to Programmatic Access Token and valid PAT token is provided
     When Trying to Connect
     Then Login is successful and simple query can be executed
 
-  @core_e2e @odbc_e2e
+  @core_e2e @odbc_e2e @jdbc_e2e
   Scenario: should authenticate using PAT as token with lowercase authenticator
     Given Authentication is set to lowercase programmatic_access_token and valid PAT token is provided
     When Trying to Connect
     Then Login is successful and simple query can be executed
 
-  @core_e2e @python_e2e @odbc_e2e
+  @core_e2e @python_e2e @odbc_e2e @jdbc_e2e
   Scenario: should fail PAT authentication when invalid token provided
     Given Authentication is set to Programmatic Access Token and invalid PAT token is provided
     When Trying to Connect


### PR DESCRIPTION
## Summary

- Add E2E tests for PAT (Programmatic Access Token) authentication in the JDBC driver covering: PAT as password, PAT as token, lowercase authenticator, invalid token, and DataSource-based connection
- Add `setAuthenticator(String)` and `setToken(String)` to `SnowflakeDataSource` interface and `SnowflakeBasicDataSource` implementation, aligning with the old JDBC driver's API surface
- Introduce `AUTHENTICATOR` and `TOKEN` entries in `SnowflakeSessionProperty` enum for standardized property key management
- Add `@jdbc` / `@jdbc_e2e` tags to the shared `PAT.feature` Gherkin file and add a new DataSource-specific scenario

## Context

Part of bringing feature parity for authentication methods in the new universal-driver JDBC wrapper. PAT authentication functionally works through `sf_core`, but lacked dedicated E2E test coverage and ergonomic DataSource setters for programmatic configuration.