### PR TITLE
SNOW-3573289: remove query modification in max_rows implementation

### DIFF
--- a/odbc/src/api/statement.rs
+++ b/odbc/src/api/statement.rs
@@ -117,9 +117,7 @@ fn exec_direct_impl(statement_handle: sql::Handle, statement_text: &str) -> Odbc
     let (bindings, _json_owner) = apply_parameter_bindings(&inner.apd, &inner.ipd, false, None)?;
     let stmt_handle = guard.stmt_handle;
     let query_timeout = inner.query_timeout;
-    let max_rows = inner.max_rows;
-    let effective_query =
-        apply_limit(statement_text, max_rows).unwrap_or_else(|| statement_text.to_string());
+    let effective_query = statement_text.to_string();
     let multi_statement_count = inner.multi_statement_count;
 
     let token = CancellationToken::new();
@@ -183,9 +181,6 @@ fn exec_direct_impl(statement_handle: sql::Handle, statement_text: &str) -> Odbc
     update_numeric_settings(&conn_handle, &mut conn.numeric_settings)?;
     apply_execute_response(&mut inner, conn_handle, response, ExecutionOrigin::Direct)?;
     inner.rows_returned = 0;
-    // Clear any SQL text cached by a prior SQLPrepare so a subsequent
-    // SQLExecute cannot inject LIMIT into stale prepared SQL.
-    inner.sql_text = None;
     Ok(())
 }
 
@@ -483,7 +478,6 @@ fn prepare_impl(statement_handle: sql::Handle, query: &str) -> OdbcResult<()> {
     }
     tracing::info!("prepare: auto-IPD populated {param_count} parameter markers (from server)");
 
-    inner.sql_text = Some(query.to_string());
     inner.state.set(StatementState::Prepared { schema });
     tracing::info!("prepare: Successfully prepared statement");
     Ok(())
@@ -559,23 +553,7 @@ pub fn execute(statement_handle: sql::Handle) -> OdbcResult<()> {
 
     let stmt_handle = guard.stmt_handle;
     let query_timeout = inner.query_timeout;
-    let max_rows = inner.max_rows;
-    let last_sent_max_rows = inner.last_sent_max_rows;
-    let sql_text = inner.sql_text.clone();
     let multi_statement_count = inner.multi_statement_count;
-
-    // Determine the query to send. We must resend whenever max_rows changed
-    // since the last execution: to add/change a LIMIT, or to restore the
-    // original query when a previous LIMIT is cleared.
-    let query_to_send: Option<String> = sql_text.as_deref().and_then(|sql| {
-        let modified = apply_limit(sql, max_rows);
-        let max_rows_changed = last_sent_max_rows != Some(max_rows);
-        match (modified, max_rows_changed) {
-            (Some(q), _) => Some(q),
-            (None, true) => Some(sql.to_string()),
-            (None, false) => None,
-        }
-    });
 
     let token = CancellationToken::new();
     let _cancel_guard = ActiveCancelGuard::arm(&guard.active_cancel, token.clone());
@@ -598,13 +576,6 @@ pub fn execute(statement_handle: sql::Handle) -> OdbcResult<()> {
                     c.statement_set_options(StatementSetOptionsRequest {
                         stmt_handle: Some(stmt_handle),
                         options,
-                    })
-                    .await?;
-                }
-                if let Some(query) = query_to_send {
-                    c.statement_set_sql_query(StatementSetSqlQueryRequest {
-                        stmt_handle: Some(stmt_handle),
-                        query,
                     })
                     .await?;
                 }
@@ -638,7 +609,6 @@ pub fn execute(statement_handle: sql::Handle) -> OdbcResult<()> {
     dbc.connection.lock().numeric_settings = settings;
     apply_execute_response(&mut inner, conn_handle, response, origin)?;
     inner.rows_returned = 0;
-    inner.last_sent_max_rows = Some(max_rows);
     Ok(())
 }
 
@@ -891,230 +861,6 @@ fn apply_parameter_bindings(
     tracing::info!("apply_parameter_bindings: Successfully bound parameters");
 
     Ok((Some(bindings), Some(json_string)))
-}
-
-/// Skip leading SQL noise (whitespace, line comments `-- …`, block comments `/* … */`)
-/// and return the remaining slice.
-fn skip_sql_noise(sql: &str) -> &str {
-    let b = sql.as_bytes();
-    let mut i = 0;
-    loop {
-        // Skip whitespace.
-        while i < b.len() && b[i].is_ascii_whitespace() {
-            i += 1;
-        }
-        if i + 1 < b.len() && b[i] == b'-' && b[i + 1] == b'-' {
-            // Line comment: skip until newline.
-            i += 2;
-            while i < b.len() && b[i] != b'\n' {
-                i += 1;
-            }
-        } else if i + 1 < b.len() && b[i] == b'/' && b[i + 1] == b'*' {
-            // Block comment: skip until `*/`.
-            i += 2;
-            while i + 1 < b.len() && !(b[i] == b'*' && b[i + 1] == b'/') {
-                i += 1;
-            }
-            if i + 1 < b.len() {
-                i += 2; // consume `*/`
-            } else {
-                i = b.len(); // unterminated block comment — treat rest as noise
-                break;
-            }
-        } else {
-            break;
-        }
-    }
-    &sql[i..]
-}
-
-/// Returns true if `sql` is a SELECT (or WITH…SELECT) query.
-/// Used to decide whether to inject LIMIT N for `SQL_ATTR_MAX_ROWS`.
-///
-/// For `WITH` queries, scans past CTE definitions (depth > 0) to find the
-/// terminal statement keyword at depth 0, so `WITH cte AS (...) INSERT ...`
-/// is correctly identified as non-SELECT and LIMIT is not injected.
-fn is_select_query(sql: &str) -> bool {
-    let t = skip_sql_noise(sql);
-    if t.get(..6).is_some_and(|s| s.eq_ignore_ascii_case("select")) {
-        return true;
-    }
-    if !t.get(..4).is_some_and(|s| s.eq_ignore_ascii_case("with")) {
-        return false;
-    }
-    // WITH query: scan past CTE bodies (enclosed in parentheses) to find the
-    // terminal statement keyword at depth 0.
-    let b = t.as_bytes();
-    let mut i = 4; // skip "WITH"
-    let mut depth: usize = 0;
-    while i < b.len() {
-        match b[i] {
-            b'\'' => {
-                i += 1;
-                while i < b.len() {
-                    if b[i] == b'\'' {
-                        i += 1;
-                        if i < b.len() && b[i] == b'\'' {
-                            i += 1;
-                        } else {
-                            break;
-                        }
-                    } else {
-                        i += 1;
-                    }
-                }
-            }
-            b'"' => {
-                i += 1;
-                while i < b.len() {
-                    if b[i] == b'"' {
-                        i += 1;
-                        if i < b.len() && b[i] == b'"' {
-                            i += 1;
-                        } else {
-                            break;
-                        }
-                    } else {
-                        i += 1;
-                    }
-                }
-            }
-            b'-' if i + 1 < b.len() && b[i + 1] == b'-' => {
-                while i < b.len() && b[i] != b'\n' {
-                    i += 1;
-                }
-            }
-            b'/' if i + 1 < b.len() && b[i + 1] == b'*' => {
-                i += 2;
-                while i + 1 < b.len() && !(b[i] == b'*' && b[i + 1] == b'/') {
-                    i += 1;
-                }
-                if i + 1 < b.len() {
-                    i += 2; // consume `*/`
-                } else {
-                    break; // unterminated block comment — treat rest as noise
-                }
-            }
-            b'(' => {
-                depth += 1;
-                i += 1;
-            }
-            b')' => {
-                depth = depth.saturating_sub(1);
-                i += 1;
-            }
-            c if depth == 0 && c.is_ascii_alphabetic() => {
-                let start = i;
-                while i < b.len() && (b[i].is_ascii_alphanumeric() || b[i] == b'_') {
-                    i += 1;
-                }
-                let word = &b[start..i];
-                if word.eq_ignore_ascii_case(b"SELECT") {
-                    return true;
-                }
-                if word.eq_ignore_ascii_case(b"INSERT")
-                    || word.eq_ignore_ascii_case(b"UPDATE")
-                    || word.eq_ignore_ascii_case(b"DELETE")
-                    || word.eq_ignore_ascii_case(b"MERGE")
-                {
-                    return false;
-                }
-                // Other identifiers (cte name, AS, RECURSIVE, etc.) — keep scanning
-            }
-            _ => {
-                i += 1;
-            }
-        }
-    }
-    false
-}
-
-/// Returns true if `sql` already contains a LIMIT keyword as a standalone word,
-/// ignoring LIMIT inside string literals and comments.
-fn has_limit_clause(sql: &str) -> bool {
-    let b = sql.as_bytes();
-    let mut i = 0;
-    while i < b.len() {
-        match b[i] {
-            // Skip single-quoted strings: '...' ('' is an escaped quote)
-            b'\'' => {
-                i += 1;
-                while i < b.len() {
-                    if b[i] == b'\'' {
-                        i += 1;
-                        if i < b.len() && b[i] == b'\'' {
-                            i += 1; // escaped ''
-                        } else {
-                            break;
-                        }
-                    } else {
-                        i += 1;
-                    }
-                }
-            }
-            // Skip double-quoted identifiers: "..."
-            b'"' => {
-                i += 1;
-                while i < b.len() {
-                    if b[i] == b'"' {
-                        i += 1;
-                        if i < b.len() && b[i] == b'"' {
-                            i += 1; // escaped ""
-                        } else {
-                            break;
-                        }
-                    } else {
-                        i += 1;
-                    }
-                }
-            }
-            // Skip line comments
-            b'-' if i + 1 < b.len() && b[i + 1] == b'-' => {
-                while i < b.len() && b[i] != b'\n' {
-                    i += 1;
-                }
-            }
-            // Skip block comments
-            b'/' if i + 1 < b.len() && b[i + 1] == b'*' => {
-                i += 2;
-                while i + 1 < b.len() && !(b[i] == b'*' && b[i + 1] == b'/') {
-                    i += 1;
-                }
-                i += 2;
-            }
-            _ => {
-                // Check for standalone LIMIT keyword (case-insensitive)
-                if i + 5 <= b.len() {
-                    let word = &b[i..i + 5];
-                    let before_ok = i == 0 || !b[i - 1].is_ascii_alphanumeric() && b[i - 1] != b'_';
-                    let after_ok =
-                        i + 5 >= b.len() || !b[i + 5].is_ascii_alphanumeric() && b[i + 5] != b'_';
-                    if before_ok && after_ok && word.eq_ignore_ascii_case(b"LIMIT") {
-                        return true;
-                    }
-                }
-                i += 1;
-            }
-        }
-    }
-    false
-}
-
-/// Returns a SQL string with `LIMIT max_rows` appended if:
-/// - `max_rows > 0`
-/// - the query is a SELECT/WITH query
-/// - no LIMIT clause is already present
-///
-/// Returns `None` when no injection is needed.
-fn apply_limit(sql: &str, max_rows: sql::ULen) -> Option<String> {
-    if max_rows == 0 || !is_select_query(sql) || has_limit_clause(sql) {
-        return None;
-    }
-    // Strip trailing whitespace and semicolons to avoid `SELECT 1; LIMIT 5`.
-    // Use a newline before LIMIT so trailing line comments (`-- …`) don't
-    // swallow the clause: `SELECT 1 -- note LIMIT 5` would be ignored.
-    let trimmed = sql.trim_end().trim_end_matches(';').trim_end();
-    Some(format!("{}\nLIMIT {}", trimmed, max_rows))
 }
 
 /// Bind a parameter to a prepared statement
@@ -2611,111 +2357,5 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert_eq!(err.to_sql_state(), SqlState::CountFieldIncorrect);
-    }
-}
-
-#[cfg(test)]
-mod limit_injection_tests {
-    use super::*;
-
-    #[test]
-    fn select_is_detected() {
-        assert!(is_select_query("SELECT 1"));
-        assert!(is_select_query("  select * from t"));
-        assert!(is_select_query("WITH cte AS (SELECT 1) SELECT * FROM cte"));
-        assert!(!is_select_query("INSERT INTO t VALUES (1)"));
-        assert!(!is_select_query("UPDATE t SET x = 1"));
-        assert!(!is_select_query("DELETE FROM t"));
-    }
-
-    #[test]
-    fn with_dml_is_not_select() {
-        // CTE-prefixed DML must not be treated as SELECT; LIMIT injection would produce invalid SQL.
-        assert!(!is_select_query(
-            "WITH cte AS (SELECT 1) INSERT INTO t SELECT * FROM cte"
-        ));
-        assert!(!is_select_query(
-            "WITH cte AS (SELECT 1) UPDATE t SET x = 1"
-        ));
-        assert!(!is_select_query(
-            "WITH cte AS (SELECT 1) DELETE FROM t WHERE id IN (SELECT id FROM cte)"
-        ));
-        // CTE followed by SELECT is still SELECT
-        assert!(is_select_query("WITH cte AS (SELECT 1) SELECT * FROM cte"));
-    }
-
-    #[test]
-    fn select_is_detected_with_leading_comments() {
-        assert!(is_select_query("/* hint */ SELECT 1"));
-        assert!(is_select_query("-- comment\nSELECT * FROM t"));
-        assert!(is_select_query("/* a */ /* b */ SELECT 1"));
-        assert!(!is_select_query("/* hint */ INSERT INTO t VALUES (1)"));
-    }
-
-    #[test]
-    fn limit_detection() {
-        assert!(has_limit_clause("SELECT 1 LIMIT 10"));
-        assert!(has_limit_clause("select * from t limit 5"));
-        assert!(!has_limit_clause("SELECT 1"));
-        assert!(!has_limit_clause("SELECT col_limit FROM t"));
-        assert!(!has_limit_clause("SELECT NOLIMIT FROM t"));
-    }
-
-    #[test]
-    fn limit_detection_ignores_string_literals() {
-        // LIMIT inside a string literal must not be detected
-        assert!(!has_limit_clause("SELECT * FROM t WHERE x = 'LIMIT'"));
-        assert!(!has_limit_clause("SELECT * FROM t WHERE x = 'NO LIMIT'"));
-        // LIMIT inside a line comment
-        assert!(!has_limit_clause("SELECT 1 -- LIMIT workaround"));
-        // LIMIT inside a block comment
-        assert!(!has_limit_clause("SELECT 1 /* LIMIT 5 */"));
-        // Real LIMIT after a string that contains the word
-        assert!(has_limit_clause(
-            "SELECT * FROM t WHERE x = 'LIMIT' LIMIT 5"
-        ));
-    }
-
-    #[test]
-    fn apply_limit_injects_when_needed() {
-        assert_eq!(
-            apply_limit("SELECT 1", 10),
-            Some("SELECT 1\nLIMIT 10".to_string())
-        );
-        assert_eq!(
-            apply_limit("  SELECT * FROM t  ", 5),
-            Some("  SELECT * FROM t\nLIMIT 5".to_string())
-        );
-    }
-
-    #[test]
-    fn apply_limit_strips_trailing_semicolons() {
-        assert_eq!(
-            apply_limit("SELECT 1;", 5),
-            Some("SELECT 1\nLIMIT 5".to_string())
-        );
-        assert_eq!(
-            apply_limit("SELECT 1 ;  ", 5),
-            Some("SELECT 1\nLIMIT 5".to_string())
-        );
-    }
-
-    #[test]
-    fn apply_limit_trailing_line_comment() {
-        // LIMIT must appear on a new line so a trailing `-- comment` does not swallow it.
-        assert_eq!(
-            apply_limit("SELECT 1 -- trailing comment", 5),
-            Some("SELECT 1 -- trailing comment\nLIMIT 5".to_string())
-        );
-    }
-
-    #[test]
-    fn apply_limit_skips_when_not_needed() {
-        // max_rows = 0 → no limit
-        assert_eq!(apply_limit("SELECT 1", 0), None);
-        // already has LIMIT
-        assert_eq!(apply_limit("SELECT 1 LIMIT 100", 10), None);
-        // non-SELECT
-        assert_eq!(apply_limit("INSERT INTO t VALUES (1)", 10), None);
     }
 }

--- a/odbc/src/api/types/odbc_types.rs
+++ b/odbc/src/api/types/odbc_types.rs
@@ -1439,9 +1439,6 @@ pub struct StatementInner {
     /// Rows returned to the application so far in the current result set.
     /// Reset to 0 on each execution. Used to enforce `max_rows`.
     pub rows_returned: sql::ULen,
-    /// SQL text stored at `SQLPrepare` time. Used in `SQLExecute` to inject
-    /// `LIMIT N` for SELECT queries when `SQL_ATTR_MAX_ROWS` is set.
-    pub sql_text: Option<String>,
     /// `SQL_ATTR_CONCURRENCY` — cursor concurrency (default SQL_CONCUR_READ_ONLY = 1).
     pub concurrency: sql::ULen,
     /// `SQL_ATTR_CURSOR_SCROLLABLE` — cursor scrollability (default SQL_NONSCROLLABLE = 0).
@@ -1454,10 +1451,6 @@ pub struct StatementInner {
     pub simulate_cursor: sql::ULen,
     /// `SQL_ATTR_RETRIEVE_DATA` — whether to retrieve data after positioned update (default SQL_RD_ON = 1).
     pub retrieve_data: sql::ULen,
-    /// The `max_rows` value last sent to the server via `statement_set_sql_query`.
-    /// `None` = never sent. Used to detect when a LIMIT must be added, removed,
-    /// or changed on re-execution of a prepared statement.
-    pub last_sent_max_rows: Option<sql::ULen>,
     /// `SQL_SF_STMT_ATTR_LAST_QUERY_ID` — query ID from the last successful execution (read-only).
     /// `None` before any execution; `Some("")` if sf_core returned an empty string.
     pub last_query_id: Option<String>,
@@ -1500,14 +1493,12 @@ impl Statement {
                 noscan: SQL_NOSCAN_OFF,
                 max_rows: 0,
                 rows_returned: 0,
-                sql_text: None,
                 concurrency: SQL_CONCUR_READ_ONLY,
                 cursor_scrollable: SQL_NONSCROLLABLE,
                 cursor_sensitivity: SQL_UNSPECIFIED,
                 keyset_size: 0,
                 simulate_cursor: SQL_SC_NON_UNIQUE,
                 retrieve_data: SQL_RD_ON,
-                last_sent_max_rows: None,
                 last_query_id: None,
                 multi_query_ids: Vec::new(),
                 multi_current_idx: 0,

--- a/odbc_tests/tests/odbc-api/connecting/stmt_attr_tests.cpp
+++ b/odbc_tests/tests/odbc-api/connecting/stmt_attr_tests.cpp
@@ -867,6 +867,68 @@ TEST_CASE("should remove row limit when SQL_ATTR_MAX_ROWS is toggled to 0 betwee
   CHECK(ret == SQL_NO_DATA);
 }
 
+TEST_CASE("should enforce SQL_ATTR_MAX_ROWS across multiple block fetches", "[odbc-api][stmt_attr][max_rows]") {
+  // Given A statement with SQL_ATTR_ROW_ARRAY_SIZE=2 and SQL_ATTR_MAX_ROWS=5
+  // returning 10 rows; 5 % 2 = 1 so the limit splits the third rowset, which
+  // exercises both the in-batch quota clamp and the post-quota SQL_NO_DATA path.
+  Connection conn;
+  auto stmt = conn.createStatement();
+
+  SQLRETURN ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_ROW_ARRAY_SIZE, reinterpret_cast<SQLPOINTER>(2), 0);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_MAX_ROWS, reinterpret_cast<SQLPOINTER>(5), 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  constexpr SQLULEN array_size = 2;
+  SQLULEN rows_fetched = 0;
+  SQLUSMALLINT row_status[array_size] = {SQL_ROW_NOROW, SQL_ROW_NOROW};
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_ROWS_FETCHED_PTR, &rows_fetched, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+  ret = SQLSetStmtAttr(stmt.getHandle(), SQL_ATTR_ROW_STATUS_PTR, row_status, 0);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  SQLINTEGER value[array_size] = {0, 0};
+  SQLLEN value_ind[array_size] = {0, 0};
+  ret = SQLBindCol(stmt.getHandle(), 1, SQL_C_LONG, value, sizeof(SQLINTEGER), value_ind);
+  REQUIRE(ret == SQL_SUCCESS);
+
+  // When A query returning 10 rows is executed
+  ret = SQLExecDirect(stmt.getHandle(),
+                      sqlchar("SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4 UNION ALL SELECT 5 "
+                              "UNION ALL SELECT 6 UNION ALL SELECT 7 UNION ALL SELECT 8 UNION ALL SELECT 9 UNION ALL "
+                              "SELECT 10"),
+                      SQL_NTS);
+  REQUIRE_ODBC(ret, stmt);
+
+  // Then The first two fetches return 2 rows each
+  ret = SQLFetch(stmt.getHandle());
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(rows_fetched == 2);
+  CHECK(row_status[0] == SQL_ROW_SUCCESS);
+  CHECK(row_status[1] == SQL_ROW_SUCCESS);
+
+  ret = SQLFetch(stmt.getHandle());
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(rows_fetched == 2);
+  CHECK(row_status[0] == SQL_ROW_SUCCESS);
+  CHECK(row_status[1] == SQL_ROW_SUCCESS);
+
+  // And The third fetch returns 1 row (clamped by the remaining quota).
+  // Pre-clear row_status because the old driver does not overwrite slots
+  // beyond rows_fetched; the contract is `rows_fetched` rows are valid.
+  row_status[0] = SQL_ROW_NOROW;
+  row_status[1] = SQL_ROW_NOROW;
+  ret = SQLFetch(stmt.getHandle());
+  REQUIRE(ret == SQL_SUCCESS);
+  CHECK(rows_fetched == 1);
+  CHECK(row_status[0] == SQL_ROW_SUCCESS);
+  CHECK(row_status[1] == SQL_ROW_NOROW);
+
+  // And A fourth fetch returns SQL_NO_DATA
+  ret = SQLFetch(stmt.getHandle());
+  CHECK(ret == SQL_NO_DATA);
+}
+
 // ============================================================================
 // SQL_ATTR_CONCURRENCY — cursor attribute rejected in Done state
 // ============================================================================


### PR DESCRIPTION
Implement SQL_ATTR_MAX_ROWS purely client-side via the existing
rows_returned counter in fetch_impl. The driver no longer parses or
rewrites the user's SQL to inject LIMIT N.

Removes:
- skip_sql_noise / is_select_query / has_limit_clause / apply_limit
- limit_injection_tests module
- StatementInner.sql_text and StatementInner.last_sent_max_rows
- prepared-statement SQL resend on max_rows change in execute()
- inner.sql_text = None reset in exec_direct