### PR TITLE
SNOW-3565558: Remove dedicated clippy job from Rust Core CI

### DIFF
--- a/.github/workflows/test-rust-core.yml
+++ b/.github/workflows/test-rust-core.yml
@@ -99,43 +99,6 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
 
-  clippy:
-    needs: detect-changes
-    if: github.event_name == 'push' || needs.detect-changes.outputs.run_rust_core == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Restore Rust cache
-        id: rust-cache
-        # Cache restore failures never fail the job — fall back to clean build.
-        continue-on-error: true
-        uses: ./.github/actions/cargo-cache
-        with:
-          mode: restore
-          shared-key: "clippy"
-
-      - name: Install clippy
-        run: rustup component add clippy
-
-      - name: Run clippy
-        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
-
-      - name: Save Rust cache
-        if: always()
-        # timeout-minutes is enforced here because it isn't supported on
-        # composite action steps. Bounds slim + registry save + target save.
-        timeout-minutes: 20
-        # Cache failures (incl. timeout-induced cancellation) never fail the job.
-        continue-on-error: true
-        uses: ./.github/actions/cargo-cache
-        with:
-          mode: save
-          shared-key: "clippy"
-          registry-cache-hit: ${{ steps.rust-cache.outputs.registry-cache-hit }}
-          target-cache-hit: ${{ steps.rust-cache.outputs.target-cache-hit }}
-
   build-without-protobuf:
     needs: detect-changes
     if: github.event_name == 'push' || needs.detect-changes.outputs.run_rust_core == 'true'
@@ -692,7 +655,7 @@ jobs:
             --parameter-path "${{ github.workspace }}/parameters.json"
 
   rust-core-status:
-    needs: [detect-changes, format, clippy, build-without-protobuf, test, test_windows_arm64_nonfips, test_windows_x86, cleanup_rust_core]
+    needs: [detect-changes, format, build-without-protobuf, test, test_windows_arm64_nonfips, test_windows_x86, cleanup_rust_core]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -709,14 +672,12 @@ jobs:
           
           # Check if any job failed or was cancelled
           if [[ "${{ needs.format.result }}" =~ ^(failure|cancelled)$ ]] || \
-             [[ "${{ needs.clippy.result }}" =~ ^(failure|cancelled)$ ]] || \
              [[ "${{ needs.build-without-protobuf.result }}" =~ ^(failure|cancelled)$ ]] || \
              [[ "${{ needs.test.result }}" =~ ^(failure|cancelled)$ ]] || \
              [[ "${{ needs.test_windows_arm64_nonfips.result }}" =~ ^(failure|cancelled)$ ]] || \
              [[ "${{ needs.test_windows_x86.result }}" =~ ^(failure|cancelled)$ ]]; then
             echo "✗ Rust Core tests were RUN and FAILED or CANCELLED"
             echo "  - format: ${{ needs.format.result }}"
-            echo "  - clippy: ${{ needs.clippy.result }}"
             echo "  - build-without-protobuf: ${{ needs.build-without-protobuf.result }}"
             echo "  - test: ${{ needs.test.result }}"
             echo "  - test_windows_arm64_nonfips: ${{ needs.test_windows_arm64_nonfips.result }}"


### PR DESCRIPTION
## Summary

- Remove the dedicated `clippy` job from `test-rust-core.yml` — pre-commit already runs `cargo clippy --all-targets --all-features` via `.pre-commit-config.yaml`
- Eliminates one redundant full Rust compilation (~5 min) from the Rust Core CI pipeline
- Updates `rust-core-status` gate job to remove clippy dependency

## Test plan

- [ ] Verify pre-commit CI workflow still runs clippy on Rust file changes
- [ ] Verify `rust-core-status` gate passes without the clippy job

🤖 Generated with [Claude Code](https://claude.com/claude-code)