### PR TITLE
SNOW-3571048: Decode Windows DM hex escapes and preserve SQLGetData buffer

### DIFF
--- a/odbc_trace_tool/src/generator/cpp.rs
+++ b/odbc_trace_tool/src/generator/cpp.rs
@@ -602,7 +602,7 @@ impl<'a> GenContext<'a> {
         let stmt_var = self.stmt_var_for(&call.handle);
         let col_num = call.column_number.unwrap_or(1);
         let target_type = call.target_type_name.as_deref().unwrap_or("SQL_C_CHAR");
-        let buf_len = call.buffer_length.unwrap_or(1024).min(4096);
+        let buf_len = call.buffer_length.unwrap_or(1024).max(0);
 
         self.writeln(&format!("// SQLGetData col {col_num}"));
         self.writeln("{");
@@ -623,14 +623,18 @@ impl<'a> GenContext<'a> {
             );
 
             if let Some(ind_val) = call.indicator {
-                if ind_val == -1 {
-                    self.writeln("CHECK(ind == SQL_NULL_DATA);");
-                } else {
-                    if let Some(val) = &call.value {
-                        let escaped = escape_cpp_string_literal(val);
-                        self.writeln(&format!("CHECK(std::string(buf.data()) == \"{escaped}\");"));
+                match ind_val {
+                    -1 => self.writeln("CHECK(ind == SQL_NULL_DATA);"),
+                    -4 => self.writeln("CHECK(ind == SQL_NO_TOTAL);"),
+                    _ => {
+                        if let Some(val) = &call.value {
+                            let escaped = escape_cpp_string_literal(val);
+                            self.writeln(&format!(
+                                "CHECK(std::string(buf.data()) == \"{escaped}\");"
+                            ));
+                        }
+                        self.writeln(&format!("CHECK(ind == {ind_val});"));
                     }
-                    self.writeln(&format!("CHECK(ind == {ind_val});"));
                 }
             } else if let Some(val) = &call.value {
                 let escaped = escape_cpp_string_literal(val);
@@ -652,13 +656,13 @@ impl<'a> GenContext<'a> {
 
             // For non-narrow target types (SQL_C_WCHAR, etc.) the indicator is
             // a byte count that depends on the driver's wide-char encoding
-            // (UTF-16 vs UTF-32) and the DM's translation. Assert presence
-            // rather than the captured byte count to keep the test portable.
+            // (UTF-16 vs UTF-32) and the DM's translation. Assert sentinel
+            // values exactly, otherwise just assert presence to stay portable.
             if let Some(ind_val) = call.indicator {
-                if ind_val == -1 {
-                    self.writeln("CHECK(ind == SQL_NULL_DATA);");
-                } else {
-                    self.writeln("CHECK(ind > 0);");
+                match ind_val {
+                    -1 => self.writeln("CHECK(ind == SQL_NULL_DATA);"),
+                    -4 => self.writeln("CHECK(ind == SQL_NO_TOTAL);"),
+                    _ => self.writeln("CHECK(ind > 0);"),
                 }
             }
         }
@@ -1164,6 +1168,64 @@ mod tests {
         assert!(
             output.contains("SQLRETURN ret = SQLFreeHandle(SQL_HANDLE_ENV, env0)"),
             "env freed"
+        );
+    }
+
+    #[test]
+    fn test_get_data_emits_sql_no_total_and_keeps_large_buffer() {
+        use crate::model::{GetData, OdbcCall};
+
+        let calls = vec![
+            OdbcCall::GetData(GetData {
+                return_code: crate::model::ReturnCode::SuccessWithInfo,
+                handle: Some("0xstmt".to_string()),
+                column_number: Some(1),
+                target_type: Some(-8),
+                target_type_name: Some("SQL_C_WCHAR".to_string()),
+                buffer_length: Some(131074),
+                value: None,
+                indicator: Some(-4),
+            }),
+            OdbcCall::GetData(GetData {
+                return_code: crate::model::ReturnCode::Success,
+                handle: Some("0xstmt".to_string()),
+                column_number: Some(1),
+                target_type: Some(-8),
+                target_type_name: Some("SQL_C_WCHAR".to_string()),
+                buffer_length: Some(262146),
+                value: None,
+                indicator: Some(2),
+            }),
+        ];
+
+        let config = GeneratorConfig {
+            test_name: "lob streaming".to_string(),
+            tag: "replay".to_string(),
+            query_map: None,
+            allow_unsupported: true,
+        };
+
+        let output = generate(&calls, &config).expect("generate");
+
+        assert!(
+            output.contains("std::vector<char> buf(131074, 0);"),
+            "131074-byte buffer must be preserved (no 4096 clamp); output:\n{output}",
+        );
+        assert!(
+            output.contains("std::vector<char> buf(262146, 0);"),
+            "262146-byte buffer must be preserved; output:\n{output}",
+        );
+        assert!(
+            output.contains("CHECK(ind == SQL_NO_TOTAL);"),
+            "ind == -4 must render as SQL_NO_TOTAL; output:\n{output}",
+        );
+        assert!(
+            output.contains("CHECK(ind > 0);"),
+            "final positive indicator should still use presence check for wide chars; output:\n{output}",
+        );
+        assert!(
+            !output.contains("CHECK(ind == -4)"),
+            "must not emit raw -4 literal; output:\n{output}",
         );
     }
 

--- a/odbc_trace_tool/src/parser/winodbc.rs
+++ b/odbc_trace_tool/src/parser/winodbc.rs
@@ -183,17 +183,7 @@ fn parse_param_value(raw: &str) -> ParamValue {
     }
 
     if let Some(caps) = STRING_VALUE_RE.captures(trimmed) {
-        let mut text = caps[1].to_string();
-        // Windows DM traces NUL as `\ 0` at end of wide strings, e.g. `"SELECT 1;\ 0"`.
-        if text.ends_with("\\ 0") {
-            text.truncate(text.len() - 3);
-        } else if text.ends_with(" 0") && text.contains(';') {
-            text.truncate(text.len() - 2);
-        }
-        text = text.replace("\\0", "");
-        if text.ends_with('\0') {
-            text.pop();
-        }
+        let text = decode_winodbc_string(&caps[1]);
         return ParamValue::StringValue {
             value: text,
             truncated: false,
@@ -234,6 +224,61 @@ fn parse_param_value(raw: &str) -> ParamValue {
     }
 
     ParamValue::Address(trimmed.to_string())
+}
+
+/// Decode the contents of a quoted string parameter as emitted by the
+/// Windows ODBC Driver Manager trace.
+///
+/// The DM emits the underlying wide-string buffer as a C-style quoted literal
+/// where:
+///   * non-printable bytes are rendered as `\ <hex>` (backslash, space, single
+///     lowercase hex digit) — e.g. `\ a` is `0x0a` (LF), `\ 0` is `0x00` (NUL),
+///     `\ 9` would be `0x09` (TAB)
+///   * standard C escapes (`\\`, `\"`, `\n`, `\r`, `\t`, `\0`) are honored as
+///     a fallback so synthetic / test traces using C-string conventions still
+///     parse correctly
+///   * the trailing NUL terminator written by the DM is stripped
+fn decode_winodbc_string(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len());
+    let mut chars = raw.chars();
+    while let Some(c) = chars.next() {
+        if c != '\\' {
+            out.push(c);
+            continue;
+        }
+        match chars.next() {
+            Some(' ') => match chars.next() {
+                Some(h) if h.is_ascii_hexdigit() => {
+                    let v = h.to_digit(16).unwrap() as u8;
+                    out.push(v as char);
+                }
+                Some(other) => {
+                    out.push('\\');
+                    out.push(' ');
+                    out.push(other);
+                }
+                None => {
+                    out.push('\\');
+                    out.push(' ');
+                }
+            },
+            Some('\\') => out.push('\\'),
+            Some('"') => out.push('"'),
+            Some('n') => out.push('\n'),
+            Some('r') => out.push('\r'),
+            Some('t') => out.push('\t'),
+            Some('0') => out.push('\0'),
+            Some(other) => {
+                out.push('\\');
+                out.push(other);
+            }
+            None => out.push('\\'),
+        }
+    }
+    if out.ends_with('\0') {
+        out.pop();
+    }
+    out
 }
 
 fn is_constant_name(s: &str) -> bool {
@@ -591,5 +636,62 @@ mod tests {
                 .any(|c| matches!(c.call, OdbcCall::Unsupported(_))),
             "no unsupported calls"
         );
+    }
+
+    #[test]
+    fn decode_string_handles_dm_hex_escapes() {
+        assert_eq!(decode_winodbc_string("SELECT 1;\\ 0"), "SELECT 1;");
+        assert_eq!(decode_winodbc_string("a\\ ab"), "a\nb");
+        assert_eq!(decode_winodbc_string("\\ 9"), "\t");
+        assert_eq!(decode_winodbc_string("\\ d"), "\r");
+        assert_eq!(
+            decode_winodbc_string(
+                "SELECT * REPLACE(\\ a  DATEADD('day', -1, TSLTZ) AS TSLTZ\\ a) \
+                 FROM ALLDATATYPES;\\ 0"
+            ),
+            "SELECT * REPLACE(\n  DATEADD('day', -1, TSLTZ) AS TSLTZ\n) FROM ALLDATATYPES;",
+        );
+    }
+
+    #[test]
+    fn decode_string_handles_c_style_escapes_for_synthetic_traces() {
+        assert_eq!(decode_winodbc_string("SELECT 1;\\0"), "SELECT 1;");
+        assert_eq!(decode_winodbc_string("a\\nb"), "a\nb");
+        assert_eq!(decode_winodbc_string("a\\\\b"), "a\\b");
+        assert_eq!(decode_winodbc_string("a\\\"b"), "a\"b");
+    }
+
+    #[test]
+    fn parse_extracts_multiline_sql_from_dm_escapes() {
+        let trace = "proc-1 1234-5678\tENTER SQLAllocHandle\n\
+             \t\tSQLSMALLINT                  1 <SQL_HANDLE_ENV>\n\
+             \t\tSQLHANDLE           0x0000000000000000\n\
+             \t\tSQLHANDLE *         0x0000018E00866BE0\n\
+             \n\
+             proc-1 1234-5678\tEXIT  SQLAllocHandle  with return code 0 (SQL_SUCCESS)\n\
+             \t\tSQLSMALLINT                  1 <SQL_HANDLE_ENV>\n\
+             \t\tSQLHANDLE           0x0000000000000000\n\
+             \t\tSQLHANDLE *         0x0000018E00866BE0 ( 0x0000018E656DAC50)\n\
+             \n\
+             proc-1 1234-5678\tENTER SQLExecDirectW\n\
+             \t\tHSTMT               0x0000018E656DA1E0\n\
+             \t\tWCHAR *             0x0000018E006DF854 [      -3] \"SELECT *\\ a  FROM T;\\ 0\"\n\
+             \t\tSDWORD                    -3\n\
+             \n\
+             proc-1 1234-5678\tEXIT  SQLExecDirectW  with return code 0 (SQL_SUCCESS)\n\
+             \t\tHSTMT               0x0000018E656DA1E0\n\
+             \t\tWCHAR *             0x0000018E006DF854 [      -3] \"SELECT *\\ a  FROM T;\\ 0\"\n\
+             \t\tSDWORD                    -3\n";
+
+        let parsed = parse_str(trace).expect("parse");
+        let exec = parsed
+            .calls
+            .iter()
+            .find_map(|c| match &c.call {
+                OdbcCall::ExecDirect(e) => Some(e),
+                _ => None,
+            })
+            .expect("exec direct");
+        assert_eq!(exec.sql.as_deref(), Some("SELECT *\n  FROM T;"));
     }
 }


### PR DESCRIPTION
### TL;DR

Fix LOB streaming support in the ODBC trace tool by correctly handling `SQL_NO_TOTAL` indicators and removing the 4096-byte buffer cap, while also improving Windows DM trace string decoding.

### What changed?

- The 4096-byte buffer length clamp in `SQLGetData` code generation has been removed. Buffers now preserve their original size (floored at 0), which is necessary for LOB streaming scenarios where large buffers (e.g. 131074 or 262146 bytes) must be faithfully replicated.
- Indicator value `-4` (`SQL_NO_TOTAL`) is now handled explicitly in both narrow and wide character `SQLGetData` paths. Instead of falling through to a raw integer check, it emits `CHECK(ind == SQL_NO_TOTAL);`.
- The Windows ODBC Driver Manager trace string decoder has been extracted into a dedicated `decode_winodbc_string` function. It now properly handles the DM's `\ <hex>` escape format (e.g. `\ a` → `0x0a`, `\ 0` → NUL terminator stripped), in addition to standard C-style escapes for synthetic traces. Previously, only a narrow set of hardcoded suffix patterns were stripped.

### How to test?

- Run the new `test_get_data_emits_sql_no_total_and_keeps_large_buffer` test, which verifies that large buffer sizes are preserved and that `ind == -4` renders as `SQL_NO_TOTAL` rather than a raw literal.
- Run `decode_string_handles_dm_hex_escapes` and `decode_string_handles_c_style_escapes_for_synthetic_traces` to verify the new string decoder handles both real DM traces and synthetic test traces.
- Run `parse_extracts_multiline_sql_from_dm_escapes` to confirm that multi-line SQL embedded in a Windows DM trace (using `\ a` for newlines and `\ 0` as a terminator) is parsed and decoded correctly.

### Why make this change?

LOB streaming via repeated `SQLGetData` calls requires large buffers and produces `SQL_NO_TOTAL` (`-4`) indicators when the driver cannot determine remaining data length. The previous code clamped buffers to 4096 bytes and had no handling for `SQL_NO_TOTAL`, causing generated replay tests to be incorrect for these scenarios. The string decoder rewrite fixes a fragile pattern-matching approach that failed on multi-line SQL and other non-trivial escape sequences emitted by the Windows DM.