### PR TITLE
SNOW-3560165: Change DMG to pkg as Mac run artifact

### DIFF
--- a/.github/workflows/_build-odbc-packages.yml
+++ b/.github/workflows/_build-odbc-packages.yml
@@ -8,20 +8,9 @@ name: Build ODBC Packages
 
 on:
   workflow_call:
-    inputs:
-      wix-ref:
-        description: >
-          WiX Toolset git ref to build the wix CLI from (e.g. "v7.0.0").
-          Threaded into the WIX_REF env var below so existing
-          env.WIX_REF references inside the jobs keep working.
-        type: string
-        required: true
 
 env:
-  # Re-publish the caller's input as an env var so existing
-  # ${{ env.WIX_REF }} references inside build_wix and build_msi resolve
-  # without per-step input plumbing.
-  WIX_REF: ${{ inputs.wix-ref }}
+  WIX_VERSION: v7.0.0
 
 jobs:
   build_wix:
@@ -42,14 +31,14 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: wix-artifacts
-          key: wix-v7-${{ env.WIX_REF }}-${{ runner.os }}-v1
+          key: wix-${{ env.WIX_VERSION }}-${{ runner.os }}
 
-      - name: Checkout wixtoolset/wix @ ${{ env.WIX_REF }}
+      - name: Checkout wixtoolset/wix @ ${{ env.WIX_VERSION }}
         if: steps.wix-cache.outputs.cache-hit != 'true'
         uses: actions/checkout@v4
         with:
           repository: wixtoolset/wix
-          ref: ${{ env.WIX_REF }}
+          ref: ${{ env.WIX_VERSION }}
           path: wix-src
           fetch-depth: 0
 
@@ -105,7 +94,7 @@ jobs:
         uses: actions/cache/save@v5
         with:
           path: wix-artifacts
-          key: wix-v7-${{ env.WIX_REF }}-${{ runner.os }}-v1
+          key: wix-${{ env.WIX_VERSION }}-${{ runner.os }}
 
       - name: Upload WiX artifacts
         uses: actions/upload-artifact@v4
@@ -186,7 +175,7 @@ jobs:
       - name: Install WiX from local source
         uses: ./.github/actions/install-wix-from-artifact
         with:
-          wix-version: ${{ env.WIX_REF }}
+          wix-version: ${{ env.WIX_VERSION }}
 
       - name: Build ODBC driver
         run: cargo build ${{ matrix.cargo_profile }} --package odbc --features vendored-openssl ${{ matrix.cargo_extra }} --target ${{ matrix.cargo_target }}

--- a/.github/workflows/_build-odbc-packages.yml
+++ b/.github/workflows/_build-odbc-packages.yml
@@ -1,7 +1,7 @@
 name: Build ODBC Packages
 
 # Reusable workflow that builds every distributable ODBC artifact (MSI on
-# Windows for x64/x86/arm64, RPM on Linux for x86_64/aarch64, DMG on macOS
+# Windows for x64/x86/arm64, RPM on Linux for x86_64/aarch64, .pkg on macOS
 # universal). The Windows MSIs depend on a WiX toolchain that we build from
 # source as the first job here, so the whole graph lives together to keep
 # the build_wix → build_msi edge inside this file.
@@ -319,31 +319,31 @@ jobs:
           name: snowflake-odbc-ud-rpm-${{ matrix.arch }}
           path: build/snowflake-odbc-ud-*.rpm
 
-  build_dmg:
+  build_pkg:
     runs-on: macos-latest
-    name: build_dmg (macOS Universal)
+    name: build_pkg (macOS Universal)
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Restore Cargo registry cache (DMG build)
+      - name: Restore Cargo registry cache (pkg build)
         uses: actions/cache/restore@v5
         with:
           path: .cargo-cache
-          key: ${{ runner.os }}-universal-cargo-registry-dmg-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-universal-cargo-registry-pkg-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-universal-cargo-registry-dmg-
+            ${{ runner.os }}-universal-cargo-registry-pkg-
 
-      - name: Restore Rust target cache (DMG build)
+      - name: Restore Rust target cache (pkg build)
         uses: actions/cache/restore@v5
         with:
-          path: .cargo-target-dmg
-          key: ${{ runner.os }}-universal-rust-dmg-release-target-${{ hashFiles('**/Cargo.lock') }}
+          path: .cargo-target-pkg
+          key: ${{ runner.os }}-universal-rust-pkg-release-target-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-universal-rust-dmg-release-target-
+            ${{ runner.os }}-universal-rust-pkg-release-target-
 
       - name: Prepare cache directories
-        run: mkdir -p .cargo-cache/registry .cargo-cache/git .cargo-target-dmg
+        run: mkdir -p .cargo-cache/registry .cargo-cache/git .cargo-target-pkg
 
       - name: Install Rust targets
         run: |
@@ -360,42 +360,42 @@ jobs:
         run: cargo build --release --package odbc --features vendored-openssl --target x86_64-apple-darwin
         env:
           CARGO_HOME: ${{ github.workspace }}/.cargo-cache
-          CARGO_TARGET_DIR: ${{ github.workspace }}/.cargo-target-dmg
+          CARGO_TARGET_DIR: ${{ github.workspace }}/.cargo-target-pkg
           RUSTFLAGS: "-L native=${{ github.workspace }}/.odbc-stub"
 
       - name: Build ODBC driver (aarch64)
         run: cargo build --release --package odbc --features vendored-openssl --target aarch64-apple-darwin
         env:
           CARGO_HOME: ${{ github.workspace }}/.cargo-cache
-          CARGO_TARGET_DIR: ${{ github.workspace }}/.cargo-target-dmg
+          CARGO_TARGET_DIR: ${{ github.workspace }}/.cargo-target-pkg
           RUSTFLAGS: "-L native=${{ github.workspace }}/.odbc-stub"
 
-      - name: Save Cargo registry cache (DMG build)
+      - name: Save Cargo registry cache (pkg build)
         if: always()
         continue-on-error: true
         timeout-minutes: 10
         uses: actions/cache/save@v5
         with:
           path: .cargo-cache
-          key: ${{ runner.os }}-universal-cargo-registry-dmg-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-universal-cargo-registry-pkg-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Save Rust target cache (DMG build)
+      - name: Save Rust target cache (pkg build)
         if: always()
         continue-on-error: true
         timeout-minutes: 15
         uses: actions/cache/save@v5
         with:
-          path: .cargo-target-dmg
-          key: ${{ runner.os }}-universal-rust-dmg-release-target-${{ hashFiles('**/Cargo.lock') }}
+          path: .cargo-target-pkg
+          key: ${{ runner.os }}-universal-rust-pkg-release-target-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Package DMG
+      - name: Package pkg
         run: ./odbc/installer/mac/package.sh
         env:
-          DRIVER_X86_64: .cargo-target-dmg/x86_64-apple-darwin/release/libsfodbc.dylib
-          DRIVER_ARM64: .cargo-target-dmg/aarch64-apple-darwin/release/libsfodbc.dylib
+          DRIVER_X86_64: .cargo-target-pkg/x86_64-apple-darwin/release/libsfodbc.dylib
+          DRIVER_ARM64: .cargo-target-pkg/aarch64-apple-darwin/release/libsfodbc.dylib
 
-      - name: Upload DMG
+      - name: Upload pkg
         uses: actions/upload-artifact@v4
         with:
           name: snowflake-odbc-ud-macos-universal
-          path: build/snowflake-odbc-ud-*.dmg
+          path: build/snowflake-odbc-ud-*.pkg

--- a/.github/workflows/build-odbc-packages.yml
+++ b/.github/workflows/build-odbc-packages.yml
@@ -1,0 +1,34 @@
+name: Build ODBC Packages
+
+# Builds every distributable ODBC artifact
+on:
+  push:
+    branches:
+      - 'release/odbc-**'
+  pull_request:
+    paths:
+      - 'odbc/installer/**'
+      - 'ci/Dockerfile.rocky-rpm-build'
+      - '.github/actions/install-wix-from-artifact/**'
+      - '.github/workflows/build-odbc-packages.yml'
+      - '.github/workflows/_build-odbc-packages.yml'
+  workflow_dispatch:
+    inputs:
+      wix-ref:
+        description: 'WiX Toolset git ref to build the wix CLI from (e.g. "v7.0.0"). Bump in lock-step with the .wxs source compatibility.'
+        required: false
+        type: string
+        default: v7.0.0
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build_odbc_packages:
+    uses: ./.github/workflows/_build-odbc-packages.yml
+    with:
+      # workflow_dispatch supplies inputs.wix-ref; push / pull_request events
+      # don't, so we fall back to the same default exposed in the dispatch
+      # input above. Keep both in sync.
+      wix-ref: ${{ inputs.wix-ref || 'v7.0.0' }}

--- a/.github/workflows/build-odbc-packages.yml
+++ b/.github/workflows/build-odbc-packages.yml
@@ -13,12 +13,6 @@ on:
       - '.github/workflows/build-odbc-packages.yml'
       - '.github/workflows/_build-odbc-packages.yml'
   workflow_dispatch:
-    inputs:
-      wix-ref:
-        description: 'WiX Toolset git ref to build the wix CLI from (e.g. "v7.0.0"). Bump in lock-step with the .wxs source compatibility.'
-        required: false
-        type: string
-        default: v7.0.0
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -27,8 +21,3 @@ concurrency:
 jobs:
   build_odbc_packages:
     uses: ./.github/workflows/_build-odbc-packages.yml
-    with:
-      # workflow_dispatch supplies inputs.wix-ref; push / pull_request events
-      # don't, so we fall back to the same default exposed in the dispatch
-      # input above. Keep both in sync.
-      wix-ref: ${{ inputs.wix-ref || 'v7.0.0' }}

--- a/.github/workflows/detect-changes.yml
+++ b/.github/workflows/detect-changes.yml
@@ -62,7 +62,7 @@ on:
         description: "True if Node.js reference tests should run (e2e tests changed)"
         value: ${{ jobs.detect.outputs.run_nodejs_reference }}
       run_odbc_packaging:
-        description: "True if ODBC packaging (MSI/RPM/DMG) should run"
+        description: "True if ODBC packaging should run"
         value: ${{ jobs.detect.outputs.run_odbc_packaging }}
 
 jobs:

--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -116,18 +116,9 @@ jobs:
     # See odbc_tests_reference above for the secrets-inherit rationale.
     secrets: inherit
 
-  build_odbc_packages:
-    needs: detect-changes
-    if: github.event_name == 'push' || needs.detect-changes.outputs.run_odbc_packaging == 'true'
-    uses: ./.github/workflows/_build-odbc-packages.yml
-    with:
-      # WiX Toolset git ref to build from source inside _build-odbc-packages.yml.
-      # Inlined here because GHA disallows env.* in `with:` of a reusable-workflow
-      # call. Bump in lock-step with the .wxs source compatibility.
-      wix-ref: v7.0.0
 
   odbc-status:
-    needs: [detect-changes, odbc_unit_tests, odbc_tests_reference, odbc_tests, build_odbc_packages]
+    needs: [detect-changes, odbc_unit_tests, odbc_tests_reference, odbc_tests]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -151,18 +142,14 @@ jobs:
           #                               (load-odbc-matrix, build_odbc_driver,
           #                                odbc_tests, cleanup_odbc)
           #   needs.odbc_tests_reference → _test-odbc-reference.yml
-          #   needs.build_odbc_packages → _build-odbc-packages.yml
-          #                               (build_wix, build_msi, build_rpm, build_dmg)
           # — any internal failure surfaces here.
           if [[ "${{ needs.odbc_unit_tests.result }}" =~ ^(failure|cancelled)$ ]] || \
              [[ "${{ needs.odbc_tests_reference.result }}" =~ ^(failure|cancelled)$ ]] || \
-             [[ "${{ needs.odbc_tests.result }}" =~ ^(failure|cancelled)$ ]] || \
-             [[ "${{ needs.build_odbc_packages.result }}" =~ ^(failure|cancelled)$ ]]; then
+             [[ "${{ needs.odbc_tests.result }}" =~ ^(failure|cancelled)$ ]]; then
             echo "✗ ODBC tests were RUN and FAILED or CANCELLED"
             echo "  - odbc_unit_tests: ${{ needs.odbc_unit_tests.result }}"
             echo "  - odbc_tests_reference: ${{ needs.odbc_tests_reference.result }}"
             echo "  - odbc_tests: ${{ needs.odbc_tests.result }}"
-            echo "  - build_odbc_packages: ${{ needs.build_odbc_packages.result }}"
             exit 1
           fi
 

--- a/odbc/Cargo.toml
+++ b/odbc/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2024"
 # registered as DriverODBCVer with unixODBC / the Windows ODBC registry.
 # Format is "MM.mm" (e.g. "03.80").
 odbc_api_version = "03.80"
-# Snowflake ODBC UD release version used as the RPM / DMG / MSI artifact
+# Snowflake ODBC UD release version used as the artifact
 # version and embedded in the Windows DLL VERSIONINFO resource. The git
 # short SHA is appended at packaging time to produce the full release string.
 # Format is "<major>.<minor>.<patch>" (e.g. "0.0.1").

--- a/odbc/installer/mac/package.sh
+++ b/odbc/installer/mac/package.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 #
-# Package the Snowflake ODBC UD driver as a macOS DMG (universal binary).
+# Package the Snowflake ODBC UD driver as a macOS .pkg (universal binary).
 #
 # Builds or accepts pre-built dylibs for x86_64 and aarch64, merges them
-# with lipo into a universal binary, creates a .pkg installer, and wraps
-# it in a .dmg.
+# with lipo into a universal binary and produces a flat .pkg installer
+# via pkgbuild.
 #
 # Must be run from the repository root on macOS.
 #
@@ -81,7 +81,6 @@ cp "$TEMPLATES_DIR/odbc.ini.template" "$SCRIPTS_STAGE_DIR/odbc.ini.template"
 mkdir -p "$BUILD_DIR"
 
 PKG_NAME="snowflake-odbc-ud-${VERSION}-universal.pkg"
-DMG_NAME="snowflake-odbc-ud-${VERSION}-universal.dmg"
 
 echo "=== Building pkg: $PKG_NAME ==="
 pkgbuild \
@@ -92,14 +91,4 @@ pkgbuild \
     --scripts "$SCRIPTS_STAGE_DIR" \
     "$BUILD_DIR/$PKG_NAME"
 
-echo "=== Creating DMG: $DMG_NAME ==="
-hdiutil create \
-    -volname "Snowflake ODBC UD" \
-    -srcfolder "$BUILD_DIR/$PKG_NAME" \
-    -ov \
-    -format UDZO \
-    "$BUILD_DIR/$DMG_NAME"
-
-rm -rf "$STAGE_DIR"
-
-echo "=== Successfully created DMG at $BUILD_DIR/$DMG_NAME ==="
+echo "=== Successfully created pkg at $BUILD_DIR/$PKG_NAME ==="


### PR DESCRIPTION
### TL;DR

Replace the macOS DMG packaging format with a flat `.pkg` installer, removing the intermediate DMG wrapping step.

### What changed?

The macOS ODBC packaging pipeline no longer wraps the `.pkg` installer inside a `.dmg` disk image. The `package.sh` script now calls `pkgbuild` and stops there, dropping the `hdiutil create` step entirely. The CI workflow job has been renamed from `build_dmg` to `build_pkg`, cache keys and directories have been updated from `dmg` to `pkg`, and the artifact upload now targets `*.pkg` instead of `*.dmg`. References to "DMG" in comments, workflow descriptions, and `Cargo.toml` have been updated accordingly.

### How to test?

Run the `Build ODBC Packages` workflow and confirm that the `snowflake-odbc-ud-macos-universal` artifact contains a `.pkg` file and no `.dmg` file. Verify the `.pkg` installs correctly on both x86_64 and aarch64 macOS machines.

### Why make this change?

The DMG was an unnecessary wrapper around the `.pkg` for a run output. The .dmg can be created as a result of the release job.