### PR TITLE
SNOW-3406388, gap 15: send UNSIGNED-PAYLOAD on S3 PutObject

### DIFF
--- a/sf_core/src/file_manager/s3_transfer.rs
+++ b/sf_core/src/file_manager/s3_transfer.rs
@@ -264,6 +264,17 @@ fn is_expired_token_error(err: &aws_sdk_s3::Error) -> bool {
 
 /// Issues the S3 `PutObject` call and folds `ExpiredToken` into the
 /// `S3AttemptError::StsExpired` arm so the generic refresh helper can catch it.
+///
+/// `disable_payload_signing()` makes the SDK send
+/// `x-amz-content-sha256: UNSIGNED-PAYLOAD` instead of pre-hashing the entire
+/// request body for SigV4. TLS already provides in-transit integrity, and the
+/// per-file SHA-256 in `prepared.digest` (sent as the `sfc-digest` metadata
+/// header) is what Snowflake itself uses to verify the upload — so the SigV4
+/// payload hash is a redundant full pass over the file. Matches the Python
+/// connector (`s3_storage_client.py:494`, `unsigned_payload=True`) and
+/// libsnowflakeclient (`SnowflakeS3Client.cpp:164`,
+/// `PayloadSigningPolicy::Never`). Applied per-operation rather than on the
+/// shared client so unrelated S3 calls keep default signing.
 async fn put_object(
     prepared: PreparedUpload,
     s3_client: &S3Client,
@@ -290,7 +301,12 @@ async fn put_object(
 
     tracing::trace!("PUT object request: {:?}", put_object_request);
 
-    match put_object_request.send().await {
+    match put_object_request
+        .customize()
+        .disable_payload_signing()
+        .send()
+        .await
+    {
         Ok(res) => {
             tracing::debug!("S3 upload result: {:?}", res);
             Ok(())
@@ -1033,5 +1049,63 @@ mod tests {
         // it as-is. S3StsRefresher must see "no rotation" against AKIA2
         // (not AKIA1).
         assert!(!sts_refresher.refresh().await.unwrap());
+    }
+
+    // --- UNSIGNED-PAYLOAD on PutObject (Gap 15) ---
+    //
+    // Locks in that uploads send `x-amz-content-sha256: UNSIGNED-PAYLOAD`
+    // rather than a precomputed body hash. Matches the Python connector
+    // (s3_storage_client.py:494) and libsnowflakeclient (PayloadSigningPolicy
+    // ::Never). A regression here — e.g. accidentally dropping
+    // `disable_payload_signing()` from `put_object` — would silently fall
+    // back to a full SHA-256 pass over every uploaded file body.
+    //
+    // Using wiremock for this rather than a stubbed S3 client because the
+    // header is set deep inside aws-sigv4 and only appears on the wire after
+    // the SDK's signing pipeline runs. Wiremock at the HTTP layer is the
+    // only place it's observable without reaching into SDK internals.
+
+    use wiremock::matchers::{header, method};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn put_object_sends_unsigned_payload_content_sha256_header() {
+        let mock = MockServer::start().await;
+
+        Mock::given(method("PUT"))
+            .and(header("x-amz-content-sha256", "UNSIGNED-PAYLOAD"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        let stage_info = StageInfo {
+            location_type: crate::file_manager::types::LocationType::S3,
+            bucket: "test-bucket".to_string(),
+            key_prefix: "prefix/".to_string(),
+            region: "us-east-1".to_string(),
+            creds: s3_creds("AKIA-TEST"),
+            endpoint: Some(mock.uri()),
+            presigned_url: None,
+            use_virtual_url: false,
+            use_regional_url: false,
+            use_s3_regional_url: false,
+            storage_account: None,
+        };
+        let prepared = PreparedUpload {
+            data: b"hello world".to_vec(),
+            digest: "0".repeat(64),
+            encryption_metadata: None,
+        };
+
+        // overwrite=true skips the HEAD probe so the only request hitting
+        // wiremock is the PUT we care about.
+        upload_to_s3_or_skip(prepared, &stage_info, "f.dat", true, &mut None)
+            .await
+            .expect("upload should succeed against the mock");
+
+        // Mock's `.expect(1)` verifies on drop — if the SDK had sent the
+        // default precomputed body hash instead of UNSIGNED-PAYLOAD,
+        // wiremock would fail the test on shutdown.
     }
 }

--- a/sf_core/src/file_manager/s3_transfer.rs
+++ b/sf_core/src/file_manager/s3_transfer.rs
@@ -265,16 +265,9 @@ fn is_expired_token_error(err: &aws_sdk_s3::Error) -> bool {
 /// Issues the S3 `PutObject` call and folds `ExpiredToken` into the
 /// `S3AttemptError::StsExpired` arm so the generic refresh helper can catch it.
 ///
-/// `disable_payload_signing()` makes the SDK send
-/// `x-amz-content-sha256: UNSIGNED-PAYLOAD` instead of pre-hashing the entire
-/// request body for SigV4. TLS already provides in-transit integrity, and the
-/// per-file SHA-256 in `prepared.digest` (sent as the `sfc-digest` metadata
-/// header) is what Snowflake itself uses to verify the upload — so the SigV4
-/// payload hash is a redundant full pass over the file. Matches the Python
-/// connector (`s3_storage_client.py:494`, `unsigned_payload=True`) and
-/// libsnowflakeclient (`SnowflakeS3Client.cpp:164`,
-/// `PayloadSigningPolicy::Never`). Applied per-operation rather than on the
-/// shared client so unrelated S3 calls keep default signing.
+/// `disable_payload_signing()` skips a redundant full pass over the file:
+/// TLS covers transit, and Snowflake verifies the upload via the `sfc-digest`
+/// metadata header rather than the SigV4 body hash.
 async fn put_object(
     prepared: PreparedUpload,
     s3_client: &S3Client,
@@ -1051,25 +1044,13 @@ mod tests {
         assert!(!sts_refresher.refresh().await.unwrap());
     }
 
-    // --- UNSIGNED-PAYLOAD on PutObject (Gap 15) ---
-    //
-    // Locks in that uploads send `x-amz-content-sha256: UNSIGNED-PAYLOAD`
-    // rather than a precomputed body hash. Matches the Python connector
-    // (s3_storage_client.py:494) and libsnowflakeclient (PayloadSigningPolicy
-    // ::Never). A regression here — e.g. accidentally dropping
-    // `disable_payload_signing()` from `put_object` — would silently fall
-    // back to a full SHA-256 pass over every uploaded file body.
-    //
-    // Using wiremock for this rather than a stubbed S3 client because the
-    // header is set deep inside aws-sigv4 and only appears on the wire after
-    // the SDK's signing pipeline runs. Wiremock at the HTTP layer is the
-    // only place it's observable without reaching into SDK internals.
+    // The SigV4 payload hash is set inside aws-sigv4 and only appears on the
+    // wire, so wiremock at the HTTP layer is the only place it's observable.
 
     use wiremock::matchers::{header, method};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
-    #[tokio::test(flavor = "multi_thread")]
-    async fn put_object_sends_unsigned_payload_content_sha256_header() {
+    async fn assert_put_sends_unsigned_payload(prepared: PreparedUpload) {
         let mock = MockServer::start().await;
 
         Mock::given(method("PUT"))
@@ -1092,20 +1073,41 @@ mod tests {
             use_s3_regional_url: false,
             storage_account: None,
         };
-        let prepared = PreparedUpload {
-            data: b"hello world".to_vec(),
-            digest: "0".repeat(64),
-            encryption_metadata: None,
-        };
 
-        // overwrite=true skips the HEAD probe so the only request hitting
-        // wiremock is the PUT we care about.
+        // overwrite=true skips the HEAD probe.
         upload_to_s3_or_skip(prepared, &stage_info, "f.dat", true, &mut None)
             .await
             .expect("upload should succeed against the mock");
+    }
 
-        // Mock's `.expect(1)` verifies on drop — if the SDK had sent the
-        // default precomputed body hash instead of UNSIGNED-PAYLOAD,
-        // wiremock would fail the test on shutdown.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn put_object_sends_unsigned_payload_for_unencrypted_upload() {
+        assert_put_sends_unsigned_payload(PreparedUpload {
+            data: b"hello world".to_vec(),
+            digest: "0".repeat(64),
+            encryption_metadata: None,
+        })
+        .await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn put_object_sends_unsigned_payload_for_encrypted_upload() {
+        // Most production stage uploads are client-side encrypted, which
+        // attaches three extra metadata headers before signing — confirm
+        // the override still applies on that path.
+        assert_put_sends_unsigned_payload(PreparedUpload {
+            data: b"hello world".to_vec(),
+            digest: "0".repeat(64),
+            encryption_metadata: Some(EncryptedFileMetadata {
+                encrypted_key: "k".to_string(),
+                iv: "i".to_string(),
+                material_desc: MaterialDescription {
+                    query_id: "q".to_string(),
+                    smk_id: "1".to_string(),
+                    key_size: "256".to_string(),
+                },
+            }),
+        })
+        .await;
     }
 }


### PR DESCRIPTION
## Summary

Calls `customize().disable_payload_signing()` on S3 `PutObject` so the SDK sends `x-amz-content-sha256: UNSIGNED-PAYLOAD` instead of pre-hashing the entire request body for SigV4. TLS covers transit, and Snowflake verifies the upload via the `sfc-digest` metadata header — the SigV4 body hash is a redundant full pass over the file. Matches Python (`s3_storage_client.py:494`) and libsnowflakeclient (`SnowflakeS3Client.cpp:164`).

Per-operation, so `head_object`/`get_object` keep default signing. S3-only — Azure (Shared Key/SAS) and GCS (HMAC/OAuth) auth schemes never sign the payload.

## Tests

- Two new wiremock-based tests on the unencrypted and encrypted upload paths, both asserting the `x-amz-content-sha256: UNSIGNED-PAYLOAD` header on the wire.
- Verified the test catches the regression: removing `disable_payload_signing()` makes wiremock 404 the request (header no longer matches) and the upload fails.

## Test plan

- [x] `cargo check -p sf_core`
- [x] `cargo clippy -p sf_core --all-targets -- -D warnings`
- [x] `cargo test -p sf_core --lib` (1004 passed)

## Out of scope

- Streaming uploads (the existing `TODO` at `s3_transfer.rs:30`).
- Multipart uploads — when added, `upload_part` should also call `disable_payload_signing()`.
- Disabling `request_checksum_calculation` to skip the CRC32 trailer pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)