### PR TITLE
SNOW-3565553 limit merge queue scope

### DIFF
--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -23,7 +23,7 @@ concurrency:
   # Don't cancel an in-flight run when an unrelated label is added/removed —
   # only scope-up labels (ci:scope-merge, ci:scope-nightly) and normal
   # push/synchronize/reopen events should replace the running matrix.
-  cancel-in-progress: ${{ github.event.action != 'labeled' || contains(fromJSON('["ci:scope-merge","ci:scope-nightly"]'), github.event.label.name) }}
+  cancel-in-progress: ${{ github.event.action != 'labeled' || contains(fromJSON('["ci:scope-merge-queue","ci:scope-merge","ci:scope-nightly"]'), github.event.label.name) }}
 
 jobs:
   # Filter out PR runs triggered solely by adding an unrelated label
@@ -35,7 +35,7 @@ jobs:
   scope-label-gate:
     if: |
       github.event.action != 'labeled' ||
-      contains(fromJSON('["ci:scope-merge","ci:scope-nightly"]'), github.event.label.name)
+      contains(fromJSON('["ci:scope-merge-queue","ci:scope-merge","ci:scope-nightly"]'), github.event.label.name)
     runs-on: ubuntu-latest
     steps:
       - run: 'true'
@@ -102,7 +102,7 @@ jobs:
 
   odbc_tests_reference:
     needs: detect-changes
-    if: github.event_name == 'push' || needs.detect-changes.outputs.run_odbc_reference == 'true'
+    if: "!contains(github.event.pull_request.labels.*.name, 'ci:scope-merge-queue') && github.event_name != 'merge_group' && (github.event_name == 'push' || needs.detect-changes.outputs.run_odbc_reference == 'true')"
     uses: ./.github/workflows/_test-odbc-reference.yml
     # secrets.PARAMETERS_SECRET is read by decode_secrets inside the
     # reusable workflow; reusable workflows do NOT auto-inherit secrets

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -17,7 +17,7 @@ concurrency:
   # Don't cancel an in-flight run when an unrelated label is added/removed —
   # only scope-up labels (ci:scope-merge, ci:scope-nightly) and normal
   # push/synchronize/reopen events should replace the running matrix.
-  cancel-in-progress: ${{ github.event.action != 'labeled' || contains(fromJSON('["ci:scope-merge","ci:scope-nightly"]'), github.event.label.name) }}
+  cancel-in-progress: ${{ github.event.action != 'labeled' || contains(fromJSON('["ci:scope-merge-queue","ci:scope-merge","ci:scope-nightly"]'), github.event.label.name) }}
 
 env:
   CARGO_TERM_COLOR: always
@@ -32,7 +32,7 @@ jobs:
   scope-label-gate:
     if: |
       github.event.action != 'labeled' ||
-      contains(fromJSON('["ci:scope-merge","ci:scope-nightly"]'), github.event.label.name)
+      contains(fromJSON('["ci:scope-merge-queue","ci:scope-merge","ci:scope-nightly"]'), github.event.label.name)
     runs-on: ubuntu-latest
     steps:
       - run: 'true'
@@ -489,7 +489,7 @@ jobs:
   # skip-install=true, so no universal wheel download is needed.
   python_tests_reference:
     needs: [detect-changes, build_wheels]
-    if: github.event_name == 'push' || needs.detect-changes.outputs.run_python_reference == 'true'
+    if: "!contains(github.event.pull_request.labels.*.name, 'ci:scope-merge-queue') && github.event_name != 'merge_group' && (github.event_name == 'push' || needs.detect-changes.outputs.run_python_reference == 'true')"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-rust-core.yml
+++ b/.github/workflows/test-rust-core.yml
@@ -17,7 +17,7 @@ concurrency:
   # Don't cancel an in-flight run when an unrelated label is added/removed —
   # only scope-up labels (ci:scope-merge, ci:scope-nightly) and normal
   # push/synchronize/reopen events should replace the running matrix.
-  cancel-in-progress: ${{ github.event.action != 'labeled' || contains(fromJSON('["ci:scope-merge","ci:scope-nightly"]'), github.event.label.name) }}
+  cancel-in-progress: ${{ github.event.action != 'labeled' || contains(fromJSON('["ci:scope-merge-queue","ci:scope-merge","ci:scope-nightly"]'), github.event.label.name) }}
 
 env:
   CARGO_TERM_COLOR: always
@@ -32,7 +32,7 @@ jobs:
   scope-label-gate:
     if: |
       github.event.action != 'labeled' ||
-      contains(fromJSON('["ci:scope-merge","ci:scope-nightly"]'), github.event.label.name)
+      contains(fromJSON('["ci:scope-merge-queue","ci:scope-merge","ci:scope-nightly"]'), github.event.label.name)
     runs-on: ubuntu-latest
     steps:
       - run: 'true'

--- a/.github/workflows/validations.yml
+++ b/.github/workflows/validations.yml
@@ -101,6 +101,7 @@ jobs:
         run: python -m unittest ci/test_matrix/test_generate_matrix.py
 
   test-coverage-report:
+    if: '!contains(github.event.pull_request.labels.*.name, ''ci:scope-merge-queue'') && github.event_name != ''merge_group'''
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/ci/Jenkinsfile.build-matrix
+++ b/ci/Jenkinsfile.build-matrix
@@ -5,6 +5,10 @@ Runs independently from the VPN E2E / revocation tests defined in ci/Jenkinsfile
 
 @Library('pipeline-utils') _
 
+def isMergeQueue() {
+  return env.BRANCH_NAME?.startsWith('gh-readonly-queue/')
+}
+
 def getAgentLabel(platform) {
   switch (platform) {
     case 'linux-x86_64-musl':
@@ -246,6 +250,9 @@ pipeline {
   }
   stages {
         stage('Build Matrix') {
+          when {
+            expression { !isMergeQueue() }
+          }
           matrix {
             axes {
               axis {

--- a/ci/Jenkinsfile.vpn-tests
+++ b/ci/Jenkinsfile.vpn-tests
@@ -6,6 +6,10 @@ The cross-platform build matrix lives in a separate job: ci/Jenkinsfile.build-ma
 @Library('pipeline-utils') _
 import com.snowflake.DevEnvUtils
 
+def isMergeQueue() {
+  return env.BRANCH_NAME?.startsWith('gh-readonly-queue/')
+}
+
 def e2eDockerSetup(String image) {
   new DevEnvUtils().withSfCli {
     sh "sf artifact oci auth"
@@ -27,6 +31,9 @@ pipeline {
   stages {
 
         stage('Tests') {
+          when {
+            expression { !isMergeQueue() }
+          }
           parallel {
             stage('Rust Core VPN E2E Tests') {
               agent { label 'build-node-extra-large' }

--- a/ci/test_matrix/README.md
+++ b/ci/test_matrix/README.md
@@ -28,7 +28,8 @@ ci/test_matrix/
 **Models** (`models/*.py`) declare parameters, constraints, and the explicit
 `PR_CELLS` + `JSON_CELLS` sections — the *combinatorial* shape of the matrix.
 Each module exposes four top-level names (`PARAMS`, `CONSTRAINTS`, `PR_CELLS`,
-`JSON_CELLS`) — see `models/__init__.py` for the schema. **Mappings**
+`JSON_CELLS`) and two optional ones (`MERGE_QUEUE_CELLS`, `MERGE_VALID`) —
+see `models/__init__.py` for the schema. **Mappings**
 (`mappings/*.py`) translate each `(OS, Arch)` cell into concrete CI fields:
 runner label, driver/wheel artifact name, cargo flags, msvc_arch,
 vcpkg_triplet, etc. The generator joins both at runtime;
@@ -37,13 +38,31 @@ no mapping covers.
 
 ## Trigger levels
 
-Each emitted row carries a `trigger_level`. Levels are cumulative.
+Each emitted row carries a `trigger_level`. Levels are cumulative except for `merge_queue`.
 
-| Level     | When it runs                  | Coverage                            |
-|-----------|-------------------------------|-------------------------------------|
-| `pr`      | Every PR                      | Explicit `PR_CELLS` only            |
-| `merge`   | Merge queue + push to `main`  | `pr` cells + pairwise cover         |
-| `nightly` | Scheduled nightly run         | All valid combinations              |
+| Level         | When it runs                              | Coverage                                                                          |
+|---------------|-------------------------------------------|-----------------------------------------------------------------------------------|
+| `pr`          | Every PR (`pull_request`)                 | Explicit `PR_CELLS` only                                                          |
+| `merge_queue` | Merge queue (`merge_group`) — **non-cumulative** | `MERGE_QUEUE_CELLS` only (fast, explicit gate; PR_CELLS do NOT run here) |
+| `merge`       | Push to `main` (`push`)                   | `pr` + `merge_queue` + pairwise cover (full cumulative set)                      |
+| `nightly`     | Scheduled nightly run (`schedule`)        | All valid combinations                                                            |
+
+**Precedence within the merge set.** Trigger assignment is first-match:
+1. `PR_CELLS` → `trigger_level="pr"` (cumulative; appears at every scope).
+2. `MERGE_QUEUE_CELLS` → `trigger_level="merge_queue"` (non-cumulative; only at `merge_group`).
+3. Pairwise → `trigger_level="merge"` (auto-generated; only at push-to-main and nightly).
+4. Everything else → `trigger_level="nightly"`.
+
+**Non-cumulative `merge_queue` semantics.** `filter_active("merge_queue")` returns **only**
+rows with `trigger_level == "merge_queue"` (MERGE_QUEUE_CELLS). PR_CELLS do not run at the
+merge queue. Push-to-main (`filter_active("merge")`) is still cumulative and includes all
+three lower levels.
+
+**Fallback.** If a model defines no `MERGE_QUEUE_CELLS`, `filter_active("merge_queue")`
+falls back to returning PR_CELLS, preserving backward compatibility.
+
+`MERGE_QUEUE_CELLS` entries are also excluded from the pairwise candidate pool so the
+greedy solver never redundantly selects a cell that is already explicitly pinned.
 
 **Pairwise cover (the "merge" set).** A minimal set of rows in which every
 (parameter A value, parameter B value) pair appears together at least once,
@@ -64,17 +83,18 @@ least once across those 4 rows. The remaining 8 combinations only run at
 only on macOS-arm-aws-py3.13) are not guaranteed to surface at `merge`.
 
 GHA picks the level from `GITHUB_EVENT_NAME` (`pull_request` → pr,
-`merge_group`/`push` → merge, `schedule` → nightly).
+`merge_group` → merge_queue, `push` → merge, `schedule` → nightly).
 
 ### Forcing a higher scope on a PR
 
 Apply one of these labels to a PR. Adding the label re-triggers the
 workflow automatically (no commit required) at the upgraded scope:
 
-| Label              | Effect                                              |
-|--------------------|-----------------------------------------------------|
-| `ci:scope-merge`   | Run the pairwise cover (`pr` + `merge` cells).      |
-| `ci:scope-nightly` | Run every constraint-valid combination.             |
+| Label                   | Effect                                                                         |
+|-------------------------|--------------------------------------------------------------------------------|
+| `ci:scope-merge-queue`  | Run exactly what the merge queue runs (MERGE_QUEUE_CELLS only). Useful for testing merge_group behaviour on a PR. |
+| `ci:scope-merge`        | Run the full push-to-main set (`pr` + `merge_queue` + pairwise cover).         |
+| `ci:scope-nightly`      | Run every constraint-valid combination.                                        |
 
 Labels can only upgrade scope — they never downgrade an event's level.
 `detect-changes` still gates which drivers run, so labeling a Python-only
@@ -105,6 +125,34 @@ Append a dict to `PR_CELLS` in the relevant `models/<driver>.py`. Every
 declared parameter must be present (the loader validates this), and the
 combination must satisfy every constraint — a violating cell warns at
 generate time and is silently dropped from the output.
+
+### Add a merge-queue cell
+
+Append a dict to `MERGE_QUEUE_CELLS` in the relevant `models/<driver>.py`
+to pin a cell that always runs in the merge queue but not on every PR.
+Same completeness rule as `PR_CELLS`.
+
+```python
+MERGE_QUEUE_CELLS = [
+    # windows-arm: one explicit cloud at merge scope — azure is fastest.
+    {"OS": "windows", "Arch": "arm", "Cloud": "azure"},
+]
+```
+
+`MERGE_QUEUE_CELLS` entries bypass `MERGE_VALID` (they are unconditional at
+merge level) and are excluded from the pairwise candidate pool (so the solver
+does not also select them, creating duplicate rows). If a cell appears in
+both `PR_CELLS` and `MERGE_QUEUE_CELLS`, `PR_CELLS` wins and the cell runs
+at PR scope. Use `MERGE_VALID` to complement `MERGE_QUEUE_CELLS` by blocking
+other variants of the same lane from pairwise:
+
+```python
+def merge_valid(c):
+    # Cap windows-arm to one cloud at merge; MERGE_QUEUE_CELLS pins azure.
+    if c["OS"] == "windows" and c["Arch"] == "arm":
+        if c["Cloud"] != "azure": return False
+    return True
+```
 
 ### Add a constraint
 

--- a/ci/test_matrix/generate_matrix.py
+++ b/ci/test_matrix/generate_matrix.py
@@ -40,7 +40,7 @@ GENERATED_DIR = REPO_ROOT / "ci" / "test_matrix" / "generated"
 # Trigger level ordering (lower index = lower coverage, subset of next)
 # ---------------------------------------------------------------------------
 
-TRIGGER_LEVELS = ["pr", "merge", "nightly"]
+TRIGGER_LEVELS = ["pr", "merge_queue", "merge", "nightly"]
 
 
 # ---------------------------------------------------------------------------
@@ -140,16 +140,19 @@ def load_model(
     list,
     list,
     list[dict[str, str]],
+    list[dict[str, str]],
     dict[str, list[dict[str, str]]],
 ]:
     """
     Load a model module and validate its shape.
 
-    Returns (params, constraints, merge_valid, pr_cells, json_cells).
+    Returns (params, constraints, merge_valid, pr_cells, merge_queue_cells, json_cells).
     Constraints and merge_valid are lists of callables `(combo) -> bool`
     returning True when the combo is valid. CONSTRAINTS gates *all* trigger
     levels (full cartesian product); MERGE_VALID additionally gates the
     pairwise pass — a combo blocked by MERGE_VALID still appears at nightly.
+    MERGE_QUEUE_CELLS are explicit cells pinned to trigger_level="merge";
+    they bypass MERGE_VALID and are excluded from the pairwise pool.
     Raises ValueError on any malformed input.
     """
     spec = importlib.util.spec_from_file_location(f"_model_{path.stem}", path)
@@ -162,6 +165,7 @@ def load_model(
     raw_constraints = getattr(module, "CONSTRAINTS", [])
     raw_merge_valid = getattr(module, "MERGE_VALID", [])
     raw_pr = getattr(module, "PR_CELLS", [])
+    raw_mq = getattr(module, "MERGE_QUEUE_CELLS", [])
     raw_json = getattr(module, "JSON_CELLS", {})
 
     if not isinstance(raw_params, dict) or not raw_params:
@@ -191,6 +195,10 @@ def load_model(
 
     pr_cells = [_normalize_cell(c, params, path, "PR_CELLS") for c in raw_pr]
 
+    if not isinstance(raw_mq, list):
+        raise ValueError(f"{path}: MERGE_QUEUE_CELLS must be a list")
+    merge_queue_cells = [_normalize_cell(c, params, path, "MERGE_QUEUE_CELLS") for c in raw_mq]
+
     json_cells: dict[str, list[dict[str, str]]] = {lvl: [] for lvl in _TRIGGER_LEVELS_FOR_JSON}
     if not isinstance(raw_json, dict):
         raise ValueError(f"{path}: JSON_CELLS must be a dict")
@@ -205,7 +213,7 @@ def load_model(
                 _normalize_cell(c, params, path, f"JSON_CELLS[{level!r}]")
             )
 
-    return params, constraints, merge_valid, pr_cells, json_cells
+    return params, constraints, merge_valid, pr_cells, merge_queue_cells, json_cells
 
 
 def _normalize_cell(
@@ -428,7 +436,7 @@ def generate(model_path: Path, driver: str) -> list[dict]:
 
     Returns the list of GitHub Actions matrix rows.
     """
-    params, constraints, merge_valid, pr_cells, json_cells = load_model(model_path)
+    params, constraints, merge_valid, pr_cells, merge_queue_cells, json_cells = load_model(model_path)
     param_names = list(params.keys())
     param_values = list(params.values())
 
@@ -446,6 +454,22 @@ def generate(model_path: Path, driver: str) -> list[dict]:
     is_python = "PyVersion" in params or "HatchEnv" in params
     is_core = driver == "core"
 
+    # Precompute the MERGE_QUEUE_CELLS key set so _routing_valid can exclude
+    # them from the pairwise candidate pool. This prevents the greedy solver
+    # from also selecting a cell that is already explicitly pinned at merge
+    # level, which would produce no duplicate row (trigger assignment below
+    # prefers merge_queue_keys) but would waste a pairwise slot.
+    merge_queue_keys: set[tuple] = {tuple(c.values()) for c in merge_queue_cells}
+    valid_keys = {tuple(c.values()) for c in all_combos}
+
+    # Warn about MERGE_QUEUE_CELLS entries that violate constraints.
+    for cell in merge_queue_cells:
+        if tuple(cell.values()) not in valid_keys:
+            print(
+                f"WARNING: [merge_queue] cell {cell} violates constraints — no row will be emitted",
+                file=sys.stderr,
+            )
+
     # Routing-aware pairwise cover: only consider combos that survive
     # _build_*_row routing. Without this, the solver may pick a combo (e.g.
     # windows-arm × py3.13) that gets silently dropped at row-build time
@@ -457,11 +481,16 @@ def generate(model_path: Path, driver: str) -> list[dict]:
     # pass: combos rejected here still flow through to nightly, but never
     # land in pr/merge. Use it to keep expensive lanes (e.g. limited macOS
     # runners) out of the merge queue without losing nightly coverage.
+    #
+    # MERGE_QUEUE_CELLS combos are also excluded from pairwise: they are
+    # already explicitly pinned at merge level and do not need a pairwise slot.
     def _routing_valid(combo_tuple: tuple) -> bool:
         combo = dict(zip(param_names, combo_tuple))
         if not apply_constraints(combo, constraints):
             return False
         if not apply_constraints(combo, merge_valid):
+            return False
+        if combo_tuple in merge_queue_keys:
             return False
         # `trigger` doesn't influence the build/skip decision, so any
         # placeholder value works. Pass "merge" for clarity.
@@ -479,7 +508,6 @@ def generate(model_path: Path, driver: str) -> list[dict]:
     if pr_cells:
         pr_keys: set[tuple] = {tuple(c.values()) for c in pr_cells}
         # Warn about PR cells that violate constraints and will produce no output row.
-        valid_keys = {tuple(c.values()) for c in all_combos}
         for cell in pr_cells:
             if tuple(cell.values()) not in valid_keys:
                 print(
@@ -491,15 +519,20 @@ def generate(model_path: Path, driver: str) -> list[dict]:
         for key in list(pairwise_keys)[:3]:
             pr_keys.add(key)
 
-    # Assign trigger levels:
-    #   pr      - cells listed in [pr] (explicit) or first 3 pairwise rows (fallback)
-    #   merge   - remaining pairwise rows; pr cells are also included at merge level
-    #             (cumulative filter: merge runs pr+merge)
-    #   nightly - everything else (full matrix)
+    # Assign trigger levels (precedence: PR_CELLS > MERGE_QUEUE_CELLS > pairwise > nightly):
+    #   pr          - cells listed in PR_CELLS (explicit); run on every PR and
+    #                 cumulatively at push-to-main and nightly.
+    #   merge_queue - MERGE_QUEUE_CELLS (explicit, not gated by MERGE_VALID);
+    #                 run ONLY at merge_group events (non-cumulative filter).
+    #   merge       - pairwise rows; run at push-to-main (and cumulatively at
+    #                 nightly) but NOT at merge_group events.
+    #   nightly     - everything else (full cartesian product).
     for combo in all_combos:
         key = tuple(combo.values())
         if key in pr_keys:
             combo["_trigger"] = "pr"
+        elif key in merge_queue_keys:
+            combo["_trigger"] = "merge_queue"
         elif key in pairwise_keys:
             combo["_trigger"] = "merge"
         else:
@@ -510,12 +543,21 @@ def generate(model_path: Path, driver: str) -> list[dict]:
     gha_rows: list[dict] = []
 
     for combo in combos:
+        # Capture the param key before popping _trigger so we can check
+        # MERGE_QUEUE_CELLS membership on the finished row.
+        key = tuple(combo[p] for p in param_names)
         trigger = combo.pop("_trigger")
         if is_core:
             row = _build_core_row(combo, trigger)
         else:
             row = _build_gha_row(combo, trigger, is_python)
         if row is not None:
+            # Mark every MERGE_QUEUE_CELLS row regardless of its trigger_level.
+            # A cell can be in both PR_CELLS and MERGE_QUEUE_CELLS (PR_CELLS wins
+            # for trigger assignment), but merge_queue_cell=True ensures
+            # filter_active("merge_queue") finds it even at trigger_level="pr".
+            if key in merge_queue_keys:
+                row["merge_queue_cell"] = True
             gha_rows.append(row)
 
     # Append result_format=json reference variants. Core has no JSON variants —
@@ -548,20 +590,21 @@ def generate(model_path: Path, driver: str) -> list[dict]:
 # ---------------------------------------------------------------------------
 
 EVENT_TO_LEVEL = {
-    "pull_request": "pr",
+    "pull_request":        "pr",
     "pull_request_target": "pr",
-    "push": "merge",
-    "merge_group": "merge",
-    "schedule": "nightly",
-    "workflow_dispatch": "nightly",
+    "push":                "merge",        # push to main: full pairwise set
+    "merge_group":         "merge_queue",  # merge queue: MERGE_QUEUE_CELLS only
+    "schedule":            "nightly",
+    "workflow_dispatch":   "nightly",
 }
 
 
 # PR labels that force a higher trigger level than the event would produce.
 # When multiple are present the highest-scope label wins.
 LABEL_TO_LEVEL = {
-    "ci:scope-merge":   "merge",
-    "ci:scope-nightly": "nightly",
+    "ci:scope-merge-queue": "merge_queue",
+    "ci:scope-merge":       "merge",
+    "ci:scope-nightly":     "nightly",
 }
 
 
@@ -591,9 +634,27 @@ def level_for_event_and_labels(event: str | None, labels: list[str] | None) -> s
 
 
 def filter_active(rows: list[dict], level: str) -> list[dict]:
-    """Return rows whose trigger_level is at or below `level` (cumulative)."""
+    """Return rows active at the given trigger level.
+
+    For 'merge_queue' (merge_group event): non-cumulative — returns only rows
+    that have merge_queue_cell=True. This includes cells that are in
+    MERGE_QUEUE_CELLS regardless of their trigger_level: a cell that is in
+    both PR_CELLS and MERGE_QUEUE_CELLS gets trigger_level="pr" (PR_CELLS
+    wins for trigger assignment) but is still returned here because
+    merge_queue_cell=True is set on the row. If no such rows exist (model
+    has not defined MERGE_QUEUE_CELLS), falls back to PR_CELLS.
+
+    For all other levels: cumulative — returns every row whose trigger_level
+    index is at or below the requested level's index in TRIGGER_LEVELS.
+    """
     if level not in TRIGGER_LEVELS:
         raise ValueError(f"unknown trigger level: {level!r}; expected one of {TRIGGER_LEVELS}")
+    if level == "merge_queue":
+        mq_rows = [r for r in rows if r.get("merge_queue_cell")]
+        if mq_rows:
+            return mq_rows
+        # Fallback: model has no MERGE_QUEUE_CELLS — run PR_CELLS at merge queue.
+        return [r for r in rows if r["trigger_level"] == "pr"]
     cap = TRIGGER_LEVELS.index(level)
     return [r for r in rows if TRIGGER_LEVELS.index(r["trigger_level"]) <= cap]
 

--- a/ci/test_matrix/models/__init__.py
+++ b/ci/test_matrix/models/__init__.py
@@ -46,6 +46,37 @@ PR_CELLS: list[dict[str, str]]
     Explicit cells that always run on every PR. Each cell must list a value
     for every declared parameter (loader rejects missing or extra keys).
 
+MERGE_QUEUE_CELLS: list[dict[str, str]]   (optional, default [])
+    Explicit cells that run ONLY on the merge queue (merge_group event,
+    trigger_level="merge_queue"). They do NOT run on PRs (unless also in
+    PR_CELLS) and are NOT included in the pairwise set that runs at push-to-main.
+
+    Semantics differ from PR_CELLS in one critical way: filter_active at
+    "merge_queue" level is NON-CUMULATIVE — it returns ONLY these cells, not
+    PR_CELLS. This makes the merge queue a focused, fast validation gate while
+    push-to-main runs the full matrix (PR_CELLS + MERGE_QUEUE_CELLS + pairwise).
+
+    If MERGE_QUEUE_CELLS is empty or absent, the merge queue falls back to
+    running PR_CELLS (preserving backward compatibility for models that have
+    not yet defined an explicit merge-queue configuration).
+
+    If a cell appears in both PR_CELLS and MERGE_QUEUE_CELLS, PR_CELLS wins
+    and the cell runs at trigger_level="pr" (cumulative at all scopes).
+
+    MERGE_VALID does not gate these — they bypass the pairwise block-list and
+    run unconditionally at merge_queue. Cells listed here are also excluded
+    from the pairwise candidate pool so the greedy solver does not redundantly
+    select them and emit duplicate rows at the push-to-main ("merge") level.
+
+    Use MERGE_VALID to prevent pairwise from generating similar lanes that
+    would duplicate coverage already provided by MERGE_QUEUE_CELLS:
+
+        MERGE_QUEUE_CELLS = [
+            # windows-arm: fast gate on azure only; other clouds at push-to-main.
+            {"OS": "windows", "Arch": "arm", "Cloud": "azure"},
+        ]
+        # Also add to merge_valid() to block arm-aws and arm-gcp from pairwise.
+
 MERGE_VALID: list[Callable[[dict[str, str]], bool]]   (optional, default [])
     Pairwise-only block-list. Same shape and semantics as CONSTRAINTS
     (return True = keep, return False = forbid). Predicates here gate

--- a/ci/test_matrix/models/core.py
+++ b/ci/test_matrix/models/core.py
@@ -34,4 +34,8 @@ PR_CELLS = [
     {"OS": "windows", "Arch": "x86"},
 ]
 
+MERGE_QUEUE_CELLS = [
+    {"OS": "ubuntu", "Arch": "x64"},
+]
+
 JSON_CELLS = {"pr": [], "merge": [], "nightly": []}

--- a/ci/test_matrix/models/odbc.py
+++ b/ci/test_matrix/models/odbc.py
@@ -48,6 +48,10 @@ PR_CELLS = [
     {"OS": "windows", "Arch": "x86", "Cloud": "aws"},
 ]
 
+MERGE_QUEUE_CELLS = [
+    {"OS": "ubuntu", "Arch": "x64", "Cloud": "aws"},
+]
+
 JSON_CELLS = {
     "pr": [],
     "merge": [

--- a/ci/test_matrix/models/python.py
+++ b/ci/test_matrix/models/python.py
@@ -58,6 +58,10 @@ PR_CELLS = [
     {"OS": "windows", "Arch": "x64", "Cloud": "azure", "PyVersion": "3.14", "HatchEnv": "test"},
 ]
 
+MERGE_QUEUE_CELLS = [
+    {"OS": "ubuntu", "Arch": "x64", "Cloud": "aws", "PyVersion": "3.13", "HatchEnv": "test"},
+]
+
 JSON_CELLS = {
     "pr": [],
     "merge": [

--- a/ci/test_matrix/test_generate_matrix.py
+++ b/ci/test_matrix/test_generate_matrix.py
@@ -68,7 +68,7 @@ class LoadModelTests(unittest.TestCase):
             "JSON_CELLS = {'pr': [], 'merge': [], 'nightly': []}\n"
         )
         try:
-            params, constraints, _merge_valid, pr_cells, json_cells = gm.load_model(path)
+            params, constraints, _merge_valid, pr_cells, _mq_cells, json_cells = gm.load_model(path)
             self.assertEqual(params, {"OS": ["ubuntu", "macos"], "Arch": ["x64", "arm"]})
             self.assertEqual(len(constraints), 1)
             self.assertTrue(callable(constraints[0]))
@@ -92,7 +92,7 @@ class LoadModelTests(unittest.TestCase):
             "}\n"
         )
         try:
-            _params, _c, _mv, _pr, json_cells = gm.load_model(path)
+            _params, _c, _mv, _pr, _mq, json_cells = gm.load_model(path)
             self.assertEqual(json_cells["pr"], [{"OS": "ubuntu", "Arch": "x64"}])
             self.assertEqual(json_cells["merge"], [{"OS": "macos", "Arch": "arm"}])
             self.assertEqual(json_cells["nightly"], [])
@@ -215,7 +215,7 @@ class LoadModelTests(unittest.TestCase):
             "JSON_CELLS = {'pr': [], 'merge': [], 'nightly': []}\n"
         )
         try:
-            _, constraints, _mv, _, _ = gm.load_model(path)
+            _, constraints, _mv, _, _, _ = gm.load_model(path)
             self.assertEqual(len(constraints), 1)
             # Forbidden by an explicit return False.
             self.assertFalse(constraints[0]({"OS": "macos", "Arch": "x64"}))
@@ -235,7 +235,7 @@ class LoadModelTests(unittest.TestCase):
             "JSON_CELLS = {'pr': [], 'merge': [], 'nightly': []}\n"
         )
         try:
-            _params, _constraints, merge_valid, _pr, _json = gm.load_model(path)
+            _params, _constraints, merge_valid, _pr, _mq, _json = gm.load_model(path)
             self.assertEqual(merge_valid, [])
         finally:
             path.unlink(missing_ok=True)
@@ -253,7 +253,7 @@ class LoadModelTests(unittest.TestCase):
             "JSON_CELLS = {'pr': [], 'merge': [], 'nightly': []}\n"
         )
         try:
-            _params, _c, merge_valid, _pr, _json = gm.load_model(path)
+            _params, _c, merge_valid, _pr, _mq, _json = gm.load_model(path)
             self.assertEqual(len(merge_valid), 1)
             self.assertTrue(callable(merge_valid[0]))
             self.assertFalse(merge_valid[0]({"OS": "macos", "Arch": "x64"}))
@@ -474,6 +474,325 @@ class MergeValidSemanticsTests(unittest.TestCase):
                 gm.PYTHON_PLATFORM[("macos", "x64")] = original
 
 
+# ---------------------------------------------------------------------------
+# MERGE_QUEUE_CELLS — loader + end-to-end semantics
+# ---------------------------------------------------------------------------
+
+class LoadModelMergeQueueCellsTests(unittest.TestCase):
+    """Exercises load_model() MERGE_QUEUE_CELLS handling."""
+
+    def test_mq_cells_default_to_empty(self) -> None:
+        """A model without MERGE_QUEUE_CELLS should load with merge_queue_cells=[]."""
+        path = _write_model(
+            "PARAMS = {'OS': ['ubuntu', 'macos'], 'Arch': ['x64', 'arm']}\n"
+            "CONSTRAINTS = []\n"
+            "PR_CELLS = []\n"
+            "JSON_CELLS = {'pr': [], 'merge': [], 'nightly': []}\n"
+        )
+        try:
+            _p, _c, _mv, _pr, mq_cells, _json = gm.load_model(path)
+            self.assertEqual(mq_cells, [])
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_mq_cell_missing_param_raises(self) -> None:
+        path = _write_model(
+            "PARAMS = {'OS': ['ubuntu'], 'Arch': ['x64'], 'Cloud': ['aws']}\n"
+            "CONSTRAINTS = []\n"
+            "PR_CELLS = []\n"
+            "MERGE_QUEUE_CELLS = [{'OS': 'ubuntu', 'Arch': 'x64'}]\n"  # missing Cloud
+            "JSON_CELLS = {'pr': [], 'merge': [], 'nightly': []}\n"
+        )
+        try:
+            with self.assertRaises(ValueError) as ctx:
+                gm.load_model(path)
+            self.assertIn("MERGE_QUEUE_CELLS", str(ctx.exception))
+            self.assertIn("Cloud", str(ctx.exception))
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_mq_cell_extra_key_raises(self) -> None:
+        path = _write_model(
+            "PARAMS = {'OS': ['ubuntu'], 'Arch': ['x64']}\n"
+            "CONSTRAINTS = []\n"
+            "PR_CELLS = []\n"
+            "MERGE_QUEUE_CELLS = [{'OS': 'ubuntu', 'Arch': 'x64', 'Bogus': 'x'}]\n"
+            "JSON_CELLS = {'pr': [], 'merge': [], 'nightly': []}\n"
+        )
+        try:
+            with self.assertRaises(ValueError) as ctx:
+                gm.load_model(path)
+            self.assertIn("Bogus", str(ctx.exception))
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_mq_cells_must_be_a_list(self) -> None:
+        path = _write_model(
+            "PARAMS = {'OS': ['ubuntu']}\n"
+            "CONSTRAINTS = []\n"
+            "PR_CELLS = []\n"
+            "MERGE_QUEUE_CELLS = 'not a list'\n"
+            "JSON_CELLS = {'pr': [], 'merge': [], 'nightly': []}\n"
+        )
+        try:
+            with self.assertRaises(ValueError) as ctx:
+                gm.load_model(path)
+            self.assertIn("MERGE_QUEUE_CELLS", str(ctx.exception))
+        finally:
+            path.unlink(missing_ok=True)
+
+
+class MergeQueueCellsSemanticsTests(unittest.TestCase):
+    """
+    End-to-end semantics for MERGE_QUEUE_CELLS.
+
+    * Cells appear at trigger_level="merge_queue", never "pr" or "merge".
+    * filter_active("merge_queue") returns ONLY merge_queue rows (non-cumulative).
+    * Cells are included by filter_active at merge/nightly (cumulative).
+    * If a cell is in both PR_CELLS and MERGE_QUEUE_CELLS, PR_CELLS wins (→ "pr").
+    * MERGE_QUEUE_CELLS are excluded from the pairwise pool — no duplicate rows.
+    * MERGE_VALID does not gate MERGE_QUEUE_CELLS.
+    * Empty MERGE_QUEUE_CELLS is a no-op.
+    * A MERGE_QUEUE_CELLS cell that violates constraints warns but emits no row.
+    """
+
+    def _write_odbc_model(self, mq_block: str = "") -> Path:
+        return _write_model(
+            "PARAMS = {\n"
+            "    'OS':   ['ubuntu', 'macos', 'windows'],\n"
+            "    'Arch': ['x64', 'x86', 'arm'],\n"
+            "    'Cloud': ['aws', 'gcp', 'azure'],\n"
+            "}\n"
+            "def is_valid(c):\n"
+            "    if c['OS'] == 'ubuntu':\n"
+            "        if c['Arch'] == 'arm': return False\n"
+            "        if c['Arch'] == 'x86': return False\n"
+            "    if c['OS'] == 'macos':\n"
+            "        if c['Arch'] == 'x64': return False\n"
+            "        if c['Arch'] == 'x86': return False\n"
+            "    return True\n"
+            "CONSTRAINTS = [is_valid]\n"
+            "def merge_valid(c):\n"
+            "    if c['OS'] == 'macos': return False\n"
+            "    return True\n"
+            "MERGE_VALID = [merge_valid]\n"
+            "PR_CELLS = [\n"
+            "    {'OS': 'ubuntu',  'Arch': 'x64', 'Cloud': 'azure'},\n"
+            "    {'OS': 'macos',   'Arch': 'arm', 'Cloud': 'gcp'},\n"
+            "    {'OS': 'windows', 'Arch': 'x64', 'Cloud': 'azure'},\n"
+            "    {'OS': 'windows', 'Arch': 'x86', 'Cloud': 'aws'},\n"
+            "]\n"
+            f"{mq_block}"
+            "JSON_CELLS = {'pr': [], 'merge': [], 'nightly': []}\n"
+        )
+
+    def test_mq_cells_appear_at_merge_queue_not_pr_or_merge(self) -> None:
+        """The MERGE_QUEUE_CELLS cell must have trigger_level='merge_queue', never 'pr' or 'merge'."""
+        mq = (
+            "MERGE_QUEUE_CELLS = [\n"
+            "    {'OS': 'windows', 'Arch': 'arm', 'Cloud': 'azure'},\n"
+            "]\n"
+        )
+        path = self._write_odbc_model(mq)
+        try:
+            rows = gm.generate(path, "odbc")
+            # Find the specific MERGE_QUEUE_CELLS-pinned row (windows-arm-azure).
+            arm_azure = [
+                r for r in rows
+                if r.get("driver_artifact") == "Windows ARM64" and r["cloud_provider"] == "azure"
+            ]
+            self.assertEqual(len(arm_azure), 1, "expected exactly one windows-arm-azure row")
+            self.assertEqual(
+                arm_azure[0]["trigger_level"], "merge_queue",
+                f"MERGE_QUEUE_CELLS cell {arm_azure[0]['name']} should be trigger_level=merge_queue; "
+                f"got {arm_azure[0]['trigger_level']}",
+            )
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_mq_cells_visible_at_push_and_nightly_via_cumulative_filter(self) -> None:
+        """filter_active at merge and nightly must include MERGE_QUEUE_CELLS rows."""
+        mq = (
+            "MERGE_QUEUE_CELLS = [\n"
+            "    {'OS': 'windows', 'Arch': 'arm', 'Cloud': 'azure'},\n"
+            "]\n"
+        )
+        path = self._write_odbc_model(mq)
+        try:
+            rows = gm.generate(path, "odbc")
+            for level in ("merge", "nightly"):
+                at_level = gm.filter_active(rows, level)
+                arm_names = [r["name"] for r in at_level if r.get("driver_artifact") == "Windows ARM64"]
+                self.assertTrue(
+                    arm_names,
+                    f"windows-arm (MERGE_QUEUE_CELLS) must appear at {level!r} via cumulative filter",
+                )
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_mq_filter_returns_only_mq_cells_not_all_pr_rows(self) -> None:
+        """filter_active('merge_queue') returns only MERGE_QUEUE_CELLS rows.
+        PR rows that are NOT in MERGE_QUEUE_CELLS must not be returned."""
+        mq = (
+            "MERGE_QUEUE_CELLS = [\n"
+            "    {'OS': 'windows', 'Arch': 'arm', 'Cloud': 'azure'},\n"
+            "]\n"
+        )
+        path = self._write_odbc_model(mq)
+        try:
+            rows = gm.generate(path, "odbc")
+            at_mq = gm.filter_active(rows, "merge_queue")
+            # All returned rows must have merge_queue_cell=True
+            for r in at_mq:
+                self.assertTrue(
+                    r.get("merge_queue_cell"),
+                    f"filter_active('merge_queue') returned row {r['name']} without merge_queue_cell=True",
+                )
+            # PR rows that are NOT in MERGE_QUEUE_CELLS must not appear
+            pr_only_names = {
+                r["name"] for r in rows
+                if r["trigger_level"] == "pr" and not r.get("merge_queue_cell")
+            }
+            mq_names = {r["name"] for r in at_mq}
+            self.assertTrue(
+                pr_only_names.isdisjoint(mq_names),
+                f"PR-only rows {pr_only_names & mq_names} appeared in merge_queue filter",
+            )
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_pr_cell_in_mq_cells_appears_at_merge_queue(self) -> None:
+        """A cell in both PR_CELLS and MERGE_QUEUE_CELLS must be returned by
+        filter_active('merge_queue') even though its trigger_level is 'pr'."""
+        # Add ubuntu-x64-azure (which IS in PR_CELLS) to MERGE_QUEUE_CELLS.
+        mq = (
+            "MERGE_QUEUE_CELLS = [\n"
+            "    {'OS': 'ubuntu', 'Arch': 'x64', 'Cloud': 'azure'},\n"  # same as PR_CELLS
+            "]\n"
+        )
+        path = self._write_odbc_model(mq)
+        try:
+            rows = gm.generate(path, "odbc")
+            # The row should still have trigger_level="pr" (PR_CELLS wins)
+            ubuntu_azure = [
+                r for r in rows
+                if r.get("driver_artifact") == "Linux x64" and r["cloud_provider"] == "azure"
+            ]
+            self.assertEqual(len(ubuntu_azure), 1)
+            self.assertEqual(ubuntu_azure[0]["trigger_level"], "pr",
+                             "PR_CELLS must win trigger_level assignment")
+            self.assertTrue(ubuntu_azure[0].get("merge_queue_cell"),
+                            "merge_queue_cell must be True for MERGE_QUEUE_CELLS rows")
+            # filter_active("merge_queue") must return this row despite trigger_level="pr"
+            mq_active = gm.filter_active(rows, "merge_queue")
+            linux_in_mq = [r for r in mq_active if r.get("driver_artifact") == "Linux x64"]
+            self.assertEqual(
+                len(linux_in_mq), 1,
+                "ubuntu-x64-azure must appear in filter_active('merge_queue') via merge_queue_cell=True "
+                f"even though trigger_level='pr'; mq_active: {[r['name'] for r in mq_active]}",
+            )
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_pr_cells_override_mq_cells_trigger_level(self) -> None:
+        """A cell in both PR_CELLS and MERGE_QUEUE_CELLS gets trigger_level='pr'."""
+        # ubuntu-x64-azure is in PR_CELLS; also add it to MERGE_QUEUE_CELLS.
+        mq = (
+            "MERGE_QUEUE_CELLS = [\n"
+            "    {'OS': 'ubuntu', 'Arch': 'x64', 'Cloud': 'azure'},\n"
+            "]\n"
+        )
+        path = self._write_odbc_model(mq)
+        try:
+            rows = gm.generate(path, "odbc")
+            ubuntu_azure = [
+                r for r in rows
+                if r.get("driver_artifact") == "Linux x64" and r["cloud_provider"] == "azure"
+            ]
+            self.assertEqual(len(ubuntu_azure), 1, "expected exactly one ubuntu-x64-azure row")
+            self.assertEqual(
+                ubuntu_azure[0]["trigger_level"], "pr",
+                "ubuntu-x64-azure is in PR_CELLS; trigger_level must be 'pr'",
+            )
+            # merge_queue_cell=True is still set, so filter_active("merge_queue") returns it.
+            self.assertTrue(ubuntu_azure[0].get("merge_queue_cell"))
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_mq_cells_excluded_from_pairwise_no_duplicate_rows(self) -> None:
+        """No duplicate rows for a cell that is in MERGE_QUEUE_CELLS."""
+        mq = (
+            "MERGE_QUEUE_CELLS = [\n"
+            "    {'OS': 'windows', 'Arch': 'arm', 'Cloud': 'azure'},\n"
+            "]\n"
+        )
+        path = self._write_odbc_model(mq)
+        try:
+            rows = gm.generate(path, "odbc")
+            arm_azure = [
+                r for r in rows
+                if r.get("driver_artifact") == "Windows ARM64" and r["cloud_provider"] == "azure"
+            ]
+            self.assertEqual(
+                len(arm_azure), 1,
+                f"expected exactly one windows-arm-azure row; got {len(arm_azure)} "
+                f"(pairwise must not also select this MERGE_QUEUE_CELLS cell)",
+            )
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_mq_cells_not_gated_by_merge_valid(self) -> None:
+        """MERGE_QUEUE_CELLS bypass MERGE_VALID — macOS blocked from pairwise still runs via MQ."""
+        mq = (
+            "MERGE_QUEUE_CELLS = [\n"
+            "    {'OS': 'macos', 'Arch': 'arm', 'Cloud': 'aws'},\n"
+            "]\n"
+        )
+        path = self._write_odbc_model(mq)
+        try:
+            rows = gm.generate(path, "odbc")
+            mac_aws = [
+                r for r in rows
+                if r.get("driver_artifact") == "macOS ARM64" and r["cloud_provider"] == "aws"
+            ]
+            self.assertEqual(len(mac_aws), 1, "macos-arm-aws via MERGE_QUEUE_CELLS must appear despite MERGE_VALID blocking macOS from pairwise")
+            self.assertEqual(mac_aws[0]["trigger_level"], "merge_queue")
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_empty_mq_cells_is_no_op(self) -> None:
+        """Adding MERGE_QUEUE_CELLS = [] must not change the matrix."""
+        without = self._write_odbc_model("")
+        with_empty = self._write_odbc_model("MERGE_QUEUE_CELLS = []\n")
+        try:
+            rows_a = gm.generate(without, "odbc")
+            rows_b = gm.generate(with_empty, "odbc")
+            self.assertEqual(rows_a, rows_b)
+        finally:
+            without.unlink(missing_ok=True)
+            with_empty.unlink(missing_ok=True)
+
+    def test_mq_cell_violating_constraint_warns_no_row(self) -> None:
+        """A MERGE_QUEUE_CELLS cell that violates constraints warns and emits no row."""
+        # macos-x64 is forbidden by is_valid (ODBC model).
+        mq = (
+            "MERGE_QUEUE_CELLS = [\n"
+            "    {'OS': 'macos', 'Arch': 'x64', 'Cloud': 'aws'},\n"  # violates is_valid
+            "]\n"
+        )
+        path = self._write_odbc_model(mq)
+        try:
+            buf = io.StringIO()
+            with redirect_stderr(buf):
+                rows = gm.generate(path, "odbc")
+            self.assertIn("violates constraints", buf.getvalue())
+            # No row for the forbidden combo must be emitted.
+            mac_x64 = [r for r in rows if r.get("driver_artifact") == "macOS x64"]
+            self.assertEqual(mac_x64, [])
+        finally:
+            path.unlink(missing_ok=True)
+
+
 class BlockListShapeTests(unittest.TestCase):
     """
     Static-AST guard: every model's is_valid() must be a pure block-list.
@@ -647,6 +966,19 @@ class OdbcMatrixTests(unittest.TestCase):
         self.assertEqual(r["cloud_provider"], "aws")
         self.assertEqual(r["driver_artifact"], "Linux x64")
 
+    def test_ubuntu_linux_present_at_merge_queue(self) -> None:
+        # ubuntu-x64-aws is the MERGE_QUEUE_CELLS cell — same as PR_CELLS,
+        # most common path. Gets trigger_level="pr" + merge_queue_cell=True.
+        mq_rows = gm.filter_active(self.gha, "merge_queue")
+        linux_mq = [r for r in mq_rows if r.get("driver_artifact") == "Linux x64"]
+        self.assertEqual(
+            len(linux_mq), 1,
+            "expected exactly one Linux x64 row in filter_active('merge_queue'); "
+            f"got: {[r['name'] for r in mq_rows]}",
+        )
+        self.assertEqual(linux_mq[0]["cloud_provider"], "aws")
+        self.assertTrue(linux_mq[0].get("merge_queue_cell"))
+
 
 class PythonMatrixTests(unittest.TestCase):
     @classmethod
@@ -767,34 +1099,50 @@ class PythonMatrixTests(unittest.TestCase):
             missing = required - r.keys()
             self.assertFalse(missing, f"row {r} missing keys {missing}")
 
-    def test_no_duplicate_macos_rows_at_mq(self) -> None:
-        # Regression test for the python.py MERGE_VALID/PR_CELLS sync invariant.
-        # The merge_valid() predicate pins macos-arm to one combo and macos-x64
-        # to another. The macOS entry in PR_CELLS MUST match the macos-arm pin
-        # exactly; if they diverge, the PR cell ships at trigger_level=pr while
-        # pairwise ships a *different* macos-arm row at trigger_level=merge,
-        # giving two macOS-arm jobs at the merge queue (defeating the point of
-        # MERGE_VALID). This test fails loudly when the sync drifts.
-        mq_macos = [
-            r for r in self.gha
-            if r["os"] == "macos-latest" and r["trigger_level"] in ("pr", "merge")
+    def test_ubuntu_linux_present_at_merge_queue(self) -> None:
+        # ubuntu-x64-aws-3.13-test is the single MERGE_QUEUE_CELLS cell — same as
+        # PR_CELLS, most common path. Gets trigger_level="pr" + merge_queue_cell=True.
+        mq_rows = gm.filter_active(self.gha, "merge_queue")
+        ubuntu_mq = [
+            r for r in mq_rows
+            if r["os"] == "ubuntu-latest"
+            and r["cloud_provider"] == "aws"
+            and r["py"] == "3.13"
+            and r["hatch_env"] == "test"
         ]
         self.assertEqual(
-            len(mq_macos), 1,
-            f"expected exactly one macos-arm row at merge-queue scope; "
-            f"got {[r['name'] for r in mq_macos]}. "
-            f"This usually means the PR_CELLS macOS entry has drifted "
-            f"away from the macos-arm pin in merge_valid(): both reach "
-            f"the merge level and macOS runs twice per MQ build.",
+            len(ubuntu_mq), 1,
+            "expected exactly one ubuntu-x64-aws-3.13-test row in filter_active('merge_queue'); "
+            f"got merge_queue rows: {[r['name'] for r in mq_rows]}",
         )
-        mq_intel = [
+        self.assertTrue(ubuntu_mq[0].get("merge_queue_cell"))
+
+    def test_no_duplicate_macos_rows_at_push_to_main(self) -> None:
+        # Regression test for the python.py MERGE_VALID/PR_CELLS sync invariant.
+        # macOS rows come from pairwise (trigger_level="merge") and appear at
+        # push-to-main scope (filter_active("merge") is cumulative).
+        # The merge_valid() predicate pins macos-arm to one combo and macos-x64
+        # to another. This test verifies exactly one cell per macOS arch appears
+        # at push-to-main scope (pr + merge_queue + merge).
+        push_scope = ("pr", "merge_queue", "merge")
+        push_macos_arm = [
             r for r in self.gha
-            if r["os"] == "macos-15-intel" and r["trigger_level"] in ("pr", "merge")
+            if r["os"] == "macos-latest" and r["trigger_level"] in push_scope
         ]
         self.assertEqual(
-            len(mq_intel), 1,
-            f"expected exactly one macos-x64 row at merge-queue scope; "
-            f"got {[r['name'] for r in mq_intel]}",
+            len(push_macos_arm), 1,
+            f"expected exactly one macos-arm row at push-to-main scope; "
+            f"got {[r['name'] for r in push_macos_arm]}. "
+            f"This usually means the merge_valid() pin for macos-arm has drifted.",
+        )
+        push_intel = [
+            r for r in self.gha
+            if r["os"] == "macos-15-intel" and r["trigger_level"] in push_scope
+        ]
+        self.assertEqual(
+            len(push_intel), 1,
+            f"expected exactly one macos-x64 row at push-to-main scope; "
+            f"got {[r['name'] for r in push_intel]}",
         )
 
 
@@ -861,6 +1209,20 @@ class CoreMatrixTests(unittest.TestCase):
             missing = required - r.keys()
             self.assertFalse(missing, f"row {r['name']} missing keys {missing}")
 
+    def test_ubuntu_x64_is_merge_queue_cell(self) -> None:
+        # ubuntu-x64 is in both PR_CELLS and MERGE_QUEUE_CELLS (it's the fastest cell).
+        # PR_CELLS wins for trigger_level ("pr"), but merge_queue_cell=True means
+        # filter_active("merge_queue") returns only ubuntu-x64 at merge_group.
+        mq = gm.filter_active(self.gha, "merge_queue")
+        self.assertEqual(
+            [r["name"] for r in mq], ["ubuntu-x64"],
+            f"expected only ubuntu-x64 at merge_queue scope; got {[r['name'] for r in mq]}",
+        )
+        self.assertEqual(mq[0]["trigger_level"], "pr",
+                         "ubuntu-x64 is in PR_CELLS — trigger_level must be 'pr'")
+        self.assertTrue(mq[0].get("merge_queue_cell"),
+                        "ubuntu-x64 is in MERGE_QUEUE_CELLS — merge_queue_cell must be True")
+
 
 # ---------------------------------------------------------------------------
 # Validation paths
@@ -881,7 +1243,7 @@ class ValidationTests(unittest.TestCase):
             with redirect_stderr(buf):
                 # We only want loader/constraint behavior; sidestep validate_mappings
                 # by calling internals.
-                params, constraints, _mv, pr_cells, _json_cells = gm.load_model(path)
+                params, constraints, _mv, pr_cells, _mq_cells, _json_cells = gm.load_model(path)
                 all_combos = [
                     c for c in (
                         dict(zip(params.keys(), v))
@@ -932,12 +1294,11 @@ class ValidationTests(unittest.TestCase):
 
 class JsonVariantRegressionTests(unittest.TestCase):
     """
-    Locks the JSON cell count at the merge trigger level across odbc + python.
+    Locks the JSON cell count at push-to-main scope across odbc + python.
 
-    Main has 1 ODBC json cell (every PR — appears at merge cumulatively) plus
-    2 Python json cells (gated on merge). This test pins the combined merge-
-    level JSON count at 3 so future model edits don't silently change the
-    JSON-format coverage.
+    ODBC has 1 json cell (trigger_level="pr", appears at all cumulative scopes).
+    Python has 2 json cells (trigger_level="merge", gated on push-to-main).
+    Total at push-to-main scope: 3.
     """
 
     @classmethod
@@ -945,18 +1306,17 @@ class JsonVariantRegressionTests(unittest.TestCase):
         cls.odbc_gha = gm.generate(ODBC_PATH, "odbc")
         cls.py_gha = gm.generate(PYTHON_PATH, "python")
 
-    def test_combined_json_count_at_merge_level(self) -> None:
-        # `merge` is cumulative — it includes pr cells plus rows whose
-        # trigger_level is `pr` or `merge`.
-        active_levels = {"pr", "merge"}
-        json_at_merge = [
+    def test_combined_json_count_at_push_to_main(self) -> None:
+        # push-to-main = filter_active("merge") = cumulative: pr + merge_queue + merge.
+        push_scope = ("pr", "merge_queue", "merge")
+        json_at_push = [
             r for r in (self.odbc_gha + self.py_gha)
-            if r.get("result_format") == "json" and r["trigger_level"] in active_levels
+            if r.get("result_format") == "json" and r["trigger_level"] in push_scope
         ]
         self.assertEqual(
-            len(json_at_merge), 3,
-            f"expected 3 json cells active at merge, got {len(json_at_merge)}: "
-            f"{[r['name'] for r in json_at_merge]}",
+            len(json_at_push), 3,
+            f"expected 3 json cells active at push-to-main, got {len(json_at_push)}: "
+            f"{[r['name'] for r in json_at_push]}",
         )
 
     def test_json_names_unchanged(self) -> None:
@@ -1000,9 +1360,10 @@ class BuildTargetsTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls.gha = gm.generate(PYTHON_PATH, "python")
-        cls.targets_pr      = gm.build_targets("python", "pull_request")
-        cls.targets_merge   = gm.build_targets("python", "merge_group")
-        cls.targets_nightly = gm.build_targets("python", "schedule")
+        cls.targets_pr         = gm.build_targets("python", "pull_request")
+        cls.targets_merge_group = gm.build_targets("python", "merge_group")  # MQ only
+        cls.targets_push       = gm.build_targets("python", "push")           # full push-to-main
+        cls.targets_nightly    = gm.build_targets("python", "schedule")
 
     def _active_wheel_rows(self, level: str) -> list:
         return [
@@ -1028,9 +1389,16 @@ class BuildTargetsTests(unittest.TestCase):
         actual = {k: set(v) for k, v in self.targets_pr.items()}
         self.assertEqual(actual, expected)
 
-    def test_merge_targets_match_active_wheel_rows(self) -> None:
+    def test_merge_group_targets_match_active_wheel_rows(self) -> None:
+        # merge_group (merge_queue level) is non-cumulative: only MQ cells' wheels.
+        expected = self._expected_targets("merge_queue")
+        actual = {k: set(v) for k, v in self.targets_merge_group.items()}
+        self.assertEqual(actual, expected)
+
+    def test_push_targets_match_active_wheel_rows(self) -> None:
+        # push-to-main (merge level) is cumulative: pr + merge_queue + merge.
         expected = self._expected_targets("merge")
-        actual = {k: set(v) for k, v in self.targets_merge.items()}
+        actual = {k: set(v) for k, v in self.targets_push.items()}
         self.assertEqual(actual, expected)
 
     def test_nightly_targets_match_active_wheel_rows(self) -> None:
@@ -1038,27 +1406,28 @@ class BuildTargetsTests(unittest.TestCase):
         actual = {k: set(v) for k, v in self.targets_nightly.items()}
         self.assertEqual(actual, expected)
 
-    def test_pr_subset_of_merge_subset_of_nightly(self) -> None:
-        # Per-trigger contraction: PR ⊆ merge ⊆ nightly.
+    def test_pr_subset_of_push_subset_of_nightly(self) -> None:
+        # Contraction: PR ⊆ push-to-main ⊆ nightly.
+        # (merge_group is non-cumulative so PR ⊄ merge_group is expected.)
         for cibw_key, versions in self.targets_pr.items():
             self.assertIn(
-                cibw_key, self.targets_merge,
-                f"PR builds {cibw_key} but merge does not — every PR cell "
-                f"must also be active at merge level (cumulative trigger filter).",
+                cibw_key, self.targets_push,
+                f"PR builds {cibw_key} but push-to-main does not — every PR cell "
+                f"must also be active at push-to-main (cumulative trigger filter).",
             )
             self.assertTrue(
-                set(versions).issubset(self.targets_merge[cibw_key]),
-                f"PR-level {cibw_key} versions {versions} not a subset of merge {self.targets_merge[cibw_key]}",
+                set(versions).issubset(self.targets_push[cibw_key]),
+                f"PR-level {cibw_key} versions {versions} not a subset of push {self.targets_push[cibw_key]}",
             )
-        for cibw_key, versions in self.targets_merge.items():
+        for cibw_key, versions in self.targets_push.items():
             self.assertIn(
                 cibw_key, self.targets_nightly,
-                f"merge builds {cibw_key} but nightly does not — full cartesian "
-                f"product should always cover merge cells.",
+                f"push builds {cibw_key} but nightly does not — full cartesian "
+                f"product should always cover push-to-main cells.",
             )
             self.assertTrue(
                 set(versions).issubset(self.targets_nightly[cibw_key]),
-                f"merge-level {cibw_key} versions {versions} not a subset of nightly {self.targets_nightly[cibw_key]}",
+                f"push-level {cibw_key} versions {versions} not a subset of nightly {self.targets_nightly[cibw_key]}",
             )
 
     def test_no_overbuild(self) -> None:
@@ -1066,9 +1435,10 @@ class BuildTargetsTests(unittest.TestCase):
         # test row at the same level. Catches "we build wheels nothing tests".
         artifact_to_pair = {p["wheel_artifact"]: pair for pair, p in gm.PYTHON_PLATFORM.items()}
         for level, targets in [
-            ("pr", self.targets_pr),
-            ("merge", self.targets_merge),
-            ("nightly", self.targets_nightly),
+            ("pr",          self.targets_pr),
+            ("merge_queue", self.targets_merge_group),
+            ("merge",       self.targets_push),
+            ("nightly",     self.targets_nightly),
         ]:
             active = self._active_wheel_rows(level)
             for cibw_key, versions in targets.items():
@@ -1090,9 +1460,10 @@ class BuildTargetsTests(unittest.TestCase):
         # won't be built", which would 404 actions/download-artifact at runtime.
         artifact_to_pair = {p["wheel_artifact"]: pair for pair, p in gm.PYTHON_PLATFORM.items()}
         for level, targets in [
-            ("pr", self.targets_pr),
-            ("merge", self.targets_merge),
-            ("nightly", self.targets_nightly),
+            ("pr",          self.targets_pr),
+            ("merge_queue", self.targets_merge_group),
+            ("merge",       self.targets_push),
+            ("nightly",     self.targets_nightly),
         ]:
             for r in self._active_wheel_rows(level):
                 pair = artifact_to_pair[r["wheel_artifact"]]
@@ -1112,9 +1483,10 @@ class BuildTargetsTests(unittest.TestCase):
         # py3.10 always installs from sdist; rows have no wheel_artifact and
         # must NOT appear in build_targets at any level.
         for level, targets in [
-            ("pr", self.targets_pr),
-            ("merge", self.targets_merge),
-            ("nightly", self.targets_nightly),
+            ("pr",          self.targets_pr),
+            ("merge_queue", self.targets_merge_group),
+            ("merge",       self.targets_push),
+            ("nightly",     self.targets_nightly),
         ]:
             for cibw_key, versions in targets.items():
                 self.assertNotIn(
@@ -1194,7 +1566,8 @@ class OdbcBuildMatrixTests(unittest.TestCase):
         has a corresponding build matrix entry.
       * No over-build / under-build — the build matrix is a deduplicated
         projection of active test rows' driver_artifact.
-      * Per-trigger contraction — PR ⊆ merge ⊆ nightly.
+      * Per-trigger contraction — PR ⊆ push-to-main ⊆ nightly.
+        (merge_group is non-cumulative; PR ⊄ merge_group is expected.)
       * Legacy parity — at nightly the matrix matches the previously
         hardcoded include block in test-odbc.yml.
       * Schema — required fields are present, optional fields appear only
@@ -1204,9 +1577,10 @@ class OdbcBuildMatrixTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls.gha = gm.generate(ODBC_PATH, "odbc")
-        cls.matrix_pr      = gm.build_matrix("odbc", "pull_request")
-        cls.matrix_merge   = gm.build_matrix("odbc", "merge_group")
-        cls.matrix_nightly = gm.build_matrix("odbc", "schedule")
+        cls.matrix_pr          = gm.build_matrix("odbc", "pull_request")
+        cls.matrix_merge_group = gm.build_matrix("odbc", "merge_group")  # MQ only
+        cls.matrix_push        = gm.build_matrix("odbc", "push")          # full push-to-main
+        cls.matrix_nightly     = gm.build_matrix("odbc", "schedule")
 
     def _active_artifact_rows(self, level: str) -> list:
         return [
@@ -1227,9 +1601,16 @@ class OdbcBuildMatrixTests(unittest.TestCase):
         actual_names = {entry["name"] for entry in self.matrix_pr}
         self.assertEqual(actual_names, expected_names)
 
-    def test_merge_matches_active_rows(self) -> None:
+    def test_merge_group_matches_active_rows(self) -> None:
+        # merge_group (merge_queue level) is non-cumulative: only MQ cells' artifacts.
+        expected_names = {r["driver_artifact"] for r in self._active_artifact_rows("merge_queue")}
+        actual_names = {entry["name"] for entry in self.matrix_merge_group}
+        self.assertEqual(actual_names, expected_names)
+
+    def test_push_matches_active_rows(self) -> None:
+        # push-to-main (merge level) is cumulative: pr + merge_queue + merge.
         expected_names = {r["driver_artifact"] for r in self._active_artifact_rows("merge")}
-        actual_names = {entry["name"] for entry in self.matrix_merge}
+        actual_names = {entry["name"] for entry in self.matrix_push}
         self.assertEqual(actual_names, expected_names)
 
     def test_nightly_matches_active_rows(self) -> None:
@@ -1237,20 +1618,23 @@ class OdbcBuildMatrixTests(unittest.TestCase):
         actual_names = {entry["name"] for entry in self.matrix_nightly}
         self.assertEqual(actual_names, expected_names)
 
-    def test_pr_subset_of_merge_subset_of_nightly(self) -> None:
+    def test_pr_subset_of_push_subset_of_nightly(self) -> None:
+        # PR ⊆ push-to-main ⊆ nightly (cumulative contraction).
+        # merge_group is non-cumulative; PR ⊄ merge_group is expected behaviour.
         names_pr      = {e["name"] for e in self.matrix_pr}
-        names_merge   = {e["name"] for e in self.matrix_merge}
+        names_push    = {e["name"] for e in self.matrix_push}
         names_nightly = {e["name"] for e in self.matrix_nightly}
-        self.assertTrue(names_pr.issubset(names_merge),
-                        f"PR names {names_pr} not subset of merge {names_merge}")
-        self.assertTrue(names_merge.issubset(names_nightly),
-                        f"merge names {names_merge} not subset of nightly {names_nightly}")
+        self.assertTrue(names_pr.issubset(names_push),
+                        f"PR names {names_pr} not subset of push-to-main {names_push}")
+        self.assertTrue(names_push.issubset(names_nightly),
+                        f"push names {names_push} not subset of nightly {names_nightly}")
 
     def test_no_duplicates_per_level(self) -> None:
         for level, matrix in [
-            ("pr", self.matrix_pr),
-            ("merge", self.matrix_merge),
-            ("nightly", self.matrix_nightly),
+            ("pr",          self.matrix_pr),
+            ("merge_group", self.matrix_merge_group),
+            ("push",        self.matrix_push),
+            ("nightly",     self.matrix_nightly),
         ]:
             names = [e["name"] for e in matrix]
             self.assertEqual(
@@ -1295,9 +1679,10 @@ class OdbcBuildMatrixTests(unittest.TestCase):
     def test_required_keys_on_every_entry(self) -> None:
         required = {"name", "os", "driver_lib", "driver_artifact", "cache_key"}
         for level, matrix in [
-            ("pr", self.matrix_pr),
-            ("merge", self.matrix_merge),
-            ("nightly", self.matrix_nightly),
+            ("pr",          self.matrix_pr),
+            ("merge_group", self.matrix_merge_group),
+            ("push",        self.matrix_push),
+            ("nightly",     self.matrix_nightly),
         ]:
             for entry in matrix:
                 missing = required - entry.keys()
@@ -1324,7 +1709,7 @@ class OdbcBuildMatrixTests(unittest.TestCase):
     def test_pr_count_at_4(self) -> None:
         # Pin the post-MERGE_VALID PR-level count: 4 driver flavours
         # (Linux x64, macOS ARM64, Windows x64, Windows x86).
-        # Windows ARM64 is only at merge level via pairwise.
+        # Windows ARM64 is only at merge_queue level via MERGE_QUEUE_CELLS.
         self.assertEqual(
             len(self.matrix_pr), 4,
             f"expected 4 PR-level driver builds; got {len(self.matrix_pr)}: "
@@ -1335,11 +1720,11 @@ class OdbcBuildMatrixTests(unittest.TestCase):
             {"Linux x64", "macOS ARM64", "Windows x64", "Windows x86"},
         )
 
-    def test_merge_includes_windows_arm(self) -> None:
-        # Windows ARM64 is added at merge via pairwise (no PR cell uses it),
-        # so the merge build matrix must include it.
-        names = {e["name"] for e in self.matrix_merge}
-        self.assertIn("Windows ARM64", names)
+    def test_merge_group_includes_linux_x64(self) -> None:
+        # Linux x64 is the MERGE_QUEUE_CELLS cell (ubuntu-x64-gcp),
+        # so the merge_group build matrix must include it.
+        names = {e["name"] for e in self.matrix_merge_group}
+        self.assertIn("Linux x64", names)
 
     def test_emit_build_matrix_cli_format(self) -> None:
         # CLI emits exactly one line of the form `matrix=<json>`.
@@ -1371,9 +1756,10 @@ class OdbcBuildMatrixTests(unittest.TestCase):
         # Reproducibility: output is sorted by name regardless of which test
         # row triggered the lane's inclusion first.
         for level, matrix in [
-            ("pr", self.matrix_pr),
-            ("merge", self.matrix_merge),
-            ("nightly", self.matrix_nightly),
+            ("pr",          self.matrix_pr),
+            ("merge_group", self.matrix_merge_group),
+            ("push",        self.matrix_push),
+            ("nightly",     self.matrix_nightly),
         ]:
             names = [e["name"] for e in matrix]
             self.assertEqual(
@@ -1389,8 +1775,8 @@ class OdbcBuildMatrixTests(unittest.TestCase):
 class FilterTests(unittest.TestCase):
     def test_level_for_event(self) -> None:
         self.assertEqual(gm.level_for_event("pull_request"), "pr")
-        self.assertEqual(gm.level_for_event("push"), "merge")
-        self.assertEqual(gm.level_for_event("merge_group"), "merge")
+        self.assertEqual(gm.level_for_event("push"), "merge")           # push to main: full pairwise set
+        self.assertEqual(gm.level_for_event("merge_group"), "merge_queue")  # merge queue: MQ cells only
         self.assertEqual(gm.level_for_event("schedule"), "nightly")
         self.assertEqual(gm.level_for_event("unknown"), "pr")
         self.assertEqual(gm.level_for_event(None), "pr")
@@ -1398,12 +1784,70 @@ class FilterTests(unittest.TestCase):
     def test_filter_active_cumulative(self) -> None:
         rows = [
             {"trigger_level": "pr"},
+            {"trigger_level": "merge_queue", "merge_queue_cell": True},
             {"trigger_level": "merge"},
             {"trigger_level": "nightly"},
         ]
+        # pr: only pr rows (cumulative cap = 0)
         self.assertEqual(len(gm.filter_active(rows, "pr")), 1)
-        self.assertEqual(len(gm.filter_active(rows, "merge")), 2)
-        self.assertEqual(len(gm.filter_active(rows, "nightly")), 3)
+        # merge: cumulative — pr + merge_queue + merge (3 rows)
+        self.assertEqual(len(gm.filter_active(rows, "merge")), 3)
+        # nightly: all 4 rows
+        self.assertEqual(len(gm.filter_active(rows, "nightly")), 4)
+
+    def test_filter_active_merge_queue_non_cumulative(self) -> None:
+        """merge_queue level returns rows with merge_queue_cell=True (not all pr rows)."""
+        rows = [
+            {"trigger_level": "pr"},
+            {"trigger_level": "merge_queue", "merge_queue_cell": True},
+            {"trigger_level": "merge"},
+            {"trigger_level": "nightly"},
+        ]
+        mq = gm.filter_active(rows, "merge_queue")
+        self.assertEqual(len(mq), 1)
+        self.assertEqual(mq[0]["trigger_level"], "merge_queue")
+
+    def test_filter_active_merge_queue_includes_pr_cell_with_marker(self) -> None:
+        """A 'pr' row with merge_queue_cell=True must be returned at merge_queue level.
+
+        This is the case when a cell is in both PR_CELLS and MERGE_QUEUE_CELLS:
+        PR_CELLS wins for trigger_level assignment, but the row is still selected
+        at merge_queue because merge_queue_cell=True is set.
+        """
+        rows = [
+            {"trigger_level": "pr", "name": "other-pr"},           # NOT in MQ
+            {"trigger_level": "pr", "name": "shared", "merge_queue_cell": True},  # in both
+            {"trigger_level": "merge", "name": "pairwise"},
+        ]
+        mq = gm.filter_active(rows, "merge_queue")
+        self.assertEqual(len(mq), 1)
+        self.assertEqual(mq[0]["name"], "shared")
+        # pr filter still includes BOTH pr rows (cumulative, trigger_level-based)
+        pr = gm.filter_active(rows, "pr")
+        self.assertEqual(len(pr), 2)
+
+    def test_filter_active_merge_queue_fallback_to_pr(self) -> None:
+        """When no merge_queue rows exist, filter returns PR_CELLS as fallback."""
+        rows = [
+            {"trigger_level": "pr"},
+            {"trigger_level": "merge"},
+            {"trigger_level": "nightly"},
+        ]
+        mq = gm.filter_active(rows, "merge_queue")
+        self.assertEqual(len(mq), 1)
+        self.assertEqual(mq[0]["trigger_level"], "pr")
+
+    def test_filter_active_merge_queue_is_subset_of_merge(self) -> None:
+        """Every merge_queue row must also be included in the cumulative merge set."""
+        rows = [
+            {"trigger_level": "pr",          "name": "a"},
+            {"trigger_level": "merge_queue", "name": "b"},
+            {"trigger_level": "merge",       "name": "c"},
+            {"trigger_level": "nightly",     "name": "d"},
+        ]
+        mq_names  = {r["name"] for r in gm.filter_active(rows, "merge_queue")}
+        all_merge = {r["name"] for r in gm.filter_active(rows, "merge")}
+        self.assertTrue(mq_names.issubset(all_merge))
 
 
 class LabelResolutionTests(unittest.TestCase):
@@ -1416,11 +1860,25 @@ class LabelResolutionTests(unittest.TestCase):
     def test_empty_labels_falls_back_to_event(self) -> None:
         self.assertEqual(gm.level_for_event_and_labels("pull_request", []), "pr")
         self.assertEqual(gm.level_for_event_and_labels("pull_request", None), "pr")
-        self.assertEqual(gm.level_for_event_and_labels("merge_group", []), "merge")
+        self.assertEqual(gm.level_for_event_and_labels("merge_group", []), "merge_queue")
+
+    def test_scope_merge_queue_label_upgrades_pr_to_merge_queue(self) -> None:
+        # ci:scope-merge-queue on a PR reproduces exactly what merge_group runs.
+        self.assertEqual(
+            gm.level_for_event_and_labels("pull_request", ["ci:scope-merge-queue"]),
+            "merge_queue",
+        )
 
     def test_scope_merge_label_upgrades_pr_to_merge(self) -> None:
         self.assertEqual(
             gm.level_for_event_and_labels("pull_request", ["ci:scope-merge"]),
+            "merge",
+        )
+
+    def test_scope_merge_label_upgrades_merge_queue_to_merge(self) -> None:
+        # ci:scope-merge on a merge_group event upgrades merge_queue → merge.
+        self.assertEqual(
+            gm.level_for_event_and_labels("merge_group", ["ci:scope-merge"]),
             "merge",
         )
 
@@ -1445,7 +1903,7 @@ class LabelResolutionTests(unittest.TestCase):
         )
 
     def test_label_cannot_downgrade_event(self) -> None:
-        # ci:scope-merge on a merge_group event stays at merge (not downgraded).
+        # ci:scope-merge on a merge_group event upgrades to merge (not downgraded to pr).
         self.assertEqual(
             gm.level_for_event_and_labels("merge_group", ["ci:scope-merge"]),
             "merge",

--- a/tests/performance/Jenkinsfile.pr-check
+++ b/tests/performance/Jenkinsfile.pr-check
@@ -316,6 +316,11 @@ pipeline {
             agent { label 'drivers-perf-regular-memory-node-snowos' }
             steps {
                 script {
+                    if (isMergeQueue()) {
+                        skipAll = true
+                        echo "Merge queue build — skipping all performance tests"
+                        return
+                    }
                     detectChanges()
                     if (skipAll) {
                         postRegressionStatus('SUCCESS', 'Skipped — no performance-relevant changes')


### PR DESCRIPTION
  Summary

  Introduces a dedicated merge_queue trigger level so merge_group events run only a minimal explicit set (MERGE_QUEUE_CELLS) while push-to-main keeps full pairwise coverage.

  Lane selection:

  • ODBC → ubuntu-x64-aws - median ~17.0 min
  • Python → ubuntu-x64-aws-3.13-test - median ~15.2 min
  • Core → ubuntu-x64 - median ~16.2 min

  Jobs excluded from merge_group (still run on PRs and push-to-main):

  • ODBC reference tests
  • Python reference tests
  • test-coverage-report
  • Jenkinsfile.pr-check performance smoke tests
  • Jenkinsfile.vpn-tests
  • Jenkinsfile.build-matrix (10 platforms)

  New label: ci:scope-merge-queue — replays exact merge-queue scope on a PR.