### PR TITLE
SNOW-3571049: SQLGetInfo — implement DRIVER_NAME, DRIVER_VER, DBMS_VER info types

### DIFF
--- a/odbc/src/api/connection.rs
+++ b/odbc/src/api/connection.rs
@@ -1189,7 +1189,7 @@ pub fn get_info<E: OdbcEncoding>(
 ) -> OdbcResult<()> {
     tracing::debug!("get_info: connection_handle={connection_handle:?}, info_type={info_type}");
 
-    let _conn = conn_from_handle(connection_handle)?;
+    let dbc = conn_from_handle(connection_handle)?;
 
     let info_type = InfoType::try_from(info_type)?;
     tracing::debug!("get_info: info_type={info_type:?}");
@@ -1209,9 +1209,68 @@ pub fn get_info<E: OdbcEncoding>(
             }
             Ok(())
         }
+        InfoType::DriverName => {
+            write_string_bytes::<E>(
+                ODBC_DRIVER_NAME,
+                info_value_ptr as *mut E::Char,
+                buffer_length,
+                string_length_ptr,
+                None,
+            );
+            Ok(())
+        }
+        InfoType::DriverVer => {
+            write_string_bytes::<E>(
+                ODBC_DRIVER_VERSION,
+                info_value_ptr as *mut E::Char,
+                buffer_length,
+                string_length_ptr,
+                None,
+            );
+            Ok(())
+        }
         InfoType::DbmsName => {
             write_string_bytes::<E>(
                 "Snowflake",
+                info_value_ptr as *mut E::Char,
+                buffer_length,
+                string_length_ptr,
+                None,
+            );
+            Ok(())
+        }
+        InfoType::DbmsVer => {
+            // Sourced from `serverVersion` in the login response (parsed in
+            // [`sf_core::rest::snowflake::auth::AuthResponseMain`]). Matches
+            // the legacy driver and avoids the extra `SELECT CURRENT_VERSION()`
+            // round trip that JDBC currently performs.
+            //
+            // Uses the dedicated `connection_get_server_version` getter
+            // rather than `connection_get_info` — Excel polls this attribute
+            // during `SQLDriverConnect` and the full info aggregation is
+            // wasteful when only the version is needed.
+            //
+            // Before the connection is established, sf_core has no
+            // `server_version` yet — return an empty string instead of
+            // surfacing an error so callers that probe this attribute during
+            // `SQLDriverConnect` (Excel does) still succeed.
+            let conn_handle = match dbc.connection.lock().state {
+                ConnectionState::Connected { conn_handle, .. } => Some(conn_handle),
+                ConnectionState::Disconnected => None,
+            };
+            let version = match conn_handle {
+                Some(handle) => global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
+                    let resp = c
+                        .connection_get_server_version(ConnectionGetServerVersionRequest {
+                            conn_handle: Some(handle),
+                        })
+                        .await?;
+                    Ok::<Option<String>, crate::api::OdbcError>(resp.server_version)
+                })?,
+                None => None,
+            };
+            write_string_bytes::<E>(
+                version.as_deref().unwrap_or(""),
                 info_value_ptr as *mut E::Char,
                 buffer_length,
                 string_length_ptr,

--- a/odbc/src/api/types/odbc_types.rs
+++ b/odbc/src/api/types/odbc_types.rs
@@ -169,8 +169,14 @@ impl ConnectionAttribute {
 #[repr(u16)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum InfoType {
+    /// `SQL_DRIVER_NAME` (6) — name of the driver shared library (string).
+    DriverName = 6,
+    /// `SQL_DRIVER_VER` (7) — driver release version (string).
+    DriverVer = 7,
     /// `SQL_DBMS_NAME` (17) — name of the DBMS product (string).
     DbmsName = 17,
+    /// `SQL_DBMS_VER` (18) — version of the DBMS the connection is talking to (string).
+    DbmsVer = 18,
     /// `SQL_CURSOR_COMMIT_BEHAVIOR` (23) — cursor behavior on commit.
     CursorCommitBehavior = 23,
     /// `SQL_CURSOR_ROLLBACK_BEHAVIOR` (24) — cursor behavior on rollback.
@@ -186,7 +192,10 @@ impl TryFrom<u16> for InfoType {
 
     fn try_from(value: u16) -> Result<Self, Self::Error> {
         match value {
+            6 => Ok(InfoType::DriverName),
+            7 => Ok(InfoType::DriverVer),
             17 => Ok(InfoType::DbmsName),
+            18 => Ok(InfoType::DbmsVer),
             23 => Ok(InfoType::CursorCommitBehavior),
             24 => Ok(InfoType::CursorRollbackBehavior),
             77 => Ok(InfoType::DriverOdbcVer),
@@ -416,6 +425,10 @@ pub enum DescField {
     Count = 1001,
     /// `SQL_DESC_TYPE` (1002) — verbose data type of the column.
     Type = 1002,
+    /// `SQL_DESC_LENGTH` (1003) — column length in characters (or scale-derived
+    /// precision for temporal types, byte length for binary types). Distinct
+    /// from `SQL_DESC_OCTET_LENGTH` (1013), which is always in bytes.
+    Length = 1003,
     /// `SQL_DESC_OCTET_LENGTH_PTR` (1004) — pointer to the octet-length buffer.
     OctetLengthPtr = 1004,
     /// `SQL_DESC_PRECISION` (1005) — numeric precision.
@@ -426,6 +439,8 @@ pub enum DescField {
     IndicatorPtr = 1009,
     /// `SQL_DESC_DATA_PTR` (1010) — pointer to the data buffer.
     DataPtr = 1010,
+    /// `SQL_DESC_NAME` (1011) — column name (string, IRD only).
+    Name = 1011,
     /// `SQL_DESC_OCTET_LENGTH` (1013) — length in bytes of the data buffer.
     OctetLength = 1013,
     /// `SQL_DESC_PARAMETER_TYPE` (33) — parameter direction (IPD only).
@@ -450,6 +465,7 @@ impl TryFrom<i16> for DescField {
             34 => Ok(DescField::RowsProcessedPtr),
             1001 => Ok(DescField::Count),
             1002 => Ok(DescField::Type),
+            1003 => Ok(DescField::Length),
             14 => Ok(DescField::TypeName),
             1004 => Ok(DescField::OctetLengthPtr),
             1005 => Ok(DescField::Precision),
@@ -457,6 +473,7 @@ impl TryFrom<i16> for DescField {
             1008 => Ok(DescField::Nullable),
             1009 => Ok(DescField::IndicatorPtr),
             1010 => Ok(DescField::DataPtr),
+            1011 => Ok(DescField::Name),
             1013 => Ok(DescField::OctetLength),
             33 => Ok(DescField::ParameterType),
             _ => {
@@ -1610,5 +1627,51 @@ mod tests {
             TimestampSubtype::from_parameter_type(sql::SqlDataType(95)),
             None
         );
+    }
+
+    /// Pin the on-the-wire mapping for `SQLGetInfo` codes the new ODBC driver
+    /// claims to support. Excel/PowerQuery probes 6/7/17/18/77/81 during
+    /// `SQLDriverConnect`; bumping these values breaks the AS-bound trace
+    /// replay tests and breaks application discovery.
+    #[test]
+    fn info_type_try_from_round_trip() {
+        assert_eq!(InfoType::try_from(6_u16).unwrap(), InfoType::DriverName);
+        assert_eq!(InfoType::try_from(7_u16).unwrap(), InfoType::DriverVer);
+        assert_eq!(InfoType::try_from(17_u16).unwrap(), InfoType::DbmsName);
+        assert_eq!(InfoType::try_from(18_u16).unwrap(), InfoType::DbmsVer);
+        assert_eq!(
+            InfoType::try_from(23_u16).unwrap(),
+            InfoType::CursorCommitBehavior
+        );
+        assert_eq!(
+            InfoType::try_from(24_u16).unwrap(),
+            InfoType::CursorRollbackBehavior
+        );
+        assert_eq!(InfoType::try_from(77_u16).unwrap(), InfoType::DriverOdbcVer);
+        assert_eq!(
+            InfoType::try_from(81_u16).unwrap(),
+            InfoType::GetDataExtensions
+        );
+
+        match InfoType::try_from(9999_u16) {
+            Err(OdbcError::UnknownInfoType { info_type, .. }) => assert_eq!(info_type, 9999),
+            other => panic!("expected UnknownInfoType, got {other:?}"),
+        }
+    }
+
+    /// Excel uses `SQLColAttribute(SQL_DESC_NAME)` and `SQL_DESC_LENGTH` while
+    /// rendering result-set previews. Pin the discriminants so descriptor
+    /// dispatch keeps routing to the column-name / column-size code paths.
+    #[test]
+    fn desc_field_try_from_round_trip() {
+        assert_eq!(DescField::try_from(1003_i16).unwrap(), DescField::Length);
+        assert_eq!(DescField::try_from(1011_i16).unwrap(), DescField::Name);
+        assert_eq!(DescField::try_from(2_i16).unwrap(), DescField::ConciseType);
+        assert_eq!(DescField::try_from(1002_i16).unwrap(), DescField::Type);
+
+        match DescField::try_from(-1_i16) {
+            Err(OdbcError::UnknownAttribute { attribute, .. }) => assert_eq!(attribute, -1),
+            other => panic!("expected UnknownAttribute, got {other:?}"),
+        }
     }
 }

--- a/odbc/src/api/utils.rs
+++ b/odbc/src/api/utils.rs
@@ -159,6 +159,38 @@ pub fn col_attribute<E: OdbcEncoding>(
             }
             Ok(())
         }
+        DescField::Name => {
+            // Per ODBC spec, SQL_DESC_NAME returns the column name when one
+            // exists. Snowflake's result-set schema always carries a name,
+            // even for `SELECT 1` (`"1"`), so no SQL_DESC_UNNAMED handling is
+            // needed here.
+            write_string_bytes::<E>(
+                field.name(),
+                character_attribute_ptr,
+                buffer_length,
+                string_length_ptr,
+                Some(warnings),
+            );
+            Ok(())
+        }
+        DescField::Length => {
+            // SQL_DESC_LENGTH is the column's logical length (characters for
+            // strings, scale-derived precision for temporal types, byte
+            // length for binary). Distinct from SQL_DESC_OCTET_LENGTH (1013),
+            // which is always in bytes. `column_size_from_field` dispatches
+            // through `SnowflakeFieldType::column_size` to the per-type
+            // `WriteODBCType::column_size` impls under `odbc/src/conversion/`,
+            // which is where the actual formulas live.
+            let dbc = guard.conn()?;
+            let settings = dbc.connection.lock().numeric_settings;
+            let col_size = column_size_from_field(field, &settings).context(ConversionSnafu)?;
+            if !numeric_attribute_ptr.is_null() {
+                unsafe {
+                    std::ptr::write(numeric_attribute_ptr, col_size as sql::Len);
+                }
+            }
+            Ok(())
+        }
         DescField::TypeName => {
             let logical_type = field
                 .metadata()

--- a/odbc_tests/BehaviorDifferences.yaml
+++ b/odbc_tests/BehaviorDifferences.yaml
@@ -812,3 +812,19 @@ behavior_differences:
       SQLCancel on an async statement sends a cancel request to the server, and subsequent polling returns SQL_ERROR with SQLSTATE HY008 ("Operation canceled") once the cancellation is acknowledged.
     impact: |
       Applications that rely on SQLCancel to abort long-running async queries will not get timely cancellation on the old driver. The query may run to completion despite the cancel request.
+
+  59:
+    name: "SQLGetInfo driver-info types no longer require an active connection"
+    status: unknown
+    type: bugfix
+    reviewed: false
+    old_driver_behavior: |
+      SQLGetInfo for SQL_DRIVER_NAME, SQL_DRIVER_VER, and SQL_DRIVER_ODBC_VER returns SQLSTATE 08003 ("Connection not open") if called on a connection handle before SQLConnect / SQLDriverConnect succeeds.
+    new_driver_behavior: |
+      SQLGetInfo for SQL_DRIVER_NAME, SQL_DRIVER_VER, and SQL_DRIVER_ODBC_VER returns SQL_SUCCESS with the driver name / version string regardless of connection state. This matches the ODBC specification, which explicitly lists SQL_DRIVER_HENV, SQL_DRIVER_HDBC, SQL_DRIVER_NAME, SQL_DRIVER_ODBC_VER, and SQL_DRIVER_VER as info types that may be queried before a connection is established (see Microsoft "SQLGetInfo Function" docs).
+    impact: |
+      Applications that interrogate the driver name or version before connecting (the typical reason the spec carves these out — e.g. version-gating code paths, telemetry, or Driver Manager probing) now work without first opening a connection. Applications that relied on receiving 08003 from SQL_DRIVER_NAME on an unconnected handle (which is non-spec) will no longer see that error.
+
+      Note: some Driver Managers (notably the Windows DM) may still intercept the call and synthesise 08003 themselves; the difference is therefore visible on iODBC / unixODBC platforms where the call is forwarded to the driver.
+
+      The test `SQLGetInfo: SQL_DRIVER_NAME before active connection` (odbc_tests/tests/odbc-api/driver_info/get_info_tests.cpp) exercises both behaviours via OLD_DRIVER_ONLY/NEW_DRIVER_ONLY branches tagged with BD#59. The new-driver branch further splits on platform (UNIX_ONLY vs WINDOWS_ONLY) because unixODBC/iODBC still synthesise 08003 themselves; Windows DM is expected to forward the call so the driver's spec-compliant SQL_SUCCESS is visible to the application.

--- a/odbc_tests/tests/odbc-api/driver_info/get_info_tests.cpp
+++ b/odbc_tests/tests/odbc-api/driver_info/get_info_tests.cpp
@@ -3983,13 +3983,27 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: HY090 - Negative BufferLengt
   SQLDisconnect(dbc_handle());
 }
 
-TEST_CASE_METHOD(DbcFixture, "SQLGetInfo: Requires active connection even for driver info",
-                 "[odbc-api][getinfo][driver_info][error]") {
+TEST_CASE_METHOD(DbcFixture, "SQLGetInfo: SQL_DRIVER_NAME before active connection",
+                 "[odbc-api][getinfo][driver_info]") {
   char driverName[256];
-  const SQLRETURN ret = SQLGetInfo(dbc_handle(), SQL_DRIVER_NAME, driverName, sizeof(driverName), nullptr);
+  SQLSMALLINT nameLen = 0;
+  const SQLRETURN ret = SQLGetInfo(dbc_handle(), SQL_DRIVER_NAME, driverName, sizeof(driverName), &nameLen);
 
-  // Note: Reference driver requires active connection even for driver info
-  REQUIRE_EXPECTED_ERROR(ret, "08003", dbc_handle(), SQL_HANDLE_DBC);
+  OLD_DRIVER_ONLY("BD#59") {
+    // Non-spec: reference driver requires an active connection even for driver-info types.
+    REQUIRE_EXPECTED_ERROR(ret, "08003", dbc_handle(), SQL_HANDLE_DBC);
+  }
+  NEW_DRIVER_ONLY("BD#59") {
+    // Per ODBC spec, SQL_DRIVER_NAME may be queried before a connection is established,
+    // and the new driver returns SQL_SUCCESS unconditionally. However, unixODBC/iODBC
+    // intercept the call on an unconnected handle and synthesise 08003 themselves, so
+    // on Unix we still observe the old behaviour at the application level.
+    UNIX_ONLY { REQUIRE_EXPECTED_ERROR(ret, "08003", dbc_handle(), SQL_HANDLE_DBC); }
+    WINDOWS_ONLY {
+      REQUIRE(ret == SQL_SUCCESS);
+      REQUIRE(nameLen > 0);
+    }
+  }
 }
 
 TEST_CASE_METHOD(DbcFixture, "SQLGetInfo: Returns error before connection for data source info",

--- a/odbc_tests/tests/odbc-api/driver_info/get_info_tests.cpp
+++ b/odbc_tests/tests/odbc-api/driver_info/get_info_tests.cpp
@@ -136,8 +136,6 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DRIVER_AWARE_POOLING_SUP
 // are implemented by the driver manager alone
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DRIVER_NAME", "[odbc-api][getinfo][driver_info]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-
   SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -147,6 +145,9 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DRIVER_NAME", "[odbc-api
 
   REQUIRE(ret == SQL_SUCCESS);
   REQUIRE(nameLen > 0);
+
+  // The exact driver name string is not finalized for the new driver yet.
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   REQUIRE(std::string(driverName) == "Snowflake");
 
   SQLDisconnect(dbc_handle());
@@ -170,8 +171,6 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DRIVER_ODBC_VER", "[odbc
 }
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DRIVER_VER", "[odbc-api][getinfo][driver_info]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-
   SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -181,6 +180,9 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DRIVER_VER", "[odbc-api]
 
   REQUIRE(ret == SQL_SUCCESS);
   REQUIRE(verLen > 0);
+
+  // The exact driver version format is not finalized for the new driver yet.
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   REQUIRE(std::count(driverVer, driverVer + verLen, '.') == 2);  // Format: ##.##.####
 
   SQLDisconnect(dbc_handle());
@@ -719,8 +721,6 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DBMS_NAME", "[odbc-api][
 }
 
 TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DBMS_VER", "[odbc-api][getinfo][driver_info]") {
-  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
-
   SQLRETURN ret = SQLConnect(dbc_handle(), sqlchar(dsn_name().c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
   REQUIRE(ret == SQL_SUCCESS);
 
@@ -730,6 +730,9 @@ TEST_CASE_METHOD(DbcDefaultDSNFixture, "SQLGetInfo: SQL_DBMS_VER", "[odbc-api][g
 
   REQUIRE(ret == SQL_SUCCESS);
   REQUIRE(verLen > 0);
+
+  // The exact DBMS version format is not finalized for the new driver yet.
+  SKIP_NEW_DRIVER_NOT_IMPLEMENTED();
   REQUIRE(std::count(dbmsVer, dbmsVer + verLen, '.') == 2);  // Format: ##.##.####
 
   SQLDisconnect(dbc_handle());

--- a/protobuf/database_driver_v1.proto
+++ b/protobuf/database_driver_v1.proto
@@ -422,6 +422,19 @@ message ConnectionGetAllParametersResponse {
   map<string, string> parameters = 1;
 }
 
+// Reads the Snowflake server version cached from the login response.
+// Distinct from ConnectionGetInfo (which aggregates ~12 fields and takes
+// several locks) so SQLGetInfo(SQL_DBMS_VER) / JDBC getDatabaseProductVersion
+// stay cheap even when callers poll them per-statement.
+message ConnectionGetServerVersionRequest {
+  ConnectionHandle conn_handle = 1;
+}
+
+message ConnectionGetServerVersionResponse {
+  // Empty when called before login completes.
+  optional string server_version = 1;
+}
+
 message ConnectionValidateOptionsRequest {
   ConnectionHandle conn_handle = 1;
 }
@@ -813,6 +826,10 @@ service DatabaseDriver {
   rpc ConnectionGetParameter(ConnectionGetParameterRequest) returns (ConnectionGetParameterResponse);
   // gets all resolved session parameters at once
   rpc ConnectionGetAllParameters(ConnectionGetAllParametersRequest) returns (ConnectionGetAllParametersResponse);
+  // returns the Snowflake server version cached from the login response
+  // (`serverVersion` in `/session/v1/login-request`); backs
+  // `SQLGetInfo(SQL_DBMS_VER)` and `getDatabaseProductVersion`
+  rpc ConnectionGetServerVersion(ConnectionGetServerVersionRequest) returns (ConnectionGetServerVersionResponse);
   // pre-flight validation of connection options - reports all issues at once
   rpc ConnectionValidateOptions(ConnectionValidateOptionsRequest) returns (ConnectionValidateOptionsResponse);
   // Fetch the result of a previously executed query by Snowflake Query ID

--- a/sf_core/src/apis/database_driver_v1/connection.rs
+++ b/sf_core/src/apis/database_driver_v1/connection.rs
@@ -312,6 +312,7 @@ impl DatabaseDriverV1 {
                     warehouse: login_result.warehouse_name,
                     role: login_result.role_name,
                 };
+                let login_server_version = login_result.server_version;
 
                 // `CLIENT_SESSION_KEEP_ALIVE` and
                 // `CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY` are read from
@@ -342,6 +343,7 @@ impl DatabaseDriverV1 {
                         login_parameters.client_info.clone(),
                         merged_params,
                         login_final_names,
+                        login_server_version,
                         resolved_snapshot,
                         logout_config,
                     )
@@ -794,6 +796,10 @@ pub struct Connection {
     /// Server-echoed final names from login and query responses (e.g. after USE DATABASE).
     /// Stored separately from session_parameters to keep concerns distinct.
     pub final_session_names: RwLock<FinalSessionNames>,
+    /// Snowflake server version reported in the login response (e.g. "9.34.0").
+    /// Read by ODBC `SQLGetInfo(SQL_DBMS_VER)` and the equivalent JDBC
+    /// `getDatabaseProductVersion`. `None` until login completes.
+    pub server_version: RwLock<Option<String>>,
     /// Wrapper identity for telemetry, set once via ConnectionInit.
     pub wrapper_identity: Option<WrapperIdentity>,
     /// Snowflake session id, populated from `tokens.session_id` once
@@ -830,6 +836,7 @@ impl Connection {
             is_closed: Arc::new(AtomicBool::new(false)),
             logout_config: LogoutConfig::default(),
             final_session_names: RwLock::new(FinalSessionNames::default()),
+            server_version: RwLock::new(None),
             wrapper_identity: None,
             session_id: None,
             heartbeat_handle: None,
@@ -890,6 +897,7 @@ impl Connection {
         client_info: ClientInfo,
         session_params: HashMap<String, String>,
         final_names: FinalSessionNames,
+        server_version: Option<String>,
         resolved_connect: ParamStore,
         logout_config: LogoutConfig,
     ) {
@@ -909,6 +917,10 @@ impl Connection {
 
         if let Ok(mut names) = self.final_session_names.write() {
             *names = final_names;
+        }
+
+        if let Ok(mut version) = self.server_version.write() {
+            *version = server_version;
         }
     }
 
@@ -1587,6 +1599,41 @@ impl DatabaseDriverV1 {
                 }
 
                 Ok(result)
+            }
+            None => InvalidArgumentSnafu {
+                argument: "Connection handle not found".to_string(),
+            }
+            .fail(),
+        }
+    }
+
+    /// Returns the Snowflake server version cached from the login response
+    /// (`serverVersion` in `/session/v1/login-request`).
+    ///
+    /// Backs `SQLGetInfo(SQL_DBMS_VER)` in ODBC and
+    /// `getDatabaseProductVersion` in JDBC. Kept separate from
+    /// [`Self::connection_get_info`] so probing this single attribute
+    /// (Excel does it during `SQLDriverConnect`) doesn't pay for the
+    /// full info aggregation — token guard, session-parameters async lock,
+    /// final-session-names lock, and the seed/resolved/override lookups
+    /// for role/database/schema/warehouse.
+    ///
+    /// Returns `Ok(None)` if the connection has not completed login yet,
+    /// so callers can render the attribute as an empty string instead of
+    /// failing the surrounding ODBC/JDBC call.
+    pub async fn connection_get_server_version(
+        &self,
+        conn_handle: Handle,
+    ) -> Result<Option<String>, ApiError> {
+        match self.connections.get_obj(conn_handle) {
+            Some(conn_ptr) => {
+                let conn = conn_ptr.lock().await;
+                let version = conn
+                    .server_version
+                    .read()
+                    .map_err(|_| ConnectionLockingSnafu {}.build())?
+                    .clone();
+                Ok(version)
             }
             None => InvalidArgumentSnafu {
                 argument: "Connection handle not found".to_string(),
@@ -2389,6 +2436,62 @@ mod tests {
         assert_eq!(info.session_id, None);
 
         ds.connection_release(handle).unwrap();
+    }
+
+    /// On a pre-login connection the cached server version must surface as
+    /// `None` so callers can render `SQL_DBMS_VER` / `getDatabaseProductVersion`
+    /// as empty rather than failing the surrounding ODBC/JDBC call.
+    #[tokio::test]
+    async fn connection_get_server_version_returns_none_before_login() {
+        let ds = DatabaseDriverV1::new();
+        let handle = ds.connection_new();
+
+        let version = ds.connection_get_server_version(handle).await.unwrap();
+
+        assert_eq!(version, None);
+
+        ds.connection_release(handle).unwrap();
+    }
+
+    /// Whatever the login response wrote into `Connection.server_version`
+    /// must round-trip through `connection_get_server_version` unchanged.
+    /// This is the invariant that backs `SQLGetInfo(SQL_DBMS_VER)` in ODBC
+    /// and `getDatabaseProductVersion` in JDBC.
+    #[tokio::test]
+    async fn connection_get_server_version_returns_cached_value() {
+        let ds = DatabaseDriverV1::new();
+        let handle = ds.connection_new();
+
+        if let Some(conn_ptr) = ds.connections.get_obj(handle) {
+            let conn = conn_ptr.lock().await;
+            *conn.server_version.write().unwrap() = Some("9.34.0".into());
+        }
+
+        let version = ds.connection_get_server_version(handle).await.unwrap();
+
+        assert_eq!(version, Some("9.34.0".into()));
+
+        ds.connection_release(handle).unwrap();
+    }
+
+    /// Calling the getter on a released handle must produce a structured
+    /// `invalid_argument`, mirroring how the other connection-scoped
+    /// getters fail. Guards against accidental panics from `unwrap()` if
+    /// someone re-wires `connections.get_obj` later.
+    #[tokio::test]
+    async fn connection_get_server_version_invalid_handle_returns_error() {
+        let ds = DatabaseDriverV1::new();
+        let handle = ds.connection_new();
+        ds.connection_release(handle).unwrap();
+
+        let err = ds
+            .connection_get_server_version(handle)
+            .await
+            .expect_err("released handle must not succeed");
+        assert!(
+            matches!(err, ApiError::InvalidArgument { .. }),
+            "expected InvalidArgument, got {err:?}"
+        );
     }
 
     #[tokio::test]

--- a/sf_core/src/protobuf/apis/database_driver_v1/mod.rs
+++ b/sf_core/src/protobuf/apis/database_driver_v1/mod.rs
@@ -417,6 +417,25 @@ impl DatabaseDriver for DatabaseDriverImpl {
     }
 
     #[instrument(
+        name = "DatabaseDriverV1::connection_get_server_version",
+        skip(self, input)
+    )]
+    async fn connection_get_server_version(
+        &self,
+        input: ConnectionGetServerVersionRequest,
+    ) -> Result<ConnectionGetServerVersionResponse, DriverException> {
+        let conn_handle = required(input.conn_handle, "Connection handle is required")?;
+
+        let server_version = self
+            .driver
+            .connection_get_server_version(conn_handle.into())
+            .await
+            .to_protobuf()?;
+
+        Ok(ConnectionGetServerVersionResponse { server_version })
+    }
+
+    #[instrument(
         name = "DatabaseDriverV1::connection_get_all_parameters",
         skip(self, input)
     )]
@@ -1065,6 +1084,10 @@ pub trait DatabaseDriverClientBlockingExt {
         &self,
         input: ConnectionGetInfoRequest,
     ) -> BlockingProtoResult<ConnectionGetInfoResponse>;
+    fn connection_get_server_version_blocking(
+        &self,
+        input: ConnectionGetServerVersionRequest,
+    ) -> BlockingProtoResult<ConnectionGetServerVersionResponse>;
     fn connection_get_result_set_blocking(
         &self,
         input: ConnectionGetResultSetRequest,
@@ -1195,6 +1218,13 @@ impl DatabaseDriverClientBlockingExt for DatabaseDriverClient {
         input: ConnectionGetInfoRequest,
     ) -> BlockingProtoResult<ConnectionGetInfoResponse> {
         block_on_client_call(self.connection_get_info(input))
+    }
+
+    fn connection_get_server_version_blocking(
+        &self,
+        input: ConnectionGetServerVersionRequest,
+    ) -> BlockingProtoResult<ConnectionGetServerVersionResponse> {
+        block_on_client_call(self.connection_get_server_version(input))
     }
 
     fn connection_get_result_set_blocking(

--- a/sf_core/src/rest/snowflake/auth.rs
+++ b/sf_core/src/rest/snowflake/auth.rs
@@ -181,7 +181,7 @@ pub struct AuthResponseMain {
     #[serde(rename = "displayUserName")]
     pub _display_user_name: Option<String>,
     #[serde(rename = "serverVersion")]
-    pub _server_version: Option<String>,
+    pub server_version: Option<String>,
     #[serde(rename = "firstLogin")]
     pub _first_login: Option<bool>,
     #[serde(rename = "remMeToken")]

--- a/sf_core/src/rest/snowflake/mod.rs
+++ b/sf_core/src/rest/snowflake/mod.rs
@@ -130,6 +130,8 @@ pub struct LoginResult {
     pub warehouse_name: Option<String>,
     /// Server-echoed role name from sessionInfo
     pub role_name: Option<String>,
+    /// Snowflake server version reported
+    pub server_version: Option<String>,
 }
 
 impl SessionTokens {
@@ -1043,11 +1045,14 @@ pub async fn snowflake_login_with_client(
             None => (None, None, None, None),
         };
 
+    let server_version = auth_response.data.server_version.clone();
+
     tracing::info!(
         session_id,
         session_validity_secs = auth_response.data.validity.map(|d| d.as_secs()),
         master_validity_secs = auth_response.data.master_validity.map(|d| d.as_secs()),
         session_params_count = session_params.as_ref().map(|p| p.len()),
+        server_version = server_version.as_deref(),
         "Snowflake login completed successfully"
     );
     Ok(LoginResult {
@@ -1064,6 +1069,7 @@ pub async fn snowflake_login_with_client(
         schema_name,
         warehouse_name,
         role_name,
+        server_version,
     })
 }
 


### PR DESCRIPTION
### TL;DR

Adds support for `SQLGetInfo(SQL_DRIVER_NAME)`, `SQL_DRIVER_VER`, `SQL_DBMS_VER`, and `SQLColAttribute(SQL_DESC_NAME / SQL_DESC_LENGTH)` in the ODBC driver, backed by a new lightweight `ConnectionGetServerVersion` RPC that reads the Snowflake server version cached from the login response.

### What changed?

- `InfoType` enum gains `DriverName` (6), `DriverVer` (7), and `DbmsVer` (18) variants, with corresponding `get_info` handlers that write the driver name, driver version, and Snowflake server version strings respectively.
- `DescField` enum gains `Length` (1003) and `Name` (1011) variants. `col_attribute` now handles `SQL_DESC_NAME` by writing the column name and `SQL_DESC_LENGTH` by computing the logical column size via `column_size_from_field`.
- `AuthResponseMain.server_version` is promoted from a dead `_server_version` field to a live `server_version` field. It is captured in `LoginResult` and written into a new `Connection.server_version: RwLock<Option<String>>` field during login completion.
- A new `ConnectionGetServerVersion` RPC is added to the `DatabaseDriver` protobuf service. It reads `Connection.server_version` directly, avoiding the heavier `ConnectionGetInfo` aggregation path. Returns `None` (rendered as an empty string) when called before login completes.
- The ODBC `get_info` handler for `DbmsVer` uses `connection_get_server_version` via the blocking runtime extension, falling back to an empty string when the connection is not yet established.

### How to test?

- New unit tests in `sf_core` cover three cases for `connection_get_server_version`: returns `None` before login, returns the cached value after login, and returns `InvalidArgument` for a released handle.
- New unit tests in `odbc_types` pin the numeric discriminants for all `InfoType` and `DescField` variants used by Excel/PowerQuery during `SQLDriverConnect`, guarding against accidental renumbering.
- Connect Excel or PowerQuery to a Snowflake DSN and verify that `SQLDriverConnect` succeeds and the driver name, driver version, and DBMS version are reported correctly in the connection dialog or driver info panel.
- Run the existing AS-bound trace replay tests to confirm no regressions in `SQLGetInfo` dispatch.

### Why make this change?

Excel and PowerQuery probe `SQL_DRIVER_NAME` (6), `SQL_DRIVER_VER` (7), `SQL_DBMS_VER` (18), `SQL_DESC_NAME`, and `SQL_DESC_LENGTH` during `SQLDriverConnect` and result-set preview rendering. Without handlers for these attributes the driver returned `UnknownInfoType` / `UnknownAttribute` errors, causing Excel to fail or silently skip the connection. The `server_version` field was already present in the Snowflake login response but was unused; surfacing it through a dedicated lightweight RPC avoids the overhead of the full `ConnectionGetInfo` aggregation on every per-statement probe.