### PR TITLE
SNOW-3406377, gap 4 pt4: python file_stream kwarg on cursor.execute()

### DIFF
--- a/protobuf/database_driver_v1.proto
+++ b/protobuf/database_driver_v1.proto
@@ -762,6 +762,36 @@ message ConfigGetPathsResponse {
 }
 
 // =============================================================================
+// FILE STREAM UPLOAD - Upload bytes from an in-memory stream via a PUT SQL
+// =============================================================================
+
+// Execute a PUT SQL statement using caller-supplied in-memory bytes as the
+// upload source instead of reading from the filesystem path in the SQL.
+//
+// The SQL string must be a valid PUT statement (e.g.
+// "PUT file://data.csv @my_stage AUTO_COMPRESS=FALSE"). Core executes it
+// against Snowflake GS to obtain stage credentials and transfer parameters,
+// then substitutes `data` for the file that would normally be read from disk.
+// The virtual filename for the stage object is taken from the `file://` path
+// in the SQL (basename only, matching reference connector behavior).
+//
+// Returns the same PUT result set shape as a normal StatementExecuteQuery on a
+// PUT statement.
+message ConnectionUploadStreamRequest {
+  ConnectionHandle conn_handle = 1;
+  // The PUT SQL statement. Must contain a `file://` path whose basename is
+  // used as the destination filename in the stage.
+  string sql = 2;
+  // Raw bytes of the file to upload. The caller has already read the stream.
+  bytes data = 3;
+}
+
+message ConnectionUploadStreamResponse {
+  ResultSetHandle result_set_handle = 1;
+  ResultSetDescriptor result_descriptor = 2;
+}
+
+// =============================================================================
 // TELEMETRY - In-band telemetry messages sent from wrappers via core
 // =============================================================================
 
@@ -827,6 +857,8 @@ service DatabaseDriver {
   rpc ConnectionRequestToken(ConnectionTokenRequest) returns (ConnectionTokenResponse);
   // Heartbeat to validate connection and session are still alive
   rpc ConnectionHeartbeat(ConnectionHeartbeatRequest) returns (ConnectionHeartbeatResponse);
+  // Upload in-memory bytes via a PUT SQL statement (Python file_stream / JDBC uploadStream)
+  rpc ConnectionUploadStream(ConnectionUploadStreamRequest) returns (ConnectionUploadStreamResponse);
 
   // Statement operations
   rpc StatementNew(StatementNewRequest) returns (StatementNewResponse);

--- a/python/src/snowflake/connector/_internal/api_client/client_api.py
+++ b/python/src/snowflake/connector/_internal/api_client/client_api.py
@@ -57,6 +57,8 @@ from ..protobuf_gen.database_driver_v1_pb2 import (
     ConnectionSetSessionParametersResponse,
     ConnectionTokenRequest,
     ConnectionTokenResponse,
+    ConnectionUploadStreamRequest,
+    ConnectionUploadStreamResponse,
     DatabaseFetchChunkRequest,
     DatabaseFetchChunkResponse,
     DatabaseHandle,
@@ -385,6 +387,31 @@ class CoreDriver:
     def connection_heartbeat(self, conn_handle: ConnectionHandle) -> ConnectionHeartbeatResponse:
         request = ConnectionHeartbeatRequest(conn_handle=conn_handle)
         return self.client.connection_heartbeat(request)
+
+    def connection_upload_stream(
+        self,
+        conn_handle: ConnectionHandle,
+        sql: str,
+        data: bytes,
+    ) -> ConnectionUploadStreamResponse:
+        """Execute a PUT SQL using caller-supplied in-memory bytes as the upload source.
+
+        This is the backend for ``cursor.execute("PUT ...", file_stream=stream)``.
+        The bytes are passed to the Rust core which executes the PUT SQL against
+        Snowflake GS to obtain stage credentials, then uploads ``data`` directly
+        instead of reading from the filesystem path in the SQL.
+
+        Args:
+            conn_handle: Active connection handle.
+            sql: A PUT SQL statement (e.g. ``"PUT file://data.csv @stage"``).
+            data: Raw bytes of the file to upload (caller has read the stream).
+
+        Returns:
+            ``ConnectionUploadStreamResponse`` with ``result_set_handle`` and
+            ``result_descriptor`` — same shape as a normal PUT result set.
+        """
+        request = ConnectionUploadStreamRequest(conn_handle=conn_handle, sql=sql, data=data)
+        return self.client.connection_upload_stream(request)
 
     def connection_get_info(
         self,

--- a/python/src/snowflake/connector/cursor/_base.py
+++ b/python/src/snowflake/connector/cursor/_base.py
@@ -12,9 +12,10 @@ import abc
 import ctypes
 import functools
 import logging
+import re
 
 from collections.abc import Callable, Iterator, Sequence
-from typing import TYPE_CHECKING, Any, TypeVar, cast, overload
+from typing import TYPE_CHECKING, Any, BinaryIO, TypeVar, cast, overload
 
 from .._internal.api_client.client_api import core_driver
 from .._internal.arrow_stream_utils import (
@@ -48,6 +49,22 @@ from ._query_result import _MultiStatementQueryResultState, _QueryResult
 from ._query_result_waiter import QueryResultWaiter
 from ._result_metadata import QueryResultStats, ResultMetadata
 from ._result_set_wrapper import _ResultSetWrapper
+
+
+# ---------------------------------------------------------------------------
+# SQL-text helpers
+# ---------------------------------------------------------------------------
+
+# Matches the leading tokens of a PUT statement, skipping whitespace.  A
+# comment-stripping pre-pass is not needed here because whitespace-only or
+# `-- comment` prefixes are uncommon in practice and the reference connector
+# likewise uses a simple regex for this detection.
+_PUT_PREFIX_RE = re.compile(r"^\s*PUT\s", re.IGNORECASE)
+
+
+def _is_put_sql(sql: str) -> bool:
+    """Return True if *sql* appears to be a PUT statement."""
+    return bool(_PUT_PREFIX_RE.match(sql))
 
 
 if TYPE_CHECKING:
@@ -433,6 +450,7 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
         parameters: Sequence[Any] | dict[str, Any] | None = None,
         _is_put_get: bool | None = None,
         num_statements: int | None = None,
+        file_stream: BinaryIO | None = None,
         **kwargs: Any,
     ) -> SnowflakeCursorBase:
         """
@@ -446,13 +464,20 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
                 For pyformat paramstyle: sequence (%s) or dict (%(name)s)
                 For format paramstyle: sequence (%s)
             num_statements (int, optional): Number of statements in a multistatement query.
+            file_stream (BinaryIO, optional): An open binary stream (e.g. ``io.BytesIO``)
+                whose bytes are uploaded in place of the local file path named in a PUT
+                SQL statement.  The stream is read fully at call time; no async I/O or
+                chunked transfer is performed.  If supplied for a non-PUT statement a
+                ``ProgrammingError`` is raised.  If both a real ``file://`` path and
+                ``file_stream`` are present in the SQL, ``file_stream`` takes precedence
+                (the path is used only as the destination filename in the stage).
         """
         if num_statements is not None:
             # TODO Create a global known parameters registry
             self.set_statement_parameter("MULTI_STATEMENT_COUNT", num_statements)
 
         self.reset()
-        return self._execute(operation, parameters, _is_put_get, **kwargs)
+        return self._execute(operation, parameters, _is_put_get, file_stream=file_stream, **kwargs)
 
     def _format_query_for_log(self, query: str) -> str:
         return self._connection._format_query_for_log(query)
@@ -462,6 +487,7 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
         operation: str,
         parameters: Sequence[Any] | dict[str, Any] | None = None,
         _is_put_get: bool | None = None,
+        file_stream: BinaryIO | None = None,
         **kwargs: Any,
     ) -> SnowflakeCursorBase:
         """Execute query logic."""
@@ -469,6 +495,30 @@ class SnowflakeCursorBase(ErrorHandlerMixin, abc.ABC):
             logger.debug("query: [%s]", self._format_query_for_log(operation))
 
         query, bindings = self._prepare_query(operation, parameters)
+
+        # ---------------------------------------------------------------
+        # file_stream path: upload in-memory bytes via ConnectionUploadStream
+        # instead of the normal statement_execute_query path.
+        # ---------------------------------------------------------------
+        if file_stream is not None:
+            if not _is_put_sql(query):
+                raise ProgrammingError(
+                    msg=(
+                        "file_stream was provided but the SQL statement is not a PUT command. "
+                        "file_stream is only supported for PUT statements."
+                    ),
+                    errno=ER_INVALID_VALUE,
+                )
+            data = file_stream.read()
+            rs_response = core_driver.connection_upload_stream(
+                conn_handle=self._connection.conn_handle,  # type: ignore[arg-type]
+                sql=query,
+                data=data,
+            )
+            self._result_set.replace(rs_response.result_set_handle)
+            self._query_result = _QueryResult.from_result_descriptor(rs_response.result_descriptor, query)
+            self._rownumber = -1
+            return self
 
         with statement(self.connection.conn_handle, query) as stmt_handle:  # type: ignore[arg-type]
             if self._statement_parameters:

--- a/python/src/snowflake/connector/cursor/_query_result.py
+++ b/python/src/snowflake/connector/cursor/_query_result.py
@@ -4,6 +4,7 @@ from .._internal.arrow_stream_utils import release_arrow_stream
 from .._internal.protobuf_gen.database_driver_v1_pb2 import (
     MultiStatementResult,
     PrepareResult,
+    ResultSetDescriptor,
     ResultSetResponse,
 )
 from .._internal.statement_utils import (
@@ -130,8 +131,26 @@ class _QueryResult:
         Returns:
             _QueryResult instance with metadata populated.
         """
-        descriptor = response.result_descriptor
+        return _QueryResult.from_result_descriptor(response.result_descriptor, query=query)
 
+    @staticmethod
+    def from_result_descriptor(
+        descriptor: ResultSetDescriptor,
+        query: str | None = None,
+    ) -> _QueryResult:
+        """Create _QueryResult from a ResultSetDescriptor proto message.
+
+        This is the canonical factory used by both ``from_result_set_response``
+        and any other code path (e.g. ``connection_upload_stream``) that
+        produces a ``ResultSetDescriptor`` but not a full ``ResultSetResponse``.
+
+        Args:
+            descriptor: ``ResultSetDescriptor`` proto message with query metadata.
+            query: Optional query text to attach to the result.
+
+        Returns:
+            _QueryResult instance with metadata populated.
+        """
         return _QueryResult(
             description=ResultMetadata.create_description(descriptor),
             sqlstate=extract_sqlstate(descriptor),

--- a/python/tests/e2e/put_get/test_put_get_file_stream.py
+++ b/python/tests/e2e/put_get/test_put_get_file_stream.py
@@ -1,0 +1,167 @@
+"""E2E tests for cursor.execute() with the ``file_stream`` keyword argument.
+
+The ``file_stream`` kwarg allows callers to supply an in-memory binary stream
+(e.g. ``io.BytesIO``) as the source for a PUT statement, bypassing the need
+for a real file on disk.  These tests verify:
+
+* The stream bytes reach the stage intact.
+* The PUT result row has the expected shape (dest filename + status).
+* A non-PUT SQL with ``file_stream`` raises ``ProgrammingError``.
+
+The tests require a live Snowflake connection (e2e) and are skipped via the
+normal ``connection`` fixture when credentials are absent.
+"""
+
+from __future__ import annotations
+
+import io
+import tempfile
+
+from pathlib import Path
+
+import pytest
+
+from snowflake.connector.errors import ProgrammingError
+from tests.compatibility import NEW_DRIVER_ONLY
+from tests.e2e.put_get.put_get_helper import (
+    create_temporary_stage,
+    get_file_from_stage,
+    list_stage_contents,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _stage_file_names(rows: list) -> list[str]:
+    """Extract just the filename component from LS stage rows."""
+    # LS rows: (name, size, md5, last_modified)
+    return [Path(row[0]).name for row in rows]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(NEW_DRIVER_ONLY("gap-4-file-stream"), reason="new driver only")
+def test_file_stream_basic_upload_and_ls(connection):
+    """PUT with file_stream uploads bytes; LS sees the destination filename.
+
+    Steps:
+      1. Create a temporary stage.
+      2. Execute a PUT using ``file_stream=io.BytesIO(b"hello")``.
+      3. Assert the PUT result row reports UPLOADED and the expected filename.
+      4. Assert LS @stage shows the filename.
+    """
+    payload = b"hello"
+    dest_filename = "data.csv"
+
+    with connection.cursor() as cursor:
+        stage_name = create_temporary_stage(cursor, "TEST_FILE_STREAM_LS")
+
+        # When PUT is executed with an in-memory stream instead of a real file
+        cursor.execute(
+            f"PUT file://{dest_filename} @{stage_name} AUTO_COMPRESS=FALSE OVERWRITE=TRUE",
+            file_stream=io.BytesIO(payload),
+        )
+
+        put_row = cursor.fetchone()
+
+        # Then the PUT result row reports UPLOADED with the expected destination filename
+        assert put_row is not None, "PUT returned no rows"
+
+        # Column 6 is the status column for the Python flavor.
+        status = put_row[6]
+        assert status == "UPLOADED", f"Expected UPLOADED, got {status!r}; full row: {put_row}"
+
+        # The target column (index 1) should contain the destination filename.
+        target = put_row[1]
+        assert dest_filename in target, (
+            f"Target column {target!r} does not contain {dest_filename!r}; full row: {put_row}"
+        )
+
+        # Then the LS output also shows the uploaded filename
+        ls_rows = list_stage_contents(cursor, stage_name)
+        names = _stage_file_names(ls_rows)
+        assert any(dest_filename in n for n in names), f"{dest_filename!r} not found in stage listing: {names}"
+
+
+@pytest.mark.skipif(NEW_DRIVER_ONLY("gap-4-file-stream"), reason="new driver only")
+def test_file_stream_content_round_trip(connection):
+    """Bytes uploaded via file_stream survive a GET and match the original payload.
+
+    Uploads b"hello" without compression, downloads the file and asserts the
+    content is identical.
+    """
+    payload = b"hello"
+    dest_filename = "roundtrip.csv"
+
+    with connection.cursor() as cursor:
+        stage_name = create_temporary_stage(cursor, "TEST_FILE_STREAM_RT")
+
+        # When file_stream bytes are PUT to the stage without compression
+        cursor.execute(
+            f"PUT file://{dest_filename} @{stage_name} AUTO_COMPRESS=FALSE OVERWRITE=TRUE",
+            file_stream=io.BytesIO(payload),
+        )
+        put_row = cursor.fetchone()
+        assert put_row is not None and put_row[6] == "UPLOADED"
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            download_dir = Path(tmp_dir)
+
+            # When the file is downloaded with GET
+            get_row = get_file_from_stage(cursor, stage_name, dest_filename, download_dir)
+
+            # Then the downloaded bytes match the original payload exactly
+            assert get_row is not None, "GET returned no rows"
+            assert get_row[2] == "DOWNLOADED", f"GET status: {get_row[2]!r}"
+
+            downloaded = download_dir / dest_filename
+            assert downloaded.exists(), f"Downloaded file not found: {downloaded}"
+            assert downloaded.read_bytes() == payload, (
+                f"Content mismatch: expected {payload!r}, got {downloaded.read_bytes()!r}"
+            )
+
+
+@pytest.mark.skipif(NEW_DRIVER_ONLY("gap-4-file-stream"), reason="new driver only")
+def test_file_stream_auto_compress(connection):
+    """file_stream with AUTO_COMPRESS=TRUE stores a .gz file on the stage."""
+    payload = b"col1,col2\n1,2\n3,4\n"
+    dest_filename = "compressed.csv"
+
+    with connection.cursor() as cursor:
+        stage_name = create_temporary_stage(cursor, "TEST_FILE_STREAM_GZ")
+
+        # When PUT is executed with AUTO_COMPRESS=TRUE and a file_stream
+        cursor.execute(
+            f"PUT file://{dest_filename} @{stage_name} AUTO_COMPRESS=TRUE OVERWRITE=TRUE",
+            file_stream=io.BytesIO(payload),
+        )
+        put_row = cursor.fetchone()
+        assert put_row is not None and put_row[6] == "UPLOADED"
+
+        # Then the stage listing shows the file with a .gz extension
+        ls_rows = list_stage_contents(cursor, stage_name)
+        names = _stage_file_names(ls_rows)
+        # With AUTO_COMPRESS=TRUE, the stage file should have a .gz extension.
+        assert any(n.endswith(".gz") for n in names), f"Expected a .gz file in stage listing: {names}"
+
+
+@pytest.mark.skipif(NEW_DRIVER_ONLY("gap-4-file-stream"), reason="new driver only")
+def test_file_stream_non_put_raises(connection):
+    """Supplying file_stream for a non-PUT SQL raises ProgrammingError.
+
+    Behavioral difference from reference connector: the reference connector
+    silently ignores file_stream on non-PUT SQL.  This driver raises
+    ProgrammingError to help users catch misuse early.  See the behavioral
+    changes log in the PR description for rationale.
+    """
+    with connection.cursor() as cursor:
+        # When file_stream is passed to a non-PUT SQL statement
+        # Then ProgrammingError is raised mentioning file_stream
+        with pytest.raises(ProgrammingError, match="(?i)file_stream"):
+            cursor.execute("SELECT 1", file_stream=io.BytesIO(b"data"))

--- a/python/tests/unit/test_cursor.py
+++ b/python/tests/unit/test_cursor.py
@@ -2197,3 +2197,119 @@ class TestExecuteAsync:
         result = cursor.execute_async("SELECT 1")
 
         assert result["queryId"] is None
+
+
+# ---------------------------------------------------------------------------
+# file_stream kwarg tests
+# ---------------------------------------------------------------------------
+
+
+class TestFileStream:
+    """Unit tests for the ``file_stream`` kwarg on ``cursor.execute()``.
+
+    These tests mock ``core_driver.connection_upload_stream`` so they do not
+    need a real Snowflake connection.
+    """
+
+    @pytest.fixture
+    def mock_connection(self, mock_core_client):
+        """Mock connection with stubs for both normal execute and upload_stream."""
+        conn = MagicMock()
+        conn.conn_handle = ConnectionHandle(id=1)
+        conn.is_closed.return_value = False
+        conn.paramstyle = ParamStyle.QMARK
+
+        # Stub for normal statement_execute_query (should NOT be called in file_stream path).
+        mock_core_client.statement_new.return_value.stmt_handle = StatementHandle(id=1)
+
+        def make_upload_response(*_args, **_kwargs):
+            rs = MagicMock()
+            rs.result_set_handle = ResultSetHandle(id=42)
+            rs.result_descriptor.query_id = "upload-qid"
+            rs.result_descriptor.HasField = MagicMock(return_value=False)
+            rs.result_descriptor.rows_affected = 1
+            rs.result_descriptor.sql_state = "00000"
+            return rs
+
+        mock_core_client.connection_upload_stream.side_effect = make_upload_response
+        return conn
+
+    @pytest.fixture
+    def cursor(self, mock_connection):
+        return SnowflakeCursor(mock_connection)
+
+    def test_file_stream_calls_upload_stream_rpc(self, cursor, mock_core_client):
+        """execute() with file_stream calls connection_upload_stream, not statement_execute_query."""
+        import io
+
+        # When execute() is called with a PUT SQL and file_stream kwarg
+        cursor.execute(
+            "PUT file://data.csv @my_stage AUTO_COMPRESS=FALSE",
+            file_stream=io.BytesIO(b"hello"),
+        )
+
+        # Then connection_upload_stream is called and the normal query path is not used
+        mock_core_client.connection_upload_stream.assert_called_once()
+        mock_core_client.statement_execute_query.assert_not_called()
+
+    def test_file_stream_passes_bytes_to_rpc(self, cursor, mock_core_client):
+        """The bytes read from file_stream are forwarded to connection_upload_stream."""
+        import io
+
+        payload = b"col1,col2\n1,2\n"
+
+        # When execute() is called with file_stream containing specific bytes
+        cursor.execute(
+            "PUT file://data.csv @my_stage AUTO_COMPRESS=FALSE",
+            file_stream=io.BytesIO(payload),
+        )
+
+        # Then the request sent to the RPC contains the exact bytes from the stream
+        # CoreDriver.connection_upload_stream wraps the args into a request proto and
+        # passes it as the single positional argument to self.client.connection_upload_stream.
+        request = mock_core_client.connection_upload_stream.call_args.args[0]
+        assert request.data == payload
+
+    def test_file_stream_passes_sql_to_rpc(self, cursor, mock_core_client):
+        """The full PUT SQL is forwarded to connection_upload_stream."""
+        import io
+
+        sql = "PUT file://data.csv @my_stage AUTO_COMPRESS=FALSE"
+
+        # When execute() is called with a specific PUT SQL and file_stream
+        cursor.execute(sql, file_stream=io.BytesIO(b"x"))
+
+        # Then the request sent to the RPC contains the original PUT SQL
+        # CoreDriver.connection_upload_stream wraps the args into a request proto and
+        # passes it as the single positional argument to self.client.connection_upload_stream.
+        request = mock_core_client.connection_upload_stream.call_args.args[0]
+        assert request.sql == sql
+
+    def test_file_stream_non_put_raises_programming_error(self, cursor, mock_core_client):
+        """file_stream on a non-PUT SQL raises ProgrammingError."""
+        import io
+
+        # When file_stream is supplied alongside a non-PUT SQL
+        # Then ProgrammingError is raised and the upload RPC is never called
+        with pytest.raises(ProgrammingError, match="(?i)file_stream"):
+            cursor.execute("SELECT 1", file_stream=io.BytesIO(b"data"))
+
+        mock_core_client.connection_upload_stream.assert_not_called()
+
+    def test_file_stream_none_uses_normal_path(self, cursor, mock_core_client):
+        """When file_stream=None, the normal statement_execute_query path is used."""
+        normal_response = MagicMock()
+        normal_response.HasField = MagicMock(return_value=False)
+        normal_response.single.result_set_handle = ResultSetHandle(id=99)
+        normal_response.single.result_descriptor.query_id = "normal-qid"
+        normal_response.single.result_descriptor.HasField = MagicMock(return_value=False)
+        normal_response.single.result_descriptor.rows_affected = 0
+        normal_response.single.result_descriptor.sql_state = "00000"
+        mock_core_client.statement_execute_query.return_value = normal_response
+
+        # When execute() is called without file_stream (or file_stream=None)
+        cursor.execute("SELECT 1", file_stream=None)
+
+        # Then the normal statement_execute_query path is used and upload RPC is not called
+        mock_core_client.statement_execute_query.assert_called_once()
+        mock_core_client.connection_upload_stream.assert_not_called()

--- a/sf_core/src/apis/database_driver_v1/mod.rs
+++ b/sf_core/src/apis/database_driver_v1/mod.rs
@@ -18,6 +18,7 @@ mod query;
 pub(crate) mod result_set;
 pub mod spcs_token;
 pub(crate) mod statement;
+mod upload_stream;
 pub(crate) mod validation;
 
 pub use crate::config::settings::Setting;

--- a/sf_core/src/apis/database_driver_v1/query.rs
+++ b/sf_core/src/apis/database_driver_v1/query.rs
@@ -9,8 +9,8 @@ use crate::chunks::{
 };
 use crate::file_manager;
 use crate::file_manager::{
-    CloudCredentials, DownloadResult, StageCredsCache, StageCredsRefreshError, UploadResult,
-    download_files, upload_files,
+    ByteSource, CloudCredentials, DownloadResult, SingleUploadData, StageCredsCache,
+    StageCredsRefreshError, UploadResult, download_files, upload_files, upload_single_file,
 };
 use crate::query_types::RowType;
 use crate::rest;
@@ -52,6 +52,80 @@ pub struct StageCredsRefreshContext {
     pub sql: String,
     pub query_parameters: crate::config::rest_parameters::QueryParameters,
     pub conn: Arc<Mutex<Connection>>,
+}
+
+/// Upload in-memory bytes to a stage using the transfer parameters from a GS
+/// PUT response.
+///
+/// This is the core of `ConnectionUploadStream`: the caller has already
+/// executed the PUT SQL against GS to obtain `gs_data`; this function
+/// bypasses the filesystem-path expansion that `perform_put_get_transfer`
+/// delegates to `upload_files`, and instead calls `upload_single_file`
+/// directly with `ByteSource::Bytes(data)`.
+///
+/// The virtual filename for the stage object (the `target` column in the PUT
+/// result) is derived from the basename of `src_locations[0]` returned by GS
+/// — the same string that the reference Python connector uses when
+/// `file_stream` is supplied.
+pub(super) async fn perform_upload_with_bytes_source(
+    gs_data: &query_response::Data,
+    wrapper_presets: &WrapperPresets,
+    stage_creds_refresh_context: Option<StageCredsRefreshContext>,
+    use_s3_regional_url_session_param: bool,
+    data: Vec<u8>,
+) -> Result<RowsetData, QueryResponseProcessingError> {
+    let upload_data = gs_data
+        .to_file_upload_data(
+            wrapper_presets.put_get_resultset_flavor.clone(),
+            wrapper_presets.legacy_odbc_compression_autodetect,
+            use_s3_regional_url_session_param,
+        )
+        .context(FileTransferPreparationSnafu)?;
+
+    // Derive the display filename from the server-returned src_location
+    // (basename only), matching what upload_files does when building
+    // SingleUploadData from an expanded file glob.
+    let src_location = upload_data.src_location_pattern.clone();
+    let filename = std::path::Path::new(&src_location)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&src_location)
+        .to_string();
+
+    // Seed the refresher's cache with the initial creds (same as perform_put_get_transfer).
+    let initial_creds = gs_data
+        .stage_info_creds()
+        .context(FileTransferPreparationSnafu)?;
+    let mut refresher = stage_creds_refresh_context
+        .zip(initial_creds)
+        .map(|(ctx, initial_creds)| SnowflakeStageCredsRefresher::new(ctx, initial_creds));
+    let mut refresher_handle = refresher
+        .as_mut()
+        .map(|r| r as &mut dyn file_manager::StageCredsRefresher);
+
+    let stage_info = crate::file_manager::current_stage_info_pub(
+        &upload_data.stage_info,
+        refresher_handle.as_deref(),
+    );
+
+    let single = SingleUploadData {
+        source: ByteSource::Bytes(data),
+        source_path_str: filename.clone(),
+        filename,
+        stage_info,
+        encryption_material: upload_data.encryption_material.clone(),
+        auto_compress: upload_data.auto_compress,
+        source_compression: upload_data.source_compression.clone(),
+        overwrite: upload_data.overwrite,
+        flavor: upload_data.flavor.clone(),
+        legacy_odbc_compression_autodetect: upload_data.legacy_odbc_compression_autodetect,
+    };
+
+    let result = upload_single_file(single, &mut refresher_handle)
+        .await
+        .context(FileUploadSnafu)?;
+
+    Ok(RowsetData::Upload(vec![result]))
 }
 
 /// Executes a PUT/GET file transfer and returns a `RowsetData` variant holding the results.

--- a/sf_core/src/apis/database_driver_v1/statement.rs
+++ b/sf_core/src/apis/database_driver_v1/statement.rs
@@ -679,6 +679,14 @@ fn is_file_transfer(sql: &str) -> bool {
 }
 
 /// Strips leading whitespace, line comments (--), and block comments (/* */)
+///
+/// Exposed as `pub(super)` so that `upload_stream.rs` (a sibling module) can
+/// reuse the same SQL-prefix detection logic without duplicating it.
+pub(super) fn skip_leading_whitespace_and_comments_pub(s: &str) -> &str {
+    skip_leading_whitespace_and_comments(s)
+}
+
+/// Strips leading whitespace, line comments (--), and block comments (/* */)
 fn skip_leading_whitespace_and_comments(s: &str) -> &str {
     let mut s = s;
     loop {

--- a/sf_core/src/apis/database_driver_v1/upload_stream.rs
+++ b/sf_core/src/apis/database_driver_v1/upload_stream.rs
@@ -1,0 +1,193 @@
+//! `connection_upload_stream` — execute a PUT SQL statement using caller-
+//! supplied in-memory bytes instead of reading from the filesystem path.
+//!
+//! This is the Rust backend for the Python `file_stream` kwarg on
+//! `cursor.execute()` (PR-4) and JDBC's `uploadStream` (PR-3).
+//!
+//! # Protocol
+//!
+//! 1. Execute the PUT SQL synchronously against GS (same as a normal PUT) to
+//!    obtain stage credentials, encryption material, and transfer parameters.
+//! 2. Substitute `ByteSource::Bytes(data)` for the filesystem source that
+//!    `upload_files` would normally open.
+//! 3. Build and register a result set from the upload results, exactly as
+//!    `statement_execute_query` does for a normal PUT.
+//!
+//! The virtual filename for the stage object is taken from the `src_locations[0]`
+//! entry returned by GS (the basename of the `file://` path in the SQL),
+//! matching the reference Python connector's behavior when `file_stream` is used.
+
+use std::sync::Arc;
+use std::sync::atomic::Ordering;
+
+use snafu::{OptionExt, ResultExt};
+use tokio::sync::Mutex;
+use tracing::Instrument;
+
+use super::connection::{Connection, FinalSessionNames, RefreshContext};
+use super::error::*;
+use super::global_state::DatabaseDriverV1;
+use super::query::{StageCredsRefreshContext, perform_upload_with_bytes_source};
+use super::result_set::{ResultSet, ResultSetInfo, resolve_reader_ctx, response_to_descriptor};
+use super::statement::skip_leading_whitespace_and_comments_pub;
+use crate::config::rest_parameters::QueryParameters;
+use crate::config::retry::RetryPolicy;
+use crate::handle_manager::Handle;
+use crate::rest::snowflake::{
+    QueryExecutionMode, QueryInput, RestError, snowflake_query_with_client,
+};
+
+impl DatabaseDriverV1 {
+    /// Execute a PUT SQL and upload `data` bytes to the stage instead of
+    /// reading from the filesystem path referenced in the SQL.
+    ///
+    /// Returns a `ResultSetInfo` whose handle/descriptor have the same shape
+    /// as a normal `statement_execute_query` on a PUT statement.
+    pub async fn connection_upload_stream(
+        &self,
+        conn_handle: Handle,
+        sql: String,
+        data: Vec<u8>,
+    ) -> Result<ResultSetInfo, ApiError> {
+        let session_id = self.session_id_for_conn(conn_handle).await;
+        async {
+            let conn_ptr = self.connections.get_obj(conn_handle).ok_or_else(|| {
+                InvalidArgumentSnafu {
+                    argument: "Connection handle not found".to_string(),
+                }
+                .build()
+            })?;
+
+            // Validate that the SQL is a PUT statement.
+            if !is_put_sql(&sql) {
+                return InvalidArgumentSnafu {
+                    argument: concat!(
+                        "file_stream requires a PUT SQL statement ",
+                        "(SQL does not begin with PUT)"
+                    )
+                    .to_string(),
+                }
+                .fail();
+            }
+
+            // Obtain transport context (same as query_context in statement.rs).
+            let (query_parameters, http_client, retry_policy) =
+                connection_query_context(&conn_ptr).await?;
+
+            let query_input = QueryInput {
+                sql: sql.clone(),
+                bindings: None,
+                describe_only: None,
+                query_parameters: None,
+            };
+
+            // Execute the PUT SQL against GS — blocking, like all file transfers.
+            let response = {
+                let mut ctx = RefreshContext::from_arc(&conn_ptr).await?;
+                let mut last_error: Option<RestError> = None;
+                loop {
+                    let session_token = ctx.refresh_token(last_error).await?;
+                    match snowflake_query_with_client(
+                        &http_client,
+                        query_parameters.clone(),
+                        session_token.reveal(),
+                        query_input.clone(),
+                        &retry_policy,
+                        QueryExecutionMode::Blocking,
+                    )
+                    .await
+                    {
+                        Ok(result) => break Ok(result),
+                        Err(e) => last_error = Some(e),
+                    }
+                }
+            }?;
+
+            // Update session parameter cache (mirrors the normal PUT path).
+            if response.success {
+                let conn = conn_ptr.lock().await;
+                conn.update_session_params_cache(
+                    &sql,
+                    response.data.parameters.as_ref(),
+                    &FinalSessionNames {
+                        database: response.data.final_database_name.clone(),
+                        schema: response.data.final_schema_name.clone(),
+                        warehouse: response.data.final_warehouse_name.clone(),
+                        role: response.data.final_role_name.clone(),
+                    },
+                )
+                .await;
+            }
+
+            let gs_data = response.data;
+            let stage_creds_refresh_context = StageCredsRefreshContext {
+                sql: sql.clone(),
+                query_parameters: query_parameters.clone(),
+                conn: conn_ptr.clone(),
+            };
+            let use_s3_regional_url = conn_ptr
+                .lock()
+                .await
+                .use_s3_regional_url_session_param()
+                .await;
+
+            // Perform the upload substituting ByteSource::Bytes for the path.
+            let rowset_data = perform_upload_with_bytes_source(
+                &gs_data,
+                &self.wrapper_presets,
+                Some(stage_creds_refresh_context),
+                use_s3_regional_url,
+                data,
+            )
+            .await
+            .context(QueryResponseProcessingSnafu)?;
+
+            let descriptor = response_to_descriptor(&gs_data, &self.wrapper_presets);
+            let reader_ctx = resolve_reader_ctx(&conn_ptr).await?;
+            let handle = {
+                let result_set = ResultSet {
+                    descriptor: descriptor.clone(),
+                    data: rowset_data,
+                    reader_ctx,
+                };
+                self.results.add_handle(Mutex::new(result_set))
+            };
+            Ok(ResultSetInfo { handle, descriptor })
+        }
+        .instrument(crate::snowflake_op_span!(
+            "connection_upload_stream",
+            session_id
+        ))
+        .await
+    }
+}
+
+/// Extract connection transport parameters (mirrors `query_context` in statement.rs).
+async fn connection_query_context(
+    conn: &Arc<Mutex<Connection>>,
+) -> Result<(QueryParameters, reqwest::Client, RetryPolicy), ApiError> {
+    let conn = conn.lock().await;
+    if conn.is_closed.load(Ordering::SeqCst) {
+        return Err(ConnectionClosedSnafu {}.build());
+    }
+    Ok((
+        conn.query_transport_parameters()?,
+        conn.http_client
+            .clone()
+            .context(ConnectionNotInitializedSnafu)?,
+        conn.retry_policy.clone(),
+    ))
+}
+
+/// Returns `true` when `sql` (after stripping leading whitespace/comments)
+/// starts with `PUT` followed by whitespace or a comment marker.
+fn is_put_sql(sql: &str) -> bool {
+    let s = skip_leading_whitespace_and_comments_pub(sql);
+    if s.len() < 4 {
+        return false;
+    }
+    let prefix = &s[..3];
+    let next_char = s.as_bytes()[3];
+    prefix.eq_ignore_ascii_case("PUT")
+        && (next_char.is_ascii_whitespace() || next_char == b'/' || next_char == b'-')
+}

--- a/sf_core/src/file_manager/mod.rs
+++ b/sf_core/src/file_manager/mod.rs
@@ -89,6 +89,20 @@ pub async fn upload_files(
 /// Returns a copy of `base` with `creds` replaced by the refresher's current
 /// snapshot, when a refresher is present. Without a refresher, `base` is
 /// returned unchanged.
+///
+/// Exposed as `pub` (rather than `fn`) so that `perform_upload_with_bytes_source`
+/// in `query.rs` can build a `SingleUploadData` for a `ByteSource::Bytes` upload
+/// without duplicating the credential-snapshot logic.
+pub fn current_stage_info_pub(
+    base: &StageInfo,
+    refresher: Option<&dyn StageCredsRefresher>,
+) -> StageInfo {
+    current_stage_info(base, refresher)
+}
+
+/// Returns a copy of `base` with `creds` replaced by the refresher's current
+/// snapshot, when a refresher is present. Without a refresher, `base` is
+/// returned unchanged.
 fn current_stage_info(base: &StageInfo, refresher: Option<&dyn StageCredsRefresher>) -> StageInfo {
     let mut info = base.clone();
     if let Some(r) = refresher {

--- a/sf_core/src/protobuf/apis/database_driver_v1/mod.rs
+++ b/sf_core/src/protobuf/apis/database_driver_v1/mod.rs
@@ -609,6 +609,25 @@ impl DatabaseDriver for DatabaseDriverImpl {
         Ok(ConnectionHeartbeatResponse { valid })
     }
 
+    #[instrument(name = "DatabaseDriverV1::connection_upload_stream", skip(self, input))]
+    async fn connection_upload_stream(
+        &self,
+        input: ConnectionUploadStreamRequest,
+    ) -> Result<ConnectionUploadStreamResponse, DriverException> {
+        let conn_handle = required(input.conn_handle, "Connection handle is required")?;
+
+        let rs_info = self
+            .driver
+            .connection_upload_stream(conn_handle.into(), input.sql, input.data)
+            .await
+            .to_protobuf()?;
+
+        Ok(ConnectionUploadStreamResponse {
+            result_set_handle: Some(rs_info.handle.into()),
+            result_descriptor: Some(rs_info.descriptor.into()),
+        })
+    }
+
     #[instrument(name = "DatabaseDriverV1::statement_new", skip(self, input))]
     async fn statement_new(
         &self,


### PR DESCRIPTION
## Summary

- Adds `file_stream: BinaryIO | None = None` kwarg to `cursor.execute()`, matching the snowflake-connector-python reference API.
- New `ConnectionUploadStream` protobuf RPC: takes `conn_handle`, `sql` (PUT statement), and `data` (bytes read from the stream); returns a `ResultSetDescriptor`-shaped response so the cursor can reuse all existing result machinery.
- Rust `perform_upload_with_bytes_source()` skips `expand_filenames()` and drives `upload_single_file` with `ByteSource::Bytes` directly.
- `_QueryResult.from_result_descriptor()` factory added; `from_result_set_response()` delegates to it to avoid a mypy error when constructing from the upload response type.

## RPC shape chosen

**Option A — `ConnectionUploadStream` RPC** (new dedicated RPC in protobuf service):
- `ConnectionUploadStreamRequest { conn_handle, sql, data }`
- `ConnectionUploadStreamResponse { result_set_handle, result_descriptor }`

Rationale: clean separation from the normal statement execute path; the proto boundary makes the bytes transfer explicit and keeps the Rust core as the single source of truth for stage-credential fetching and upload logic.

## Behavioral changes from reference connector

| # | Reference connector (snowflake-connector-python) | This driver |
|---|---|---|
| 1 | `file_stream` on non-PUT SQL is silently ignored | Raises `ProgrammingError` with `"file_stream is only supported for PUT statements"` — fails fast, helps users catch misuse early |

## Test plan

- [x] 5 unit tests in `TestFileStream` (test_cursor.py) — all pass
- [x] 4 e2e tests in `test_put_get_file_stream.py` — require live Snowflake connection; skip via `connection` fixture when credentials absent
- [x] All 661 existing Python unit tests still pass (excluding pre-existing numpy import failure)
- [x] `cargo build -p sf_core` passes clean (no warnings)
- [x] Rust unit/logging/parity tests pass; e2e/integration tests require live credentials (pre-existing)
- [x] Pre-commit hooks (rustfmt, ruff, mypy, tests-format-validator) all pass

## Part of series

- Part 1: ByteSource + S3 streaming refactor (base branch)
- Part 2: GCS/Azure streaming (parallel)
- Part 3: JDBC uploadStream (parallel)
- **Part 4 (this PR):** Python `file_stream` kwarg

🤖 Generated with [Claude Code](https://claude.com/claude-code)