### PR TITLE
SNOW-3406377, gap 12: accept explicit SOURCE_COMPRESSION=PARQUET / =ORC

### DIFF
--- a/sf_core/src/file_manager/mod.rs
+++ b/sf_core/src/file_manager/mod.rs
@@ -264,6 +264,8 @@ fn get_source_compression(
         SourceCompressionParam::Zstd => Ok(CompressionType::Zstd),
         SourceCompressionParam::Deflate => Ok(CompressionType::Deflate),
         SourceCompressionParam::RawDeflate => Ok(CompressionType::RawDeflate),
+        SourceCompressionParam::Parquet => Ok(CompressionType::Parquet),
+        SourceCompressionParam::Orc => Ok(CompressionType::Orc),
     }
 }
 
@@ -864,6 +866,42 @@ mod tests {
                 get_source_compression("ignored.xz", b"", &SourceCompressionParam::None, legacy)
                     .unwrap(),
                 CompressionType::None,
+            );
+        }
+    }
+
+    // Explicit SOURCE_COMPRESSION=PARQUET / =ORC short-circuits auto-detect:
+    // user-specified compression is trusted, regardless of filename or
+    // magic bytes. Mirrors Python `file_transfer_agent.py:1207`
+    // (`current_file_compression_type = user_specified_source_compression`).
+    #[test]
+    fn get_source_compression_explicit_parquet_skips_autodetect() {
+        for legacy in [false, true] {
+            assert_eq!(
+                get_source_compression(
+                    "actually-not-parquet.csv",
+                    b"some-csv,content",
+                    &SourceCompressionParam::Parquet,
+                    legacy,
+                )
+                .unwrap(),
+                CompressionType::Parquet,
+            );
+        }
+    }
+
+    #[test]
+    fn get_source_compression_explicit_orc_skips_autodetect() {
+        for legacy in [false, true] {
+            assert_eq!(
+                get_source_compression(
+                    "actually-not-orc.csv",
+                    b"some-csv,content",
+                    &SourceCompressionParam::Orc,
+                    legacy,
+                )
+                .unwrap(),
+                CompressionType::Orc,
             );
         }
     }

--- a/sf_core/src/file_manager/mod.rs
+++ b/sf_core/src/file_manager/mod.rs
@@ -944,6 +944,50 @@ mod tests {
         );
     }
 
+    // Upload-prep passthrough on the explicit-param path: when the user
+    // sets `SOURCE_COMPRESSION=PARQUET` / `=ORC`, the file must NOT be
+    // re-wrapped in gzip even with `auto_compress = true`. Parallels the
+    // auto-detect passthrough tests above; the difference is that the
+    // compression type is taken from the user param rather than sniffed
+    // from filename or magic bytes.
+    #[test]
+    fn preprocess_parquet_passthrough_under_explicit_param() {
+        let payload = b"PAR1\x00\x01\x02\x03some-parquet-bytes-go-here".to_vec();
+        let data = SingleUploadData {
+            source_compression: SourceCompressionParam::Parquet,
+            ..passthrough_upload_data("data.parquet", PutGetResultsetFlavor::Python, false)
+        };
+
+        let (prepared, metadata) = preprocess_file_before_upload(payload.clone(), &data).unwrap();
+
+        assert_eq!(metadata.target, "data.parquet", "no .gz suffix expected");
+        assert_eq!(metadata.target_compression, CompressionType::Parquet);
+        assert_eq!(metadata.source_compression, CompressionType::Parquet);
+        assert_eq!(
+            prepared.data, payload,
+            "payload must pass through bit-identical (no gzip wrap)",
+        );
+    }
+
+    #[test]
+    fn preprocess_orc_passthrough_under_explicit_param() {
+        let payload = b"ORC\x00\x01\x02some-orc-bytes-go-here".to_vec();
+        let data = SingleUploadData {
+            source_compression: SourceCompressionParam::Orc,
+            ..passthrough_upload_data("data.orc", PutGetResultsetFlavor::Python, false)
+        };
+
+        let (prepared, metadata) = preprocess_file_before_upload(payload.clone(), &data).unwrap();
+
+        assert_eq!(metadata.target, "data.orc", "no .gz suffix expected");
+        assert_eq!(metadata.target_compression, CompressionType::Orc);
+        assert_eq!(metadata.source_compression, CompressionType::Orc);
+        assert_eq!(
+            prepared.data, payload,
+            "payload must pass through bit-identical"
+        );
+    }
+
     // Locks in PR2 of Gap-12: parquet/orc detection is independent of the
     // unsupported-compression flag (ODBC sets the flag to true, matching
     // legacy libsnowflakeclient which detects PAR1/ORC magic via

--- a/sf_core/src/file_manager/types.rs
+++ b/sf_core/src/file_manager/types.rs
@@ -135,6 +135,8 @@ pub enum SourceCompressionParam {
     Zstd,
     Deflate,
     RawDeflate,
+    Parquet,
+    Orc,
     None,
     AutoDetect,
 }

--- a/sf_core/src/rest/snowflake/query_response.rs
+++ b/sf_core/src/rest/snowflake/query_response.rs
@@ -397,6 +397,8 @@ impl Data {
             "ZSTD" => SourceCompressionParam::Zstd,
             "DEFLATE" => SourceCompressionParam::Deflate,
             "RAW_DEFLATE" => SourceCompressionParam::RawDeflate,
+            "PARQUET" => SourceCompressionParam::Parquet,
+            "ORC" => SourceCompressionParam::Orc,
             "NONE" => SourceCompressionParam::None,
             _ => InvalidFormatSnafu {
                 message: format!("Unknown source compression type: {source_compression_string}"),
@@ -1371,6 +1373,58 @@ mod tests {
             .unwrap();
         assert_eq!(upload.flavor, PutGetResultsetFlavor::Odbc);
         assert!(upload.legacy_odbc_compression_autodetect);
+    }
+
+    // Explicit `SOURCE_COMPRESSION=PARQUET` / `=ORC` parses to the matching
+    // `SourceCompressionParam` variant. Mirrors Python's
+    // `file_compression_type.py` which lists both with `is_supported=True`.
+    fn upload_json_with_source_compression(value: &str) -> String {
+        format!(
+            r#"{{
+                "src_locations": ["path/to/file.csv"],
+                "stageInfo": {{
+                    "locationType": "GCS",
+                    "location": "bucket/prefix/",
+                    "creds": {{ "GCS_ACCESS_TOKEN": "fake" }},
+                    "region": "us-central1"
+                }},
+                "autoCompress": false,
+                "sourceCompression": "{value}",
+                "overwrite": false
+            }}"#
+        )
+    }
+
+    #[test]
+    fn upload_data_parses_explicit_source_compression_parquet() {
+        for value in ["PARQUET", "parquet", "Parquet"] {
+            let json = upload_json_with_source_compression(value);
+            let data: Data = serde_json::from_str(&json).unwrap();
+            let upload = data
+                .to_file_upload_data(PutGetResultsetFlavor::Python, false, false)
+                .unwrap();
+            assert!(
+                matches!(upload.source_compression, SourceCompressionParam::Parquet),
+                "value={value:?} must parse to SourceCompressionParam::Parquet, got: {:?}",
+                upload.source_compression,
+            );
+        }
+    }
+
+    #[test]
+    fn upload_data_parses_explicit_source_compression_orc() {
+        for value in ["ORC", "orc", "Orc"] {
+            let json = upload_json_with_source_compression(value);
+            let data: Data = serde_json::from_str(&json).unwrap();
+            let upload = data
+                .to_file_upload_data(PutGetResultsetFlavor::Python, false, false)
+                .unwrap();
+            assert!(
+                matches!(upload.source_compression, SourceCompressionParam::Orc),
+                "value={value:?} must parse to SourceCompressionParam::Orc, got: {:?}",
+                upload.source_compression,
+            );
+        }
     }
 
     fn make_download_json() -> String {

--- a/sf_core/src/rest/snowflake/query_response.rs
+++ b/sf_core/src/rest/snowflake/query_response.rs
@@ -389,6 +389,11 @@ impl Data {
             })?
             .clone();
 
+        // TODO: explicit `SOURCE_COMPRESSION=PARQUET` / `=ORC` is accepted
+        // by the Python connector (both have `is_supported=True` in
+        // `file_compression_type.py`) and would skip auto-detect. Universal
+        // driver currently rejects them via the catch-all arm below; PR2 of
+        // Gap-12 only covers the AUTO_DETECT path. Track as follow-up.
         let source_compression = match source_compression_string.to_uppercase().as_str() {
             "AUTO_DETECT" => SourceCompressionParam::AutoDetect,
             "GZIP" => SourceCompressionParam::Gzip,

--- a/sf_core/src/rest/snowflake/query_response.rs
+++ b/sf_core/src/rest/snowflake/query_response.rs
@@ -389,11 +389,6 @@ impl Data {
             })?
             .clone();
 
-        // TODO: explicit `SOURCE_COMPRESSION=PARQUET` / `=ORC` is accepted
-        // by the Python connector (both have `is_supported=True` in
-        // `file_compression_type.py`) and would skip auto-detect. Universal
-        // driver currently rejects them via the catch-all arm below; PR2 of
-        // Gap-12 only covers the AUTO_DETECT path. Track as follow-up.
         let source_compression = match source_compression_string.to_uppercase().as_str() {
             "AUTO_DETECT" => SourceCompressionParam::AutoDetect,
             "GZIP" => SourceCompressionParam::Gzip,


### PR DESCRIPTION
## Summary

PR3 of the [Gap-12](https://snowflakecomputing.atlassian.net/browse/SNOW-3406388) series. Closes the explicit-parameter half of parquet/orc parity that PR2 (#1248) deliberately scoped out.

Until now, a user-issued
```sql
PUT file://data.parquet @stage SOURCE_COMPRESSION=PARQUET
```
hit the catch-all `InvalidFormatSnafu` arm in `query_response.rs`. PR2 (#1248) fixed the `AUTO_DETECT` path; this PR fixes the explicit-string path so user-specified `PARQUET`/`ORC` short-circuits auto-detect entirely — matching Python `file_transfer_agent.py:1207` which assigns `current_file_compression_type = user_specified_source_compression` without consulting filename or magic bytes.

### Changes

- `SourceCompressionParam`: add `Parquet` and `Orc` variants.
- `query_response.rs`: parse `"PARQUET"` / `"ORC"` (case-insensitive via the existing `to_uppercase` match); drop the TODO that PR2 added flagging this as a follow-up.
- `file_manager::mod::get_source_compression`: route the new variants to `CompressionType::Parquet` / `::Orc`.

### Tests

- `get_source_compression_explicit_parquet_skips_autodetect` / `_orc_*` — locks "user-specified compression beats filename / magic" (uses a `.csv` filename + CSV-shaped buffer to prove auto-detect is skipped).
- `upload_data_parses_explicit_source_compression_parquet` / `_orc` — verifies the JSON parser accepts `PARQUET` / `parquet` / `Parquet` (and the `ORC` equivalents) since the existing match uses `to_uppercase()`.

### Reference parity

- Python `file_compression_type.py` lists ORC and PARQUET with `is_supported=True`, accepted by `lookup_by_mime_sub_type` for user-specified compression.
- libsnowflakeclient `FileCompressionType.cpp` registers PARQUET and ORC with `isSupported=true`.

No change to the `AUTO_DETECT` path (PR2's territory).

## Stack

 * #1247
 * #1248
 * this PR

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test -p sf_core --lib` (1007 passed, 0 failed; +4 from PR2's 1003)
- [x] `PARAMETER_PATH=parameters.json cargo test -p sf_core --test e2e_tests --release`