### PR TITLE
NO-SNOW: implement getDatabaseProductVersion via cached SELECT CURRENT_VERSION()

### DIFF
--- a/jdbc/src/main/java/net/snowflake/client/api/driver/SnowflakeDriver.java
+++ b/jdbc/src/main/java/net/snowflake/client/api/driver/SnowflakeDriver.java
@@ -110,7 +110,7 @@ public class SnowflakeDriver implements Driver {
    * Returns the {@code index}-th dot-separated component as a non-negative int, or {@code 0} when
    * absent or non-numeric (e.g. {@code "0-SNAPSHOT"} yields {@code 0}).
    */
-  static int parseVersionComponent(String version, int index) {
+  public static int parseVersionComponent(String version, int index) {
     if (version == null || index < 0) {
       return 0;
     }

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/connection/SnowflakeConnectionImpl.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/connection/SnowflakeConnectionImpl.java
@@ -58,6 +58,9 @@ public class SnowflakeConnectionImpl implements SnowflakeConnection, Connection 
   private final DatabaseHandle databaseHandle;
   public final ConnectionHandle connectionHandle;
 
+  private volatile String cachedDatabaseVersion;
+  private final Object databaseVersionLock = new Object();
+
   public SnowflakeConnectionImpl(String url, Properties properties) throws SQLException {
     this(url, properties, ProtobufApis.coreDriverApi);
   }
@@ -539,16 +542,51 @@ public class SnowflakeConnectionImpl implements SnowflakeConnection, Connection 
 
   @Override
   public int getDatabaseMajorVersion() throws SQLException {
-    throw new NotImplementedException();
+    return SnowflakeDriver.parseVersionComponent(getDatabaseVersion(), 0);
   }
 
   @Override
   public int getDatabaseMinorVersion() throws SQLException {
-    throw new NotImplementedException();
+    return SnowflakeDriver.parseVersionComponent(getDatabaseVersion(), 1);
   }
 
+  /** Issues a single {@code SELECT CURRENT_VERSION()} on first call per connection; cached. */
   @Override
   public String getDatabaseVersion() throws SQLException {
-    throw new NotImplementedException();
+    checkClosed();
+    String cached = cachedDatabaseVersion;
+    if (cached != null) {
+      return cached;
+    }
+    synchronized (databaseVersionLock) {
+      if (cachedDatabaseVersion == null) {
+        cachedDatabaseVersion = fetchDatabaseVersion();
+      }
+      return cachedDatabaseVersion;
+    }
+  }
+
+  private String fetchDatabaseVersion() throws SQLException {
+    try (Statement stmt = createStatement();
+        ResultSet rs = stmt.executeQuery("SELECT CURRENT_VERSION()")) {
+      if (!rs.next()) {
+        throw new SQLException("SELECT CURRENT_VERSION() returned no rows");
+      }
+      String raw = rs.getString(1);
+      if (raw == null) {
+        throw new SQLException("SELECT CURRENT_VERSION() returned NULL");
+      }
+      return stripVersionSuffix(raw);
+    }
+  }
+
+  // The server returns e.g. "8.46.1 abcdef"; the build suffix is not part of the public version.
+  static String stripVersionSuffix(String raw) {
+    if (raw == null) {
+      return null;
+    }
+    String trimmed = raw.trim();
+    int spaceIdx = trimmed.indexOf(' ');
+    return spaceIdx < 0 ? trimmed : trimmed.substring(0, spaceIdx);
   }
 }

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/metadata/SnowflakeDatabaseMetaDataImpl.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/metadata/SnowflakeDatabaseMetaDataImpl.java
@@ -85,7 +85,7 @@ public class SnowflakeDatabaseMetaDataImpl implements DatabaseMetaData, Snowflak
   @Override
   public String getDatabaseProductVersion() throws SQLException {
     connection.checkClosed();
-    throw new NotImplementedException();
+    return connection.getDatabaseVersion();
   }
 
   @Override

--- a/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/connection/SnowflakeConnectionImplTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/connection/SnowflakeConnectionImplTest.java
@@ -73,6 +73,31 @@ public class SnowflakeConnectionImplTest {
     assertNull(SnowflakeConnectionImpl.toConfigSetting(new Object()));
   }
 
+  @Test
+  public void stripVersionSuffixReturnsInputWhenNoSpace() {
+    assertEquals("8.46.1", SnowflakeConnectionImpl.stripVersionSuffix("8.46.1"));
+  }
+
+  @Test
+  public void stripVersionSuffixDropsBuildSuffix() {
+    assertEquals("8.46.1", SnowflakeConnectionImpl.stripVersionSuffix("8.46.1 abcdef"));
+    assertEquals("8.46.1", SnowflakeConnectionImpl.stripVersionSuffix("8.46.1 a b c"));
+  }
+
+  @Test
+  public void stripVersionSuffixHandlesEmptyAndNull() {
+    assertNull(SnowflakeConnectionImpl.stripVersionSuffix(null));
+    assertEquals("", SnowflakeConnectionImpl.stripVersionSuffix(""));
+    assertEquals("", SnowflakeConnectionImpl.stripVersionSuffix("   "));
+  }
+
+  @Test
+  public void stripVersionSuffixTrimsLeadingAndTrailingWhitespace() {
+    assertEquals("8.46.1", SnowflakeConnectionImpl.stripVersionSuffix(" 8.46.1"));
+    assertEquals("8.46.1", SnowflakeConnectionImpl.stripVersionSuffix("8.46.1 "));
+    assertEquals("8.46.1", SnowflakeConnectionImpl.stripVersionSuffix("  8.46.1 abc  "));
+  }
+
   @Nested
   class Close {
 

--- a/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/metadata/SnowflakeDatabaseMetaDataImplTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/metadata/SnowflakeDatabaseMetaDataImplTest.java
@@ -2,6 +2,9 @@ package net.snowflake.client.internal.api.implementation.metadata;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import net.snowflake.client.api.driver.SnowflakeDriver;
 import net.snowflake.client.internal.api.implementation.connection.SnowflakeConnectionImpl;
@@ -40,5 +43,12 @@ class SnowflakeDatabaseMetaDataImplTest {
   void getJDBCMajorMinorReturnFourTwo() throws Exception {
     assertEquals(4, metadata.getJDBCMajorVersion());
     assertEquals(2, metadata.getJDBCMinorVersion());
+  }
+
+  @Test
+  void getDatabaseProductVersionDelegatesToConnection() throws Exception {
+    when(connection.getDatabaseVersion()).thenReturn("8.46.1");
+    assertEquals("8.46.1", metadata.getDatabaseProductVersion());
+    verify(connection, times(1)).getDatabaseVersion();
   }
 }

--- a/jdbc/src/test/java/net/snowflake/jdbc/e2e/session/DatabaseVersionTests.java
+++ b/jdbc/src/test/java/net/snowflake/jdbc/e2e/session/DatabaseVersionTests.java
@@ -1,0 +1,81 @@
+package net.snowflake.jdbc.e2e.session;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import net.snowflake.jdbc.utils.SnowflakeIntegrationTestBase;
+import org.junit.jupiter.api.Test;
+
+public class DatabaseVersionTests extends SnowflakeIntegrationTestBase {
+
+  @Test
+  public void getDatabaseProductVersionMatchesSemverRegex() throws Exception {
+    // Given Snowflake client is logged in
+    Connection conn = getDefaultConnection();
+
+    // When DatabaseMetaData.getDatabaseProductVersion() is called
+    String version = conn.getMetaData().getDatabaseProductVersion();
+
+    // Then the result is a stripped semver-style string with no build suffix
+    assertNotNull(version, "getDatabaseProductVersion should not return null");
+    assertTrue(
+        version.matches("^\\d+\\.\\d+\\.\\d+$"), "Expected stripped SEMVER, got: " + version);
+  }
+
+  @Test
+  public void getDatabaseProductVersionMatchesRawCurrentVersionQuery() throws Exception {
+    // Given Snowflake client is logged in
+    Connection conn = getDefaultConnection();
+
+    // When the metadata version and the raw SELECT CURRENT_VERSION() result are both fetched
+    String fromMetadata = conn.getMetaData().getDatabaseProductVersion();
+    String fromQuery;
+    try (Statement stmt = conn.createStatement();
+        ResultSet rs = stmt.executeQuery("SELECT CURRENT_VERSION()")) {
+      assertTrue(rs.next(), "Expected one row from SELECT CURRENT_VERSION()");
+      fromQuery = rs.getString(1).split(" ")[0];
+    }
+
+    // Then both should return the same stripped version string
+    assertEquals(fromQuery, fromMetadata);
+  }
+
+  @Test
+  public void getDatabaseMajorAndMinorMatchVersionString() throws Exception {
+    // Given Snowflake client is logged in
+    Connection conn = getDefaultConnection();
+    DatabaseMetaData metadata = conn.getMetaData();
+
+    // When the version string and the major/minor integers are read from DatabaseMetaData
+    String version = metadata.getDatabaseProductVersion();
+    int major = metadata.getDatabaseMajorVersion();
+    int minor = metadata.getDatabaseMinorVersion();
+
+    // Then the integers match the dot-separated components of the version string
+    String[] parts = version.split("\\.");
+    assertEquals(Integer.parseInt(parts[0]), major);
+    assertEquals(Integer.parseInt(parts[1]), minor);
+  }
+
+  @Test
+  public void getDatabaseProductVersionIsStableAcrossCalls() throws Exception {
+    // Given Snowflake client is logged in
+    Connection conn = getDefaultConnection();
+    DatabaseMetaData metadata = conn.getMetaData();
+
+    // When DatabaseMetaData.getDatabaseProductVersion() is called twice
+    // (value-equality only; this asserts the cache returns consistently, not that the
+    //  cache prevents a second query - CURRENT_VERSION() is server-invariant within a session,
+    //  so an uncached implementation would also pass this)
+    String first = metadata.getDatabaseProductVersion();
+    String second = metadata.getDatabaseProductVersion();
+
+    // Then both calls return the same string
+    assertEquals(first, second);
+  }
+}


### PR DESCRIPTION
Implement getDatabaseVersion/MajorVersion/MinorVersion on SnowflakeConnectionImpl
via a per-connection cache populated lazily on first call by running
SELECT CURRENT_VERSION() (mirrors the Python connector pattern). Wire
SnowflakeDatabaseMetaDataImpl.getDatabaseProductVersion() to the connection.

The build suffix returned by the server (e.g. "8.46.1 abcdef") is stripped
to match the legacy Snowflake JDBC driver and the Python connector.
Failures propagate as SQLException; the cache is not populated on failure
so the next call retries.

Cache uses double-checked locking with a volatile field. Widens
SnowflakeDriver.parseVersionComponent to public so the connection (in a
different package) can reuse it.

The protobuf ConnectionGetInfoResponse does not currently carry
vendor_version, so we follow the SELECT CURRENT_VERSION() approach.
Avoiding the round-trip via a protocol extension is a worthwhile follow-up
but out of scope here.

Adds 4 unit tests for stripVersionSuffix, 1 Mockito test verifying
metadata-to-connection delegation, and a DatabaseVersionTests e2e suite
covering anchored regex, parity with raw query, major/minor parsing, and
value-stability across calls.