### PR TITLE
SNOW-3166337: Implement batch parameter binding for Statement and PreparedStatement

### DIFF
--- a/jdbc/BehaviorDifferences.yaml
+++ b/jdbc/BehaviorDifferences.yaml
@@ -32,3 +32,37 @@ behavior_differences:
       authenticators except SNOWFLAKE_JWT and EXTERNALBROWSER. This prevents PAT (Programmatic
       Access Token) authentication via DataSource even though setToken() and setAuthenticator()
       exist. The new driver correctly allows token-based authentication without a password.
+  2:
+    name: "Statement.executeBatch update-count int overflow"
+    status: unknown
+    type: bugfix
+    reviewed: false
+    status_rationale: |
+      The old driver throws SnowflakeSQLLoggedException(EXECUTE_BATCH_INTEGER_OVERFLOW,
+      NUMERIC_VALUE_OUT_OF_RANGE) for any per-row count that exceeds Integer.MAX_VALUE in
+      executeBatch(). The new driver maps such counts to Statement.SUCCESS_NO_INFO so the
+      batch result array stays valid and length-correct; callers wanting full fidelity should
+      use executeLargeBatch().
+  3:
+    name: "getBatchQueryIDs positional alignment with updateCounts"
+    status: unknown
+    type: enhancement
+    reviewed: false
+    status_rationale: |
+      In the old driver, Statement.executeBatch's success branch is the only place that appends
+      to batchQueryIDs, so failed entries skip the append and the resulting list is shorter than
+      updateCounts (positional alignment broken). The new driver always appends, using null for
+      failed entries, so callers can correlate updateCounts[i] with batchQueryIDs.get(i).
+      For the PreparedStatement array-bind path, the old driver does not populate batchQueryIDs
+      at all; the new driver appends a single entry covering the whole batch (or null on RPC
+      failure).
+  4:
+    name: "executeBatch resets current-result state on return"
+    status: unknown
+    type: bugfix
+    reviewed: false
+    status_rationale: |
+      Per JDBC spec, after Statement.executeBatch() the statement should have no current result
+      (getResultSet() returns null, getUpdateCount() returns -1). The old driver leaves
+      currentResultSet / currentUpdateCount populated by the last batched entry. The new driver
+      resets both in finalizeBatch.

--- a/jdbc/src/main/java/net/snowflake/client/api/exception/ErrorCode.java
+++ b/jdbc/src/main/java/net/snowflake/client/api/exception/ErrorCode.java
@@ -1,16 +1,15 @@
 package net.snowflake.client.api.exception;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public enum ErrorCode {
-  INTERNAL_ERROR(200001),
-  INVALID_VALUE_CONVERT(200038);
+  INTERNAL_ERROR(200001, null),
+  INVALID_VALUE_CONVERT(200038, null),
+  ARRAY_BIND_MIXED_TYPES_NOT_SUPPORTED(200023, "0A000");
 
   private final int messageCode;
-
-  ErrorCode(int messageCode) {
-    this.messageCode = messageCode;
-  }
-
-  public int getMessageCode() {
-    return messageCode;
-  }
+  private final String sqlState;
 }

--- a/jdbc/src/main/java/net/snowflake/client/api/exception/SnowflakeSQLException.java
+++ b/jdbc/src/main/java/net/snowflake/client/api/exception/SnowflakeSQLException.java
@@ -15,6 +15,10 @@ public class SnowflakeSQLException extends SQLException {
     super(message, cause);
   }
 
+  public SnowflakeSQLException(ErrorCode errorCode, String message) {
+    super(message, errorCode.getSqlState(), errorCode.getMessageCode());
+  }
+
   public SnowflakeSQLException(DatabaseDriverV1.DriverException error, Throwable cause) {
     super(
         error.hasRootCause() ? error.getRootCause() : error.getMessage(),

--- a/jdbc/src/main/java/net/snowflake/client/api/statement/SnowflakeStatement.java
+++ b/jdbc/src/main/java/net/snowflake/client/api/statement/SnowflakeStatement.java
@@ -14,7 +14,18 @@ public interface SnowflakeStatement {
   String getQueryID() throws SQLException;
 
   /**
-   * @return the Snowflake query IDs of the latest executed batch queries
+   * Returns the Snowflake query IDs of the latest executed batch.
+   *
+   * <ul>
+   *   <li>{@link java.sql.Statement} batch: one ID per submitted entry, in order; {@code null} for
+   *       failed entries (preserves positional alignment with {@code executeBatch()} counts).
+   *   <li>{@link java.sql.PreparedStatement} array-bind batch: a single ID covering all rows.
+   * </ul>
+   *
+   * <p>Populated at the start of every {@code executeBatch()}; {@code clearBatch()} does NOT clear
+   * it.
+   *
+   * @return non-null list, possibly containing {@code null} entries for failed iterations
    * @throws SQLException if an error is encountered
    */
   List<String> getBatchQueryIDs() throws SQLException;

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/BatchColumnValidator.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/BatchColumnValidator.java
@@ -1,0 +1,58 @@
+package net.snowflake.client.internal.api.implementation.statement;
+
+import java.sql.SQLException;
+import java.util.List;
+import net.snowflake.client.api.exception.ErrorCode;
+import net.snowflake.client.api.exception.SnowflakeSQLException;
+import net.snowflake.client.internal.api.implementation.statement.PreparedStatementBindingSerializer.ParameterValue;
+
+final class BatchColumnValidator {
+
+  private BatchColumnValidator() {}
+
+  static void validate(int parameterIndex, ParameterValue existing, ParameterValue newValue)
+      throws SQLException {
+    if (newValue == null) {
+      throw new SnowflakeSQLException("Missing value for parameter index: " + parameterIndex);
+    }
+    if (existing == null) {
+      return;
+    }
+    String stringValue = (String) newValue.value();
+    if (stringValue == null) {
+      return;
+    }
+    String prevType = existing.bindType();
+    String newType = newValue.bindType();
+    if ("ANY".equalsIgnoreCase(prevType) || prevType.equalsIgnoreCase(newType)) {
+      return;
+    }
+    @SuppressWarnings("unchecked")
+    List<String> values = (List<String>) existing.value();
+    if (allNullsSoFar(values)) {
+      return;
+    }
+    int prevRow = values.size();
+    throw new SnowflakeSQLException(
+        ErrorCode.ARRAY_BIND_MIXED_TYPES_NOT_SUPPORTED,
+        "Array binding does not support mixed types: parameter "
+            + parameterIndex
+            + " was bound with type "
+            + prevType
+            + " in row "
+            + prevRow
+            + " and type "
+            + newType
+            + " in row "
+            + (prevRow + 1));
+  }
+
+  private static boolean allNullsSoFar(List<String> values) {
+    for (String v : values) {
+      if (v != null) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/PreparedBatch.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/PreparedBatch.java
@@ -1,0 +1,202 @@
+package net.snowflake.client.internal.api.implementation.statement;
+
+import java.sql.BatchUpdateException;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import net.snowflake.client.api.exception.ErrorCode;
+import net.snowflake.client.api.exception.SnowflakeSQLException;
+import net.snowflake.client.internal.api.implementation.statement.PreparedStatementBindingSerializer.ParameterValue;
+import net.snowflake.client.internal.log.SFLogger;
+import net.snowflake.client.internal.log.SFLoggerFactory;
+
+/**
+ * Column-major accumulation of parameter values across {@code addBatch()} calls. Each map entry
+ * holds a {@code List<String>} — one element per accumulated row. The entry's bind type is promoted
+ * from {@code "ANY"} to a real type when the first non-null value arrives in a column that has been
+ * all-nulls so far.
+ */
+final class PreparedBatch {
+  private static final SFLogger logger = SFLoggerFactory.getLogger(PreparedBatch.class);
+
+  private final Map<Integer, ParameterValue> columns = new HashMap<>();
+
+  /**
+   * Append a row built from the per-row {@code currentValues} map. Two-pass: every column is
+   * validated before any is mutated so a type-mismatch on a later column doesn't leave earlier
+   * columns at a different length.
+   */
+  void addRow(SqlPlaceholderMetadata meta, Map<Integer, ParameterValue> currentValues)
+      throws SQLException {
+    if (meta.hasMixedPlaceholderStyles()) {
+      throw new SnowflakeSQLException(
+          "Mixed positional and numeric placeholders are not supported");
+    }
+    for (int parameterIndex : meta.referencedParameterIndexes()) {
+      validate(parameterIndex, currentValues);
+    }
+    for (int parameterIndex : meta.referencedParameterIndexes()) {
+      commit(parameterIndex, currentValues);
+    }
+  }
+
+  void clear() {
+    columns.clear();
+  }
+
+  /** Number of accumulated rows; derived from any column's list size (every column same length). */
+  int size() {
+    if (columns.isEmpty()) {
+      return 0;
+    }
+    return ((List<?>) columns.values().iterator().next().value()).size();
+  }
+
+  boolean isEmpty() {
+    return size() == 0;
+  }
+
+  private Map<Integer, ParameterValue> snapshot() {
+    return new HashMap<>(columns);
+  }
+
+  /**
+   * Single-roundtrip array-bind execution. Returns one entry per row: per-row {@code 1} when the
+   * server's aggregate count equals {@code batchSize} (SNOW-14034), else {@link
+   * Statement#SUCCESS_NO_INFO}. On failure throws {@link BatchUpdateException} with all entries set
+   * to {@link Statement#EXECUTE_FAILED}.
+   */
+  long[] executeAll(SnowflakePreparedStatementImpl stmt, String sql, SqlPlaceholderMetadata meta)
+      throws SQLException {
+    final int batchSize = size();
+    stmt.clearBatchQueryIds();
+    if (batchSize == 0) {
+      stmt.finalizeBatch(null);
+      return new long[0];
+    }
+    long[] result = new long[0];
+    BatchUpdateException pending = null;
+    try {
+      long updateCount = runOnce(stmt, sql, meta);
+      result = expandUpdateCounts(updateCount, batchSize);
+      stmt.recordBatchQueryId();
+    } catch (SQLException e) {
+      pending = SnowflakeStatementImpl.buildBatchFailureException(e, allFailed(batchSize));
+      stmt.recordBatchQueryId();
+    } finally {
+      stmt.finalizeBatch(pending);
+    }
+    if (pending != null) {
+      throw pending;
+    }
+    return result;
+  }
+
+  /**
+   * Manual try/finally rather than try-with-resources: a close-throws-after-RPC-success would
+   * otherwise be caught by the outer catch(SQLException) and falsely mark the batch as failed.
+   */
+  private long runOnce(SnowflakePreparedStatementImpl stmt, String sql, SqlPlaceholderMetadata meta)
+      throws SQLException {
+    PreparedStatementBindingSerializer.NativeBindings nativeBindings =
+        PreparedStatementBindingSerializer.serialize(meta, snapshot());
+    try {
+      return stmt.executeLargeUpdateWithBindings(sql, nativeBindings);
+    } finally {
+      try {
+        nativeBindings.close();
+      } catch (RuntimeException closeEx) {
+        logger.warn("Failed to close native binding buffer after RPC", closeEx);
+      }
+    }
+  }
+
+  private static long[] expandUpdateCounts(long aggregate, int batchSize) {
+    long perRow = aggregate == batchSize ? 1L : Statement.SUCCESS_NO_INFO;
+    long[] result = new long[batchSize];
+    Arrays.fill(result, perRow);
+    return result;
+  }
+
+  private static int[] allFailed(int batchSize) {
+    int[] failed = new int[batchSize];
+    Arrays.fill(failed, Statement.EXECUTE_FAILED);
+    return failed;
+  }
+
+  private void validate(int parameterIndex, Map<Integer, ParameterValue> currentValues)
+      throws SQLException {
+    ParameterValue parameterValue = currentValues.get(parameterIndex);
+    if (parameterValue == null) {
+      throw new SnowflakeSQLException("Missing value for parameter index: " + parameterIndex);
+    }
+    ParameterValue existing = columns.get(parameterIndex);
+    if (existing == null) {
+      return;
+    }
+    String stringValue = (String) parameterValue.value();
+    if (stringValue == null) {
+      return;
+    }
+    String prevType = existing.bindType();
+    String newType = parameterValue.bindType();
+    if ("ANY".equalsIgnoreCase(prevType) || prevType.equalsIgnoreCase(newType)) {
+      return;
+    }
+    @SuppressWarnings("unchecked")
+    List<String> values = (List<String>) existing.value();
+    if (allNullsSoFar(values)) {
+      return;
+    }
+    int prevRow = values.size();
+    throw new SnowflakeSQLException(
+        ErrorCode.ARRAY_BIND_MIXED_TYPES_NOT_SUPPORTED,
+        "Array binding does not support mixed types: parameter "
+            + parameterIndex
+            + " was bound with type "
+            + prevType
+            + " in row "
+            + prevRow
+            + " and type "
+            + newType
+            + " in row "
+            + (prevRow + 1));
+  }
+
+  private void commit(int parameterIndex, Map<Integer, ParameterValue> currentValues) {
+    ParameterValue parameterValue = currentValues.get(parameterIndex);
+    String newType = parameterValue.bindType();
+    String stringValue = (String) parameterValue.value();
+    ParameterValue existing = columns.get(parameterIndex);
+    if (existing == null) {
+      List<String> values = new ArrayList<>();
+      values.add(stringValue);
+      columns.put(parameterIndex, new ParameterValue(newType, values));
+      return;
+    }
+    @SuppressWarnings("unchecked")
+    List<String> values = (List<String>) existing.value();
+    String prevType = existing.bindType();
+    // Promote ANY (or all-null column) → real type on first non-null. Safe — no existing
+    // data is reinterpreted.
+    if (stringValue != null
+        && !prevType.equalsIgnoreCase(newType)
+        && ("ANY".equalsIgnoreCase(prevType) || allNullsSoFar(values))) {
+      columns.put(parameterIndex, new ParameterValue(newType, values));
+    }
+    values.add(stringValue);
+  }
+
+  private static boolean allNullsSoFar(List<String> values) {
+    for (String v : values) {
+      if (v != null) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/PreparedBatch.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/PreparedBatch.java
@@ -8,7 +8,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import net.snowflake.client.api.exception.ErrorCode;
 import net.snowflake.client.api.exception.SnowflakeSQLException;
 import net.snowflake.client.internal.api.implementation.statement.PreparedStatementBindingSerializer.ParameterValue;
 import net.snowflake.client.internal.log.SFLogger;
@@ -24,6 +23,7 @@ final class PreparedBatch {
   private static final SFLogger logger = SFLoggerFactory.getLogger(PreparedBatch.class);
 
   private final Map<Integer, ParameterValue> columns = new HashMap<>();
+  private int rowCount = 0;
 
   /**
    * Append a row built from the per-row {@code currentValues} map. Two-pass: every column is
@@ -37,27 +37,26 @@ final class PreparedBatch {
           "Mixed positional and numeric placeholders are not supported");
     }
     for (int parameterIndex : meta.referencedParameterIndexes()) {
-      validate(parameterIndex, currentValues);
+      BatchColumnValidator.validate(
+          parameterIndex, columns.get(parameterIndex), currentValues.get(parameterIndex));
     }
     for (int parameterIndex : meta.referencedParameterIndexes()) {
       commit(parameterIndex, currentValues);
     }
+    rowCount++;
   }
 
   void clear() {
     columns.clear();
+    rowCount = 0;
   }
 
-  /** Number of accumulated rows; derived from any column's list size (every column same length). */
   int size() {
-    if (columns.isEmpty()) {
-      return 0;
-    }
-    return ((List<?>) columns.values().iterator().next().value()).size();
+    return rowCount;
   }
 
   boolean isEmpty() {
-    return size() == 0;
+    return rowCount == 0;
   }
 
   private Map<Integer, ParameterValue> snapshot() {
@@ -126,45 +125,6 @@ final class PreparedBatch {
     int[] failed = new int[batchSize];
     Arrays.fill(failed, Statement.EXECUTE_FAILED);
     return failed;
-  }
-
-  private void validate(int parameterIndex, Map<Integer, ParameterValue> currentValues)
-      throws SQLException {
-    ParameterValue parameterValue = currentValues.get(parameterIndex);
-    if (parameterValue == null) {
-      throw new SnowflakeSQLException("Missing value for parameter index: " + parameterIndex);
-    }
-    ParameterValue existing = columns.get(parameterIndex);
-    if (existing == null) {
-      return;
-    }
-    String stringValue = (String) parameterValue.value();
-    if (stringValue == null) {
-      return;
-    }
-    String prevType = existing.bindType();
-    String newType = parameterValue.bindType();
-    if ("ANY".equalsIgnoreCase(prevType) || prevType.equalsIgnoreCase(newType)) {
-      return;
-    }
-    @SuppressWarnings("unchecked")
-    List<String> values = (List<String>) existing.value();
-    if (allNullsSoFar(values)) {
-      return;
-    }
-    int prevRow = values.size();
-    throw new SnowflakeSQLException(
-        ErrorCode.ARRAY_BIND_MIXED_TYPES_NOT_SUPPORTED,
-        "Array binding does not support mixed types: parameter "
-            + parameterIndex
-            + " was bound with type "
-            + prevType
-            + " in row "
-            + prevRow
-            + " and type "
-            + newType
-            + " in row "
-            + (prevRow + 1));
   }
 
   private void commit(int parameterIndex, Map<Integer, ParameterValue> currentValues) {

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/PreparedStatementBindingSerializer.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/PreparedStatementBindingSerializer.java
@@ -5,6 +5,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
+import java.util.List;
 import java.util.Map;
 import net.snowflake.client.internal.log.SFLogger;
 import net.snowflake.client.internal.log.SFLoggerFactory;
@@ -17,6 +18,14 @@ import org.json.JSONStringer;
 final class PreparedStatementBindingSerializer {
   private static final SFLogger logger =
       SFLoggerFactory.getLogger(PreparedStatementBindingSerializer.class);
+
+  /** Process-wide; a fresh allocator per execute is measurably expensive in batch scenarios. */
+  private static final RootAllocator SHARED_ALLOCATOR = new RootAllocator(Long.MAX_VALUE);
+
+  /** Test-only: outstanding bytes on the shared allocator (for {@code @AfterAll} leak checks). */
+  static long sharedAllocatorAllocatedBytes() {
+    return SHARED_ALLOCATOR.getAllocatedMemory();
+  }
 
   static final class ParameterValue {
     private final String bindType;
@@ -36,10 +45,16 @@ final class PreparedStatementBindingSerializer {
     }
   }
 
-  /** Holds bindings plus the native buffer backing the pointer stored in the RPC payload. */
+  /**
+   * The {@link BinaryDataPtr} address is a raw {@code long}, not a Java reference to the underlying
+   * {@link ArrowBuf}. Callers must keep this object reachable until the synchronous {@code
+   * statementExecuteQuery} returns — the standard try-with-resources around the RPC suffices per
+   * JLS §12.6.1.
+   */
   static final class NativeBindings implements AutoCloseable {
     private final QueryBindings bindings;
     private final NativeBuffer buffer;
+    private boolean closed;
 
     NativeBindings(QueryBindings bindings, NativeBuffer buffer) {
       this.bindings = bindings;
@@ -52,8 +67,11 @@ final class PreparedStatementBindingSerializer {
 
     @Override
     public void close() {
-      // The bindings payload includes a pointer into this native buffer, so the owner must release
-      // it after the RPC has been constructed and sent.
+      // Idempotent — guards against double-close in nested try-with-resources / finally chains.
+      if (closed) {
+        return;
+      }
+      closed = true;
       if (buffer != null) {
         buffer.close();
       }
@@ -88,18 +106,51 @@ final class PreparedStatementBindingSerializer {
             "Bindings serialization failed: missing parameter value for index {}", parameterIndex);
         throw new SQLException("Missing value for parameter index: " + parameterIndex);
       }
-
       jsonStringer.key(String.valueOf(parameterIndex)).object();
       jsonStringer.key("type").value(parameterValue.bindType());
-      if (parameterValue.value() == null) {
-        jsonStringer.key("value").value(null);
-      } else {
-        jsonStringer.key("value").value(String.valueOf(parameterValue.value()));
-      }
+      jsonStringer.key("value");
+      writeBindingValue(jsonStringer, parameterIndex, parameterValue.value());
       jsonStringer.endObject();
     }
     jsonStringer.endObject();
     return jsonStringer.toString().getBytes(StandardCharsets.UTF_8);
+  }
+
+  private static void writeBindingValue(JSONStringer json, int parameterIndex, Object value)
+      throws SQLException {
+    if (value == null || value instanceof String) {
+      json.value(value);
+      return;
+    }
+    if (value instanceof List) {
+      json.array();
+      for (Object element : (List<?>) value) {
+        requireNullOrString(element, parameterIndex, "list-valued binding");
+        json.value(element);
+      }
+      json.endArray();
+      return;
+    }
+    throw unsupportedBindingValue(parameterIndex, value, "binding");
+  }
+
+  private static void requireNullOrString(Object element, int parameterIndex, String context)
+      throws SQLException {
+    if (element != null && !(element instanceof String)) {
+      throw unsupportedBindingValue(parameterIndex, element, context);
+    }
+  }
+
+  private static SQLException unsupportedBindingValue(
+      int parameterIndex, Object value, String context) {
+    return new SQLException(
+        "Internal error: "
+            + context
+            + " for parameter "
+            + parameterIndex
+            + " has an unsupported value type ("
+            + value.getClass().getCanonicalName()
+            + ")");
   }
 
   private static NativeBindings allocateNativeBindings(byte[] jsonBytes) throws SQLException {
@@ -128,23 +179,20 @@ final class PreparedStatementBindingSerializer {
   }
 
   private static final class NativeBuffer implements AutoCloseable {
-    private final RootAllocator allocator;
     private final ArrowBuf arrowBuf;
     private final long address;
+    private boolean closed;
 
-    private NativeBuffer(RootAllocator allocator, ArrowBuf arrowBuf, long address) {
-      this.allocator = allocator;
+    private NativeBuffer(ArrowBuf arrowBuf, long address) {
       this.arrowBuf = arrowBuf;
       this.address = address;
     }
 
     private static NativeBuffer fromBytes(byte[] source) throws SQLException {
-      RootAllocator allocator = null;
       ArrowBuf arrowBuf = null;
       boolean success = false;
       try {
-        allocator = new RootAllocator(Long.MAX_VALUE);
-        arrowBuf = allocator.buffer(source.length);
+        arrowBuf = SHARED_ALLOCATOR.buffer(source.length);
         arrowBuf.setBytes(0, source);
         long address = arrowBuf.memoryAddress();
         if (address == 0L) {
@@ -154,15 +202,10 @@ final class PreparedStatementBindingSerializer {
         }
         logger.debug("Allocated native binding buffer: payloadBytes={}", source.length);
         success = true;
-        return new NativeBuffer(allocator, arrowBuf, address);
+        return new NativeBuffer(arrowBuf, address);
       } finally {
-        if (!success) {
-          if (arrowBuf != null) {
-            arrowBuf.close();
-          }
-          if (allocator != null) {
-            allocator.close();
-          }
+        if (!success && arrowBuf != null) {
+          arrowBuf.close();
         }
       }
     }
@@ -176,8 +219,11 @@ final class PreparedStatementBindingSerializer {
 
     @Override
     public void close() {
+      if (closed) {
+        return;
+      }
+      closed = true;
       arrowBuf.close();
-      allocator.close();
     }
   }
 }

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/PreparedStatementBindingSerializer.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/PreparedStatementBindingSerializer.java
@@ -20,12 +20,7 @@ final class PreparedStatementBindingSerializer {
       SFLoggerFactory.getLogger(PreparedStatementBindingSerializer.class);
 
   /** Process-wide; a fresh allocator per execute is measurably expensive in batch scenarios. */
-  private static final RootAllocator SHARED_ALLOCATOR = new RootAllocator(Long.MAX_VALUE);
-
-  /** Test-only: outstanding bytes on the shared allocator (for {@code @AfterAll} leak checks). */
-  static long sharedAllocatorAllocatedBytes() {
-    return SHARED_ALLOCATOR.getAllocatedMemory();
-  }
+  static final RootAllocator SHARED_ALLOCATOR = new RootAllocator(Long.MAX_VALUE);
 
   static final class ParameterValue {
     private final String bindType;

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakePreparedStatementImpl.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakePreparedStatementImpl.java
@@ -41,6 +41,7 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
   private final String sql;
   private final SqlPlaceholderMetadata placeholderMetadata;
   private final Map<Integer, PreparedStatementBindingSerializer.ParameterValue> parameterValues;
+  private final PreparedBatch batch = new PreparedBatch();
 
   public SnowflakePreparedStatementImpl(
       InternalSnowflakeConnection connection, String sql, CoreDriverApi coreDriverApi) {
@@ -55,7 +56,7 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
     checkClosed();
     try (PreparedStatementBindingSerializer.NativeBindings nativeBindings =
         PreparedStatementBindingSerializer.serialize(placeholderMetadata, parameterValues)) {
-      return executeQueryWithBindings(sql, nativeBindings.bindings());
+      return executeQueryWithBindings(sql, nativeBindings);
     }
   }
 
@@ -64,13 +65,14 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
     checkClosed();
     try (PreparedStatementBindingSerializer.NativeBindings nativeBindings =
         PreparedStatementBindingSerializer.serialize(placeholderMetadata, parameterValues)) {
-      return executeUpdateWithBindings(sql, nativeBindings.bindings());
+      return executeUpdateWithBindings(sql, nativeBindings);
     }
   }
 
   @Override
   public void setNull(int parameterIndex, int sqlType) throws SQLException {
     checkClosed();
+    // ANY is the sentinel; addBatch promotes the column to a real type on first non-null.
     setParameter(parameterIndex, "ANY", null);
   }
 
@@ -285,13 +287,44 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
     checkClosed();
     try (PreparedStatementBindingSerializer.NativeBindings nativeBindings =
         PreparedStatementBindingSerializer.serialize(placeholderMetadata, parameterValues)) {
-      return executeWithBindings(sql, nativeBindings.bindings());
+      return executeWithBindings(sql, nativeBindings);
     }
   }
 
   @Override
   public void addBatch() throws SQLException {
-    throw new SQLFeatureNotSupportedException("addBatch not supported");
+    checkClosed();
+    batch.addRow(placeholderMetadata, parameterValues);
+  }
+
+  @Override
+  public void clearBatch() throws SQLException {
+    super.clearBatch();
+    batch.clear();
+  }
+
+  @Override
+  public void addBatch(String sql) throws SQLException {
+    checkClosed();
+    throw new SQLFeatureNotSupportedException(
+        "addBatch(String) is not allowed on PreparedStatement");
+  }
+
+  @Override
+  public int[] executeBatch() throws SQLException {
+    checkClosed();
+    long[] expanded = batch.executeAll(this, sql, placeholderMetadata);
+    int[] result = new int[expanded.length];
+    for (int i = 0; i < expanded.length; i++) {
+      result[i] = toBatchInt(expanded[i]);
+    }
+    return result;
+  }
+
+  @Override
+  public long[] executeLargeBatch() throws SQLException {
+    checkClosed();
+    return batch.executeAll(this, sql, placeholderMetadata);
   }
 
   @Override
@@ -472,8 +505,12 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
           placeholderMetadata.placeholderCount());
       return;
     }
+    // Boxed primitives passed through setObject must be stringified before they reach the
+    // serializer (which rejects non-String values).
+    String normalized = java.util.Objects.toString(value, null);
     parameterValues.put(
-        parameterIndex, new PreparedStatementBindingSerializer.ParameterValue(bindType, value));
+        parameterIndex,
+        new PreparedStatementBindingSerializer.ParameterValue(bindType, normalized));
     logger.debug(
         "Prepared parameter set: index={}, bindType={}, isNull={}, placeholders={}",
         parameterIndex,
@@ -486,7 +523,11 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
       int parameterIndex, int sqlType, String bindType, T value, Function<T, String> serializer)
       throws SQLException {
     if (value == null) {
-      setNull(parameterIndex, sqlType);
+      // Preserve the typed bind type for the typed setX-with-null path. The generic
+      // setNull(idx, sqlType) entry point still maps to "ANY" (matches reference); this avoids
+      // silently widening every typed null to ANY when the user clearly intended a typed
+      // column.
+      setParameter(parameterIndex, bindType, null);
       return;
     }
     setParameter(parameterIndex, bindType, serializer.apply(value));
@@ -525,6 +566,7 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
 
   @Override
   public void setBigInteger(int parameterIndex, BigInteger x) throws SQLException {
+    checkClosed();
     throw new SQLFeatureNotSupportedException("setBigInteger not supported");
   }
 

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakePreparedStatementImpl.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakePreparedStatementImpl.java
@@ -25,6 +25,7 @@ import java.sql.Types;
 import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 import net.snowflake.client.api.statement.SnowflakePreparedStatement;
 import net.snowflake.client.internal.api.implementation.connection.InternalSnowflakeConnection;
@@ -507,7 +508,7 @@ public class SnowflakePreparedStatementImpl extends SnowflakeStatementImpl
     }
     // Boxed primitives passed through setObject must be stringified before they reach the
     // serializer (which rejects non-String values).
-    String normalized = java.util.Objects.toString(value, null);
+    String normalized = Objects.toString(value, null);
     parameterValues.put(
         parameterIndex,
         new PreparedStatementBindingSerializer.ParameterValue(bindType, normalized));

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakeStatementImpl.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakeStatementImpl.java
@@ -2,12 +2,14 @@ package net.snowflake.client.internal.api.implementation.statement;
 
 import static net.snowflake.client.internal.api.implementation.statement.StatementTypeClassifier.NO_UPDATE_COUNT;
 
+import java.sql.BatchUpdateException;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.sql.SQLWarning;
 import java.sql.Statement;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -29,6 +31,7 @@ import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.Resul
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetHandle;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetResponse;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementHandle;
+import net.snowflake.client.internal.util.StringUtil;
 
 public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
   private static final SFLogger logger = SFLoggerFactory.getLogger(SnowflakeStatementImpl.class);
@@ -45,6 +48,9 @@ public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
   protected long currentUpdateCount = NO_UPDATE_COUNT;
   protected String queryId;
   protected final Set<ResultSet> openResultSets = ConcurrentHashMap.newKeySet();
+  private final StatementBatch batch = new StatementBatch();
+  /** Per-batch-entry query IDs collected during {@link #executeBatch()}. */
+  private final List<String> batchQueryIds = new ArrayList<>();
   /** Non-null only while navigating a multi-statement result set sequence. */
   private MultiStatementState multiState;
 
@@ -62,18 +68,19 @@ public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
   @Override
   public ResultSet executeQuery(String sql) throws SQLException {
     checkClosed();
-    return executeQueryWithBindings(sql, null);
+    return executeQueryWithBindings(sql, (PreparedStatementBindingSerializer.NativeBindings) null);
   }
 
-  protected ResultSet executeQueryWithBindings(String sql, QueryBindings bindings)
-      throws SQLException {
+  protected ResultSet executeQueryWithBindings(
+      String sql, PreparedStatementBindingSerializer.NativeBindings bindings) throws SQLException {
     checkClosed();
     ExecuteQueryResponse response = executeStatement(sql, bindings);
     applyExecuteQueryResult(response);
     return currentResultSet;
   }
 
-  protected int executeUpdateWithBindings(String sql, QueryBindings bindings) throws SQLException {
+  protected int executeUpdateWithBindings(
+      String sql, PreparedStatementBindingSerializer.NativeBindings bindings) throws SQLException {
     boolean producedResultSet = executeWithBindings(sql, bindings);
     if (producedResultSet) {
       throw new SnowflakeSQLException(
@@ -82,18 +89,33 @@ public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
     return getCurrentUpdateCountAsInt();
   }
 
-  protected boolean executeWithBindings(String sql, QueryBindings bindings) throws SQLException {
+  protected long executeLargeUpdateWithBindings(
+      String sql, PreparedStatementBindingSerializer.NativeBindings bindings) throws SQLException {
+    boolean producedResultSet = executeWithBindings(sql, bindings);
+    if (producedResultSet) {
+      throw new SnowflakeSQLException(
+          "executeUpdate() cannot be used for statements that produce a ResultSet");
+    }
+    return currentUpdateCount;
+  }
+
+  protected boolean executeWithBindings(
+      String sql, PreparedStatementBindingSerializer.NativeBindings bindings) throws SQLException {
     checkClosed();
     ExecuteQueryResponse response = executeStatement(sql, bindings);
     return updateExecutionStateAndReturnHasResultSet(response);
   }
 
-  private ExecuteQueryResponse executeStatement(String sql, QueryBindings bindings)
+  private ExecuteQueryResponse executeStatement(
+      String sql, PreparedStatementBindingSerializer.NativeBindings nativeBindings)
       throws SQLException {
+    QueryBindings bindings = nativeBindings != null ? nativeBindings.bindings() : null;
     boolean hasBindings = bindings != null;
     logger.debug("Statement executeWithBindings start: sql={}, hasBindings={}", sql, hasBindings);
     prepareForExecution();
     coreDriverApi.statementSetSqlQuery(statementHandle, sql);
+    // PreparedStatement callers must wrap this in try-with-resources on the NativeBindings so
+    // the embedded native pointer remains valid across the synchronous RPC (JLS §12.6.1).
     ExecuteQueryResponse response = coreDriverApi.statementExecuteQuery(statementHandle, bindings);
     logger.debug("statementExecuteQuery succeeded: hasBindings={}", hasBindings);
     return response;
@@ -420,17 +442,88 @@ public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
 
   @Override
   public void addBatch(String sql) throws SQLException {
-    throw new SQLFeatureNotSupportedException("addBatch not supported");
+    checkClosed();
+    if (sql == null) {
+      throw new SnowflakeSQLException("addBatch requires a non-null SQL string");
+    }
+    batch.add(sql);
   }
 
   @Override
   public void clearBatch() throws SQLException {
-    throw new SQLFeatureNotSupportedException("clearBatch not supported");
+    checkClosed();
+    batch.clear();
+    // batchQueryIds is intentionally not cleared here — see SnowflakeStatement#getBatchQueryIDs.
   }
 
+  // TODO: honour CLIENT_CLEAR_BATCH_ONLY_AFTER_SUCCESSFUL_EXECUTION once sf_core surfaces session
+  // params; today we always clear in finally.
   @Override
   public int[] executeBatch() throws SQLException {
-    throw new SQLFeatureNotSupportedException("executeBatch not supported");
+    checkClosed();
+    return batch.executeAll(this);
+  }
+
+  protected static BatchUpdateException buildBatchFailureException(
+      SQLException firstFailure, int[] updateCounts) {
+    return new BatchUpdateException(
+        firstFailure.getLocalizedMessage(),
+        firstFailure.getSQLState(),
+        firstFailure.getErrorCode(),
+        updateCounts,
+        firstFailure);
+  }
+
+  /**
+   * Shared cleanup for executeBatch paths: clear the batch and reset current-result state. If a BUE
+   * is pending from the catch path, attach cleanup failures as suppressed; on the success path, log
+   * + swallow so cleanup errors don't mask successful update counts.
+   */
+  protected void finalizeBatch(BatchUpdateException pending) {
+    try {
+      clearBatch();
+    } catch (SQLException cleanupEx) {
+      if (pending != null) {
+        pending.addSuppressed(cleanupEx);
+      } else {
+        logger.warn("clearBatch failed after successful executeBatch", cleanupEx);
+      }
+    }
+    resetCurrentResultState();
+  }
+
+  /**
+   * Map a long update count to a JDBC batch int. {@code NO_UPDATE_COUNT} and out-of-int values
+   * collapse to {@link Statement#SUCCESS_NO_INFO}; callers wanting full fidelity should use {@link
+   * Statement#executeLargeBatch()}.
+   */
+  protected static int toBatchInt(long value) {
+    if (value == NO_UPDATE_COUNT || value > Integer.MAX_VALUE || value < Integer.MIN_VALUE) {
+      return Statement.SUCCESS_NO_INFO;
+    }
+    return (int) value;
+  }
+
+  /** Both {@code null} and the empty string (proto3 default) collapse to {@code null}. */
+  protected static String normalizeQueryId(String queryId) {
+    return StringUtil.isNullOrEmpty(queryId) ? null : queryId;
+  }
+
+  protected void recordBatchQueryId() {
+    batchQueryIds.add(normalizeQueryId(queryId));
+  }
+
+  protected void clearBatchQueryIds() {
+    batchQueryIds.clear();
+  }
+
+  /**
+   * Per JDBC spec, after {@code executeBatch()} {@link Statement#getResultSet()} returns null and
+   * {@link Statement#getUpdateCount()} returns -1.
+   */
+  protected void resetCurrentResultState() {
+    currentResultSet = null;
+    currentUpdateCount = NO_UPDATE_COUNT;
   }
 
   @Override
@@ -573,7 +666,8 @@ public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
 
   @Override
   public List<String> getBatchQueryIDs() throws SQLException {
-    throw new SQLFeatureNotSupportedException("getBatchQueryIDs not supported");
+    checkClosed();
+    return Collections.unmodifiableList(new ArrayList<>(batchQueryIds));
   }
 
   @Override

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakeStatementImpl.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakeStatementImpl.java
@@ -81,22 +81,31 @@ public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
 
   protected int executeUpdateWithBindings(
       String sql, PreparedStatementBindingSerializer.NativeBindings bindings) throws SQLException {
-    boolean producedResultSet = executeWithBindings(sql, bindings);
-    if (producedResultSet) {
-      throw new SnowflakeSQLException(
-          "executeUpdate() cannot be used for statements that produce a ResultSet");
-    }
+    ensureNoResultSet(executeWithBindings(sql, bindings), "executeUpdate");
     return getCurrentUpdateCountAsInt();
   }
 
   protected long executeLargeUpdateWithBindings(
       String sql, PreparedStatementBindingSerializer.NativeBindings bindings) throws SQLException {
-    boolean producedResultSet = executeWithBindings(sql, bindings);
+    ensureNoResultSet(executeWithBindings(sql, bindings), "executeLargeUpdate");
+    return currentUpdateCount;
+  }
+
+  /**
+   * Enforce the JDBC contract for {@code executeUpdate}/{@code executeLargeUpdate}: the spec
+   * requires throwing when the SQL produced a {@link ResultSet}. The query has already been
+   * executed at this point, but we cannot detect ResultSet-vs-update-count up front — Snowflake's
+   * SQL surface (dynamic SQL, multi-statements) means the server's response is the only authority.
+   * snowflake-jdbc throws here too (see {@code executeUpdateInternal} → {@code
+   * UNSUPPORTED_STATEMENT_TYPE_IN_EXECUTION_API}); silently swallowing would let {@code
+   * executeUpdate("SELECT …")} return 0 and surprise callers.
+   */
+  private static void ensureNoResultSet(boolean producedResultSet, String methodName)
+      throws SQLException {
     if (producedResultSet) {
       throw new SnowflakeSQLException(
-          "executeUpdate() cannot be used for statements that produce a ResultSet");
+          methodName + "() cannot be used for statements that produce a ResultSet");
     }
-    return currentUpdateCount;
   }
 
   protected boolean executeWithBindings(

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/StatementBatch.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/StatementBatch.java
@@ -1,0 +1,74 @@
+package net.snowflake.client.internal.api.implementation.statement;
+
+import java.sql.BatchUpdateException;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Per-statement batch of SQL strings. {@link #executeAll} runs each entry sequentially per JDBC §14
+ * (continue-on-error) and surfaces the first failure as a {@link BatchUpdateException}.
+ */
+final class StatementBatch {
+  private final List<String> entries = new ArrayList<>();
+
+  void add(String sql) {
+    entries.add(sql);
+  }
+
+  void clear() {
+    entries.clear();
+  }
+
+  int size() {
+    return entries.size();
+  }
+
+  int[] executeAll(SnowflakeStatementImpl stmt) throws SQLException {
+    int[] updateCounts = new int[entries.size()];
+    stmt.clearBatchQueryIds();
+    BatchUpdateException pending = null;
+    try {
+      SQLException firstFailure = runEntries(stmt, updateCounts);
+      if (firstFailure != null) {
+        pending = SnowflakeStatementImpl.buildBatchFailureException(firstFailure, updateCounts);
+      }
+    } finally {
+      stmt.finalizeBatch(pending);
+    }
+    if (pending != null) {
+      throw pending;
+    }
+    return updateCounts;
+  }
+
+  /** Returns the first per-row failure, or {@code null} if every entry succeeded. */
+  private SQLException runEntries(SnowflakeStatementImpl stmt, int[] updateCounts) {
+    SQLException firstFailure = null;
+    for (int i = 0; i < entries.size(); i++) {
+      SQLException rowFailure = runOne(stmt, entries.get(i), updateCounts, i);
+      if (rowFailure != null && firstFailure == null) {
+        firstFailure = rowFailure;
+      }
+    }
+    return firstFailure;
+  }
+
+  /** Returns {@code null} on success, or the failure exception on per-row error. */
+  private static SQLException runOne(
+      SnowflakeStatementImpl stmt, String sql, int[] updateCounts, int row) {
+    try {
+      long count = stmt.executeLargeUpdateWithBindings(sql, null);
+      updateCounts[row] = SnowflakeStatementImpl.toBatchInt(count);
+      return null;
+    } catch (SQLException e) {
+      updateCounts[row] = Statement.EXECUTE_FAILED;
+      return e;
+    } finally {
+      // Always append, even on failure (queryId is null when applySingleResult never ran), so
+      // updateCounts and batchQueryIds stay positionally aligned.
+      stmt.recordBatchQueryId();
+    }
+  }
+}

--- a/jdbc/src/test/java/net/snowflake/client/api/statement/SnowflakeBatchExecutionTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/api/statement/SnowflakeBatchExecutionTest.java
@@ -1,0 +1,173 @@
+package net.snowflake.client.api.statement;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.sql.Types;
+import net.snowflake.jdbc.utils.SnowflakeIntegrationTestBase;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end coverage for {@code addBatch} / {@code executeBatch} on Statement and
+ * PreparedStatement.
+ */
+public class SnowflakeBatchExecutionTest extends SnowflakeIntegrationTestBase {
+
+  @Test
+  public void testStatementBatchExecutesEachSqlAndReturnsCounts() throws Exception {
+    Connection conn = getDefaultConnection();
+    String tableName = createTempTable(conn, "ud_stmt_batch_", "v INTEGER");
+
+    try (Statement stmt = conn.createStatement()) {
+      stmt.addBatch("INSERT INTO " + tableName + " VALUES (1)");
+      stmt.addBatch("INSERT INTO " + tableName + " VALUES (2), (3)");
+      stmt.addBatch("INSERT INTO " + tableName + " VALUES (4), (5), (6)");
+
+      int[] counts = stmt.executeBatch();
+      assertArrayEquals(new int[] {1, 2, 3}, counts);
+    }
+
+    try (Statement stmt = conn.createStatement();
+        ResultSet rs = stmt.executeQuery("SELECT COUNT(*), SUM(v) FROM " + tableName)) {
+      assertTrue(rs.next());
+      assertEquals(6, rs.getInt(1));
+      assertEquals(21, rs.getInt(2));
+    }
+  }
+
+  @Test
+  public void testStatementClearBatchPreventsExecution() throws Exception {
+    Connection conn = getDefaultConnection();
+    String tableName = createTempTable(conn, "ud_stmt_clear_", "v INTEGER");
+
+    try (Statement stmt = conn.createStatement()) {
+      stmt.addBatch("INSERT INTO " + tableName + " VALUES (1)");
+      stmt.addBatch("INSERT INTO " + tableName + " VALUES (2)");
+      stmt.clearBatch();
+
+      int[] counts = stmt.executeBatch();
+      assertEquals(0, counts.length);
+    }
+
+    try (Statement stmt = conn.createStatement();
+        ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM " + tableName)) {
+      assertTrue(rs.next());
+      assertEquals(0, rs.getInt(1));
+    }
+  }
+
+  @Test
+  public void testPreparedStatementBatchInsertExpandsToPerRowCounts() throws Exception {
+    Connection conn = getDefaultConnection();
+    String tableName = createTempTable(conn, "ud_ps_batch_", "n INTEGER, s STRING");
+
+    try (PreparedStatement ps =
+        conn.prepareStatement("INSERT INTO " + tableName + " (n, s) VALUES (?, ?)")) {
+      ps.setInt(1, 1);
+      ps.setString(2, "one");
+      ps.addBatch();
+
+      ps.setInt(1, 2);
+      ps.setString(2, "two");
+      ps.addBatch();
+
+      ps.setInt(1, 3);
+      ps.setString(2, "three");
+      ps.addBatch();
+
+      int[] counts = ps.executeBatch();
+      // Snowflake aggregates inserts; the driver expands the count when it equals batchSize.
+      assertArrayEquals(new int[] {1, 1, 1}, counts);
+    }
+
+    try (Statement stmt = conn.createStatement();
+        ResultSet rs = stmt.executeQuery("SELECT n, s FROM " + tableName + " ORDER BY n")) {
+      assertTrue(rs.next());
+      assertEquals(1, rs.getInt(1));
+      assertEquals("one", rs.getString(2));
+      assertTrue(rs.next());
+      assertEquals(2, rs.getInt(1));
+      assertEquals("two", rs.getString(2));
+      assertTrue(rs.next());
+      assertEquals(3, rs.getInt(1));
+      assertEquals("three", rs.getString(2));
+    }
+  }
+
+  @Test
+  public void testPreparedStatementBatchInsertWithNullValuesAcrossRows() throws Exception {
+    Connection conn = getDefaultConnection();
+    String tableName = createTempTable(conn, "ud_ps_batch_null_", "n INTEGER, s STRING");
+
+    try (PreparedStatement ps =
+        conn.prepareStatement("INSERT INTO " + tableName + " (n, s) VALUES (?, ?)")) {
+      ps.setNull(1, Types.INTEGER);
+      ps.setString(2, "first-null");
+      ps.addBatch();
+
+      ps.setInt(1, 7);
+      ps.setNull(2, Types.VARCHAR);
+      ps.addBatch();
+
+      ps.setInt(1, 8);
+      ps.setString(2, "third");
+      ps.addBatch();
+
+      int[] counts = ps.executeBatch();
+      assertEquals(3, counts.length);
+    }
+
+    try (Statement stmt = conn.createStatement();
+        ResultSet rs =
+            stmt.executeQuery("SELECT n, s FROM " + tableName + " ORDER BY n NULLS FIRST")) {
+      assertTrue(rs.next());
+      rs.getInt(1);
+      assertTrue(rs.wasNull());
+      assertEquals("first-null", rs.getString(2));
+
+      assertTrue(rs.next());
+      assertEquals(7, rs.getInt(1));
+      rs.getString(2);
+      assertTrue(rs.wasNull());
+
+      assertTrue(rs.next());
+      assertEquals(8, rs.getInt(1));
+      assertEquals("third", rs.getString(2));
+    }
+  }
+
+  @Test
+  public void testPreparedStatementClearBatchResetsAccumulatedRows() throws Exception {
+    Connection conn = getDefaultConnection();
+    String tableName = createTempTable(conn, "ud_ps_clear_", "n INTEGER");
+
+    try (PreparedStatement ps = conn.prepareStatement("INSERT INTO " + tableName + " VALUES (?)")) {
+      ps.setInt(1, 1);
+      ps.addBatch();
+      ps.setInt(1, 2);
+      ps.addBatch();
+      ps.clearBatch();
+
+      int[] counts = ps.executeBatch();
+      assertEquals(0, counts.length);
+
+      ps.setInt(1, 99);
+      ps.addBatch();
+      counts = ps.executeBatch();
+      assertEquals(1, counts.length);
+    }
+
+    try (Statement stmt = conn.createStatement();
+        ResultSet rs = stmt.executeQuery("SELECT n FROM " + tableName)) {
+      assertTrue(rs.next());
+      assertEquals(99, rs.getInt(1));
+      assertNotNull(rs);
+    }
+  }
+}

--- a/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/statement/PreparedBatchTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/statement/PreparedBatchTest.java
@@ -1,0 +1,109 @@
+package net.snowflake.client.internal.api.implementation.statement;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+import net.snowflake.client.api.exception.SnowflakeSQLException;
+import net.snowflake.client.internal.api.implementation.statement.PreparedStatementBindingSerializer.ParameterValue;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link PreparedBatch} via its public API only. */
+class PreparedBatchTest {
+
+  private static SqlPlaceholderMetadata twoCol() {
+    return SqlPlaceholderMetadata.analyze("INSERT INTO t VALUES (?, ?)");
+  }
+
+  private static SqlPlaceholderMetadata oneCol() {
+    return SqlPlaceholderMetadata.analyze("INSERT INTO t VALUES (?)");
+  }
+
+  private static Map<Integer, ParameterValue> row(Object... pairs) {
+    if (pairs.length % 3 != 0) {
+      throw new IllegalArgumentException("pairs must be (idx, type, value) triples");
+    }
+    Map<Integer, ParameterValue> r = new HashMap<>();
+    for (int i = 0; i < pairs.length; i += 3) {
+      r.put((Integer) pairs[i], new ParameterValue((String) pairs[i + 1], pairs[i + 2]));
+    }
+    return r;
+  }
+
+  @Test
+  void rejectsTypeMismatchWithErrorCodeAndSqlState() throws SQLException {
+    PreparedBatch batch = new PreparedBatch();
+    SqlPlaceholderMetadata meta = oneCol();
+    batch.addRow(meta, row(1, "FIXED", "1"));
+
+    SnowflakeSQLException ex =
+        assertThrows(SnowflakeSQLException.class, () -> batch.addRow(meta, row(1, "TEXT", "boom")));
+    assertEquals(200023, ex.getErrorCode());
+    assertEquals("0A000", ex.getSQLState());
+  }
+
+  @Test
+  void typeMismatchDoesNotAdvanceBatchSize() throws SQLException {
+    PreparedBatch batch = new PreparedBatch();
+    SqlPlaceholderMetadata meta = twoCol();
+    batch.addRow(meta, row(1, "FIXED", "1", 2, "TEXT", "ok"));
+    assertEquals(1, batch.size());
+
+    assertThrows(
+        SnowflakeSQLException.class,
+        () -> batch.addRow(meta, row(1, "FIXED", "2", 2, "FIXED", "999")));
+
+    // size() reads the first column's list length; if the failed addRow had partially
+    // appended to column 1 before throwing on column 2, size would be 2.
+    assertEquals(1, batch.size(), "failed addRow must not advance batch size");
+  }
+
+  @Test
+  void allNullsThenTypedDoesNotThrow() {
+    PreparedBatch batch = new PreparedBatch();
+    SqlPlaceholderMetadata meta = oneCol();
+    assertDoesNotThrow(
+        () -> {
+          batch.addRow(meta, row(1, "ANY", null));
+          batch.addRow(meta, row(1, "ANY", null));
+          batch.addRow(meta, row(1, "FIXED", "7"));
+        });
+  }
+
+  @Test
+  void typedThenNullThenTypedDoesNotThrow() {
+    PreparedBatch batch = new PreparedBatch();
+    SqlPlaceholderMetadata meta = oneCol();
+    assertDoesNotThrow(
+        () -> {
+          batch.addRow(meta, row(1, "TEXT", "hi"));
+          batch.addRow(meta, row(1, "ANY", null));
+          batch.addRow(meta, row(1, "TEXT", "there"));
+        });
+  }
+
+  @Test
+  void rejectsMissingValue() {
+    PreparedBatch batch = new PreparedBatch();
+    SQLException ex =
+        assertThrows(SQLException.class, () -> batch.addRow(twoCol(), row(1, "FIXED", "1")));
+    assertTrue(ex.getMessage().contains("Missing value for parameter index: 2"));
+  }
+
+  @Test
+  void clearResetsState() throws SQLException {
+    PreparedBatch batch = new PreparedBatch();
+    SqlPlaceholderMetadata meta = oneCol();
+    batch.addRow(meta, row(1, "FIXED", "1"));
+    batch.addRow(meta, row(1, "FIXED", "2"));
+
+    batch.clear();
+
+    assertEquals(0, batch.size());
+    assertTrue(batch.isEmpty());
+  }
+}

--- a/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/statement/PreparedStatementBindingSerializerTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/statement/PreparedStatementBindingSerializerTest.java
@@ -11,13 +11,29 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.BinaryDataPtr;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.QueryBindings;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 
 public class PreparedStatementBindingSerializerTest {
+
+  /**
+   * Detect ArrowBuf leaks. Any code path inside {@code serialize()} that allocates a buffer but
+   * fails to close it (e.g. a future refactor that throws between {@code allocator.buffer(…)} and
+   * {@code NativeBindings} construction) leaves bytes accounted on the shared allocator; this
+   * assertion fires immediately after the test class completes.
+   */
+  @AfterAll
+  public static void assertSharedAllocatorEmpty() {
+    assertEquals(
+        0L,
+        PreparedStatementBindingSerializer.sharedAllocatorAllocatedBytes(),
+        "ArrowBuf leak: shared allocator still has bytes after binding serializer tests");
+  }
 
   @Test
   public void testSerializeEmptyParametersReturnsNullBindings() throws Exception {
@@ -97,6 +113,36 @@ public class PreparedStatementBindingSerializerTest {
           expectedJsonBytes.length,
           bindings.getJson().getLength(),
           "JSON byte length should match numeric placeholder payload length");
+    }
+  }
+
+  @Test
+  public void testSerializeListValuedParameterEmitsJsonArrayWithNullSlots() throws Exception {
+    Map<Integer, PreparedStatementBindingSerializer.ParameterValue> params = new HashMap<>();
+    params.put(
+        1,
+        new PreparedStatementBindingSerializer.ParameterValue(
+            "FIXED", Arrays.asList("1", "2", null, "4")));
+    params.put(
+        2,
+        new PreparedStatementBindingSerializer.ParameterValue(
+            "TEXT", Arrays.asList("a", null, "c", "d")));
+
+    String expectedJson =
+        "{\"1\":{\"type\":\"FIXED\",\"value\":[\"1\",\"2\",null,\"4\"]},"
+            + "\"2\":{\"type\":\"TEXT\",\"value\":[\"a\",null,\"c\",\"d\"]}}";
+    byte[] expectedJsonBytes = expectedJson.getBytes(StandardCharsets.UTF_8);
+
+    try (PreparedStatementBindingSerializer.NativeBindings nativeBindings =
+        PreparedStatementBindingSerializer.serialize(
+            SqlPlaceholderMetadata.analyze("INSERT INTO t VALUES (?, ?)"), params)) {
+      QueryBindings bindings = nativeBindings.bindings();
+      assertNotNull(bindings, "Expected non-null bindings for array bind");
+      assertTrue(bindings.hasJson(), "Expected JSON variant for array bind");
+      assertEquals(
+          expectedJsonBytes.length,
+          bindings.getJson().getLength(),
+          "Array-bind JSON byte length should match the canonical payload");
     }
   }
 }

--- a/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/statement/PreparedStatementBindingSerializerTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/statement/PreparedStatementBindingSerializerTest.java
@@ -31,7 +31,7 @@ public class PreparedStatementBindingSerializerTest {
   public static void assertSharedAllocatorEmpty() {
     assertEquals(
         0L,
-        PreparedStatementBindingSerializer.sharedAllocatorAllocatedBytes(),
+        PreparedStatementBindingSerializer.SHARED_ALLOCATOR.getAllocatedMemory(),
         "ArrowBuf leak: shared allocator still has bytes after binding serializer tests");
   }
 

--- a/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/statement/SnowflakePreparedStatementImplTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/statement/SnowflakePreparedStatementImplTest.java
@@ -1,0 +1,186 @@
+package net.snowflake.client.internal.api.implementation.statement;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.notNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.sql.Statement;
+import net.snowflake.client.internal.api.implementation.connection.InternalSnowflakeConnection;
+import net.snowflake.client.internal.unicore.CoreDriverApi;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionHandle;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ExecuteQueryResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.QueryBindings;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetDescriptor;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementHandle;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementNewResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementReleaseResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class SnowflakePreparedStatementImplTest {
+
+  private static final long INSERT_TYPE_ID = 0x3000L + 0x100L;
+
+  private final ConnectionHandle connHandle =
+      ConnectionHandle.newBuilder().setId(1).setMagic(100).build();
+  private final StatementHandle stmtHandle =
+      StatementHandle.newBuilder().setId(10).setMagic(1000).build();
+
+  private CoreDriverApi mockCoreApi;
+  private InternalSnowflakeConnection mockConnection;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    mockCoreApi = mock(CoreDriverApi.class);
+    mockConnection = mock(InternalSnowflakeConnection.class);
+    when(mockConnection.getHandle()).thenReturn(connHandle);
+    when(mockCoreApi.statementNew(any()))
+        .thenReturn(StatementNewResponse.newBuilder().setStmtHandle(stmtHandle).build());
+    when(mockCoreApi.statementRelease(any()))
+        .thenReturn(StatementReleaseResponse.getDefaultInstance());
+  }
+
+  private SnowflakePreparedStatementImpl createPreparedStatement(String sql) {
+    return new SnowflakePreparedStatementImpl(mockConnection, sql, mockCoreApi);
+  }
+
+  @Test
+  void executeBatchSendsSingleQueryAndExpandsAggregateUpdateCount() throws Exception {
+    SnowflakePreparedStatementImpl ps = createPreparedStatement("INSERT INTO t VALUES (?)");
+    when(mockCoreApi.statementExecuteQuery(any(), notNull(QueryBindings.class)))
+        .thenReturn(insertResponse(3L));
+
+    ps.setInt(1, 1);
+    ps.addBatch();
+    ps.setInt(1, 2);
+    ps.addBatch();
+    ps.setInt(1, 3);
+    ps.addBatch();
+
+    int[] counts = ps.executeBatch();
+
+    assertArrayEquals(new int[] {1, 1, 1}, counts);
+    verify(mockCoreApi, times(1)).statementExecuteQuery(any(), notNull(QueryBindings.class));
+  }
+
+  @Test
+  void executeBatchReturnsSuccessNoInfoWhenServerCountDiffersFromBatchSize() throws Exception {
+    SnowflakePreparedStatementImpl ps = createPreparedStatement("INSERT INTO t VALUES (?)");
+    when(mockCoreApi.statementExecuteQuery(any(), notNull(QueryBindings.class)))
+        .thenReturn(insertResponse(7L));
+
+    ps.setInt(1, 1);
+    ps.addBatch();
+    ps.setInt(1, 2);
+    ps.addBatch();
+
+    int[] counts = ps.executeBatch();
+    assertArrayEquals(
+        new int[] {Statement.SUCCESS_NO_INFO, Statement.SUCCESS_NO_INFO},
+        counts,
+        "non-matching aggregate must fan out to one SUCCESS_NO_INFO per batch row");
+  }
+
+  @Test
+  void executeBatchOnEmptyBatchReturnsEmptyArrayAndSkipsRpc() throws Exception {
+    SnowflakePreparedStatementImpl ps = createPreparedStatement("INSERT INTO t VALUES (?)");
+
+    int[] counts = ps.executeBatch();
+    assertEquals(0, counts.length);
+    verify(mockCoreApi, times(0)).statementExecuteQuery(any(), any());
+  }
+
+  @Test
+  void executeLargeBatchReturnsLongCountsExpandedFromAggregate() throws Exception {
+    SnowflakePreparedStatementImpl ps = createPreparedStatement("INSERT INTO t VALUES (?)");
+    when(mockCoreApi.statementExecuteQuery(any(), notNull(QueryBindings.class)))
+        .thenReturn(insertResponse(2L));
+
+    ps.setInt(1, 1);
+    ps.addBatch();
+    ps.setInt(1, 2);
+    ps.addBatch();
+
+    long[] counts = ps.executeLargeBatch();
+    assertEquals(2, counts.length);
+    assertEquals(1L, counts[0]);
+    assertEquals(1L, counts[1]);
+  }
+
+  @Test
+  void preparedStatementRejectsAddBatchWithSql() {
+    PreparedStatement ps = createPreparedStatement("INSERT INTO t VALUES (?)");
+    assertThrows(
+        SQLFeatureNotSupportedException.class, () -> ps.addBatch("INSERT INTO t VALUES (1)"));
+  }
+
+  @Test
+  void executeBatchOnFailureWrapsAsBatchUpdateExceptionWithExecuteFailedSlots() throws Exception {
+    SnowflakePreparedStatementImpl ps = createPreparedStatement("INSERT INTO t VALUES (?)");
+    when(mockCoreApi.statementExecuteQuery(any(), notNull(QueryBindings.class)))
+        .thenThrow(new SQLException("boom", "42000", 7));
+
+    ps.setInt(1, 1);
+    ps.addBatch();
+    ps.setInt(1, 2);
+    ps.addBatch();
+    ps.setInt(1, 3);
+    ps.addBatch();
+
+    java.sql.BatchUpdateException ex =
+        assertThrows(java.sql.BatchUpdateException.class, ps::executeBatch);
+    assertArrayEquals(
+        new int[] {Statement.EXECUTE_FAILED, Statement.EXECUTE_FAILED, Statement.EXECUTE_FAILED},
+        ex.getUpdateCounts());
+    assertEquals("42000", ex.getSQLState());
+    assertEquals(7, ex.getErrorCode());
+
+    int[] second = ps.executeBatch();
+    assertEquals(0, second.length, "batch is cleared even after a failed executeBatch");
+  }
+
+  @Test
+  void executeBatchPopulatesAndResetsBatchQueryIds() throws Exception {
+    SnowflakePreparedStatementImpl ps = createPreparedStatement("INSERT INTO t VALUES (?)");
+    when(mockCoreApi.statementExecuteQuery(any(), notNull(QueryBindings.class)))
+        .thenReturn(insertResponse(1L));
+
+    ps.setInt(1, 1);
+    ps.addBatch();
+    ps.executeBatch();
+    assertEquals(
+        1,
+        ((net.snowflake.client.api.statement.SnowflakeStatement) ps).getBatchQueryIDs().size(),
+        "PS array-bind batch is a single round-trip");
+
+    ps.setInt(1, 2);
+    ps.addBatch();
+    ps.executeBatch();
+    assertEquals(
+        1,
+        ((net.snowflake.client.api.statement.SnowflakeStatement) ps).getBatchQueryIDs().size(),
+        "second executeBatch resets and re-populates rather than appending");
+  }
+
+  private static ExecuteQueryResponse insertResponse(long rowsAffected) {
+    ResultSetDescriptor descriptor =
+        ResultSetDescriptor.newBuilder()
+            .setQueryId("qid")
+            .setStatementTypeId(INSERT_TYPE_ID)
+            .setRowsAffected(rowsAffected)
+            .build();
+    ResultSetResponse single =
+        ResultSetResponse.newBuilder().setResultDescriptor(descriptor).build();
+    return ExecuteQueryResponse.newBuilder().setSingle(single).build();
+  }
+}

--- a/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/statement/SnowflakeStatementImplTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/statement/SnowflakeStatementImplTest.java
@@ -1,18 +1,25 @@
 package net.snowflake.client.internal.api.implementation.statement;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.sql.BatchUpdateException;
 import java.sql.SQLException;
 import java.sql.Statement;
 import net.snowflake.client.internal.api.implementation.connection.InternalSnowflakeConnection;
 import net.snowflake.client.internal.unicore.CoreDriverApi;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionHandle;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ExecuteQueryResponse;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetDescriptor;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetResponse;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementHandle;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementNewResponse;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.StatementReleaseResponse;
@@ -92,5 +99,82 @@ public class SnowflakeStatementImplTest {
 
     assertThrows(SQLException.class, () -> stmt.execute("SELECT 1"));
     assertThrows(SQLException.class, () -> stmt.executeQuery("SELECT 1"));
+  }
+
+  @Test
+  void executeBatchReturnsUpdateCountsForEachAddedSql() throws Exception {
+    Statement stmt = createStatement();
+    when(mockCoreApi.statementExecuteQuery(any(), isNull()))
+        .thenReturn(insertResponse(1L), insertResponse(2L), insertResponse(3L));
+
+    stmt.addBatch("INSERT INTO t VALUES (1)");
+    stmt.addBatch("INSERT INTO t VALUES (2), (3)");
+    stmt.addBatch("INSERT INTO t VALUES (4), (5), (6)");
+
+    int[] counts = stmt.executeBatch();
+
+    assertArrayEquals(new int[] {1, 2, 3}, counts);
+    verify(mockCoreApi, times(3)).statementExecuteQuery(any(), isNull());
+  }
+
+  @Test
+  void clearBatchEmptiesAccumulatedSql() throws Exception {
+    Statement stmt = createStatement();
+
+    stmt.addBatch("INSERT INTO t VALUES (1)");
+    stmt.addBatch("INSERT INTO t VALUES (2)");
+    stmt.clearBatch();
+
+    int[] counts = stmt.executeBatch();
+    assertEquals(0, counts.length);
+    verify(mockCoreApi, times(0)).statementExecuteQuery(any(), isNull());
+  }
+
+  @Test
+  void executeBatchContinuesAfterFailureAndAlignsBatchQueryIds() throws Exception {
+    Statement stmt = createStatement();
+    when(mockCoreApi.statementExecuteQuery(any(), isNull()))
+        .thenReturn(insertResponse(1L, "qid-ok-1"))
+        .thenThrow(new SQLException("boom", "42000", 1234))
+        .thenReturn(insertResponse(3L, "qid-ok-3"));
+
+    stmt.addBatch("INSERT INTO t VALUES (1)");
+    stmt.addBatch("INSERT INTO t VALUES (2)");
+    stmt.addBatch("INSERT INTO t VALUES (3), (4), (5)");
+
+    BatchUpdateException ex = assertThrows(BatchUpdateException.class, stmt::executeBatch);
+    assertArrayEquals(
+        new int[] {1, Statement.EXECUTE_FAILED, 3},
+        ex.getUpdateCounts(),
+        "continue-on-error: failed slot is EXECUTE_FAILED, surrounding entries keep real counts");
+    assertEquals("42000", ex.getSQLState());
+    assertEquals(1234, ex.getErrorCode());
+
+    java.util.List<String> ids =
+        ((net.snowflake.client.api.statement.SnowflakeStatement) stmt).getBatchQueryIDs();
+    assertArrayEquals(
+        new String[] {"qid-ok-1", null, "qid-ok-3"},
+        ids.toArray(new String[0]),
+        "batchQueryIds positionally aligns with updateCounts; failed slot is null");
+
+    int[] secondRun = stmt.executeBatch();
+    assertEquals(0, secondRun.length, "batch is cleared even after a failed executeBatch");
+  }
+
+  private static ExecuteQueryResponse insertResponse(long rowsAffected) {
+    return insertResponse(rowsAffected, "qid-" + rowsAffected);
+  }
+
+  private static ExecuteQueryResponse insertResponse(long rowsAffected, String queryId) {
+    long INSERT_TYPE_ID = 0x3000L + 0x100L;
+    ResultSetDescriptor descriptor =
+        ResultSetDescriptor.newBuilder()
+            .setQueryId(queryId)
+            .setStatementTypeId(INSERT_TYPE_ID)
+            .setRowsAffected(rowsAffected)
+            .build();
+    ResultSetResponse single =
+        ResultSetResponse.newBuilder().setResultDescriptor(descriptor).build();
+    return ExecuteQueryResponse.newBuilder().setSingle(single).build();
   }
 }


### PR DESCRIPTION
  Implements addBatch / executeBatch / clearBatch for Statement and PreparedStatement (previously SQLFeatureNotSupportedException stubs).

  - Statement-level: continue-on-error per JDBC §14; failed entries get EXECUTE_FAILED; any failure throws BatchUpdateException with the full-length array.
  - PreparedStatement-level: single array-bind RPC with SNOW-14034 expansion when the server count matches batchSize, else fan-out to SUCCESS_NO_INFO.

  Batch state and orchestration live in StatementBatch and PreparedBatch; the JDBC impls just delegate.

  getBatchQueryIDs() returns one entry per submitted row (Statement, null for failures) or one per array-bind batch (PS).