### PR TITLE
NO-SNOW: Load native lib from JAR resource so it works without CORE_PATH

### DIFF
--- a/jdbc/build.gradle
+++ b/jdbc/build.gradle
@@ -158,10 +158,17 @@ jar {
     }
 }
 
+// Copy the cargo-built native lib into the JAR's resources so JNICoreTransport
+// can extract it at runtime (no CORE_PATH env var required for end users).
+// Path inside the JAR: net/snowflake/client/internal/unicore/native/.
+// The actual filenames produced by `cargo build --package jdbc_bridge`:
+//   - linux:   libjdbc_bridge.so
+//   - macos:   libjdbc_bridge.dylib
+//   - windows: jdbc_bridge.dll
 def copyNativeLib = tasks.register('copyNativeLib', Copy) {
     from '../target/release'
-    include 'libjdbc.*'
-    into 'build/resources/main'
+    include 'libjdbc_bridge.*', 'jdbc_bridge.dll'
+    into 'build/resources/main/net/snowflake/client/internal/unicore/native'
 }
 
 tasks.named('processResources') {

--- a/jdbc/src/main/java/net/snowflake/client/internal/unicore/JNICoreTransport.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/unicore/JNICoreTransport.java
@@ -6,7 +6,7 @@ import net.snowflake.client.internal.log.SFLoggerFactory;
 public class JNICoreTransport implements CoreTransport {
   private static final SFLogger logger = SFLoggerFactory.getLogger(JNICoreTransport.class);
 
-  static {
+  public JNICoreTransport() {
     NativeLibraryLoader.init();
   }
 

--- a/jdbc/src/main/java/net/snowflake/client/internal/unicore/JNICoreTransport.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/unicore/JNICoreTransport.java
@@ -1,6 +1,5 @@
 package net.snowflake.client.internal.unicore;
 
-import net.snowflake.client.api.driver.SnowflakeDriver;
 import net.snowflake.client.internal.log.SFLogger;
 import net.snowflake.client.internal.log.SFLoggerFactory;
 
@@ -8,8 +7,7 @@ public class JNICoreTransport implements CoreTransport {
   private static final SFLogger logger = SFLoggerFactory.getLogger(JNICoreTransport.class);
 
   static {
-    NativeLibraryLoader.load();
-    logger.info("JDBC driver starting v{}", SnowflakeDriver.getDriverVersion());
+    NativeLibraryLoader.init();
   }
 
   @Override

--- a/jdbc/src/main/java/net/snowflake/client/internal/unicore/JNICoreTransport.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/unicore/JNICoreTransport.java
@@ -1,10 +1,5 @@
 package net.snowflake.client.internal.unicore;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 import net.snowflake.client.api.driver.SnowflakeDriver;
 import net.snowflake.client.internal.log.SFLogger;
 import net.snowflake.client.internal.log.SFLoggerFactory;
@@ -12,93 +7,9 @@ import net.snowflake.client.internal.log.SFLoggerFactory;
 public class JNICoreTransport implements CoreTransport {
   private static final SFLogger logger = SFLoggerFactory.getLogger(JNICoreTransport.class);
 
-  /** Resource directory inside the JAR where {@code copyNativeLib} (build.gradle) places the lib. */
-  private static final String NATIVE_RESOURCE_DIR =
-      "/net/snowflake/client/internal/unicore/native/";
-
   static {
-    loadNativeLibrary();
+    NativeLibraryLoader.load();
     logger.info("JDBC driver starting v{}", SnowflakeDriver.getDriverVersion());
-  }
-
-  /**
-   * Load the {@code libjdbc_bridge} native library.
-   *
-   * <p>Resolution order:
-   *
-   * <ol>
-   *   <li>{@code CORE_PATH} env var — explicit absolute path (back-compat for dev/CI setups).
-   *   <li>{@code jdbc.library.path} system property — explicit absolute path.
-   *   <li>JAR resource — extract the bundled native lib to a temp file and load from there.
-   * </ol>
-   *
-   * <p>The JAR-resource path is the default for end users: it works in sandboxed JVMs
-   * (e.g. UDFs, BucketFS, Lambda) where host env vars and host filesystem layouts aren't
-   * predictable.
-   */
-  private static void loadNativeLibrary() {
-    String corePath = System.getenv("CORE_PATH");
-    if (corePath != null && !corePath.isEmpty()) {
-      System.load(corePath);
-      return;
-    }
-
-    String libraryPath = System.getProperty("jdbc.library.path");
-    if (libraryPath != null && !libraryPath.isEmpty()) {
-      System.load(libraryPath);
-      return;
-    }
-
-    Path extracted;
-    try {
-      extracted = extractNativeLibFromResource();
-    } catch (IOException e) {
-      throw new RuntimeException(
-          "Failed to extract bundled native library from JAR resources. Either ensure the lib is "
-              + "bundled in the JAR (built via Gradle copyNativeLib) or set CORE_PATH / "
-              + "jdbc.library.path explicitly.",
-          e);
-    }
-    System.load(extracted.toAbsolutePath().toString());
-  }
-
-  /** Copy the bundled native lib resource into a temp file the JVM can {@code System.load}. */
-  private static Path extractNativeLibFromResource() throws IOException {
-    String libFileName = nativeLibFileName();
-    String resourcePath = NATIVE_RESOURCE_DIR + libFileName;
-    try (InputStream in = JNICoreTransport.class.getResourceAsStream(resourcePath)) {
-      if (in == null) {
-        throw new IOException(
-            "Native library not found in JAR at " + resourcePath + ". The driver JAR was built "
-                + "without the platform-specific native lib bundled.");
-      }
-      // Use a per-version subdir so concurrent JVMs don't clobber each other and the OS
-      // doesn't refuse to load a file that's been overwritten while still mapped.
-      Path tmpDir =
-          Files.createTempDirectory("snowflake-jdbc-native-" + SnowflakeDriver.getDriverVersion());
-      tmpDir.toFile().deleteOnExit();
-      Path tmpLib = tmpDir.resolve(libFileName);
-      Files.copy(in, tmpLib, StandardCopyOption.REPLACE_EXISTING);
-      tmpLib.toFile().deleteOnExit();
-      return tmpLib;
-    }
-  }
-
-  /**
-   * Resolve the native lib filename for the current OS. Architecture isn't currently encoded in
-   * the resource path because cargo only produces one binary per OS in {@code target/release/};
-   * if we ship multi-arch builds in the future, extend this to include {@code os.arch}.
-   */
-  private static String nativeLibFileName() {
-    String osName = System.getProperty("os.name", "").toLowerCase();
-    if (osName.contains("mac") || osName.contains("darwin")) {
-      return "libjdbc_bridge.dylib";
-    }
-    if (osName.contains("windows")) {
-      return "jdbc_bridge.dll";
-    }
-    // Linux and other POSIX systems
-    return "libjdbc_bridge.so";
   }
 
   @Override

--- a/jdbc/src/main/java/net/snowflake/client/internal/unicore/JNICoreTransport.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/unicore/JNICoreTransport.java
@@ -1,5 +1,10 @@
 package net.snowflake.client.internal.unicore;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import net.snowflake.client.api.driver.SnowflakeDriver;
 import net.snowflake.client.internal.log.SFLogger;
 import net.snowflake.client.internal.log.SFLoggerFactory;
@@ -7,32 +12,93 @@ import net.snowflake.client.internal.log.SFLoggerFactory;
 public class JNICoreTransport implements CoreTransport {
   private static final SFLogger logger = SFLoggerFactory.getLogger(JNICoreTransport.class);
 
+  /** Resource directory inside the JAR where {@code copyNativeLib} (build.gradle) places the lib. */
+  private static final String NATIVE_RESOURCE_DIR =
+      "/net/snowflake/client/internal/unicore/native/";
+
   static {
-    // Load the native library
-    try {
-      // Try to load from CORE_PATH environment variable
-      String corePath = System.getenv("CORE_PATH");
-      if (corePath == null) {
-        throw new RuntimeException("CORE_PATH environment variable not set");
-      }
-      System.load(corePath);
-    } catch (UnsatisfiedLinkError e) {
-      // Fallback to explicit path if needed
-      try {
-        String libraryPath = System.getProperty("jdbc.library.path");
-        if (libraryPath != null) {
-          System.load(libraryPath);
-        } else {
-          throw new RuntimeException(
-              "jdbc native library not found. Please ensure the library is available or set the"
-                  + " jdbc.library.path system property.",
-              e);
-        }
-      } catch (UnsatisfiedLinkError e2) {
-        throw new RuntimeException("Failed to load jdbc native library", e2);
-      }
-    }
+    loadNativeLibrary();
     logger.info("JDBC driver starting v{}", SnowflakeDriver.getDriverVersion());
+  }
+
+  /**
+   * Load the {@code libjdbc_bridge} native library.
+   *
+   * <p>Resolution order:
+   *
+   * <ol>
+   *   <li>{@code CORE_PATH} env var — explicit absolute path (back-compat for dev/CI setups).
+   *   <li>{@code jdbc.library.path} system property — explicit absolute path.
+   *   <li>JAR resource — extract the bundled native lib to a temp file and load from there.
+   * </ol>
+   *
+   * <p>The JAR-resource path is the default for end users: it works in sandboxed JVMs
+   * (e.g. UDFs, BucketFS, Lambda) where host env vars and host filesystem layouts aren't
+   * predictable.
+   */
+  private static void loadNativeLibrary() {
+    String corePath = System.getenv("CORE_PATH");
+    if (corePath != null && !corePath.isEmpty()) {
+      System.load(corePath);
+      return;
+    }
+
+    String libraryPath = System.getProperty("jdbc.library.path");
+    if (libraryPath != null && !libraryPath.isEmpty()) {
+      System.load(libraryPath);
+      return;
+    }
+
+    Path extracted;
+    try {
+      extracted = extractNativeLibFromResource();
+    } catch (IOException e) {
+      throw new RuntimeException(
+          "Failed to extract bundled native library from JAR resources. Either ensure the lib is "
+              + "bundled in the JAR (built via Gradle copyNativeLib) or set CORE_PATH / "
+              + "jdbc.library.path explicitly.",
+          e);
+    }
+    System.load(extracted.toAbsolutePath().toString());
+  }
+
+  /** Copy the bundled native lib resource into a temp file the JVM can {@code System.load}. */
+  private static Path extractNativeLibFromResource() throws IOException {
+    String libFileName = nativeLibFileName();
+    String resourcePath = NATIVE_RESOURCE_DIR + libFileName;
+    try (InputStream in = JNICoreTransport.class.getResourceAsStream(resourcePath)) {
+      if (in == null) {
+        throw new IOException(
+            "Native library not found in JAR at " + resourcePath + ". The driver JAR was built "
+                + "without the platform-specific native lib bundled.");
+      }
+      // Use a per-version subdir so concurrent JVMs don't clobber each other and the OS
+      // doesn't refuse to load a file that's been overwritten while still mapped.
+      Path tmpDir =
+          Files.createTempDirectory("snowflake-jdbc-native-" + SnowflakeDriver.getDriverVersion());
+      tmpDir.toFile().deleteOnExit();
+      Path tmpLib = tmpDir.resolve(libFileName);
+      Files.copy(in, tmpLib, StandardCopyOption.REPLACE_EXISTING);
+      tmpLib.toFile().deleteOnExit();
+      return tmpLib;
+    }
+  }
+
+  /**
+   * Resolve the native lib filename for the current OS. Architecture isn't currently encoded in
+   * the resource path because cargo only produces one binary per OS in {@code target/release/};
+   * if we ship multi-arch builds in the future, extend this to include {@code os.arch}.
+   */
+  private static String nativeLibFileName() {
+    String osName = System.getProperty("os.name", "").toLowerCase();
+    if (osName.contains("mac") || osName.contains("darwin")) {
+      return "libjdbc_bridge.dylib";
+    }
+    if (osName.contains("windows")) {
+      return "jdbc_bridge.dll";
+    }
+    // Linux and other POSIX systems
+    return "libjdbc_bridge.so";
   }
 
   @Override

--- a/jdbc/src/main/java/net/snowflake/client/internal/unicore/NativeLibraryLoader.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/unicore/NativeLibraryLoader.java
@@ -1,0 +1,100 @@
+package net.snowflake.client.internal.unicore;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import net.snowflake.client.api.driver.SnowflakeDriver;
+
+/**
+ * Loads the {@code libjdbc_bridge} native library for {@link JNICoreTransport}.
+ *
+ * <p>Resolution order:
+ *
+ * <ol>
+ *   <li>{@code CORE_PATH} env var — explicit absolute path (back-compat for dev/CI setups).
+ *   <li>{@code jdbc.library.path} system property — explicit absolute path.
+ *   <li>JAR resource — extract the bundled native lib to a temp file and load from there.
+ * </ol>
+ *
+ * <p>The JAR-resource path is the default for end users: it works in sandboxed JVMs (e.g. UDFs,
+ * BucketFS, Lambda) where host env vars and host filesystem layouts aren't predictable.
+ */
+final class NativeLibraryLoader {
+
+  /**
+   * Resource directory inside the JAR where {@code copyNativeLib} (build.gradle) places the lib.
+   */
+  private static final String NATIVE_RESOURCE_DIR =
+      "/net/snowflake/client/internal/unicore/native/";
+
+  private NativeLibraryLoader() {}
+
+  static void load() {
+    String corePath = System.getenv("CORE_PATH");
+    if (corePath != null && !corePath.isEmpty()) {
+      System.load(corePath);
+      return;
+    }
+
+    String libraryPath = System.getProperty("jdbc.library.path");
+    if (libraryPath != null && !libraryPath.isEmpty()) {
+      System.load(libraryPath);
+      return;
+    }
+
+    Path extracted;
+    try {
+      extracted = extractNativeLibFromResource();
+    } catch (IOException e) {
+      throw new RuntimeException(
+          "Failed to extract bundled native library from JAR resources. Either ensure the lib is "
+              + "bundled in the JAR (built via Gradle copyNativeLib) or set CORE_PATH / "
+              + "jdbc.library.path explicitly.",
+          e);
+    }
+    System.load(extracted.toAbsolutePath().toString());
+  }
+
+  /** Copy the bundled native lib resource into a temp file the JVM can {@code System.load}. */
+  private static Path extractNativeLibFromResource() throws IOException {
+    String libFileName = nativeLibFileName();
+    String resourcePath = NATIVE_RESOURCE_DIR + libFileName;
+    try (InputStream in = NativeLibraryLoader.class.getResourceAsStream(resourcePath)) {
+      if (in == null) {
+        throw new IOException(
+            "Native library not found in JAR at "
+                + resourcePath
+                + ". The driver JAR was built "
+                + "without the platform-specific native lib bundled.");
+      }
+      // Use a per-version subdir so concurrent JVMs don't clobber each other and the OS
+      // doesn't refuse to load a file that's been overwritten while still mapped.
+      Path tmpDir =
+          Files.createTempDirectory("snowflake-jdbc-native-" + SnowflakeDriver.getDriverVersion());
+      tmpDir.toFile().deleteOnExit();
+      Path tmpLib = tmpDir.resolve(libFileName);
+      Files.copy(in, tmpLib, StandardCopyOption.REPLACE_EXISTING);
+      tmpLib.toFile().deleteOnExit();
+      return tmpLib;
+    }
+  }
+
+  /**
+   * Resolve the native lib filename for the current OS. Architecture isn't currently encoded in the
+   * resource path because cargo only produces one binary per OS in {@code target/release/}; if we
+   * ship multi-arch builds in the future, extend this to include {@code os.arch}.
+   */
+  private static String nativeLibFileName() {
+    String osName = System.getProperty("os.name", "").toLowerCase();
+    if (osName.contains("mac") || osName.contains("darwin")) {
+      return "libjdbc_bridge.dylib";
+    }
+    if (osName.contains("windows")) {
+      return "jdbc_bridge.dll";
+    }
+    // Linux and other POSIX systems
+    return "libjdbc_bridge.so";
+  }
+}

--- a/jdbc/src/main/java/net/snowflake/client/internal/unicore/NativeLibraryLoader.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/unicore/NativeLibraryLoader.java
@@ -23,8 +23,9 @@ import net.snowflake.client.internal.log.SFLoggerFactory;
  * <p>The JAR-resource path is the default for end users: it works in sandboxed JVMs (e.g. UDFs,
  * BucketFS, Lambda) where host env vars and host filesystem layouts aren't predictable.
  *
- * <p>The load runs once, in this class's static initializer. {@link JNICoreTransport} triggers
- * initialization via {@link #init()} so the native lib is in place before any JNI call.
+ * <p>The load runs once, in this class's static initializer. {@link JNICoreTransport}'s constructor
+ * calls {@link #init()} to trigger that initialization, ensuring the native lib is in place before
+ * any JNI call.
  */
 final class NativeLibraryLoader {
 

--- a/jdbc/src/main/java/net/snowflake/client/internal/unicore/NativeLibraryLoader.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/unicore/NativeLibraryLoader.java
@@ -6,6 +6,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import net.snowflake.client.api.driver.SnowflakeDriver;
+import net.snowflake.client.internal.log.SFLogger;
+import net.snowflake.client.internal.log.SFLoggerFactory;
 
 /**
  * Loads the {@code libjdbc_bridge} native library for {@link JNICoreTransport}.
@@ -20,8 +22,13 @@ import net.snowflake.client.api.driver.SnowflakeDriver;
  *
  * <p>The JAR-resource path is the default for end users: it works in sandboxed JVMs (e.g. UDFs,
  * BucketFS, Lambda) where host env vars and host filesystem layouts aren't predictable.
+ *
+ * <p>The load runs once, in this class's static initializer. {@link JNICoreTransport} triggers
+ * initialization via {@link #init()} so the native lib is in place before any JNI call.
  */
 final class NativeLibraryLoader {
+
+  private static final SFLogger logger = SFLoggerFactory.getLogger(NativeLibraryLoader.class);
 
   /**
    * Resource directory inside the JAR where {@code copyNativeLib} (build.gradle) places the lib.
@@ -29,9 +36,17 @@ final class NativeLibraryLoader {
   private static final String NATIVE_RESOURCE_DIR =
       "/net/snowflake/client/internal/unicore/native/";
 
+  static {
+    load();
+    logger.info("JDBC driver starting v{}", SnowflakeDriver.getDriverVersion());
+  }
+
   private NativeLibraryLoader() {}
 
-  static void load() {
+  /** No-op; calling this forces class initialization, which runs the static block above. */
+  static void init() {}
+
+  private static void load() {
     String corePath = System.getenv("CORE_PATH");
     if (corePath != null && !corePath.isEmpty()) {
       System.load(corePath);


### PR DESCRIPTION
The JNI native lib (libjdbc_bridge.so/.dylib/.dll) was previously loadable only via the CORE_PATH env var (or jdbc.library.path system property), both of which require the user to know an absolute filesystem path to the lib. This breaks deployment to sandboxed JVMs - Snowflake UDFs, Exasol BucketFS UDFs, AWS Lambda, GraalVM Native Image runners, etc. - where host env vars aren't visible and the host filesystem layout isn't predictable.

Fix:

1. jdbc/build.gradle copyNativeLib task: glob the actual cargo output filenames (libjdbc_bridge.so/.dylib + jdbc_bridge.dll) instead of libjdbc.* which never matched anything. Place them under build/resources/main/net/snowflake/client/internal/unicore/native/ so they're addressable as a JAR resource at runtime.

2. JNICoreTransport static initializer: try CORE_PATH and jdbc.library.path first (back-compat), then fall back to extracting the bundled native lib from the JAR resource into a per-JVM temp dir and System.load()ing it.

This is the standard sqlite-jdbc / netty / snappy-java pattern. No behavioral change for existing CORE_PATH-based callers.