### PR TITLE
SNOW-3560164: Separate ODBC packaging into a self-defined job

### DIFF
--- a/.github/workflows/_build-odbc-packages.yml
+++ b/.github/workflows/_build-odbc-packages.yml
@@ -8,20 +8,9 @@ name: Build ODBC Packages
 
 on:
   workflow_call:
-    inputs:
-      wix-ref:
-        description: >
-          WiX Toolset git ref to build the wix CLI from (e.g. "v7.0.0").
-          Threaded into the WIX_REF env var below so existing
-          env.WIX_REF references inside the jobs keep working.
-        type: string
-        required: true
 
 env:
-  # Re-publish the caller's input as an env var so existing
-  # ${{ env.WIX_REF }} references inside build_wix and build_msi resolve
-  # without per-step input plumbing.
-  WIX_REF: ${{ inputs.wix-ref }}
+  WIX_VERSION: v7.0.0
 
 jobs:
   build_wix:
@@ -42,14 +31,14 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: wix-artifacts
-          key: wix-v7-${{ env.WIX_REF }}-${{ runner.os }}-v1
+          key: wix-${{ env.WIX_VERSION }}-${{ runner.os }}
 
-      - name: Checkout wixtoolset/wix @ ${{ env.WIX_REF }}
+      - name: Checkout wixtoolset/wix @ ${{ env.WIX_VERSION }}
         if: steps.wix-cache.outputs.cache-hit != 'true'
         uses: actions/checkout@v4
         with:
           repository: wixtoolset/wix
-          ref: ${{ env.WIX_REF }}
+          ref: ${{ env.WIX_VERSION }}
           path: wix-src
           fetch-depth: 0
 
@@ -105,7 +94,7 @@ jobs:
         uses: actions/cache/save@v5
         with:
           path: wix-artifacts
-          key: wix-v7-${{ env.WIX_REF }}-${{ runner.os }}-v1
+          key: wix-${{ env.WIX_VERSION }}-${{ runner.os }}
 
       - name: Upload WiX artifacts
         uses: actions/upload-artifact@v4
@@ -186,7 +175,7 @@ jobs:
       - name: Install WiX from local source
         uses: ./.github/actions/install-wix-from-artifact
         with:
-          wix-version: ${{ env.WIX_REF }}
+          wix-version: ${{ env.WIX_VERSION }}
 
       - name: Build ODBC driver
         run: cargo build ${{ matrix.cargo_profile }} --package odbc --features vendored-openssl ${{ matrix.cargo_extra }} --target ${{ matrix.cargo_target }}

--- a/.github/workflows/build-odbc-packages.yml
+++ b/.github/workflows/build-odbc-packages.yml
@@ -1,0 +1,34 @@
+name: Build ODBC Packages
+
+# Builds every distributable ODBC artifact
+on:
+  push:
+    branches:
+      - 'release/odbc-**'
+  pull_request:
+    paths:
+      - 'odbc/installer/**'
+      - 'ci/Dockerfile.rocky-rpm-build'
+      - '.github/actions/install-wix-from-artifact/**'
+      - '.github/workflows/build-odbc-packages.yml'
+      - '.github/workflows/_build-odbc-packages.yml'
+  workflow_dispatch:
+    inputs:
+      wix-ref:
+        description: 'WiX Toolset git ref to build the wix CLI from (e.g. "v7.0.0"). Bump in lock-step with the .wxs source compatibility.'
+        required: false
+        type: string
+        default: v7.0.0
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build_odbc_packages:
+    uses: ./.github/workflows/_build-odbc-packages.yml
+    with:
+      # workflow_dispatch supplies inputs.wix-ref; push / pull_request events
+      # don't, so we fall back to the same default exposed in the dispatch
+      # input above. Keep both in sync.
+      wix-ref: ${{ inputs.wix-ref || 'v7.0.0' }}

--- a/.github/workflows/build-odbc-packages.yml
+++ b/.github/workflows/build-odbc-packages.yml
@@ -13,12 +13,6 @@ on:
       - '.github/workflows/build-odbc-packages.yml'
       - '.github/workflows/_build-odbc-packages.yml'
   workflow_dispatch:
-    inputs:
-      wix-ref:
-        description: 'WiX Toolset git ref to build the wix CLI from (e.g. "v7.0.0"). Bump in lock-step with the .wxs source compatibility.'
-        required: false
-        type: string
-        default: v7.0.0
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -27,8 +21,3 @@ concurrency:
 jobs:
   build_odbc_packages:
     uses: ./.github/workflows/_build-odbc-packages.yml
-    with:
-      # workflow_dispatch supplies inputs.wix-ref; push / pull_request events
-      # don't, so we fall back to the same default exposed in the dispatch
-      # input above. Keep both in sync.
-      wix-ref: ${{ inputs.wix-ref || 'v7.0.0' }}

--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -116,18 +116,9 @@ jobs:
     # See odbc_tests_reference above for the secrets-inherit rationale.
     secrets: inherit
 
-  build_odbc_packages:
-    needs: detect-changes
-    if: github.event_name == 'push' || needs.detect-changes.outputs.run_odbc_packaging == 'true'
-    uses: ./.github/workflows/_build-odbc-packages.yml
-    with:
-      # WiX Toolset git ref to build from source inside _build-odbc-packages.yml.
-      # Inlined here because GHA disallows env.* in `with:` of a reusable-workflow
-      # call. Bump in lock-step with the .wxs source compatibility.
-      wix-ref: v7.0.0
 
   odbc-status:
-    needs: [detect-changes, odbc_unit_tests, odbc_tests_reference, odbc_tests, build_odbc_packages]
+    needs: [detect-changes, odbc_unit_tests, odbc_tests_reference, odbc_tests]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -151,18 +142,14 @@ jobs:
           #                               (load-odbc-matrix, build_odbc_driver,
           #                                odbc_tests, cleanup_odbc)
           #   needs.odbc_tests_reference → _test-odbc-reference.yml
-          #   needs.build_odbc_packages → _build-odbc-packages.yml
-          #                               (build_wix, build_msi, build_rpm, build_dmg)
           # — any internal failure surfaces here.
           if [[ "${{ needs.odbc_unit_tests.result }}" =~ ^(failure|cancelled)$ ]] || \
              [[ "${{ needs.odbc_tests_reference.result }}" =~ ^(failure|cancelled)$ ]] || \
-             [[ "${{ needs.odbc_tests.result }}" =~ ^(failure|cancelled)$ ]] || \
-             [[ "${{ needs.build_odbc_packages.result }}" =~ ^(failure|cancelled)$ ]]; then
+             [[ "${{ needs.odbc_tests.result }}" =~ ^(failure|cancelled)$ ]]; then
             echo "✗ ODBC tests were RUN and FAILED or CANCELLED"
             echo "  - odbc_unit_tests: ${{ needs.odbc_unit_tests.result }}"
             echo "  - odbc_tests_reference: ${{ needs.odbc_tests_reference.result }}"
             echo "  - odbc_tests: ${{ needs.odbc_tests.result }}"
-            echo "  - build_odbc_packages: ${{ needs.build_odbc_packages.result }}"
             exit 1
           fi
 


### PR DESCRIPTION
### TL;DR

Moves ODBC package building out of `test-odbc.yml` into its own dedicated workflow file.

### What changed?

The `build_odbc_packages` job has been extracted from `test-odbc.yml` and placed into a new standalone workflow, `.github/workflows/build-odbc-packages.yml`. This new workflow triggers on pushes to `release/odbc-**` branches, pull requests that touch relevant ODBC installer or workflow paths, and manual `workflow_dispatch` invocations (with an optional `wix-ref` input defaulting to `v7.0.0`).

The `odbc-status` job in `test-odbc.yml` no longer depends on `build_odbc_packages`, and all related result checks and log output for that job have been removed from the status step.

### How to test?

- Open a pull request that modifies a file under `odbc/installer/` or the relevant workflow paths and verify the `Build ODBC Packages` workflow triggers independently.
- Verify that the `odbc-status` job in `test-odbc.yml` still passes or fails correctly based only on the remaining test jobs (`odbc_unit_tests`, `odbc_tests_reference`, `odbc_tests`).
- Trigger the workflow manually via `workflow_dispatch` with and without a custom `wix-ref` to confirm the default fallback (`v7.0.0`) works correctly.

### Why make this change?

Decoupling package building from the ODBC test workflow allows each concern to be triggered and managed independently. Package builds are now only run when relevant packaging files change or on release branches, rather than being tied to every ODBC test run, reducing unnecessary CI overhead and making the workflows easier to reason about.