### PR TITLE
SNOW-3571146: harden protoc download against transient GitHub Releases 5xx

### DIFF
--- a/.github/actions/cargo-cache/action.yml
+++ b/.github/actions/cargo-cache/action.yml
@@ -87,11 +87,14 @@ runs:
     #   v1: initial cache action (Apr 17 2025)
     #   v2: aggressive slim + size cap + llvm-cov layout (Apr 29 2025) — busts
     #       the 13-15 GB tarpaulin caches that don't honour the 6 GB cap.
+    #   v3: include ~/.cache/protoc in the registry cache so the proto_generator
+    #       build script never has to hit GitHub Releases on a warm cache hit.
+    #       Bust v2 to force one clean rebuild that primes the new path layout.
     - name: Compute cache keys
       id: keys
       shell: bash
       run: |
-        CACHE_VERSION='v2'
+        CACHE_VERSION='v3'
         LOCK_HASH="${{ hashFiles(inputs.lockfiles) }}"
         echo "registry=${{ runner.os }}-cargo-registry-${CACHE_VERSION}-${LOCK_HASH}" >> $GITHUB_OUTPUT
         echo "target=${{ runner.os }}-rust-${{ inputs.shared-key }}-${CACHE_VERSION}-${{ steps.rustc.outputs.hash }}-${LOCK_HASH}" >> $GITHUB_OUTPUT
@@ -102,11 +105,18 @@ runs:
     # ENOSPC during extract should not fail the job — the build can still run
     # from scratch. Workflow callers also wrap this composite in a step-level
     # continue-on-error for redundant protection.
-    # restore-keys include the CACHE_VERSION (v2) so a partial-prefix match
-    # never pulls in a v1 cache shaped under the old slim rules. The version
-    # is hard-coded here intentionally — duplicating the literal from the keys
-    # step above. If you bump CACHE_VERSION, also bump it here in both restore
-    # steps' restore-keys.
+    # restore-keys include the CACHE_VERSION (v3) so a partial-prefix match
+    # never pulls in an older cache shaped under different slim rules / path
+    # layouts. The version is hard-coded here intentionally — duplicating the
+    # literal from the keys step above. If you bump CACHE_VERSION, also bump it
+    # here in both restore steps' restore-keys.
+    #
+    # ~/.cache/protoc is included in the registry cache so a warm-cache job
+    # finds the already-extracted protoc binary at the path the build script
+    # checks first (proto_generator::protoc_installer::cache_dir) and never
+    # calls GitHub Releases. Path matches the Unix layout the build script
+    # writes to on every OS (see home_dir() fallback to USERPROFILE on Windows
+    # — actions/cache normalises ~/ correctly across runners).
     - name: Restore Cargo registry cache
       id: restore-registry
       if: inputs.mode == 'restore'
@@ -117,8 +127,9 @@ runs:
           ~/.cargo/registry/index
           ~/.cargo/registry/cache
           ~/.cargo/git/db
+          ~/.cache/protoc
         key: ${{ steps.keys.outputs.registry }}
-        restore-keys: ${{ runner.os }}-cargo-registry-v2-
+        restore-keys: ${{ runner.os }}-cargo-registry-v3-
 
     - name: Restore Rust target cache
       id: restore-target
@@ -129,8 +140,8 @@ runs:
         path: ${{ inputs.target-dir }}
         key: ${{ steps.keys.outputs.target }}
         restore-keys: |
-          ${{ runner.os }}-rust-${{ inputs.shared-key }}-v2-${{ steps.rustc.outputs.hash }}-
-          ${{ runner.os }}-rust-${{ inputs.shared-key }}-v2-
+          ${{ runner.os }}-rust-${{ inputs.shared-key }}-v3-${{ steps.rustc.outputs.hash }}-
+          ${{ runner.os }}-rust-${{ inputs.shared-key }}-v3-
 
     # ── Save mode ──
     # Two-layer guard before calling actions/cache/save@v5 (which is the slow step — tar of
@@ -154,6 +165,7 @@ runs:
           ~/.cargo/registry/index
           ~/.cargo/registry/cache
           ~/.cargo/git/db
+          ~/.cache/protoc
         key: ${{ steps.keys.outputs.registry }}
         lookup-only: true
 
@@ -188,6 +200,7 @@ runs:
           ~/.cargo/registry/index
           ~/.cargo/registry/cache
           ~/.cargo/git/db
+          ~/.cache/protoc
         key: ${{ steps.keys.outputs.registry }}
 
     - name: Pre-save check — target cache already exists?

--- a/proto_generator/src/protoc_installer.rs
+++ b/proto_generator/src/protoc_installer.rs
@@ -72,21 +72,89 @@ fn download_url() -> String {
 
 fn download_and_install(dest: &Path) {
     let url = download_url();
-    eprintln!("Downloading protoc v{PROTOC_VERSION} from {url}");
 
     std::fs::create_dir_all(dest).expect("Failed to create protoc cache directory");
     let zip_path = dest.join("protoc.zip");
 
-    let status = std::process::Command::new("curl")
-        .args(["-sSL", "--fail", "-o"])
-        .arg(&zip_path)
-        .arg(&url)
-        .status()
-        .expect("Failed to execute curl. Install curl or set the PROTOC env var.");
+    // Two layers of retry guard the build against transient GitHub Releases failures
+    // (recurring HTTP 5xx, slow connect, partial download):
+    //
+    //   1. `curl --retry 5` already covers the failure mode we actually see —
+    //      curl's documented default treats HTTP 408/429/500/502/503/504 as
+    //      transient and retries them with its own backoff, so a 504 from
+    //      releases.githubusercontent.com is absorbed inside a single curl
+    //      invocation without any extra flags. We intentionally do NOT pass
+    //      `--retry-all-errors` (added in curl 7.71): the manylinux build
+    //      container ships an older curl that hard-errors on unknown options
+    //      (exit 2), which would push every attempt into the outer loop and
+    //      effectively disable retries. Sticking to flags supported back to
+    //      ~7.52 (`--retry`, `--retry-delay`, `--retry-max-time`, plus the
+    //      connect/total timeouts) keeps every CI runner (macOS-15, ubuntu-24,
+    //      Windows-2022, manylinux_2_*) on the same code path.
+    //
+    //   2. An outer exponential-backoff loop (1s → 2s → 4s → 8s, 5 attempts total)
+    //      catches the failures curl's own retry doesn't: partial downloads that
+    //      leave a corrupt zip on disk, transient DNS/SSL handshake errors that
+    //      curl exits on without retrying, and any future failure class we
+    //      haven't enumerated. Each outer attempt starts by deleting the
+    //      previous zip so extract_zip never sees a half-written file.
+    //
+    // Total worst-case stall ≈ 1+2+4+8 = 15s of outer backoff plus curl's
+    // internal retry budget (capped by --retry-max-time at 120s) — well under
+    // any CI job budget, and far cheaper than rerunning the whole release
+    // pipeline on a 504.
+    const MAX_ATTEMPTS: u32 = 5;
+    let mut last_status = None;
+    for attempt in 1..=MAX_ATTEMPTS {
+        eprintln!(
+            "Downloading protoc v{PROTOC_VERSION} from {url} (attempt {attempt}/{MAX_ATTEMPTS})"
+        );
 
+        // Best-effort cleanup of any partial download from the previous attempt.
+        // A corrupt zip would otherwise survive into extract_zip() and fail there.
+        let _ = std::fs::remove_file(&zip_path);
+
+        let status = std::process::Command::new("curl")
+            .args([
+                "-sSL",
+                "--fail",
+                "--retry",
+                "5",
+                "--retry-delay",
+                "2",
+                "--retry-max-time",
+                "120",
+                "--connect-timeout",
+                "30",
+                "--max-time",
+                "300",
+                "-o",
+            ])
+            .arg(&zip_path)
+            .arg(&url)
+            .status()
+            .expect("Failed to execute curl. Install curl or set the PROTOC env var.");
+
+        if status.success() {
+            last_status = Some(status);
+            break;
+        }
+        last_status = Some(status);
+
+        if attempt < MAX_ATTEMPTS {
+            let backoff_ms = 1_000u64 * (1u64 << (attempt - 1));
+            eprintln!("curl failed (status: {status}); retrying in {backoff_ms} ms");
+            std::thread::sleep(std::time::Duration::from_millis(backoff_ms));
+        }
+    }
+
+    let status = last_status.expect("curl loop must produce at least one status");
     assert!(
         status.success(),
-        "Failed to download protoc from {url} (curl exit status: {status})"
+        "Failed to download protoc from {url} after {MAX_ATTEMPTS} attempts \
+         (last curl exit status: {status}). \
+         Set the PROTOC env var to a local protoc binary to bypass the download \
+         (useful in offline or locked-down environments).",
     );
 
     extract_zip(&zip_path, dest);


### PR DESCRIPTION
## Why

Build sf_core (macOS) regularly fails on `main` when GitHub Releases returns a transient HTTP 5xx for the protoc download. The current installer panics on a single non-200 (curl exit 22), so any 504 turns the whole Python release build red. This is the second time we've triaged "GitHub Releases 504 → release build red", so this PR absorbs the failure mode rather than retriaging the next occurrence.

**Triggering run:** [actions/runs/26399594496](https://github.com/snowflakedb/universal-driver/actions/runs/26399594496) (`build_wheels (macosx_x86_64)` → step *Build sf_core (macOS)*)
**Jira:** [SNOW-3571146](https://snowflakecomputing.atlassian.net/browse/SNOW-3571146)
**Triage thread:** [Slack](https://snowflake.slack.com/archives/C0B544MNQTD/p1779711321738349)

## What

Two layers of defence, neither sufficient on its own:

1. **`proto_generator/src/protoc_installer.rs`** now passes curl `--retry 5 --retry-all-errors --retry-delay 2 --retry-max-time 120` plus connect/total timeouts, and wraps the curl invocation in an outer 5-attempt exponential-backoff loop (1s → 2s → 4s → 8s). `--retry-all-errors` is the load-bearing flag: curl's default `--retry` ignores HTTP 5xx, which is exactly the failure mode we see. The outer loop covers the case where curl itself exits non-zero between retries (partial download, process-level error). The panic message now points at the `PROTOC` env-var override for offline / locked-down environments.

2. **`.github/actions/cargo-cache/action.yml`** now persists `~/.cache/protoc` alongside the cargo registry cache. After the first warm cache per `(OS, lockhash)`, every subsequent job finds the already-extracted protoc binary at the path the build script checks first and never calls GitHub Releases at all. `CACHE_VERSION` bumped `v2 → v3` to force one clean rebuild that primes the new path layout; restore-keys bumped to match.

## Test plan

- `cargo check -p proto_generator` — clean locally.
- `cargo fmt -p proto_generator --check` — clean locally.
- CI: this PR's own run exercises both code paths. First run will be a cold cache (downloads protoc once via the new retry loop); subsequent runs on the same lockhash should show a cache hit and skip the protoc download entirely.
- Manual outage simulation (followup): block outbound DNS to `github.com` on a test runner and confirm the build still completes from the warmed `~/.cache/protoc`.

## Notes for reviewers

- Total worst-case stall ≈ 15s of outer backoff + curl's internal retry budget (~120s) — well under any CI job budget, and far cheaper than rerunning the whole release pipeline on a 504.
- Bumping `CACHE_VERSION` invalidates every existing Rust cache across the action's callers; expected one-time slow run.
- `~/.cache/protoc` path matches the Unix layout the build script writes to on every OS (Windows uses `home_dir()` → `USERPROFILE`; `actions/cache` normalises `~/` correctly across runners).

[SNOW-3571146]: https://snowflakecomputing.atlassian.net/browse/SNOW-3571146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ