### PR TITLE
NO-SNOW: consolidate JDBC driver version constants

### DIFF
--- a/jdbc/build.gradle
+++ b/jdbc/build.gradle
@@ -36,7 +36,7 @@ configurations {
 
 dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
-    testImplementation 'org.mockito:mockito-core:4.6.1'
+    testImplementation 'org.mockito:mockito-core:4.11.0'
     testImplementation 'org.apache.httpcomponents.client5:httpclient5:5.4.4'
     testCompileOnly "org.projectlombok:lombok:${lombokVersion}"
     testAnnotationProcessor "org.projectlombok:lombok:${lombokVersion}"
@@ -80,6 +80,7 @@ checkstyle {
 tasks.withType(Checkstyle).configureEach {
     // Don't check generated sources
     exclude '**/protobuf_gen/**'
+    exclude '**/DriverVersion.java'
     reports {
         xml.required = true
         html.required = true
@@ -112,8 +113,35 @@ tasks.register('generateProtobuf', Exec) {
         '--output', 'src/main/java/'
 }
 
+def generatedVersionDir = layout.buildDirectory.dir("generated/sources/version/main/java")
+
+tasks.register('generateDriverVersion') {
+    inputs.property("version", project.version)
+    outputs.dir(generatedVersionDir)
+    doLast {
+        def pkgDir = generatedVersionDir.get()
+            .dir("net/snowflake/client/api/driver").asFile
+        pkgDir.mkdirs()
+        new File(pkgDir, "DriverVersion.java").text = """\
+package net.snowflake.client.api.driver;
+
+import javax.annotation.Generated;
+
+@Generated("generateDriverVersion")
+final class DriverVersion {
+  static final String VALUE = "${project.version}";
+
+  private DriverVersion() {}
+}
+"""
+    }
+}
+
+sourceSets.main.java.srcDir(generatedVersionDir)
+
 tasks.named('compileJava') {
     dependsOn('generateProtobuf')
+    dependsOn('generateDriverVersion')
 }
 
 // ====================
@@ -183,6 +211,9 @@ def configureCommonTestTask = { t ->
     if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_19)) {
         t.jvmArgs '--enable-native-access=ALL-UNNAMED'
     }
+    if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_21)) {
+        t.jvmArgs '-Dnet.bytebuddy.experimental=true'
+    }
 
     t.outputs.upToDateWhen { false }
 
@@ -222,6 +253,9 @@ tasks.register('referenceTest', Test) {
     testClassesDirs = sourceSets.test.output.classesDirs
     include 'net/snowflake/client/api/**'
     include 'net/snowflake/jdbc/**'
+    // Tests that reference symbols only present in this module's SnowflakeDriver
+    // (not on the legacy snowflake-jdbc artifact) must be excluded from this run.
+    exclude '**/SnowflakeDriverVersionTest.class'
     // Isolate old-driver reference tests from this module's main runtime deps.
     // Keep only test output/resources + test-only runtime deps + old JDBC driver deps.
     classpath = sourceSets.test.output +
@@ -253,7 +287,8 @@ jacocoTestReport {
     afterEvaluate {
         classDirectories.setFrom(files(classDirectories.files.collect {
             fileTree(dir: it, exclude: [
-                '**/protobuf_gen/**'
+                '**/protobuf_gen/**',
+                '**/DriverVersion.class'
             ])
         }))
     }

--- a/jdbc/src/main/java/net/snowflake/client/api/driver/SnowflakeDriver.java
+++ b/jdbc/src/main/java/net/snowflake/client/api/driver/SnowflakeDriver.java
@@ -7,6 +7,8 @@ import java.sql.DriverPropertyInfo;
 import java.sql.SQLException;
 import java.util.Properties;
 import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import net.snowflake.client.api.exception.SnowflakeSQLException;
 import net.snowflake.client.internal.api.implementation.connection.ConnectionString;
 import net.snowflake.client.internal.api.implementation.connection.SnowflakeConnectionImpl;
@@ -21,15 +23,27 @@ import net.snowflake.client.internal.log.SFLoggerFactory;
  */
 public class SnowflakeDriver implements Driver {
   private static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeDriver.class);
-  private static final String DRIVER_NAME = "Snowflake JDBC Driver";
-  private static final String DRIVER_VERSION = "4.0.0";
+
+  // Up to 9 digits keeps the result within Integer.MAX_VALUE so parseInt cannot overflow.
+  // Declared before the constants below because their initializers call parseVersionComponent.
+  private static final Pattern LEADING_DIGITS = Pattern.compile("\\d{1,9}");
+
+  public static final String DRIVER_NAME = "Snowflake JDBC Driver";
+
+  public static final String JDBC_SPEC_VERSION = "4.2";
+
+  /** Sourced from {@code build.gradle}'s {@code project.version} via the generated class. */
+  public static final String DRIVER_VERSION = DriverVersion.VALUE;
+
+  public static final int MAJOR_VERSION = parseVersionComponent(DRIVER_VERSION, 0);
+  public static final int MINOR_VERSION = parseVersionComponent(DRIVER_VERSION, 1);
+
+  public static final int JDBC_SPEC_MAJOR = parseVersionComponent(JDBC_SPEC_VERSION, 0);
+  public static final int JDBC_SPEC_MINOR = parseVersionComponent(JDBC_SPEC_VERSION, 1);
 
   public static String getDriverVersion() {
     return DRIVER_VERSION;
   }
-
-  private static final int MAJOR_VERSION = 4;
-  private static final int MINOR_VERSION = 0;
 
   public static void empty() {}
 
@@ -68,7 +82,6 @@ public class SnowflakeDriver implements Driver {
 
   @Override
   public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) throws SQLException {
-    // Return empty array for stub implementation
     return new DriverPropertyInfo[0];
   }
 
@@ -84,11 +97,28 @@ public class SnowflakeDriver implements Driver {
 
   @Override
   public boolean jdbcCompliant() {
-    return false; // Not fully compliant to JDBC 4.2 specification
+    // Not fully compliant with the JDBC 4.2 specification.
+    return false;
   }
 
   @Override
   public Logger getParentLogger() {
     return null;
+  }
+
+  /**
+   * Returns the {@code index}-th dot-separated component as a non-negative int, or {@code 0} when
+   * absent or non-numeric (e.g. {@code "0-SNAPSHOT"} yields {@code 0}).
+   */
+  static int parseVersionComponent(String version, int index) {
+    if (version == null || index < 0) {
+      return 0;
+    }
+    String[] parts = version.split("\\.", -1);
+    if (index >= parts.length) {
+      return 0;
+    }
+    Matcher matcher = LEADING_DIGITS.matcher(parts[index]);
+    return matcher.lookingAt() ? Integer.parseInt(matcher.group()) : 0;
   }
 }

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/connection/SnowflakeConnectionImpl.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/connection/SnowflakeConnectionImpl.java
@@ -27,6 +27,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import net.snowflake.client.api.connection.DownloadStreamConfig;
 import net.snowflake.client.api.connection.SnowflakeConnection;
 import net.snowflake.client.api.connection.UploadStreamConfig;
+import net.snowflake.client.api.driver.SnowflakeDriver;
 import net.snowflake.client.api.resultset.QueryStatus;
 import net.snowflake.client.internal.api.implementation.metadata.SnowflakeDatabaseMetaDataImpl;
 import net.snowflake.client.internal.api.implementation.statement.SnowflakePreparedStatementImpl;
@@ -92,7 +93,7 @@ public class SnowflakeConnectionImpl implements SnowflakeConnection, Connection 
     Builder identityBuilder =
         WrapperIdentity.newBuilder()
             .setDriverName("JDBC")
-            .setDriverVersion(determineClientAppVersion());
+            .setDriverVersion(SnowflakeDriver.DRIVER_VERSION);
     String runtimeName = System.getProperty("java.vm.name");
     if (runtimeName != null && !runtimeName.trim().isEmpty()) {
       identityBuilder.setLanguageRuntime(runtimeName);
@@ -184,17 +185,6 @@ public class SnowflakeConnectionImpl implements SnowflakeConnection, Connection 
           warning.getCode(),
           warning.getMessage());
     }
-  }
-
-  private String determineClientAppVersion() {
-    Package pkg = SnowflakeConnectionImpl.class.getPackage();
-    if (pkg != null) {
-      String version = pkg.getImplementationVersion();
-      if (version != null && !version.trim().isEmpty()) {
-        return version;
-      }
-    }
-    return "4.0.0";
   }
 
   @Override

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/metadata/SnowflakeDatabaseMetaDataImpl.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/metadata/SnowflakeDatabaseMetaDataImpl.java
@@ -7,14 +7,13 @@ import java.sql.RowIdLifetime;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import net.snowflake.client.api.connection.SnowflakeDatabaseMetaData;
+import net.snowflake.client.api.driver.SnowflakeDriver;
 import net.snowflake.client.internal.api.implementation.connection.SnowflakeConnectionImpl;
 import net.snowflake.client.internal.util.NotImplementedException;
 
 public class SnowflakeDatabaseMetaDataImpl implements DatabaseMetaData, SnowflakeDatabaseMetaData {
   private static final String DatabaseProductName = "Snowflake";
-  private static final String DriverName = "Snowflake";
   private static final char SEARCH_STRING_ESCAPE = '\\';
-  private static final String JDBCVersion = "4.2";
 
   private final SnowflakeConnectionImpl connection;
 
@@ -92,23 +91,23 @@ public class SnowflakeDatabaseMetaDataImpl implements DatabaseMetaData, Snowflak
   @Override
   public String getDriverName() throws SQLException {
     connection.checkClosed();
-    return DriverName;
+    return SnowflakeDriver.DRIVER_NAME;
   }
 
   @Override
   public String getDriverVersion() throws SQLException {
     connection.checkClosed();
-    throw new NotImplementedException();
+    return SnowflakeDriver.DRIVER_VERSION;
   }
 
   @Override
   public int getDriverMajorVersion() {
-    throw new NotImplementedException();
+    return SnowflakeDriver.MAJOR_VERSION;
   }
 
   @Override
   public int getDriverMinorVersion() {
-    throw new NotImplementedException();
+    return SnowflakeDriver.MINOR_VERSION;
   }
 
   @Override
@@ -1004,13 +1003,13 @@ public class SnowflakeDatabaseMetaDataImpl implements DatabaseMetaData, Snowflak
   @Override
   public int getJDBCMajorVersion() throws SQLException {
     connection.checkClosed();
-    return Integer.parseInt(JDBCVersion.split("\\.", 2)[0]);
+    return SnowflakeDriver.JDBC_SPEC_MAJOR;
   }
 
   @Override
   public int getJDBCMinorVersion() throws SQLException {
     connection.checkClosed();
-    return Integer.parseInt(JDBCVersion.split("\\.", 2)[1]);
+    return SnowflakeDriver.JDBC_SPEC_MINOR;
   }
 
   @Override

--- a/jdbc/src/test/java/net/snowflake/client/api/driver/SnowflakeDriverTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/api/driver/SnowflakeDriverTest.java
@@ -19,12 +19,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-/** Basic tests for the Snowflake JDBC Driver */
+/** Basic tests for the Snowflake JDBC Driver. */
 public class SnowflakeDriverTest {
 
   @Test
   public void testDriverRegistration() throws SQLException {
-    // Test that the driver is properly registered
     Driver driver = DriverManager.getDriver("jdbc:snowflake://test.snowflakecomputing.com");
     assertNotNull(driver, "Driver should be registered");
     assertInstanceOf(SnowflakeDriver.class, driver, "Driver should be instance of SnowflakeDriver");

--- a/jdbc/src/test/java/net/snowflake/client/api/driver/SnowflakeDriverVersionTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/api/driver/SnowflakeDriverVersionTest.java
@@ -1,0 +1,80 @@
+package net.snowflake.client.api.driver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Excluded from the old-driver reference test because these assertions reference fields and methods
+ * (MAJOR_VERSION, JDBC_SPEC_MAJOR, parseVersionComponent) that do not exist on the legacy
+ * snowflake-jdbc artifact.
+ */
+public class SnowflakeDriverVersionTest {
+
+  @Test
+  public void driverNameIsExpectedLiteral() {
+    assertEquals("Snowflake JDBC Driver", SnowflakeDriver.DRIVER_NAME);
+  }
+
+  @Test
+  public void driverVersionIsPopulatedFromGeneratedConstant() {
+    assertNotNull(SnowflakeDriver.DRIVER_VERSION);
+    assertFalse(SnowflakeDriver.DRIVER_VERSION.trim().isEmpty());
+  }
+
+  @Test
+  public void majorAndMinorVersionAgreeWithDriverVersion() {
+    assertEquals(
+        SnowflakeDriver.MAJOR_VERSION,
+        SnowflakeDriver.parseVersionComponent(SnowflakeDriver.DRIVER_VERSION, 0));
+    assertEquals(
+        SnowflakeDriver.MINOR_VERSION,
+        SnowflakeDriver.parseVersionComponent(SnowflakeDriver.DRIVER_VERSION, 1));
+  }
+
+  @Test
+  public void instanceMethodsAgreeWithConstants() {
+    SnowflakeDriver driver = new SnowflakeDriver();
+    assertEquals(SnowflakeDriver.MAJOR_VERSION, driver.getMajorVersion());
+    assertEquals(SnowflakeDriver.MINOR_VERSION, driver.getMinorVersion());
+    assertEquals(SnowflakeDriver.DRIVER_VERSION, SnowflakeDriver.getDriverVersion());
+  }
+
+  @Test
+  public void jdbcSpecVersionIsFourDotTwo() {
+    assertEquals("4.2", SnowflakeDriver.JDBC_SPEC_VERSION);
+    assertEquals(4, SnowflakeDriver.JDBC_SPEC_MAJOR);
+    assertEquals(2, SnowflakeDriver.JDBC_SPEC_MINOR);
+  }
+
+  @Test
+  public void parseVersionComponentHandlesStandardSemver() {
+    assertEquals(1, SnowflakeDriver.parseVersionComponent("1.2.3", 0));
+    assertEquals(2, SnowflakeDriver.parseVersionComponent("1.2.3", 1));
+    assertEquals(3, SnowflakeDriver.parseVersionComponent("1.2.3", 2));
+  }
+
+  @Test
+  public void parseVersionComponentReturnsZeroForOutOfBoundsIndex() {
+    assertEquals(1, SnowflakeDriver.parseVersionComponent("1", 0));
+    assertEquals(0, SnowflakeDriver.parseVersionComponent("1", 1));
+    assertEquals(0, SnowflakeDriver.parseVersionComponent("1.2", 5));
+    assertEquals(0, SnowflakeDriver.parseVersionComponent("1.2.3", -1));
+  }
+
+  @Test
+  public void parseVersionComponentReturnsZeroForInvalidInput() {
+    assertEquals(0, SnowflakeDriver.parseVersionComponent("", 0));
+    assertEquals(0, SnowflakeDriver.parseVersionComponent(null, 0));
+    assertEquals(0, SnowflakeDriver.parseVersionComponent("1.x", 1));
+    assertEquals(1, SnowflakeDriver.parseVersionComponent("1.x", 0));
+  }
+
+  @Test
+  public void parseVersionComponentStripsTrailingNonDigits() {
+    assertEquals(4, SnowflakeDriver.parseVersionComponent("4.0.0-SNAPSHOT", 0));
+    assertEquals(0, SnowflakeDriver.parseVersionComponent("4.0.0-SNAPSHOT", 2));
+  }
+}

--- a/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/metadata/SnowflakeDatabaseMetaDataImplTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/metadata/SnowflakeDatabaseMetaDataImplTest.java
@@ -1,0 +1,44 @@
+package net.snowflake.client.internal.api.implementation.metadata;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import net.snowflake.client.api.driver.SnowflakeDriver;
+import net.snowflake.client.internal.api.implementation.connection.SnowflakeConnectionImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SnowflakeDatabaseMetaDataImplTest {
+
+  private SnowflakeConnectionImpl connection;
+  private SnowflakeDatabaseMetaDataImpl metadata;
+
+  @BeforeEach
+  void setUp() {
+    connection = mock(SnowflakeConnectionImpl.class);
+    metadata = new SnowflakeDatabaseMetaDataImpl(connection);
+  }
+
+  @Test
+  void getDriverNameReturnsCanonicalDriverName() throws Exception {
+    assertEquals(SnowflakeDriver.DRIVER_NAME, metadata.getDriverName());
+    assertEquals("Snowflake JDBC Driver", metadata.getDriverName());
+  }
+
+  @Test
+  void getDriverVersionReturnsConstant() throws Exception {
+    assertEquals(SnowflakeDriver.DRIVER_VERSION, metadata.getDriverVersion());
+  }
+
+  @Test
+  void getDriverMajorMinorReturnConstants() {
+    assertEquals(SnowflakeDriver.MAJOR_VERSION, metadata.getDriverMajorVersion());
+    assertEquals(SnowflakeDriver.MINOR_VERSION, metadata.getDriverMinorVersion());
+  }
+
+  @Test
+  void getJDBCMajorMinorReturnFourTwo() throws Exception {
+    assertEquals(4, metadata.getJDBCMajorVersion());
+    assertEquals(2, metadata.getJDBCMinorVersion());
+  }
+}


### PR DESCRIPTION
Make build.gradle's project.version the single source of truth for the
JDBC driver version via a new generateDriverVersion Gradle task that
writes a package-private DriverVersion.java at compile time (mirrors
the existing generateProtobuf pattern). Promote DRIVER_NAME, DRIVER_VERSION,
JDBC_SPEC_VERSION, MAJOR_VERSION, MINOR_VERSION, JDBC_SPEC_MAJOR,
JDBC_SPEC_MINOR to public constants on SnowflakeDriver and derive
major/minor from DRIVER_VERSION via a regex-based parseVersionComponent
helper so they cannot drift.

Wire SnowflakeDatabaseMetaDataImpl.getDriverName/Version/Major/Minor
(previously NotImplementedException) and the JDBC-spec methods through
the SnowflakeDriver constants. Align getDriverName() to "Snowflake JDBC
Driver" (was "Snowflake"). Delete SnowflakeConnectionImpl.determineClientAppVersion()
and read SnowflakeDriver.DRIVER_VERSION directly when populating
WrapperIdentity.

Latent-bug fix: previously Driver.getDriverVersion()/getMajorVersion()/
getMinorVersion() returned hardcoded constants while WrapperIdentity sent
a manifest-resolved value. They now agree by construction.

Adds SnowflakeDriverTest version cases on top of the existing URL/
registration tests, plus a new SnowflakeDatabaseMetaDataImplTest.