### PR TITLE
SNOW-3560626: Excel/Power Query raw_sql replay select_1 test

### DIFF
--- a/odbc_tests/tests/replay/CMakeLists.txt
+++ b/odbc_tests/tests/replay/CMakeLists.txt
@@ -13,3 +13,4 @@ cmake_minimum_required(VERSION 4.0)
 add_odbc_test(replay_iodbctest_select_1 iodbctest/select_1.cpp)
 
 add_subdirectory(datometry)
+add_subdirectory(excel)

--- a/odbc_tests/tests/replay/excel/CMakeLists.txt
+++ b/odbc_tests/tests/replay/excel/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 4.0)
+
+# Replay tests generated from Excel ODBC traces.
+#
+# Layout:
+#   excel/
+#     powerquery/      - Power Query (Get Data) connector
+#       raw_sql/       - "Advanced options" > custom SQL text
+#       navigator/     - Navigator-driven catalog/schema/table browsing
+#     ado/             - Excel's older ADO/MSQuery path
+add_subdirectory(powerquery)

--- a/odbc_tests/tests/replay/excel/powerquery/CMakeLists.txt
+++ b/odbc_tests/tests/replay/excel/powerquery/CMakeLists.txt
@@ -1,0 +1,3 @@
+cmake_minimum_required(VERSION 4.0)
+
+add_subdirectory(raw_sql)

--- a/odbc_tests/tests/replay/excel/powerquery/raw_sql/CMakeLists.txt
+++ b/odbc_tests/tests/replay/excel/powerquery/raw_sql/CMakeLists.txt
@@ -1,0 +1,3 @@
+cmake_minimum_required(VERSION 4.0)
+
+add_odbc_test(replay_excel_powerquery_raw_sql_select_1 select_1/test.cpp)

--- a/odbc_tests/tests/replay/excel/powerquery/raw_sql/select_1/queries.yaml
+++ b/odbc_tests/tests/replay/excel/powerquery/raw_sql/select_1/queries.yaml
@@ -1,0 +1,4 @@
+queries:
+- index: 0
+  original: SELECT 1;
+  mapped: SELECT 1;

--- a/odbc_tests/tests/replay/excel/powerquery/raw_sql/select_1/test.cpp
+++ b/odbc_tests/tests/replay/excel/powerquery/raw_sql/select_1/test.cpp
@@ -1,0 +1,233 @@
+#include <vector>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "ODBCConfig.hpp"
+#include "odbc_cast.hpp"
+#include "odbc_matchers.hpp"
+
+TEST_CASE("Replay: excel powerquery raw_sql select_1", "[excel][powerquery][raw_sql]") {
+  auto config = DataSourceConfig::Snowflake().install();
+
+  SQLHENV env0 = SQL_NULL_HENV;
+  // SQLAllocHandle - SQLHENV (implicit)
+  {
+    SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &env0);
+    REQUIRE(ret == SQL_SUCCESS);
+    REQUIRE(env0 != SQL_NULL_HENV);
+  }
+
+  // SQLSetEnvAttr - SQL_ATTR_ODBC_VERSION (implicit)
+  {
+    SQLRETURN ret = SQLSetEnvAttr(env0, SQL_ATTR_ODBC_VERSION, (SQLPOINTER)SQL_OV_ODBC3, 0);
+    REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_ENV, env0), OdbcMatchers::IsSuccess());
+  }
+
+  SQLHDBC dbc0 = SQL_NULL_HDBC;
+  // SQLAllocHandle - SQLHDBC
+  {
+    SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_DBC, env0, &dbc0);
+    REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_ENV, env0), OdbcMatchers::IsSuccess());
+    REQUIRE(dbc0 != SQL_NULL_HDBC);
+  }
+
+  // SQLSetConnectAttr - SQL_ATTR_LOGIN_TIMEOUT
+  {
+    SQLRETURN ret = SQLSetConnectAttr(dbc0, SQL_ATTR_LOGIN_TIMEOUT, (SQLPOINTER)15, -5);
+    CHECK_THAT(OdbcResult(ret, SQL_HANDLE_DBC, dbc0), OdbcMatchers::IsSuccess());
+  }
+
+  // SQLDriverConnect
+  {
+    SQLRETURN ret = SQLDriverConnect(dbc0, nullptr, sqlchar(config.connection_string().c_str()), SQL_NTS, nullptr, 0,
+                                     nullptr, SQL_DRIVER_NOPROMPT);
+    REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_DBC, dbc0), OdbcMatchers::Succeeded());
+  }
+
+  // SQLGetInfo - SQL_DRIVER_NAME
+  {
+    char buf[256] = {};
+    SQLSMALLINT len = 0;
+    SQLRETURN ret = SQLGetInfo(dbc0, SQL_DRIVER_NAME, buf, 255, &len);
+    CHECK_THAT(OdbcResult(ret, SQL_HANDLE_DBC, dbc0), OdbcMatchers::Succeeded());
+  }
+
+  // SQLGetInfo - SQL_DRIVER_VER
+  {
+    char buf[256] = {};
+    SQLSMALLINT len = 0;
+    SQLRETURN ret = SQLGetInfo(dbc0, SQL_DRIVER_VER, buf, 255, &len);
+    CHECK_THAT(OdbcResult(ret, SQL_HANDLE_DBC, dbc0), OdbcMatchers::Succeeded());
+  }
+
+  // SQLGetInfo - SQL_DBMS_NAME
+  {
+    char buf[256] = {};
+    SQLSMALLINT len = 0;
+    SQLRETURN ret = SQLGetInfo(dbc0, SQL_DBMS_NAME, buf, 255, &len);
+    CHECK_THAT(OdbcResult(ret, SQL_HANDLE_DBC, dbc0), OdbcMatchers::Succeeded());
+  }
+
+  // SQLGetInfo - SQL_DBMS_VER
+  {
+    char buf[256] = {};
+    SQLSMALLINT len = 0;
+    SQLRETURN ret = SQLGetInfo(dbc0, SQL_DBMS_VER, buf, 255, &len);
+    CHECK_THAT(OdbcResult(ret, SQL_HANDLE_DBC, dbc0), OdbcMatchers::Succeeded());
+  }
+
+  SQLHSTMT stmt0 = SQL_NULL_HSTMT;
+  // SQLAllocHandle - SQLHSTMT
+  {
+    SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc0, &stmt0);
+    REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_DBC, dbc0), OdbcMatchers::IsSuccess());
+    REQUIRE(stmt0 != SQL_NULL_HSTMT);
+  }
+
+  // SQLGetInfo - SQL_DRIVER_ODBC_VER
+  {
+    char buf[256] = {};
+    SQLSMALLINT len = 0;
+    SQLRETURN ret = SQLGetInfo(dbc0, SQL_DRIVER_ODBC_VER, buf, 255, &len);
+    CHECK_THAT(OdbcResult(ret, SQL_HANDLE_DBC, dbc0), OdbcMatchers::Succeeded());
+  }
+
+  // SQLGetInfo - SQL_DRIVER_NAME
+  {
+    char buf[256] = {};
+    SQLSMALLINT len = 0;
+    SQLRETURN ret = SQLGetInfo(dbc0, SQL_DRIVER_NAME, buf, 255, &len);
+    CHECK_THAT(OdbcResult(ret, SQL_HANDLE_DBC, dbc0), OdbcMatchers::Succeeded());
+  }
+
+  // SQLExecDirect
+  {
+    SQLRETURN ret = SQLExecDirect(stmt0, sqlchar("SELECT 1;"), SQL_NTS);
+    REQUIRE_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt0), OdbcMatchers::IsSuccess());
+  }
+
+  // SQLNumResultCols
+  {
+    SQLSMALLINT numCols = 0;
+    SQLRETURN ret = SQLNumResultCols(stmt0, &numCols);
+    CHECK_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt0), OdbcMatchers::IsSuccess());
+    CHECK(numCols == 1);
+  }
+
+  // SQLColAttribute - SQL_DESC_CONCISE_TYPE
+  {
+    SQLUSMALLINT col = 1;
+    SQLLEN numAttr = 0;
+    SQLSMALLINT strLen = 0;
+    SQLRETURN ret = SQLColAttribute(stmt0, col, SQL_DESC_CONCISE_TYPE, nullptr, 0, &strLen, &numAttr);
+    CHECK_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt0), OdbcMatchers::IsSuccess());
+  }
+
+  // SQLColAttribute - SQL_DESC_NAME
+  {
+    SQLUSMALLINT col = 1;
+    SQLLEN numAttr = 0;
+    SQLSMALLINT strLen = 0;
+    char buf[4096] = {};
+    SQLRETURN ret = SQLColAttribute(stmt0, col, SQL_DESC_NAME, buf, 4096, &strLen, &numAttr);
+    CHECK_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt0), OdbcMatchers::IsSuccess());
+  }
+
+  // SQLColAttribute - SQL_DESC_NULLABLE
+  {
+    SQLUSMALLINT col = 1;
+    SQLLEN numAttr = 0;
+    SQLSMALLINT strLen = 0;
+    SQLRETURN ret = SQLColAttribute(stmt0, col, SQL_DESC_NULLABLE, nullptr, 0, &strLen, &numAttr);
+    CHECK_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt0), OdbcMatchers::IsSuccess());
+  }
+
+  // SQLColAttribute - SQL_DESC_TYPE_NAME
+  {
+    SQLUSMALLINT col = 1;
+    SQLLEN numAttr = 0;
+    SQLSMALLINT strLen = 0;
+    char buf[4096] = {};
+    SQLRETURN ret = SQLColAttribute(stmt0, col, SQL_DESC_TYPE_NAME, buf, 4096, &strLen, &numAttr);
+    CHECK_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt0), OdbcMatchers::IsSuccess());
+  }
+
+  // SQLColAttribute - SQL_DESC_LENGTH
+  {
+    SQLUSMALLINT col = 1;
+    SQLLEN numAttr = 0;
+    SQLSMALLINT strLen = 0;
+    SQLRETURN ret = SQLColAttribute(stmt0, col, SQL_DESC_LENGTH, nullptr, 0, &strLen, &numAttr);
+    CHECK_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt0), OdbcMatchers::IsSuccess());
+  }
+
+  // SQLColAttribute - SQL_DESC_SCALE
+  {
+    SQLUSMALLINT col = 1;
+    SQLLEN numAttr = 0;
+    SQLSMALLINT strLen = 0;
+    SQLRETURN ret = SQLColAttribute(stmt0, col, SQL_DESC_SCALE, nullptr, 0, &strLen, &numAttr);
+    CHECK_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt0), OdbcMatchers::IsSuccess());
+  }
+
+  // SQLGetInfo - SQL_GETDATA_EXTENSIONS
+  {
+    char buf[256] = {};
+    SQLSMALLINT len = 0;
+    SQLRETURN ret = SQLGetInfo(dbc0, SQL_GETDATA_EXTENSIONS, buf, 255, &len);
+    CHECK_THAT(OdbcResult(ret, SQL_HANDLE_DBC, dbc0), OdbcMatchers::IsSuccess());
+  }
+
+  // SQLSetStmtAttr - SQL_ATTR_ROWS_FETCHED_PTR
+  {
+    SQLRETURN ret = SQLSetStmtAttr(stmt0, SQL_ATTR_ROWS_FETCHED_PTR, nullptr, 0);
+    CHECK_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt0), OdbcMatchers::IsSuccess());
+  }
+
+  // SQLFetch
+  {
+    SQLRETURN ret = SQLFetch(stmt0);
+    CHECK_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt0), OdbcMatchers::IsSuccess());
+  }
+
+  // SQLGetData col 1
+  {
+    SQLLEN ind = 0;
+    std::vector<char> buf(2048, 0);
+    SQLRETURN ret = SQLGetData(stmt0, 1, SQL_C_WCHAR, buf.data(), 2048, &ind);
+    CHECK_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt0), OdbcMatchers::IsSuccess());
+    CHECK(ind > 0);
+  }
+
+  // SQLFetch
+  {
+    SQLRETURN ret = SQLFetch(stmt0);
+    CHECK_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt0), OdbcMatchers::IsNoData());
+  }
+
+  // SQLMoreResults
+  {
+    SQLRETURN ret = SQLMoreResults(stmt0);
+    CHECK_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt0), OdbcMatchers::IsNoData());
+  }
+
+  // SQLFreeHandle - SQLHSTMT
+  {
+    SQLRETURN ret = SQLFreeHandle(SQL_HANDLE_STMT, stmt0);
+    CHECK_THAT(OdbcResult(ret, SQL_HANDLE_STMT, stmt0), OdbcMatchers::IsSuccess());
+  }
+
+  // SQLDisconnect
+  {
+    SQLRETURN ret = SQLDisconnect(dbc0);
+    CHECK_THAT(OdbcResult(ret, SQL_HANDLE_DBC, dbc0), OdbcMatchers::Succeeded());
+  }
+
+  // SQLFreeHandle - SQLHDBC
+  {
+    SQLRETURN ret = SQLFreeHandle(SQL_HANDLE_DBC, dbc0);
+    CHECK_THAT(OdbcResult(ret, SQL_HANDLE_DBC, dbc0), OdbcMatchers::IsSuccess());
+  }
+
+  // skipped 1 SQLColAttribute call(s) with undocumented field id
+}


### PR DESCRIPTION
### TL;DR

Adds a replay test for Excel Power Query's "raw SQL" path executing `SELECT 1` against a Snowflake ODBC connection.

### What changed?

A new replay test suite for Excel ODBC traces has been introduced under `odbc_tests/tests/replay/excel/`. The directory structure is organized to accommodate multiple Excel connector paths (`powerquery/raw_sql`, `powerquery/navigator`, and `ado`), with the first test covering the Power Query raw SQL flow.

The `select_1` test replays the full ODBC call sequence that Excel Power Query issues when a user enters a custom SQL query via "Advanced options", including environment and connection setup, `SQLGetInfo` calls for driver/DBMS metadata, `SQLExecDirect` with `SELECT 1`, column attribute inspection, data fetching via `SQLGetData`, and proper teardown.

A `queries.yaml` file accompanies the test, mapping the original query `SELECT 1;` to itself.

### How to test?

Build and run the `replay_excel_powerquery_raw_sql_select_1` test target with a valid Snowflake ODBC data source configured. The test will connect, execute `SELECT 1`, verify the result set contains one column with a non-empty value, and confirm no additional rows or result sets are returned.

### Why make this change?

Establishes a baseline replay test for Excel's Power Query ODBC connector to ensure the driver correctly handles the specific sequence of ODBC calls Excel issues, catching regressions in driver behavior for this common client application.