### PR TITLE
SNOW-2881687: Expose lastQueryId in API

### DIFF
--- a/jdbc/src/main/java/net/snowflake/client/api/exception/SnowflakeSQLException.java
+++ b/jdbc/src/main/java/net/snowflake/client/api/exception/SnowflakeSQLException.java
@@ -1,22 +1,33 @@
 package net.snowflake.client.api.exception;
 
 import java.sql.SQLException;
+import lombok.Getter;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverService;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1;
 
+@Getter
 public class SnowflakeSQLException extends SQLException {
   private static final long serialVersionUID = 1L;
 
+  /**
+   * @return the Snowflake query ID associated with the failed query, or {@code null} when the
+   *     server did not surface one.
+   */
+  private final String queryId;
+
   public SnowflakeSQLException(String message) {
     super(message);
+    this.queryId = null;
   }
 
   public SnowflakeSQLException(String message, Throwable cause) {
     super(message, cause);
+    this.queryId = null;
   }
 
   public SnowflakeSQLException(ErrorCode errorCode, String message) {
     super(message, errorCode.getSqlState(), errorCode.getMessageCode());
+    this.queryId = null;
   }
 
   public SnowflakeSQLException(DatabaseDriverV1.DriverException error, Throwable cause) {
@@ -25,6 +36,7 @@ public class SnowflakeSQLException extends SQLException {
         error.hasSqlState() ? error.getSqlState() : null,
         error.hasVendorCode() ? error.getVendorCode() : 0,
         cause);
+    this.queryId = error.hasQueryId() ? error.getQueryId() : null;
   }
 
   public static SnowflakeSQLException fromServiceException(

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/resultset/SnowflakeResultSetImpl.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/resultset/SnowflakeResultSetImpl.java
@@ -1146,7 +1146,6 @@ public class SnowflakeResultSetImpl implements ResultSet, SnowflakeResultSet {
 
   @Override
   public String getQueryID() throws SQLException {
-    checkClosed();
     return queryId;
   }
 

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/resultset/SnowflakeResultSetImpl.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/resultset/SnowflakeResultSetImpl.java
@@ -46,6 +46,7 @@ import org.apache.arrow.vector.VectorSchemaRoot;
 public class SnowflakeResultSetImpl implements ResultSet, SnowflakeResultSet {
 
   private final SnowflakeStatementImpl statement;
+  private final String queryId;
   private final CursorState cursor = new CursorState();
   private final SchemaState schema;
   private final ArrowResources resources;
@@ -54,9 +55,11 @@ public class SnowflakeResultSetImpl implements ResultSet, SnowflakeResultSet {
   private int fetchSize = 0;
   private int fetchDirection = FETCH_FORWARD;
 
-  public SnowflakeResultSetImpl(SnowflakeStatementImpl statement, ResultSetGetStreamResponse result)
+  public SnowflakeResultSetImpl(
+      SnowflakeStatementImpl statement, String queryId, ResultSetGetStreamResponse result)
       throws SQLException {
     this.statement = statement;
+    this.queryId = queryId;
     ByteString streamPointerBytes = result.getStream().getValue();
     // TODO Check how will this behave on AIX (Big Endian)
     long pointer =
@@ -288,7 +291,8 @@ public class SnowflakeResultSetImpl implements ResultSet, SnowflakeResultSet {
   @Override
   public ResultSetMetaData getMetaData() throws SQLException {
     checkClosed();
-    return new SnowflakeResultSetMetaDataImpl(schema.getColumnNames(), schema.getColumnTypes());
+    return new SnowflakeResultSetMetaDataImpl(
+        schema.getColumnNames(), schema.getColumnTypes(), queryId);
   }
 
   @Override
@@ -1142,7 +1146,8 @@ public class SnowflakeResultSetImpl implements ResultSet, SnowflakeResultSet {
 
   @Override
   public String getQueryID() throws SQLException {
-    throw new NotImplementedException();
+    checkClosed();
+    return queryId;
   }
 
   @Override

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/resultset/SnowflakeResultSetMetaDataImpl.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/resultset/SnowflakeResultSetMetaDataImpl.java
@@ -12,10 +12,12 @@ public class SnowflakeResultSetMetaDataImpl
     implements ResultSetMetaData, SnowflakeResultSetMetaData {
   private final String[] columnNames;
   private final int[] columnTypes;
+  private final String queryId;
 
-  public SnowflakeResultSetMetaDataImpl(String[] columnNames, int[] columnTypes) {
+  public SnowflakeResultSetMetaDataImpl(String[] columnNames, int[] columnTypes, String queryId) {
     this.columnNames = columnNames;
     this.columnTypes = columnTypes;
+    this.queryId = queryId;
   }
 
   @Override
@@ -178,7 +180,7 @@ public class SnowflakeResultSetMetaDataImpl
 
   @Override
   public String getQueryID() throws SQLException {
-    throw new SQLFeatureNotSupportedException("getQueryID not supported");
+    return queryId;
   }
 
   @Override

--- a/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakeStatementImpl.java
+++ b/jdbc/src/main/java/net/snowflake/client/internal/api/implementation/statement/SnowflakeStatementImpl.java
@@ -116,9 +116,27 @@ public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
     coreDriverApi.statementSetSqlQuery(statementHandle, sql);
     // PreparedStatement callers must wrap this in try-with-resources on the NativeBindings so
     // the embedded native pointer remains valid across the synchronous RPC (JLS §12.6.1).
-    ExecuteQueryResponse response = coreDriverApi.statementExecuteQuery(statementHandle, bindings);
+    ExecuteQueryResponse response;
+    try {
+      response = coreDriverApi.statementExecuteQuery(statementHandle, bindings);
+    } catch (SQLException e) {
+      // Mirror snowflake-jdbc: surface the server-side queryId on a failed execute so callers
+      // can correlate the error with a Snowflake history entry.
+      captureQueryIdFromException(e);
+      throw e;
+    }
     logger.debug("statementExecuteQuery succeeded: hasBindings={}", hasBindings);
     return response;
+  }
+
+  private void captureQueryIdFromException(SQLException e) {
+    // prepareForExecution() already cleared queryId; only overwrite when the server surfaced one.
+    if (e instanceof SnowflakeSQLException) {
+      String exceptionQueryId = ((SnowflakeSQLException) e).getQueryId();
+      if (!StringUtil.isNullOrEmpty(exceptionQueryId)) {
+        this.queryId = exceptionQueryId;
+      }
+    }
   }
 
   private ResultSetResponse fetchResultSetByQueryId(String queryId) throws SQLException {
@@ -184,7 +202,7 @@ public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
     if (StatementTypeClassifier.producesResultSet(descriptor)) {
       ResultSetGetStreamResponse streamResponse =
           fetchStreamAndRelease(rsResponse.getResultSetHandle());
-      currentResultSet = new SnowflakeResultSetImpl(this, streamResponse);
+      currentResultSet = new SnowflakeResultSetImpl(this, queryId, streamResponse);
       currentUpdateCount = NO_UPDATE_COUNT;
       return true;
     }
@@ -195,7 +213,7 @@ public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
       ResultSetGetStreamResponse streamResponse =
           fetchStreamAndRelease(rsResponse.getResultSetHandle());
       if (streamResponse.hasStream() && !streamResponse.getStream().getValue().isEmpty()) {
-        currentResultSet = new SnowflakeResultSetImpl(this, streamResponse);
+        currentResultSet = new SnowflakeResultSetImpl(this, queryId, streamResponse);
         currentUpdateCount = NO_UPDATE_COUNT;
         return true;
       }
@@ -234,7 +252,7 @@ public class SnowflakeStatementImpl implements Statement, SnowflakeStatement {
     if (producesResultSet) {
       ResultSetGetStreamResponse streamResponse =
           fetchStreamAndRelease(rsResponse.getResultSetHandle());
-      currentResultSet = new SnowflakeResultSetImpl(this, streamResponse);
+      currentResultSet = new SnowflakeResultSetImpl(this, childQueryId, streamResponse);
       currentUpdateCount = NO_UPDATE_COUNT;
     } else {
       currentResultSet = null;

--- a/jdbc/src/test/java/net/snowflake/client/api/statement/LastQueryIdTests.java
+++ b/jdbc/src/test/java/net/snowflake/client/api/statement/LastQueryIdTests.java
@@ -1,4 +1,4 @@
-package net.snowflake.jdbc.e2e.query;
+package net.snowflake.client.api.statement;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -11,7 +11,6 @@ import java.sql.Statement;
 import java.util.regex.Pattern;
 import net.snowflake.client.api.resultset.SnowflakeResultSet;
 import net.snowflake.client.api.resultset.SnowflakeResultSetMetaData;
-import net.snowflake.client.api.statement.SnowflakeStatement;
 import net.snowflake.jdbc.utils.SnowflakeIntegrationTestBase;
 import org.junit.jupiter.api.Test;
 
@@ -22,10 +21,8 @@ public class LastQueryIdTests extends SnowflakeIntegrationTestBase {
 
   @Test
   public void shouldExposeSameLastQueryIdAcrossStatementResultSetAndMetaData() throws Exception {
-    // Given Snowflake client is logged in
     Connection connection = getDefaultConnection();
 
-    // When a SELECT is executed
     try (Statement statement = connection.createStatement();
         ResultSet resultSet = statement.executeQuery("SELECT 1")) {
       String statementQueryId = statement.unwrap(SnowflakeStatement.class).getQueryID();
@@ -33,16 +30,28 @@ public class LastQueryIdTests extends SnowflakeIntegrationTestBase {
       ResultSetMetaData metaData = resultSet.getMetaData();
       String metaDataQueryId = metaData.unwrap(SnowflakeResultSetMetaData.class).getQueryID();
 
-      // Then a valid Snowflake query ID is exposed
       assertNotNull(statementQueryId, "Expected a non-null query ID");
       assertTrue(
           QUERY_ID_PATTERN.matcher(statementQueryId).matches(),
           "Expected a Snowflake-shaped query ID, got: " + statementQueryId);
 
-      // And the same ID is reachable through the Statement, the ResultSet, and the
-      // ResultSetMetaData
       assertEquals(statementQueryId, resultSetQueryId);
       assertEquals(statementQueryId, metaDataQueryId);
+    }
+  }
+
+  @Test
+  public void shouldExposeLastQueryIdOnClosedResultSet() throws Exception {
+    Connection connection = getDefaultConnection();
+
+    try (Statement statement = connection.createStatement()) {
+      ResultSet resultSet = statement.executeQuery("SELECT 1");
+      String queryIdBeforeClose = resultSet.unwrap(SnowflakeResultSet.class).getQueryID();
+
+      resultSet.close();
+
+      String queryIdAfterClose = resultSet.unwrap(SnowflakeResultSet.class).getQueryID();
+      assertEquals(queryIdBeforeClose, queryIdAfterClose);
     }
   }
 }

--- a/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/resultset/SnowflakeResultSetMetaDataImplTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/resultset/SnowflakeResultSetMetaDataImplTest.java
@@ -1,0 +1,24 @@
+package net.snowflake.client.internal.api.implementation.resultset;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.sql.Types;
+import org.junit.jupiter.api.Test;
+
+class SnowflakeResultSetMetaDataImplTest {
+
+  @Test
+  void getQueryIdReturnsValueProvidedAtConstruction() throws Exception {
+    SnowflakeResultSetMetaDataImpl meta =
+        new SnowflakeResultSetMetaDataImpl(new String[] {"C"}, new int[] {Types.INTEGER}, "qid-1");
+    assertEquals("qid-1", meta.getQueryID());
+  }
+
+  @Test
+  void getQueryIdReturnsNullWhenConstructedWithoutOne() throws Exception {
+    SnowflakeResultSetMetaDataImpl meta =
+        new SnowflakeResultSetMetaDataImpl(new String[] {"C"}, new int[] {Types.INTEGER}, null);
+    assertNull(meta.getQueryID());
+  }
+}

--- a/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/statement/SnowflakePreparedStatementImplTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/statement/SnowflakePreparedStatementImplTest.java
@@ -14,9 +14,12 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Statement;
+import net.snowflake.client.api.exception.SnowflakeSQLException;
+import net.snowflake.client.api.statement.SnowflakeStatement;
 import net.snowflake.client.internal.api.implementation.connection.InternalSnowflakeConnection;
 import net.snowflake.client.internal.unicore.CoreDriverApi;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionHandle;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DriverException;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ExecuteQueryResponse;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.QueryBindings;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetDescriptor;
@@ -172,10 +175,51 @@ public class SnowflakePreparedStatementImplTest {
         "second executeBatch resets and re-populates rather than appending");
   }
 
+  @Test
+  void getQueryIdReflectsLastSuccessfulExecuteQuery() throws Exception {
+    SnowflakePreparedStatementImpl ps = createPreparedStatement("INSERT INTO t VALUES (?)");
+    when(mockCoreApi.statementExecuteQuery(any(), notNull(QueryBindings.class)))
+        .thenReturn(insertResponse(1L, "qid-prepared"));
+
+    ps.setInt(1, 1);
+    ps.executeUpdate();
+
+    assertEquals("qid-prepared", ((SnowflakeStatement) ps).getQueryID());
+  }
+
+  @Test
+  void getQueryIdIsPreservedFromFailedPreparedExecuteWhenServerProvidesIt() throws Exception {
+    SnowflakePreparedStatementImpl ps = createPreparedStatement("INSERT INTO t VALUES (?)");
+    when(mockCoreApi.statementExecuteQuery(any(), notNull(QueryBindings.class)))
+        .thenReturn(insertResponse(1L, "qid-prior"))
+        .thenThrow(driverExceptionWithQueryId("qid-prepared-failed"));
+
+    ps.setInt(1, 1);
+    ps.executeUpdate();
+    assertEquals("qid-prior", ((SnowflakeStatement) ps).getQueryID());
+
+    ps.setInt(1, 2);
+    assertThrows(SQLException.class, ps::executeUpdate);
+    assertEquals(
+        "qid-prepared-failed",
+        ((SnowflakeStatement) ps).getQueryID(),
+        "Failed prepared execute should overwrite the prior id with the server-side one");
+  }
+
+  private static SnowflakeSQLException driverExceptionWithQueryId(String queryId) {
+    DriverException error =
+        DriverException.newBuilder().setMessage("server-side failure").setQueryId(queryId).build();
+    return new SnowflakeSQLException(error, new RuntimeException("test cause"));
+  }
+
   private static ExecuteQueryResponse insertResponse(long rowsAffected) {
+    return insertResponse(rowsAffected, "qid");
+  }
+
+  private static ExecuteQueryResponse insertResponse(long rowsAffected, String queryId) {
     ResultSetDescriptor descriptor =
         ResultSetDescriptor.newBuilder()
-            .setQueryId("qid")
+            .setQueryId(queryId)
             .setStatementTypeId(INSERT_TYPE_ID)
             .setRowsAffected(rowsAffected)
             .build();

--- a/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/statement/SnowflakeStatementImplTest.java
+++ b/jdbc/src/test/java/net/snowflake/client/internal/api/implementation/statement/SnowflakeStatementImplTest.java
@@ -2,6 +2,7 @@ package net.snowflake.client.internal.api.implementation.statement;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -14,9 +15,12 @@ import static org.mockito.Mockito.when;
 import java.sql.BatchUpdateException;
 import java.sql.SQLException;
 import java.sql.Statement;
+import net.snowflake.client.api.exception.SnowflakeSQLException;
+import net.snowflake.client.api.statement.SnowflakeStatement;
 import net.snowflake.client.internal.api.implementation.connection.InternalSnowflakeConnection;
 import net.snowflake.client.internal.unicore.CoreDriverApi;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ConnectionHandle;
+import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.DriverException;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ExecuteQueryResponse;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetDescriptor;
 import net.snowflake.client.internal.unicore.protobuf_gen.DatabaseDriverV1.ResultSetResponse;
@@ -159,6 +163,71 @@ public class SnowflakeStatementImplTest {
 
     int[] secondRun = stmt.executeBatch();
     assertEquals(0, secondRun.length, "batch is cleared even after a failed executeBatch");
+  }
+
+  @Test
+  void getQueryIdIsNullOnFreshStatement() throws Exception {
+    Statement stmt = createStatement();
+    assertNull(((SnowflakeStatement) stmt).getQueryID());
+  }
+
+  @Test
+  void getQueryIdReflectsLastSuccessfulExecute() throws Exception {
+    Statement stmt = createStatement();
+    when(mockCoreApi.statementExecuteQuery(any(), isNull()))
+        .thenReturn(insertResponse(1L, "qid-A"))
+        .thenReturn(insertResponse(1L, "qid-B"));
+
+    stmt.executeUpdate("INSERT INTO t VALUES (1)");
+    assertEquals("qid-A", ((SnowflakeStatement) stmt).getQueryID());
+
+    stmt.executeUpdate("INSERT INTO t VALUES (2)");
+    assertEquals(
+        "qid-B",
+        ((SnowflakeStatement) stmt).getQueryID(),
+        "Second execute should overwrite the first query ID");
+  }
+
+  @Test
+  void getQueryIdIsPreservedFromFailedExecuteWhenServerProvidesIt() throws Exception {
+    Statement stmt = createStatement();
+    // Seed a prior successful execute so a buggy implementation that simply ignored the failure
+    // path on a fresh field would not pass: the failed execute MUST overwrite the prior value.
+    when(mockCoreApi.statementExecuteQuery(any(), isNull()))
+        .thenReturn(insertResponse(1L, "qid-prior-success"))
+        .thenThrow(driverExceptionWithQueryId("qid-failed"));
+
+    stmt.executeUpdate("INSERT INTO t VALUES (1)");
+    assertEquals("qid-prior-success", ((SnowflakeStatement) stmt).getQueryID());
+
+    assertThrows(SQLException.class, () -> stmt.executeUpdate("INSERT INTO t VALUES (2)"));
+    assertEquals(
+        "qid-failed",
+        ((SnowflakeStatement) stmt).getQueryID(),
+        "Failed execute should overwrite the prior successful query ID with the server-side one");
+  }
+
+  @Test
+  void getQueryIdIsNullAfterFailedExecuteWithoutServerQueryId() throws Exception {
+    Statement stmt = createStatement();
+    // First a successful execute populates the field.
+    when(mockCoreApi.statementExecuteQuery(any(), isNull()))
+        .thenReturn(insertResponse(1L, "qid-stale"))
+        .thenThrow(new SQLException("transport error"));
+
+    stmt.executeUpdate("INSERT INTO t VALUES (1)");
+    assertEquals("qid-stale", ((SnowflakeStatement) stmt).getQueryID());
+
+    assertThrows(SQLException.class, () -> stmt.executeUpdate("INSERT INTO t VALUES (2)"));
+    assertNull(
+        ((SnowflakeStatement) stmt).getQueryID(),
+        "Failed execute with no server-side query id wipes any stale value");
+  }
+
+  private static SnowflakeSQLException driverExceptionWithQueryId(String queryId) {
+    DriverException error =
+        DriverException.newBuilder().setMessage("server-side failure").setQueryId(queryId).build();
+    return new SnowflakeSQLException(error, new RuntimeException("test cause"));
   }
 
   private static ExecuteQueryResponse insertResponse(long rowsAffected) {

--- a/jdbc/src/test/java/net/snowflake/jdbc/e2e/query/LastQueryIdTests.java
+++ b/jdbc/src/test/java/net/snowflake/jdbc/e2e/query/LastQueryIdTests.java
@@ -1,0 +1,48 @@
+package net.snowflake.jdbc.e2e.query;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.Statement;
+import java.util.regex.Pattern;
+import net.snowflake.client.api.resultset.SnowflakeResultSet;
+import net.snowflake.client.api.resultset.SnowflakeResultSetMetaData;
+import net.snowflake.client.api.statement.SnowflakeStatement;
+import net.snowflake.jdbc.utils.SnowflakeIntegrationTestBase;
+import org.junit.jupiter.api.Test;
+
+public class LastQueryIdTests extends SnowflakeIntegrationTestBase {
+
+  private static final Pattern QUERY_ID_PATTERN =
+      Pattern.compile("[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}");
+
+  @Test
+  public void shouldExposeSameLastQueryIdAcrossStatementResultSetAndMetaData() throws Exception {
+    // Given Snowflake client is logged in
+    Connection connection = getDefaultConnection();
+
+    // When a SELECT is executed
+    try (Statement statement = connection.createStatement();
+        ResultSet resultSet = statement.executeQuery("SELECT 1")) {
+      String statementQueryId = statement.unwrap(SnowflakeStatement.class).getQueryID();
+      String resultSetQueryId = resultSet.unwrap(SnowflakeResultSet.class).getQueryID();
+      ResultSetMetaData metaData = resultSet.getMetaData();
+      String metaDataQueryId = metaData.unwrap(SnowflakeResultSetMetaData.class).getQueryID();
+
+      // Then a valid Snowflake query ID is exposed
+      assertNotNull(statementQueryId, "Expected a non-null query ID");
+      assertTrue(
+          QUERY_ID_PATTERN.matcher(statementQueryId).matches(),
+          "Expected a Snowflake-shaped query ID, got: " + statementQueryId);
+
+      // And the same ID is reachable through the Statement, the ResultSet, and the
+      // ResultSetMetaData
+      assertEquals(statementQueryId, resultSetQueryId);
+      assertEquals(statementQueryId, metaDataQueryId);
+    }
+  }
+}


### PR DESCRIPTION
  ## Summary
  - Implement the `getQueryID()` API on `SnowflakeStatement`, `SnowflakeResultSet`, and `SnowflakeResultSetMetaData`, mirroring the contract from the legacy snowflake-jdbc driver.
  - Surface the server-side query ID on `SnowflakeSQLException` (sourced from `DriverException.query_id` in the proto layer) so callers can correlate failed queries with the Snowflake query history.
  - Preserve the failed query's ID on the parent `Statement` so `getQueryID()` returns it after an exception, matching the legacy `setQueryIdWhenValidOrNull` semantics.

  ## Behavior
  - **Fresh statement** — `getQueryID()` returns `null`.
  - **Successful execute** — overwrites with the new query ID; same ID is reachable via the producing `Statement`, `ResultSet`, and `ResultSetMetaData`.
  - **Failed execute with server-side ID** — `Statement.getQueryID()` returns the failed query's ID; equal to `((SnowflakeSQLException) ex).getQueryId()`.
  - **Failed execute without server-side ID** (e.g. transport error) — any prior stale ID is wiped; `getQueryID()` returns `null`.
  - **Multi-statement** — `Statement.getQueryID()` returns the parent batch ID; each child `ResultSet` exposes its own per-child ID.
  - **Batch** — `getBatchQueryIDs()` is positionally aligned with `executeBatch()` update counts; failed slots can carry a server-side ID when one was returned.

  ## Files
  **Production**
  - `SnowflakeSQLException` — new `queryId` field + `getQueryId()` getter; populated from the proto.
  - `SnowflakeStatementImpl` — `executeStatement` catches `SQLException`, calls `captureQueryIdFromException` to preserve the server-side ID before rethrowing; result-set construction now passes the query ID at
  construction (final field, captured eagerly so a later execute on the same statement doesn't contaminate prior result sets).
  - `SnowflakeResultSetImpl` — final `queryId` field, surfaced by `getQueryID()`, propagated into `getMetaData()`.
  - `SnowflakeResultSetMetaDataImpl` — final `queryId` field, surfaced by `getQueryID()`.