### PR TITLE
SNOW-3406389: GCS multi-file GET respects server-supplied per-file presigned URLs

### DIFF
--- a/sf_core/src/file_manager/gcs_transfer.rs
+++ b/sf_core/src/file_manager/gcs_transfer.rs
@@ -25,7 +25,8 @@ pub async fn upload_to_gcs_or_skip(
     let client = create_gcs_client()?;
     let key = format!("{}{filename}", stage_info.key_prefix);
     let using_presigned_url = stage_info.presigned_url.is_some();
-    let (url, token) = resolve_url_and_token(stage_info, &key)?;
+    // PUT path: per-file URL list is GET-only, so we never pass one here.
+    let (url, token) = resolve_url_and_token(stage_info, &key, None)?;
 
     if !overwrite && check_file_exists_gcs(&client, &url, token).await {
         tracing::info!("File already exists in GCS: {key}");
@@ -44,14 +45,28 @@ pub async fn upload_to_gcs_or_skip(
 /// GCS `Content-Length` (i.e. the stored object size) for non-streamed
 /// responses. This is the wire byte count, not the decrypted/decoded
 /// size of the original file.
+///
+/// `per_file_presigned_url` is the URL GS issued for this specific file via
+/// `data.presignedUrls[i]` on GCS GET in presigned-only mode. When `Some`,
+/// it takes precedence over `stage_info.presigned_url` (Strategy 0 in
+/// `resolve_url_and_token`); when `None`, the function falls back to the
+/// existing strategies (PUT-side single presigned URL, then bearer token,
+/// then `MissingGcsCredentials`). See
+/// `--gcp--/2.2-server_supplied_presigned_url_list_on_download.md`.
 pub async fn download_from_gcs(
     stage_info: &StageInfo,
     filename: &str,
+    per_file_presigned_url: Option<&str>,
 ) -> Result<DownloadResponse, GcsDownloadError> {
     let client = create_gcs_client()?;
     let key = format!("{}{filename}", stage_info.key_prefix);
-    let (url, token) = resolve_url_and_token(stage_info, &key)?;
-    let using_presigned_url = stage_info.presigned_url.is_some();
+    let (url, token) = resolve_url_and_token(stage_info, &key, per_file_presigned_url)?;
+    // Either presigned-URL source enables the 400-retry policy: the URL
+    // may have expired and reissuing it produces a fresh signature. The
+    // PUT-side single-slot URL and the per-file GET list are both signed
+    // and both subject to the same expiry semantics.
+    let using_presigned_url =
+        per_file_presigned_url.is_some() || stage_info.presigned_url.is_some();
 
     let response = gcs_request_with_retry(
         || {
@@ -291,7 +306,13 @@ fn create_gcs_client() -> Result<reqwest::Client, GcsRequestError> {
 /// Constructs the GCS URL and extracts the bearer token from stage info.
 ///
 /// URL strategy priority (matching JDBC/ODBC/Python):
-/// 1. Presigned URL — use directly, no token
+/// 0. Per-file presigned URL (GET, `data.presignedUrls[i]`) — use directly,
+///    no token. Wins over the stage-info single slot to mirror Python's
+///    `meta.presigned_url or stage_info.get("presignedUrl")` order in
+///    `gcs_storage_client.py:77`. Reasoning: GS issues this URL for this
+///    specific object; the token is generic and may have narrower ACLs.
+/// 1. `stage_info.presigned_url` (PUT-side single slot) — use directly,
+///    no token. PUT path is unchanged by step 2.2.
 /// 2. Custom endpoint — `https://{endpoint}/{bucket}/{key}`
 /// 3. Virtual host — `https://{bucket}.storage.googleapis.com/{key}`
 /// 4. Regional — `https://storage.{region}.rep.googleapis.com/{bucket}/{key}`
@@ -299,8 +320,14 @@ fn create_gcs_client() -> Result<reqwest::Client, GcsRequestError> {
 fn resolve_url_and_token<'a>(
     stage_info: &'a StageInfo,
     key: &str,
+    per_file_presigned_url: Option<&str>,
 ) -> Result<(String, Option<&'a str>), GcsRequestError> {
-    // Strategy 1: presigned URL
+    // Strategy 0: per-file presigned URL (GCS GET multi-file path)
+    if let Some(presigned) = per_file_presigned_url {
+        return Ok((presigned.to_string(), None));
+    }
+
+    // Strategy 1: stage-info presigned URL (PUT path)
     if let Some(presigned) = &stage_info.presigned_url {
         return Ok((presigned.clone(), None));
     }
@@ -698,21 +725,81 @@ mod tests {
     fn resolve_with_bearer_token() {
         // Matches ODBC test_simple_get_gcs_with_token
         let stage = make_stage_info(StageInfoOverrides::default());
-        let (url, token) = resolve_url_and_token(&stage, "file.csv.gz").unwrap();
+        let (url, token) = resolve_url_and_token(&stage, "file.csv.gz", None).unwrap();
         assert_eq!(url, "https://storage.googleapis.com/my-bucket/file.csv.gz");
         assert_eq!(token, Some("fake-token"));
     }
 
     #[test]
     fn resolve_with_presigned_url() {
-        // Matches ODBC test_simple_get_gcs_with_presignedurl
+        // Matches ODBC test_simple_get_gcs_with_presignedurl. PUT-side
+        // single presigned URL slot — preserved as Strategy 1 by step 2.2.
         let stage = make_stage_info(StageInfoOverrides {
             presigned_url: Some("https://faked.presigned.url".to_string()),
             ..Default::default()
         });
-        let (url, token) = resolve_url_and_token(&stage, "file.csv.gz").unwrap();
+        let (url, token) = resolve_url_and_token(&stage, "file.csv.gz", None).unwrap();
         assert_eq!(url, "https://faked.presigned.url");
         assert!(token.is_none(), "presigned URL mode should not use a token");
+    }
+
+    #[test]
+    fn resolve_per_file_presigned_url_wins_over_stage_info_presigned_url() {
+        // Strategy 0 must beat Strategy 1: GS issues `data.presignedUrls[i]`
+        // for this specific object on GCS GET, while `stageInfo.presignedUrl`
+        // is the PUT-side single slot. See
+        // `--gcp--/2.2-server_supplied_presigned_url_list_on_download.md`,
+        // §4 "Mixed-mode stages" — matches Python's
+        // `meta.presigned_url or stage_info.get("presignedUrl")` ordering in
+        // `gcs_storage_client.py:77`.
+        let stage = make_stage_info(StageInfoOverrides {
+            presigned_url: Some("https://stage-info.presigned.url/put-slot".to_string()),
+            ..Default::default()
+        });
+        let (url, token) = resolve_url_and_token(
+            &stage,
+            "file.csv.gz",
+            Some("https://per-file.presigned.url/get-slot"),
+        )
+        .unwrap();
+        assert_eq!(url, "https://per-file.presigned.url/get-slot");
+        assert!(
+            token.is_none(),
+            "per-file presigned URL mode must not return a token"
+        );
+    }
+
+    #[test]
+    fn resolve_per_file_presigned_url_wins_over_bearer_token() {
+        // Mixed mode: GS sometimes emits both `presignedUrls[]` and a token
+        // during stage transitions. Per-file URL must still win — the URL is
+        // object-scoped and the token is generic.
+        let stage = make_stage_info(StageInfoOverrides::default());
+        let (url, token) = resolve_url_and_token(
+            &stage,
+            "file.csv.gz",
+            Some("https://per-file.presigned.url/get-slot"),
+        )
+        .unwrap();
+        assert_eq!(url, "https://per-file.presigned.url/get-slot");
+        assert!(
+            token.is_none(),
+            "per-file presigned URL mode must not return a token even when one is available"
+        );
+    }
+
+    #[test]
+    fn resolve_falls_back_to_stage_info_presigned_url_when_per_file_is_none() {
+        // PUT path semantics must not regress: when no per-file URL is
+        // supplied, `stage_info.presigned_url` is still honoured (Strategy
+        // 1 — the original PUT-side single-slot path).
+        let stage = make_stage_info(StageInfoOverrides {
+            presigned_url: Some("https://stage-info.presigned.url/put-slot".to_string()),
+            ..Default::default()
+        });
+        let (url, token) = resolve_url_and_token(&stage, "file.csv.gz", None).unwrap();
+        assert_eq!(url, "https://stage-info.presigned.url/put-slot");
+        assert!(token.is_none());
     }
 
     #[test]
@@ -724,7 +811,7 @@ mod tests {
             }),
             ..Default::default()
         });
-        let result = resolve_url_and_token(&stage, "file.csv.gz");
+        let result = resolve_url_and_token(&stage, "file.csv.gz", None);
         assert!(matches!(
             result,
             Err(GcsRequestError::MissingGcsCredentials)
@@ -741,7 +828,7 @@ mod tests {
             }),
             ..Default::default()
         });
-        let result = resolve_url_and_token(&stage, "file.csv.gz");
+        let result = resolve_url_and_token(&stage, "file.csv.gz", None);
         assert!(matches!(
             result,
             Err(GcsRequestError::MissingGcsCredentials)

--- a/sf_core/src/file_manager/mod.rs
+++ b/sf_core/src/file_manager/mod.rs
@@ -306,17 +306,24 @@ pub async fn download_files(
 ) -> Result<Vec<DownloadResult>, FileManagerError> {
     let mut results = Vec::new();
 
-    for (file_location, encryption_material) in data
+    // Three-way zip: src_locations / encryption_materials / presigned_urls.
+    // `presigned_urls` is built in `query_response::to_file_download_data` to
+    // be the same length as `src_locations` (padded with `None` when GS
+    // omitted entries) so the zip never silently drops a file. See
+    // `DownloadData.presigned_urls` doc-comment for the alignment invariant.
+    let download_iter = data
         .src_locations
         .drain(..)
         .zip(data.encryption_materials.drain(..))
-    {
+        .zip(data.presigned_urls.drain(..));
+    for ((file_location, encryption_material), presigned_url) in download_iter {
         let stage_info = current_stage_info(&data.stage_info, refresher.as_deref());
         let single_download_data = SingleDownloadData {
             src_location: file_location,
             local_location: data.local_location.clone(),
             stage_info,
             encryption_material,
+            presigned_url,
             flavor: data.flavor.clone(),
         };
 
@@ -339,16 +346,24 @@ pub async fn download_single_file(
         cloud_byte_count,
     } = match data.stage_info.location_type {
         LocationType::S3 => {
+            // `data.presigned_url` is GCS-only; S3 ignores it (uses STS creds).
             download_from_s3(&data.stage_info, data.src_location.as_str(), refresher)
                 .await
                 .context(S3DownloadSnafu)?
         }
-        LocationType::Gcs => download_from_gcs(&data.stage_info, data.src_location.as_str())
-            .await
-            .context(GcsDownloadSnafu)?,
-        LocationType::Azure => download_from_azure(&data.stage_info, data.src_location.as_str())
-            .await
-            .context(AzureDownloadSnafu)?,
+        LocationType::Gcs => download_from_gcs(
+            &data.stage_info,
+            data.src_location.as_str(),
+            data.presigned_url.as_deref(),
+        )
+        .await
+        .context(GcsDownloadSnafu)?,
+        LocationType::Azure => {
+            // `data.presigned_url` is GCS-only; Azure ignores it (uses SAS).
+            download_from_azure(&data.stage_info, data.src_location.as_str())
+                .await
+                .context(AzureDownloadSnafu)?
+        }
     };
 
     let output_data = match data.encryption_material.as_ref() {

--- a/sf_core/src/file_manager/types.rs
+++ b/sf_core/src/file_manager/types.rs
@@ -62,6 +62,18 @@ pub struct DownloadData {
     pub local_location: String,
     pub stage_info: StageInfo,
     pub encryption_materials: Vec<Option<EncryptionMaterial>>,
+    /// Server-supplied per-file pre-signed URLs, aligned by index against
+    /// `src_locations`. `Some(url)` is the URL GS issued for that file on
+    /// GCS GET in presigned-only mode (no access token); `None` means GS
+    /// did not provide one for this file (PUT path, GET-with-token path,
+    /// S3/Azure stages, or a partial list during stage reconfiguration).
+    ///
+    /// Invariant: `presigned_urls.len() == src_locations.len()`. The
+    /// alignment is established in
+    /// `query_response::Data::to_file_download_data` and preserved by the
+    /// three-way zip in `download_files`. See
+    /// `--gcp--/2.2-server_supplied_presigned_url_list_on_download.md`.
+    pub presigned_urls: Vec<Option<String>>,
     /// Wrapper-specific shape of the GET result set. Forwarded into each
     /// `SingleDownloadData` so that `download_single_file` can populate the
     /// `size` column according to the active wrapper's contract (cloud
@@ -76,6 +88,12 @@ pub struct SingleDownloadData {
     pub local_location: String,
     pub stage_info: StageInfo,
     pub encryption_material: Option<EncryptionMaterial>,
+    /// Per-file pre-signed URL chosen by `download_files` from
+    /// `DownloadData.presigned_urls`. `Some(url)` is preferred over
+    /// `stage_info.presigned_url` (the PUT-only single slot) by the GCS
+    /// branch in `download_single_file`. The S3 and Azure branches ignore
+    /// this field — neither cloud uses a per-file URL list on GET.
+    pub presigned_url: Option<String>,
     pub flavor: PutGetResultsetFlavor,
 }
 

--- a/sf_core/src/rest/snowflake/query_response.rs
+++ b/sf_core/src/rest/snowflake/query_response.rs
@@ -113,8 +113,14 @@ pub struct Data {
     _threshold: Option<i64>,
     #[serde(rename = "clientShowEncryptionParameter")]
     _show_encryption_parameter: Option<bool>,
+    /// Per-file pre-signed URLs returned by GS for GCS GET in
+    /// presigned-only mode (no `GCS_ACCESS_TOKEN`). Aligned by index
+    /// against `src_locations`. `None` when GS did not emit the field
+    /// (PUT path, GET-with-token path, S3/Azure stages). Consumed by
+    /// `to_file_download_data` and routed through `DownloadData`. See
+    /// `--gcp--/2.2-server_supplied_presigned_url_list_on_download.md`.
     #[serde(rename = "presignedUrls")]
-    _presigned_urls: Option<serde_json::Value>,
+    presigned_urls: Option<Vec<String>>,
     #[serde(rename = "kind")]
     _kind: Option<String>,
     #[serde(rename = "operation")]
@@ -478,6 +484,8 @@ impl Data {
                 None => vec![None; src_locations.len()],
             };
 
+        let presigned_urls = align_presigned_urls(self.presigned_urls.as_deref(), &src_locations);
+
         let local_location: String = self
             .local_location
             .as_ref()
@@ -491,6 +499,7 @@ impl Data {
             local_location,
             stage_info,
             encryption_materials,
+            presigned_urls,
             flavor: flavor.clone(),
         })
     }
@@ -579,6 +588,45 @@ impl Data {
             _ => None,
         }
     }
+}
+
+/// Aligns the optional server-supplied per-file pre-signed URL list to
+/// `src_locations` for routing through `DownloadData`.
+///
+/// GS guarantees `presignedUrls[i]` corresponds to `src_locations[i]` on
+/// GCS GET in presigned-only mode, but rare stage reconfigurations can
+/// emit a partial list. We mirror Python's `idx < len(...)` tolerance:
+/// shorter lists pad with `None`, longer lists are truncated with a
+/// `tracing::warn!`. Cross-driver parity:
+/// - Python connector: `gcs_storage_client.py:77` uses `meta.presigned_url
+///   or stage_info.get("presignedUrl")`, with `meta.presigned_url` set
+///   only when `idx < len(presigned_urls)` in `file_transfer_agent.py`.
+/// - JDBC: `SnowflakeFileTransferAgent.java:994-999` zips the two arrays
+///   and silently skips when sizes differ.
+///
+/// Returns a `Vec<Option<String>>` of length `src_locations.len()`. URLs
+/// are not logged — they carry signed query strings with object-scope
+/// credentials.
+fn align_presigned_urls(
+    presigned_urls: Option<&[String]>,
+    src_locations: &[String],
+) -> Vec<Option<String>> {
+    let target_len = src_locations.len();
+    let Some(urls) = presigned_urls else {
+        return vec![None; target_len];
+    };
+
+    if urls.len() > target_len {
+        tracing::warn!(
+            presigned_url_count = urls.len(),
+            src_location_count = target_len,
+            "GCS presignedUrls[] longer than src_locations[]; truncating extras"
+        );
+    }
+
+    let mut out: Vec<Option<String>> = urls.iter().take(target_len).cloned().map(Some).collect();
+    out.resize(target_len, None);
+    out
 }
 
 #[derive(Debug)]
@@ -1403,6 +1451,142 @@ mod tests {
             .to_file_download_data(&PutGetResultsetFlavor::Odbc, false)
             .unwrap();
         assert_eq!(download.flavor, PutGetResultsetFlavor::Odbc);
+    }
+
+    // ---- presignedUrls[] alignment (gap 2.2) ----
+    //
+    // Cross-driver parity: Python uses `idx < len(...)` to gate
+    // `meta.presigned_url`; JDBC zips arrays in
+    // `SnowflakeFileTransferAgent.java:994-999` and silently skips on
+    // length mismatch. Our `align_presigned_urls` matches Python's
+    // tolerance (pad short, truncate long with warn).
+
+    fn make_download_json_multi_with_urls(presigned_urls_field: &str) -> String {
+        format!(
+            r#"{{
+                "src_locations": ["a", "b", "c"],
+                "stageInfo": {{
+                    "locationType": "GCS",
+                    "location": "bucket/prefix/",
+                    "creds": {{}},
+                    "region": "us-central1"
+                }},
+                "localLocation": "/tmp/dl"
+                {presigned_urls_field}
+            }}"#
+        )
+    }
+
+    #[test]
+    fn download_data_copies_presigned_urls_when_aligned() {
+        // GS sent one URL per source file — the common GCS GET case
+        // post-2.2. Each `presigned_urls[i]` must round-trip into
+        // `DownloadData.presigned_urls[i]` exactly.
+        let json = make_download_json_multi_with_urls(r#", "presignedUrls": ["u0", "u1", "u2"]"#);
+        let data: Data = serde_json::from_str(&json).unwrap();
+        let download = data
+            .to_file_download_data(&PutGetResultsetFlavor::Python, false)
+            .unwrap();
+        assert_eq!(
+            download.presigned_urls,
+            vec![
+                Some("u0".to_string()),
+                Some("u1".to_string()),
+                Some("u2".to_string())
+            ]
+        );
+    }
+
+    #[test]
+    fn download_data_presigned_urls_none_when_field_absent() {
+        // Pre-2.2 PUT-side / S3 / Azure responses omit `presignedUrls`.
+        // The alignment helper still produces a `Vec<Option<String>>`
+        // matched to `src_locations.len()` so the downstream zip in
+        // `download_files` is well-defined.
+        let json = make_download_json_multi_with_urls("");
+        let data: Data = serde_json::from_str(&json).unwrap();
+        let download = data
+            .to_file_download_data(&PutGetResultsetFlavor::Python, false)
+            .unwrap();
+        assert_eq!(download.presigned_urls, vec![None, None, None]);
+    }
+
+    #[test]
+    fn download_data_short_presigned_urls_pads_with_none() {
+        // Stage reconfiguration mid-batch can return a partial list. Match
+        // Python's `idx < len(presigned_urls)` tolerance: pad the tail
+        // with `None` so the un-URL'd files fall back to the token (when
+        // present) or surface `MissingGcsCredentials` per-file.
+        let json = make_download_json_multi_with_urls(r#", "presignedUrls": ["u0", "u1"]"#);
+        let data: Data = serde_json::from_str(&json).unwrap();
+        let download = data
+            .to_file_download_data(&PutGetResultsetFlavor::Python, false)
+            .unwrap();
+        assert_eq!(
+            download.presigned_urls,
+            vec![Some("u0".to_string()), Some("u1".to_string()), None]
+        );
+    }
+
+    #[test]
+    #[tracing_test::traced_test]
+    fn download_data_long_presigned_urls_truncates_with_warn() {
+        // GS occasionally over-emits during stage reconfigurations. Match
+        // Python: silently truncate, but emit a structured warning so the
+        // mismatch is observable in the captured log.
+        let json = make_download_json_multi_with_urls(
+            r#", "presignedUrls": ["u0", "u1", "u2", "u3", "u4"]"#,
+        );
+        let data: Data = serde_json::from_str(&json).unwrap();
+        let download = data
+            .to_file_download_data(&PutGetResultsetFlavor::Python, false)
+            .unwrap();
+        assert_eq!(
+            download.presigned_urls,
+            vec![
+                Some("u0".to_string()),
+                Some("u1".to_string()),
+                Some("u2".to_string())
+            ]
+        );
+        assert!(
+            logs_contain("longer than src_locations"),
+            "expected truncation warning to be logged"
+        );
+        // URLs themselves must never appear in the log — they carry
+        // signed query strings with object-scope credentials.
+        assert!(
+            !logs_contain("u3"),
+            "presigned URL contents must not be logged"
+        );
+        assert!(
+            !logs_contain("u4"),
+            "presigned URL contents must not be logged"
+        );
+    }
+
+    #[test]
+    fn download_data_empty_presigned_urls_pads_to_src_locations_length() {
+        // GS may send `presignedUrls: []` on a non-presigned-only path.
+        // Treat as fully-absent: every slot becomes `None`.
+        let json = make_download_json_multi_with_urls(r#", "presignedUrls": []"#);
+        let data: Data = serde_json::from_str(&json).unwrap();
+        let download = data
+            .to_file_download_data(&PutGetResultsetFlavor::Python, false)
+            .unwrap();
+        assert_eq!(download.presigned_urls, vec![None, None, None]);
+    }
+
+    #[test]
+    fn align_presigned_urls_helper_returns_empty_when_no_src_locations() {
+        // Sanity check on the helper: zero source files means zero slots,
+        // even when GS sent a URL list (degenerate input — should not
+        // panic on the truncation path).
+        let aligned = align_presigned_urls(
+            Some(&["u0".to_string(), "u1".to_string()]),
+            &Vec::<String>::new(),
+        );
+        assert!(aligned.is_empty());
     }
 
     #[test]

--- a/sf_core/tests/integration/http/gcs_retry.rs
+++ b/sf_core/tests/integration/http/gcs_retry.rs
@@ -1,4 +1,7 @@
-use sf_core::file_manager::{CloudCredentials, LocationType, StageInfo};
+use sf_core::apis::database_driver_v1::PutGetResultsetFlavor;
+use sf_core::file_manager::{
+    CloudCredentials, DownloadData, LocationType, StageInfo, download_files,
+};
 use sf_core::sensitive::SensitiveString;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -82,7 +85,7 @@ async fn gcs_download_401_returns_token_expired() {
         .await;
 
     let stage = gcs_stage_with_presigned_url(&format!("{}/download", server.uri()));
-    let result = sf_core::file_manager::download_from_gcs(&stage, "file.csv").await;
+    let result = sf_core::file_manager::download_from_gcs(&stage, "file.csv", None).await;
 
     let err = result.unwrap_err();
     let err_str = format!("{err}");
@@ -117,7 +120,7 @@ async fn gcs_download_403_is_retried_then_succeeds() {
         .await;
 
     let stage = gcs_stage_with_presigned_url(&format!("{}/download", server.uri()));
-    let result = sf_core::file_manager::download_from_gcs(&stage, "file.csv").await;
+    let result = sf_core::file_manager::download_from_gcs(&stage, "file.csv", None).await;
 
     assert!(result.is_ok(), "403 should be retried and succeed");
     assert_eq!(
@@ -152,7 +155,7 @@ async fn gcs_download_400_with_presigned_url_is_retried() {
         .await;
 
     let stage = gcs_stage_with_presigned_url(&format!("{}/download", server.uri()));
-    let result = sf_core::file_manager::download_from_gcs(&stage, "file.csv").await;
+    let result = sf_core::file_manager::download_from_gcs(&stage, "file.csv", None).await;
 
     assert!(
         result.is_ok(),
@@ -177,7 +180,7 @@ async fn gcs_download_400_without_presigned_url_is_not_retried() {
         .await;
 
     let stage = gcs_stage_with_token(&server.uri());
-    let result = sf_core::file_manager::download_from_gcs(&stage, "file.csv").await;
+    let result = sf_core::file_manager::download_from_gcs(&stage, "file.csv", None).await;
 
     assert!(
         result.is_err(),
@@ -210,7 +213,7 @@ async fn gcs_download_404_is_not_retried() {
         .await;
 
     let stage = gcs_stage_with_presigned_url(&format!("{}/download", server.uri()));
-    let result = sf_core::file_manager::download_from_gcs(&stage, "file.csv").await;
+    let result = sf_core::file_manager::download_from_gcs(&stage, "file.csv", None).await;
 
     assert!(result.is_err(), "404 should be a hard failure");
     assert_eq!(attempt.load(Ordering::SeqCst), 1, "should NOT retry 404");
@@ -241,7 +244,7 @@ async fn gcs_download_503_is_retried_then_succeeds() {
         .await;
 
     let stage = gcs_stage_with_presigned_url(&format!("{}/download", server.uri()));
-    let result = sf_core::file_manager::download_from_gcs(&stage, "file.csv").await;
+    let result = sf_core::file_manager::download_from_gcs(&stage, "file.csv", None).await;
 
     assert!(
         result.is_ok(),
@@ -251,5 +254,126 @@ async fn gcs_download_503_is_retried_then_succeeds() {
         attempt.load(Ordering::SeqCst),
         3,
         "should have retried twice"
+    );
+}
+
+// ---------------------------------------------------------------
+// Server-supplied per-file pre-signed URL list on multi-file GET
+// (gap 2.2 — see `--gcp--/2.2-server_supplied_presigned_url_list_on_download.md`)
+// ---------------------------------------------------------------
+
+/// Stage info for presigned-only multi-file GET: no token, no PUT-side
+/// `presigned_url`; the URLs come from `DownloadData.presigned_urls`.
+fn gcs_stage_presigned_only_no_stage_url() -> StageInfo {
+    StageInfo {
+        location_type: LocationType::Gcs,
+        bucket: "test-bucket".to_string(),
+        key_prefix: "prefix/".to_string(),
+        region: "us-central1".to_string(),
+        creds: CloudCredentials::Gcs {
+            gcs_access_token: None,
+        },
+        endpoint: None,
+        presigned_url: None,
+        use_virtual_url: false,
+        use_regional_url: false,
+        use_s3_regional_url: false,
+        storage_account: None,
+    }
+}
+
+/// SSE response template (no encryption metadata headers): the body is
+/// written to disk verbatim, so the test can read it back to verify
+/// per-file routing.
+fn gcs_sse_response(body: &'static [u8]) -> ResponseTemplate {
+    ResponseTemplate::new(200)
+        .set_body_bytes(body.to_vec())
+        .insert_header("x-goog-meta-sfc-digest", "test-digest")
+}
+
+#[tokio::test]
+async fn gcs_download_files_routes_each_file_to_its_per_file_presigned_url() {
+    // Pre-2.2 this fails on the first file with `MissingGcsCredentials`
+    // because `DownloadData` carries no per-file URL slot. Post-2.2, GS's
+    // `data.presignedUrls[i]` is preserved through the pipeline and each
+    // file is fetched from its own URL — matching Python connector
+    // (`gcs_storage_client.py:77`), libsfclient (`SnowflakeGCSClient.cpp:144`),
+    // and JDBC (`SnowflakeFileTransferAgent.java:1762`).
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/presigned/a"))
+        .respond_with(gcs_sse_response(b"alpha-bytes"))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/presigned/b"))
+        .respond_with(gcs_sse_response(b"beta-bytes"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let local_location = tmp.path().to_string_lossy().to_string();
+
+    let url_a = format!("{}/presigned/a", server.uri());
+    let url_b = format!("{}/presigned/b", server.uri());
+
+    let data = DownloadData {
+        src_locations: vec!["a".to_string(), "b".to_string()],
+        local_location: local_location.clone(),
+        stage_info: gcs_stage_presigned_only_no_stage_url(),
+        encryption_materials: vec![None, None],
+        presigned_urls: vec![Some(url_a.clone()), Some(url_b.clone())],
+        flavor: PutGetResultsetFlavor::Python,
+    };
+
+    let results = download_files(data, None)
+        .await
+        .expect("multi-file presigned GET should succeed");
+
+    assert_eq!(results.len(), 2);
+    let dir = std::path::Path::new(&local_location);
+    assert_eq!(
+        std::fs::read(dir.join("a")).expect("read file a"),
+        b"alpha-bytes"
+    );
+    assert_eq!(
+        std::fs::read(dir.join("b")).expect("read file b"),
+        b"beta-bytes"
+    );
+}
+
+#[tokio::test]
+async fn gcs_download_files_fails_with_missing_credentials_when_no_url_and_no_token() {
+    // Pin the post-2.2 failure mode: the only path that still surfaces
+    // `MissingGcsCredentials` is the genuinely degenerate one (no per-file
+    // URL, no `stage_info.presigned_url`, no token). Guards against silent
+    // regressions if a future change accidentally promotes a default URL.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let local_location = tmp.path().to_string_lossy().to_string();
+
+    let data = DownloadData {
+        src_locations: vec!["a".to_string()],
+        local_location,
+        stage_info: gcs_stage_presigned_only_no_stage_url(),
+        encryption_materials: vec![None],
+        presigned_urls: vec![None],
+        flavor: PutGetResultsetFlavor::Python,
+    };
+
+    let err = download_files(data, None)
+        .await
+        .expect_err("download must fail when neither URL nor token is available");
+    // Walk the error chain (snafu wraps the leaf `MissingGcsCredentials`
+    // through `GcsDownloadError` → `FileManagerError`).
+    let chain: Vec<String> =
+        std::iter::successors(Some(&err as &dyn std::error::Error), |e| e.source())
+            .map(|e| e.to_string())
+            .collect();
+    assert!(
+        chain.iter().any(|m| m == "Missing GCS credentials"),
+        "expected MissingGcsCredentials in error chain, got: {chain:?}"
     );
 }


### PR DESCRIPTION
## Summary
- For GCS GET in presigned-only mode, GS returns one signed URL per source file in `data.presignedUrls[i]`. Today `sf_core` parses this field as `_presigned_urls: Option<serde_json::Value>` and discards it, so multi-file GET against a GCS stage with no access token fails on the first file with `MissingGcsCredentials`. This change promotes the field to `presigned_urls: Option<Vec<String>>`, plumbs a `Vec<Option<String>>` aligned to `src_locations` through `DownloadData` → `SingleDownloadData` → `download_from_gcs`, and adds a "Strategy 0" in `resolve_url_and_token` that prefers the per-file URL over `stage_info.presigned_url`.
- Length-mismatch tolerance matches Python's `idx < len(...)` guard: a short list pads with `None`, a long list is silently truncated with a structured `tracing::warn!` (URL contents never logged). Behaviour mirrors Python (`gcs_storage_client.py:77`), libsfclient (`SnowflakeGCSClient.cpp:144`), and JDBC (`SnowflakeFileTransferAgent.java:1762`).
- Internal `sf_core` change only — no public API, protobuf, or binding change. PUT path, S3, Azure, and the existing 400-retry-for-presigned-URLs policy are all preserved (the policy now triggers when *either* presigned-URL source is `Some`).

## Context
- Design contract: [`--gcp--/2.2-server_supplied_presigned_url_list_on_download.md`](https://github.com/snowflakedb/universal-driver/blob/main/--gcp--/2.2-server_supplied_presigned_url_list_on_download.md). This PR implements §3.2 verbatim.
- This is the **floor** of the GCS PUT/GET gap-closure stack (Jira: SNOW-3406389). Step 2 (gaps 2.1 + 2.4 — `StageInfoRefresher` for URL refresh on 400 and access-token renewal) stacks on top: it has nothing to refresh `presigned_urls[]` into until this step lands.
- Cross-driver parity verified against the references in the spec (`file_transfer_agent.py:1103-1117` + `gcs_storage_client.py:77` for Python; `FileTransferAgent.cpp:173-175` + `SnowflakeGCSClient.cpp:144-151` for libsfclient; `SnowflakeFileTransferAgent.java:225-239, 994-999, 1762, 1798, 1814` for JDBC).

## Test plan
New tests added in this PR:
- **Unit (`sf_core/src/rest/snowflake/query_response.rs`):** `download_data_copies_presigned_urls_when_aligned`, `download_data_presigned_urls_none_when_field_absent`, `download_data_short_presigned_urls_pads_with_none`, `download_data_long_presigned_urls_truncates_with_warn` (uses `tracing_test::traced_test` to assert the warn fires *and* that URL contents are never logged), `download_data_empty_presigned_urls_pads_to_src_locations_length`, `align_presigned_urls_helper_returns_empty_when_no_src_locations`.
- **Unit (`sf_core/src/file_manager/gcs_transfer.rs`):** `resolve_per_file_presigned_url_wins_over_stage_info_presigned_url`, `resolve_per_file_presigned_url_wins_over_bearer_token`, `resolve_falls_back_to_stage_info_presigned_url_when_per_file_is_none` (preserves PUT-side behaviour).
- **Integration (`sf_core/tests/integration/http/gcs_retry.rs`):** `gcs_download_files_routes_each_file_to_its_per_file_presigned_url` end-to-end via `wiremock` with two files mocked at distinct paths and a `tempfile::tempdir` for the local destination — asserts both files land at their distinct per-file URLs and the bytes round-trip; `gcs_download_files_fails_with_missing_credentials_when_no_url_and_no_token` pins the post-2.2 failure mode for the genuinely degenerate case.
- Existing `resolve_with_bearer_token`, `resolve_with_presigned_url`, `resolve_with_no_token_and_no_presigned_url_returns_error`, `resolve_with_s3_creds_returns_error`, `gcs_retry_policy_*` tests, and the six `gcs_download_*` integration tests in `gcs_retry.rs` were updated to thread the new `Option<&str>` argument through and continue to pass — preserving the PUT-side regression coverage called out in the spec test plan.

Commands run locally:

```
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test -p sf_core --lib
cargo test -p sf_core --test integration_tests -- gcs put_get http
```

Results:
- `cargo fmt`: clean.
- `cargo clippy --workspace --all-targets -- -D warnings`: clean (entire workspace).
- `cargo test -p sf_core --lib`: **1007 passed; 0 failed; 1 ignored**.
- `cargo test -p sf_core --test integration_tests -- gcs put_get http`: **34 passed; 0 failed**, including all eight `http::gcs_retry::*` tests (six pre-existing + the two new multi-file/missing-creds tests).
- `sf ai review run` (Arctic Owl): **No issues found** across the 5 modified files. The agentic Claude reviewer was unavailable in this environment (Snowhouse OAuth token expired locally — needs `sfid` refresh), so only the static Cortex pass ran.

The unrelated `query::json_result_set*` integration tests are not run here — they require a private key in `parameters.json` which is not provisioned in this environment, and their failures are pre-existing on `main` and orthogonal to this change.

## Drift / deviations from the spec
- **File:line drift only** (no design changes): the spec's §5 test plan says to extend `sf_core/tests/integration/http/gcs_retry.rs` with the PUT-path regression tests at "~line 707, 765, 774". Those tests actually live in the unit-test module of `sf_core/src/file_manager/gcs_transfer.rs` (lines 707, 765, 774 of *that* file — `resolve_with_presigned_url`, `gcs_retry_policy_includes_400_for_presigned_urls`, `gcs_retry_policy_excludes_400_without_presigned_urls`). They were updated in place rather than duplicated into the integration suite, and continue to pass.
- No design deviations.
