### PR TITLE
Mark show_schemas JSON result test as flaky

### DIFF
--- a/sf_core/tests/integration/query/json_result_set_nulls.rs
+++ b/sf_core/tests/integration/query/json_result_set_nulls.rs
@@ -146,7 +146,8 @@ fn should_handle_null_values_in_json_result_set() {
 }
 
 #[test]
-fn should_handle_show_schemas_json_result_with_nulls() {
+#[ignore]
+fn flaky_should_handle_show_schemas_json_result_with_nulls() {
     let client = SnowflakeTestClient::connect_with_default_auth();
 
     // SHOW SCHEMAS returns JSON format with nullable columns like comment, options


### PR DESCRIPTION
## Summary
- Mark `should_handle_show_schemas_json_result_with_nulls` as flaky (`flaky_` prefix + `#[ignore]`)
- Test relies on `SHOW SCHEMAS` returning at least one row, which depends on server-side schema state
- Observed failing across 4 concurrent Rust Core CI runs (3 PRs + merge queue) at 07:10 UTC 2026-05-27, then passing on runs ~1h later on the same code

## Evidence
| Run ID | Event | Result |
|--------|-------|--------|
| 26496518027 | pull_request | FAILED (1/193) |
| 26496511768 | pull_request | FAILED (1/193) |
| 26496506391 | pull_request | FAILED (1/193) |
| 26496517029 | merge_group | FAILED (1/193) |
| 26499752658 | pull_request | PASSED |
| 26500821235 | pull_request | PASSED |

## Test plan
- [ ] Rust Core CI passes (test is now `#[ignore]`d from normal run)
- [ ] Test still runs in the "Run flaky tests (non-blocking)" step

🤖 Generated with [Claude Code](https://claude.com/claude-code)