### PR TITLE
[Node] e2e coverage for number data types

### DIFF
--- a/nodejs/BCR_LOG.md
+++ b/nodejs/BCR_LOG.md
@@ -1,4 +1,4 @@
-This document outlines APIs that we should consider _not_ porting to the new driver.
+This document outlines API behavior changes that should be reviewed or addressed in the new driver.
 
 ### snowflake .connectAsync(callback)
 
@@ -13,6 +13,10 @@ This document outlines APIs that we should consider _not_ porting to the new dri
 
 - These methods are publicly exported but not documented. There is no practical use case for end users, as heartbeat is sent automatically by the driver.
 
+### Special values for FLOAT
+
+- In the old driver, querying FLOAT special values (`NaN`, `inf`, `-inf`) does not work as documented; all such values are returned as `NaN`.
+
 ### statement.getColumn() API
 
 - The methods `getRowValue(row: object)` and `getRowValueAsString(row: object)` are publicly documented in `index.d.ts`, but they were never covered by tests and do not work as intended. The `(row: object)` parameter requires a special internal row class that is not exposed to users. The public API returns rows as `externalizeRow`, so calling these methods will result in a runtime error.
@@ -22,3 +26,10 @@ This document outlines APIs that we should consider _not_ porting to the new dri
 ### Statement Buffer Monkey Patching
 
 - Currently, when a query returns a BINARY column, the driver returns a Buffer object monkey-patched methods: `.toStringSf()` and `.getFormat()`. These methods are not part of the documented API. There is no use case for them, as node can convert Buffer to both hex and base64.
+
+## Future Breaking Changes (BCRs)
+
+These are potential improvements to consider after the UD release:
+
+- Remove the `big-number` dependency and use native `BigInt` throughout the codebase for large integers.
+- Reevaluate the `jsTreatIntegerAsBigInt` parameter; consider either always converting all fixed numeric values to `BigInt`, or using `BigInt` only when the value exceeds the safe integer range (using `Number.isSafeInteger()`), and review approaches for handling floating-point numbers in a similar, consistent manner.

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -35,5 +35,8 @@
     "snowflake-sdk": "^2.4.2",
     "typescript": "^6.0.3",
     "vitest": "^4.1.5"
+  },
+  "dependencies": {
+    "big-integer": "^1.6.52"
   }
 }

--- a/nodejs/tests/_old-driver-reference/integration/testDataType.js
+++ b/nodejs/tests/_old-driver-reference/integration/testDataType.js
@@ -3,149 +3,18 @@ const assert = require('assert');
 const GlobalConfig = require('./../../lib/global_config');
 const snowflake = require('./../../lib/snowflake').default;
 const testUtil = require('./testUtil');
-const bigInt = require('big-integer');
 
 describe('Test DataType', function () {
-  let connection;
   const createTableWithVariant = 'create or replace table testVariant(colA variant)';
-  const createTableWithNumber = 'create or replace table testNumber(colA number)';
-  const createTableWithDouble = 'create or replace table testDouble(colA double)';
-  const dropTableWithString = 'drop table if exists testString';
   const dropTableWithVariant = 'drop table if exists testVariant';
-  const dropTableWithArray = 'drop table if exists testArray';
-  const dropTableWithNumber = 'drop table if exists testNumber';
-  const dropTableWithDouble = 'drop table if exists testDouble';
-  const dropTableWithDate = 'drop table if exists testDate';
-  const dropTableWithTime = 'drop table if exists testTime';
-  const dropTableWithTimestamp = 'drop table if exists testTimestamp';
-  const dropTableWithBoolean = 'drop table if exists testBoolean';
   const truncateTableWithVariant = 'truncate table if exists testVariant;';
-  const insertDouble = 'insert into testDouble values(123.456)';
-  const insertLargeNumber =
-    'insert into testNumber values (12345678901234567890123456789012345678)';
-  const insertRegularSizedNumber = 'insert into testNumber values (100000001)';
   const insertVariantJSON =
     "insert into testVariant select parse_json('{a : 1 , b :[1 , 2 , 3, -Infinity, undefined], c : {a : 1}}')";
   const insertVariantJSONForCustomParser =
     "insert into testVariant select parse_json('{a : 1 , b :[1 , 2 , 3], c : {a : 1}}')";
   const insertVariantXML =
     "insert into testVariant select parse_xml('<root><a>1</a><b>1</b><c><a>1</a></c></root>')";
-  const selectDouble = 'select * from testDouble';
-  const selectNumber = 'select * from testNumber';
   const selectVariant = 'select * from testVariant';
-
-  before(function (done) {
-    connection = testUtil.createConnection();
-    async.series(
-      [
-        function (callback) {
-          testUtil.connect(connection, callback);
-        },
-      ],
-      done,
-    );
-  });
-
-  after(function (done) {
-    async.series(
-      [
-        function (callback) {
-          testUtil.executeCmd(connection, dropTableWithString, callback);
-        },
-        function (callback) {
-          testUtil.executeCmd(connection, dropTableWithVariant, callback);
-        },
-        function (callback) {
-          testUtil.executeCmd(connection, dropTableWithArray, callback);
-        },
-        function (callback) {
-          testUtil.executeCmd(connection, dropTableWithNumber, callback);
-        },
-        function (callback) {
-          testUtil.executeCmd(connection, dropTableWithDouble, callback);
-        },
-        function (callback) {
-          testUtil.executeCmd(connection, dropTableWithDate, callback);
-        },
-        function (callback) {
-          testUtil.executeCmd(connection, dropTableWithTime, callback);
-        },
-        function (callback) {
-          testUtil.executeCmd(connection, dropTableWithTimestamp, callback);
-        },
-        function (callback) {
-          testUtil.executeCmd(connection, dropTableWithBoolean, callback);
-        },
-        function (callback) {
-          testUtil.destroyConnection(connection, callback);
-        },
-      ],
-      done,
-    );
-  });
-
-  describe('testNumber', function () {
-    it('testDouble', function (done) {
-      async.series(
-        [
-          function (callback) {
-            testUtil.executeCmd(connection, createTableWithDouble, callback);
-          },
-          function (callback) {
-            testUtil.executeCmd(connection, insertDouble, callback);
-          },
-          function (callback) {
-            testUtil.executeQueryAndVerify(connection, selectDouble, [{ COLA: 123.456 }], callback);
-          },
-        ],
-        done,
-      );
-    });
-
-    it('testLargeNumber', function (done) {
-      async.series(
-        [
-          function (callback) {
-            testUtil.executeCmd(connection, createTableWithNumber, callback);
-          },
-          function (callback) {
-            testUtil.executeCmd(connection, insertLargeNumber, callback);
-          },
-          function (callback) {
-            testUtil.executeQueryAndVerify(
-              connection,
-              selectNumber,
-              [{ COLA: 1.2345678901234568e37 }],
-              callback,
-            );
-          },
-        ],
-        done,
-      );
-    });
-
-    it('testRegularSizedInteger', function (done) {
-      async.series(
-        [
-          function (callback) {
-            testUtil.executeCmd(connection, createTableWithNumber, callback);
-          },
-          function (callback) {
-            testUtil.executeCmd(connection, insertRegularSizedNumber, callback);
-          },
-          function (callback) {
-            testUtil.executeQueryAndVerify(
-              connection,
-              selectNumber,
-              [{ COLA: 100000001 }],
-              callback,
-            );
-          },
-        ],
-        done,
-      );
-    });
-  });
 
   describe('testSemiStructuredDataType', function () {
     describe('testVariant', function () {
@@ -267,13 +136,6 @@ describe('JS_TREAT_INTEGER_AS_BIGINT', () => {
     return Object.values(rows[0])[0];
   }
 
-  it('returns integer as BigInt', async () => {
-    const { rows } = await testUtil.executeCmdAsync(connection, `select 4611693738694448603`);
-    const selectedValue = getFirstRowValue(rows);
-    assert.ok(bigInt.isInstance(selectedValue));
-    assert.strictEqual(selectedValue.toString(), bigInt('4611693738694448603').toString());
-  });
-
   // TODO: https://snowflakecomputing.atlassian.net/browse/SNOW-3155825
   // We need to revisit JSON/ARRAY column types and their conversion to JS objects.
   // Regardless of whether structured types are enabled or not, JSON.parse will lose precision.
@@ -283,16 +145,6 @@ describe('JS_TREAT_INTEGER_AS_BIGINT', () => {
       `select {'bigIntVal': 4611693738694448603}::OBJECT(bigIntVal BIGINT)`,
     );
     const selectedValue = getFirstRowValue(rows).bigIntVal;
-    assert.strictEqual(Number.isInteger(selectedValue), true);
-    assert.strictEqual(Number.isSafeInteger(selectedValue), false);
-  });
-
-  it('returns float as number with precision loss', async () => {
-    const { rows } = await testUtil.executeCmdAsync(
-      connection,
-      'select 4611693738694448603.45::FLOAT',
-    );
-    const selectedValue = getFirstRowValue(rows);
     assert.strictEqual(Number.isInteger(selectedValue), true);
     assert.strictEqual(Number.isSafeInteger(selectedValue), false);
   });

--- a/nodejs/tests/_old-driver-reference/unit/connection/result/result_test_number.js
+++ b/nodejs/tests/_old-driver-reference/unit/connection/result/result_test_number.js
@@ -3,6 +3,8 @@ const Logger = require('./../../../../lib/logger').default;
 const assert = require('assert');
 const ResultTestCommon = require('./result_test_common');
 
+// TODO:
+// New driver needs coverage for precision loss warning and telemetry
 describe('Result: test number', function () {
   let logWarnSpy;
 

--- a/nodejs/tests/e2e/REFACTOR.MD
+++ b/nodejs/tests/e2e/REFACTOR.MD
@@ -1,0 +1,9 @@
+* When we begin implementing Gherkin coverage, reorganize the tests into clearer groups using folders, and split large test files (those with many tests) into smaller files. e.g.
+tests/e2e/query-data-types/
+  numbers.test.ts         // current query-data-types-for-numbers.test.ts
+  strings.test.ts         // VARCHAR/CHAR/STRING/TEXT
+  binary.test.ts          // BINARY
+  boolean.test.ts         // BOOLEAN
+  datetime.test.ts        // DATE, TIME, TIMESTAMP_LTZ/TZ/NTZ
+  semi-structured.test.ts // OBJECT, MAP, ARRAY, VARIANT
+  null.test.ts            // NULL handling

--- a/nodejs/tests/e2e/query-data-types-numbers.test.ts
+++ b/nodejs/tests/e2e/query-data-types-numbers.test.ts
@@ -1,0 +1,156 @@
+import BigInteger from 'big-integer';
+import { Connection } from 'snowflake-sdk';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import {
+  createTestConnection,
+  destroyConnectionAsync,
+  executeAsync,
+  getSnowflakeSDK,
+} from './utils';
+
+describe('Query returning number data types', () => {
+  const snowflake = getSnowflakeSDK();
+  let connection: Connection;
+
+  beforeAll(async () => {
+    connection = createTestConnection(snowflake);
+    await connection.connectAsync();
+  });
+
+  afterAll(async () => {
+    await destroyConnectionAsync(connection);
+  });
+
+  it('returns fixed-point types as Number', async () => {
+    const { statement, rows } = await executeAsync(
+      connection,
+      `SELECT
+        1::NUMBER,
+        1::DECIMAL,
+        1::NUMERIC,
+        1::INT,
+        1::INTEGER,
+        1::BIGINT,
+        1::SMALLINT,
+        1::TINYINT,
+        1::BYTEINT
+      `,
+    );
+    const resultValues = Object.values(rows![0]);
+    for (const column of statement.getColumns()!) {
+      expect(column.getType()).toBe('fixed');
+      expect(column.isNumber()).toBe(true);
+      expect(resultValues[column.getIndex()]).toBe(1);
+    }
+  });
+
+  it('exposes precision and scale of fixed-point types', async () => {
+    const { statement } = await executeAsync(
+      connection,
+      `SELECT
+        1::NUMBER(10,3),
+        1::DECIMAL(10,3),
+        1::NUMERIC(10,3)`,
+    );
+    for (const column of statement.getColumns()!) {
+      expect(column.getPrecision()).toBe(10);
+      expect(column.getScale()).toBe(3);
+    }
+  });
+
+  it('returns float-point types as Number', async () => {
+    const { statement, rows } = await executeAsync(
+      connection,
+      `SELECT
+        1.15::FLOAT,
+        1.15::DOUBLE,
+        1.15::DOUBLE PRECISION,
+        1.15::REAL
+      `,
+    );
+    const resultValues = Object.values(rows![0]);
+    for (const column of statement.getColumns()!) {
+      expect(column.getType()).toBe('real');
+      expect(column.isNumber()).toBe(true);
+      expect(resultValues[column.getIndex()]).toBe(1.15);
+    }
+  });
+
+  // TODO: this test must have warning and telemetry event check
+  it('returns large numbers (> Number.MAX_SAFE_INTEGER) with precision loss', async () => {
+    const { rows } = await executeAsync(
+      connection,
+      `SELECT
+        9007199254740995 as LARGE_FIXED_COLUMN,
+        9007199254740930.13231312::FLOAT as LARGE_FLOAT_COLUMN`,
+    );
+    const selectedFixedValue = rows![0].LARGE_FIXED_COLUMN as number;
+    const selectedFloatValue = rows![0].LARGE_FLOAT_COLUMN as number;
+    expect(selectedFixedValue.toString()).toBe('9007199254740996');
+    expect(selectedFloatValue.toString()).toBe('9007199254740930');
+  });
+
+  // Bug - doesn't work in old driver
+  // https://snowflake.slack.com/archives/C09TH5U3QP2/p1779268894662169
+  it.todo('returns FLOAT special values "NaN", "inf", "-inf" as JS types', async () => {
+    const { rows } = await executeAsync(
+      connection,
+      `SELECT
+        'NaN'::FLOAT as NAN_COLUMN,
+        'inf'::FLOAT as INF_COLUMN,
+        '-inf'::FLOAT as -INF_COLUMN
+    `,
+    );
+    expect(rows![0].NAN_COLUMN).toBe(NaN);
+    expect(rows![0].INF_COLUMN).toBe(Infinity);
+    expect(rows![0]['-INF_COLUMN']).toBe(-Infinity);
+  });
+
+  it.each([
+    {
+      name: 'JS_TREAT_INTEGER_AS_BIGINT session parameter',
+      connectionFactory: async () => {
+        const connection = createTestConnection(snowflake);
+        await connection.connectAsync();
+        await executeAsync(connection, 'ALTER SESSION SET JS_TREAT_INTEGER_AS_BIGINT = true');
+        return connection;
+      },
+    },
+    {
+      name: 'jsTreatIntegerAsBigInt connection parameter',
+      connectionFactory: async () => {
+        const connection = createTestConnection(snowflake, {
+          jsTreatIntegerAsBigInt: true,
+        });
+        await connection.connectAsync();
+        return connection;
+      },
+    },
+  ])('returns integer as BigInt instance when $name is set', async ({ connectionFactory }) => {
+    const bigIntConnection = await connectionFactory();
+    try {
+      const { statement, rows } = await executeAsync(
+        bigIntConnection,
+        'SELECT 90071992547409954434323 as INT_COLUMN',
+      );
+      const resultColumn = statement.getColumn(0);
+      const selectedValue = rows![0].INT_COLUMN as typeof BigInteger;
+      expect(resultColumn.getType()).toBe('fixed');
+      expect(resultColumn.isNumber()).toBe(true);
+      expect(BigInteger.isInstance(selectedValue)).toBe(true);
+      expect(selectedValue.toString()).toBe('90071992547409954434323');
+    } finally {
+      await destroyConnectionAsync(bigIntConnection);
+    }
+  });
+
+  it('returns DECFLOAT as String', async () => {
+    const { statement, rows } = await executeAsync(
+      connection,
+      "SELECT '-9.8765432099999998623226732747455716901e-250'::DECFLOAT as DECFLOAT_COLUMN",
+    );
+    // NO isDecfloat method available :/
+    expect(statement.getColumn(0).getType()).toBe('decfloat');
+    expect(rows![0].DECFLOAT_COLUMN).toBe('-9.8765432099999998623226732747455716901e-250');
+  });
+});

--- a/nodejs/tests/e2e/query-data-types.test.ts
+++ b/nodejs/tests/e2e/query-data-types.test.ts
@@ -83,16 +83,6 @@ describe('Query returning data types', () => {
     expect(rows![0].FALSE_COLUMN).toBe(false);
   });
 
-  it('returns DECFLOAT as String', async () => {
-    const { statement, rows } = await executeAsync(
-      connection,
-      "SELECT '-9.8765432099999998623226732747455716901e-250'::DECFLOAT as DECFLOAT_COLUMN",
-    );
-    // NO isDecfloat method available :/
-    expect(statement.getColumn(0).getType()).toBe('decfloat');
-    expect(rows![0].DECFLOAT_COLUMN).toBe('-9.8765432099999998623226732747455716901e-250');
-  });
-
   // NOTE: DATE_OUTPUT_FORMAT does not affect results, we always convert to Date
   it('returns DATE as Date', async () => {
     const { statement, rows } = await executeAsync(

--- a/nodejs/vitest.config.ts
+++ b/nodejs/vitest.config.ts
@@ -9,6 +9,9 @@ export default defineConfig({
     //   reporter: ["text", "html", "lcov"],
     //   include: ["src/**/*.ts"],
     // },
+    chaiConfig: {
+      truncateThreshold: 0,
+    },
     projects: [
       {
         extends: true,


### PR DESCRIPTION
## Summary

Adds E2E coverage for the numeric data type surface (FIXED, REAL, DECFLOAT, BigInt conversion) and clears the corresponding numeric tests out of the legacy reference suite.

## Changes

### New tests

- `nodejs/tests/e2e/query-data-types-numbers.test.ts` — new file covering:
  - All FIXED aliases (`NUMBER`, `DECIMAL`, `NUMERIC`, `INT`, `INTEGER`, `BIGINT`, `SMALLINT`, `TINYINT`, `BYTEINT`) land on `column.getType() === 'fixed'`.
  - REAL aliases (`FLOAT`, `DOUBLE`, `DOUBLE PRECISION`, `REAL`) land on `column.getType() === 'real'`.
  - `column.getPrecision()` / `column.getScale()` are populated for `NUMBER(p,s)` / `DECIMAL(p,s)` / `NUMERIC(p,s)`.
  - Values past `Number.MAX_SAFE_INTEGER` come back as JS `Number` (driver doesn't throw on precision loss).
  - `jsTreatIntegerAsBigInt` converts large integer FIXED values to `BigInt`, verified for both the connection-option form and the `JS_TREAT_INTEGER_AS_BIGINT` session-parameter form via `it.each`.
  - `DECFLOAT` falls through to string (moved from `query-data-types.test.ts` since DECFLOAT is a numeric SF type).
  - `it.todo` for FLOAT special values (`'NaN'`, `'inf'`, `'-inf'`) — blocked on an upstream driver bug, see `BCR_LOG.md`.

### Legacy cleanup

- Removed migrated `it()` blocks from `nodejs/tests/_old-driver-reference/integration/testDataType.js`:
  - `testDouble`, `testLargeNumber`, `testRegularSizedInteger`
  - `returns integer as BigInt`, `returns float as number with precision loss` from the `JS_TREAT_INTEGER_AS_BIGINT` describe
- Added a `TODO` in `nodejs/tests/_old-driver-reference/unit/connection/result/result_test_number.js` flagging that the precision-loss warning + telemetry assertions need to be ported to `sf_core` rather than E2E.

### Supporting changes

- `nodejs/BCR_LOG.md` — reframed file purpose from "APIs not to port" to "API behavior changes that should be reviewed or addressed in the new driver." Added entries for:
  - FLOAT special values (`NaN`, `inf`, `-inf`) returning as `NaN` in the old driver — documents the deferred test above.
  - "Future Breaking Changes" section flagging the `big-integer` dependency removal and a reevaluation of the `jsTreatIntegerAsBigInt` parameter for the new driver.
- `nodejs/package.json` — added `big-integer` as a runtime dependency (used by the driver, not just tests).
- `nodejs/vitest.config.ts` — set `chaiConfig.truncateThreshold: 0` so assertion diffs aren't truncated.
- `nodejs/tests/e2e/REFACTOR.MD` — note about eventually splitting `tests/e2e/` into a `query-data-types/` folder; this PR is the first file in that direction.
