### PR TITLE
SNOW-2467854: jdbc_bridge - use multi-threaded tokio runtime for chunk prefetch

### DIFF
--- a/jdbc_bridge/src/lib.rs
+++ b/jdbc_bridge/src/lib.rs
@@ -1,3 +1,4 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{LazyLock, Mutex};
 
 use jni::JNIEnv;
@@ -26,9 +27,16 @@ impl JdbcBridge {
             wrapper_presets: WrapperPresets::jdbc(),
             ..Default::default()
         };
+        let parallelism = std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(2);
         Self {
             runtime: tokio::runtime::Builder::new_multi_thread()
-                .worker_threads(1)
+                .worker_threads(parallelism.clamp(2, 8))
+                .thread_name_fn(|| {
+                    static N: AtomicUsize = AtomicUsize::new(0);
+                    format!("sf-jdbc-worker-{}", N.fetch_add(1, Ordering::Relaxed))
+                })
                 .enable_all()
                 .build()
                 .expect("Failed to create tokio runtime"),


### PR DESCRIPTION
The bridge runtime was pinned to worker_threads(1), which serialized sf_core's chunk prefetch tasks (network I/O, gzip, Arrow IPC decode) on a single OS thread and made CLIENT_PREFETCH_THREADS effectively a no-op for large result set fetch.
Name workers sf-jdbc-worker-N for jstack / async-profiler.