### PR TITLE
NO-SNOW: jdbc - extract MultiStatementState to encapsulate multi-statement navigation

### DIFF
--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/MultiStatementState.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/MultiStatementState.java
@@ -1,0 +1,63 @@
+package net.snowflake.client.internal.api.implementation.statement;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.MultiStatementResult;
+
+/**
+ * Navigation state for multi-statement query results.
+ *
+ * <p>Tracks child query IDs and statement type IDs returned by the server, along with the current
+ * position in the child result sequence.
+ */
+@RequiredArgsConstructor
+class MultiStatementState {
+
+  private final String parentQueryId;
+  private final List<String> childQueryIds;
+  private final List<Long> childStatementTypeIds;
+  private int nextIndex = 0;
+
+  static MultiStatementState from(MultiStatementResult multi) {
+    return new MultiStatementState(
+        multi.getParent().getQueryId(), multi.getQueryIdsList(), multi.getStatementTypeIdsList());
+  }
+
+  String getParentQueryId() {
+    return parentQueryId;
+  }
+
+  boolean isEmpty() {
+    return childQueryIds.isEmpty();
+  }
+
+  boolean hasMore() {
+    return nextIndex < childQueryIds.size();
+  }
+
+  String advance() {
+    if (!hasMore()) {
+      return null;
+    }
+    return childQueryIds.get(nextIndex++);
+  }
+
+  int currentIndex() {
+    return nextIndex - 1;
+  }
+
+  /**
+   * Returns whether the child at the given index produces a result set, using the statement type ID
+   * if available.
+   */
+  boolean producesResultSet(int index) {
+    if (index < childStatementTypeIds.size()) {
+      return StatementTypeClassifier.producesResultSet(childStatementTypeIds.get(index));
+    }
+    return false;
+  }
+
+  boolean hasStatementTypeFor(int index) {
+    return index < childStatementTypeIds.size();
+  }
+}

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakeStatementImpl.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakeStatementImpl.java
@@ -42,9 +42,8 @@ public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
   protected long currentUpdateCount = NO_UPDATE_COUNT;
   protected String queryId;
   protected final Set<ResultSet> openResultSets = ConcurrentHashMap.newKeySet();
-  private List<String> childQueryIds;
-  private List<Long> childStatementTypeIds;
-  private int childResultIndex;
+  /** Non-null only while navigating a multi-statement result set sequence. */
+  private MultiStatementState multiState;
 
   public SnowflakeStatementImpl(SnowflakeConnectionImpl connection) {
     this.connection = connection;
@@ -183,29 +182,26 @@ public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
   }
 
   private void applyMultiStatementResult(MultiStatementResult multi) throws SQLException {
-    childQueryIds = multi.getQueryIdsList();
-    childStatementTypeIds = multi.getStatementTypeIdsList();
-    childResultIndex = 0;
-    queryId = multi.getParent().getQueryId();
-    if (childQueryIds.isEmpty()) {
+    multiState = MultiStatementState.from(multi);
+    queryId = multiState.getParentQueryId();
+    if (multiState.isEmpty()) {
       currentResultSet = null;
       currentUpdateCount = NO_UPDATE_COUNT;
       return;
     }
-    applyChildResult(0);
+    advanceToNextChild();
   }
 
-  private void applyChildResult(int index) throws SQLException {
-    String childQueryId = childQueryIds.get(index);
+  private void advanceToNextChild() throws SQLException {
+    String childQueryId = multiState.advance();
+    int index = multiState.currentIndex();
+
     ResultSetResponse rsResponse = fetchResultSetByQueryId(childQueryId);
     ResultSetDescriptor descriptor = rsResponse.getResultDescriptor();
 
-    // Use statement type from the initial multi-statement response if available,
-    // otherwise fall back to the descriptor from the fetched result set.
     boolean producesResultSet;
-    if (index < childStatementTypeIds.size()) {
-      producesResultSet =
-          StatementTypeClassifier.producesResultSet(childStatementTypeIds.get(index));
+    if (multiState.hasStatementTypeFor(index)) {
+      producesResultSet = multiState.producesResultSet(index);
     } else {
       producesResultSet = StatementTypeClassifier.producesResultSet(descriptor);
     }
@@ -225,9 +221,7 @@ public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
     currentResultSet = null;
     currentUpdateCount = NO_UPDATE_COUNT;
     queryId = null;
-    childQueryIds = null;
-    childStatementTypeIds = null;
-    childResultIndex = -1;
+    multiState = null;
   }
 
   private void prepareForExecution() throws SQLException {
@@ -457,24 +451,18 @@ public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
       openResultSets.add(currentResultSet);
     }
 
-    if (childQueryIds == null || childResultIndex + 1 >= childQueryIds.size()) {
+    if (multiState == null || !multiState.hasMore()) {
       currentResultSet = null;
       currentUpdateCount = NO_UPDATE_COUNT;
       return false;
     }
 
-    childResultIndex++;
-    applyChildResult(childResultIndex);
+    advanceToNextChild();
 
-    // Multi-statement queries return true if the current result is a ResultSet.
-    // For update counts (DML/DDL), return true only if there are more results after this one.
-    // This matches the behavior of the legacy Snowflake JDBC driver.
     if (currentResultSet != null) {
       return true;
     }
-
-    // For update counts, return true if there are more children after this one
-    return childResultIndex + 1 < childQueryIds.size();
+    return multiState.hasMore();
   }
 
   @Override

--- a/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/statement/MultiStatementStateTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/statement/MultiStatementStateTest.java
@@ -1,0 +1,125 @@
+package net.snowflake.client.internal.api.implementation.statement;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.MultiStatementResult;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetDescriptor;
+import org.junit.jupiter.api.Test;
+
+class MultiStatementStateTest {
+
+  @Test
+  void fromMultiStatementResult() {
+    MultiStatementResult multi =
+        MultiStatementResult.newBuilder()
+            .setParent(ResultSetDescriptor.newBuilder().setQueryId("parent-qid"))
+            .addQueryIds("child-1")
+            .addQueryIds("child-2")
+            .addQueryIds("child-3")
+            .addStatementTypeIds(4096L)
+            .addStatementTypeIds(4096L)
+            .addStatementTypeIds(0L)
+            .build();
+
+    MultiStatementState state = MultiStatementState.from(multi);
+
+    assertEquals("parent-qid", state.getParentQueryId());
+    assertFalse(state.isEmpty());
+    assertTrue(state.hasMore());
+  }
+
+  @Test
+  void emptyMultiStatement() {
+    MultiStatementResult multi =
+        MultiStatementResult.newBuilder()
+            .setParent(ResultSetDescriptor.newBuilder().setQueryId("parent-qid"))
+            .build();
+
+    MultiStatementState state = MultiStatementState.from(multi);
+
+    assertTrue(state.isEmpty());
+    assertFalse(state.hasMore());
+    assertNull(state.advance());
+  }
+
+  @Test
+  void advanceIteratesThroughChildren() {
+    MultiStatementResult multi =
+        MultiStatementResult.newBuilder()
+            .setParent(ResultSetDescriptor.newBuilder().setQueryId("p"))
+            .addQueryIds("q1")
+            .addQueryIds("q2")
+            .addQueryIds("q3")
+            .build();
+
+    MultiStatementState state = MultiStatementState.from(multi);
+
+    assertTrue(state.hasMore());
+    assertEquals("q1", state.advance());
+    assertEquals(0, state.currentIndex());
+
+    assertTrue(state.hasMore());
+    assertEquals("q2", state.advance());
+    assertEquals(1, state.currentIndex());
+
+    assertTrue(state.hasMore());
+    assertEquals("q3", state.advance());
+    assertEquals(2, state.currentIndex());
+
+    assertFalse(state.hasMore());
+    assertNull(state.advance());
+  }
+
+  @Test
+  void hasStatementTypeForRespectsAvailableTypes() {
+    MultiStatementResult multi =
+        MultiStatementResult.newBuilder()
+            .setParent(ResultSetDescriptor.newBuilder().setQueryId("p"))
+            .addQueryIds("q1")
+            .addQueryIds("q2")
+            .addQueryIds("q3")
+            .addStatementTypeIds(4096L)
+            .addStatementTypeIds(0L)
+            .build();
+
+    MultiStatementState state = MultiStatementState.from(multi);
+
+    assertTrue(state.hasStatementTypeFor(0));
+    assertTrue(state.hasStatementTypeFor(1));
+    assertFalse(state.hasStatementTypeFor(2));
+  }
+
+  @Test
+  void producesResultSetDelegatesToClassifier() {
+    MultiStatementResult multi =
+        MultiStatementResult.newBuilder()
+            .setParent(ResultSetDescriptor.newBuilder().setQueryId("p"))
+            .addQueryIds("q1")
+            .addQueryIds("q2")
+            .addStatementTypeIds(0x1000L) // SELECT → produces result set
+            .addStatementTypeIds(0x3000L) // DML → does not produce result set
+            .build();
+
+    MultiStatementState state = MultiStatementState.from(multi);
+
+    assertTrue(state.producesResultSet(0));
+    assertFalse(state.producesResultSet(1));
+  }
+
+  @Test
+  void producesResultSetReturnsFalseForOutOfBoundsIndex() {
+    MultiStatementResult multi =
+        MultiStatementResult.newBuilder()
+            .setParent(ResultSetDescriptor.newBuilder().setQueryId("p"))
+            .addQueryIds("q1")
+            .addStatementTypeIds(4096L)
+            .build();
+
+    MultiStatementState state = MultiStatementState.from(multi);
+
+    assertFalse(state.producesResultSet(5));
+  }
+}


### PR DESCRIPTION
## Summary

- Extract `MultiStatementState` class to encapsulate multi-statement result navigation logic
- Replace three loose fields (`childQueryIds`, `childStatementTypeIds`, `childResultIndex`) with a single nullable `multiState` field
- Add unit tests for `MultiStatementState` covering iteration, boundary conditions, and statement type classification

## Context

Ported from the Python wrapper's `_MultiStatementQueryResultState` concept. The multi-statement navigation state was scattered across multiple fields in `SnowflakeStatementImpl`, making it easy to get out of sync. This refactoring encapsulates the state and navigation logic into a dedicated class, improving readability and reducing the surface area for bugs.