### PR TITLE
SNOW-3406389: disable reqwest auto-gunzip on GCS storage client

### DIFF
--- a/sf_core/src/file_manager/gcs_transfer.rs
+++ b/sf_core/src/file_manager/gcs_transfer.rs
@@ -284,6 +284,18 @@ fn map_http_error(e: HttpError) -> GcsRequestError {
 fn create_gcs_client() -> Result<reqwest::Client, GcsRequestError> {
     reqwest::Client::builder()
         .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
+        // Disable reqwest's auto-gzip path so a GCS response carrying
+        // `Content-Encoding: gzip` (typically set by external loaders such
+        // as `gsutil cp -Z` or BigQuery exports) is handed to the caller
+        // verbatim. The driver is moving opaque, possibly CSE-encrypted
+        // bytes, and downstream SHA-256 digest / Content-Length checks
+        // assume wire bytes == body bytes. Mirrors JDBC's
+        // `HttpUtil.disableContentCompression()`
+        // (`SnowflakeGCSClient.java:237,:432` via `HttpUtil.java:420`) and
+        // the intent of Python's `remove_content_encoding` urllib3 hook
+        // (`storage_client.py:54-59`); the upload-side `content-encoding`
+        // strip in `upload_to_gcs` is the matching PUT-side defense.
+        .no_gzip()
         .build()
         .map_err(|source| GcsRequestError::Http { source })
 }

--- a/sf_core/tests/integration/http/gcs_retry.rs
+++ b/sf_core/tests/integration/http/gcs_retry.rs
@@ -1,5 +1,8 @@
+use flate2::Compression;
+use flate2::write::GzEncoder;
 use sf_core::file_manager::{CloudCredentials, LocationType, StageInfo};
 use sf_core::sensitive::SensitiveString;
+use std::io::Write;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
 use wiremock::matchers::{method, path};
@@ -251,5 +254,175 @@ async fn gcs_download_503_is_retried_then_succeeds() {
         attempt.load(Ordering::SeqCst),
         3,
         "should have retried twice"
+    );
+}
+
+// ---------------------------------------------------------------
+// Response-side gzip auto-decode is disabled on the GCS client
+// (matches JDBC `HttpUtil.disableContentCompression()` at
+//   `HttpUtil.java:420`, used by `SnowflakeGCSClient.java:237,:432`;
+//  Python `remove_content_encoding` hook at `storage_client.py:54-59`
+//   — see `--gcp--/2.6-response_gzip_workaround.md`).
+//
+// External tooling (`gsutil cp -Z`, BigQuery exports, customer ETL)
+// can land objects on a stage whose stored metadata advertises
+// `Content-Encoding: gzip` while the body is the raw payload (or, for
+// CSE stages, ciphertext). The driver must hand the body to the caller
+// verbatim — otherwise CSE decrypt and the SHA-256/Content-Length
+// checks (gaps 2.3, 2.5) silently fail.
+// ---------------------------------------------------------------
+
+fn gzip_encode(payload: &[u8]) -> Vec<u8> {
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(payload).expect("gzip encode write");
+    encoder.finish().expect("gzip encode finish")
+}
+
+/// A GCS response that claims `Content-Encoding: gzip` but ships a
+/// non-gzip body. With reqwest auto-decompression on, the body reader
+/// would either error (gunzip on non-gzip bytes) or return decoded
+/// garbage; either way the caller wouldn't see the wire bytes.
+#[tokio::test]
+async fn gcs_download_content_encoding_gzip_with_non_gzip_body_is_returned_verbatim() {
+    let server = MockServer::start().await;
+
+    let payload: &[u8] = b"hello world (raw plaintext, NOT gzip)";
+
+    Mock::given(method("GET"))
+        .and(path("/download"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(payload.to_vec())
+                .insert_header("content-encoding", "gzip")
+                .insert_header("x-goog-meta-sfc-digest", "test-digest"),
+        )
+        .mount(&server)
+        .await;
+
+    let stage = gcs_stage_with_presigned_url(&format!("{}/download", server.uri()));
+    let result = sf_core::file_manager::download_from_gcs(&stage, "file.csv").await;
+
+    let response = result.expect(
+        "download must succeed: reqwest auto-gunzip must be disabled on the GCS client \
+         (otherwise the body reader errors on non-gzip bytes)",
+    );
+    assert_eq!(
+        response.data, payload,
+        "wire body bytes must reach the caller verbatim (no auto-decode)"
+    );
+    assert_eq!(
+        response.cloud_byte_count,
+        payload.len() as i64,
+        "cloud_byte_count must reflect the wire bytes"
+    );
+}
+
+/// Even when the body is *valid* gzip and the header says `gzip`, the
+/// driver must hand the caller the compressed wire bytes — proving the
+/// auto-decoder is off (positive byte-equality, not just "did not
+/// error"). This is the case that matters for CSE: ciphertext that
+/// happens to follow the gzip magic must not be re-decoded.
+#[tokio::test]
+async fn gcs_download_content_encoding_gzip_with_gzip_body_is_not_decoded() {
+    let server = MockServer::start().await;
+
+    let raw_payload: &[u8] = b"raw bytes that were gzipped on the way in";
+    let gzipped = gzip_encode(raw_payload);
+    assert_ne!(
+        gzipped, raw_payload,
+        "sanity: gzip output should differ from input"
+    );
+
+    let body_for_mock = gzipped.clone();
+    Mock::given(method("GET"))
+        .and(path("/download"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(body_for_mock)
+                .insert_header("content-encoding", "gzip")
+                .insert_header("x-goog-meta-sfc-digest", "test-digest"),
+        )
+        .mount(&server)
+        .await;
+
+    let stage = gcs_stage_with_presigned_url(&format!("{}/download", server.uri()));
+    let response = sf_core::file_manager::download_from_gcs(&stage, "file.csv")
+        .await
+        .expect("download must succeed");
+
+    assert_eq!(
+        response.data, gzipped,
+        "driver must return the gzipped wire bytes, NOT the decoded payload"
+    );
+    assert_ne!(
+        response.data, raw_payload,
+        "if this fires, reqwest auto-gunzip ran — the .no_gzip() fix has regressed"
+    );
+}
+
+/// Regression guard: a response with no `Content-Encoding` header
+/// behaves identically to the pre-fix happy path.
+#[tokio::test]
+async fn gcs_download_without_content_encoding_header_is_unchanged() {
+    let server = MockServer::start().await;
+
+    let payload: &[u8] = b"plain body, no Content-Encoding header";
+
+    Mock::given(method("GET"))
+        .and(path("/download"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(payload.to_vec())
+                .insert_header("x-goog-meta-sfc-digest", "test-digest"),
+        )
+        .mount(&server)
+        .await;
+
+    let stage = gcs_stage_with_presigned_url(&format!("{}/download", server.uri()));
+    let response = sf_core::file_manager::download_from_gcs(&stage, "file.csv")
+        .await
+        .expect("happy-path download must still succeed");
+
+    assert_eq!(response.data, payload);
+}
+
+/// The GCS download path must not advertise `Accept-Encoding: gzip` on
+/// the wire either. `.no_gzip()` on reqwest also suppresses the
+/// automatic `Accept-Encoding` header injection — mirroring libcurl's
+/// default (no opt-in) and JDBC's `disableContentCompression`. This
+/// guards against a future regression where someone calls `.gzip(true)`
+/// or removes `.no_gzip()` and only the auto-decoder check is asserted.
+#[tokio::test]
+async fn gcs_download_does_not_advertise_gzip_accept_encoding() {
+    let server = MockServer::start().await;
+
+    let payload: &[u8] = b"plain body";
+
+    Mock::given(method("GET"))
+        .and(path("/download"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(payload.to_vec())
+                .insert_header("x-goog-meta-sfc-digest", "test-digest"),
+        )
+        .mount(&server)
+        .await;
+
+    let stage = gcs_stage_with_presigned_url(&format!("{}/download", server.uri()));
+    sf_core::file_manager::download_from_gcs(&stage, "file.csv")
+        .await
+        .expect("download must succeed");
+
+    let requests = server.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1, "exactly one GET expected");
+    let accept_encoding = requests[0]
+        .headers
+        .get("accept-encoding")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    assert!(
+        !accept_encoding.to_ascii_lowercase().contains("gzip"),
+        "GCS GET must not advertise gzip in Accept-Encoding (reqwest .no_gzip() also \
+         suppresses the auto-injected header); got: {accept_encoding:?}"
     );
 }


### PR DESCRIPTION
## Summary

- Add `.no_gzip()` to `create_gcs_client` in `sf_core/src/file_manager/gcs_transfer.rs` so reqwest no longer auto-decompresses GCS GET responses that carry `Content-Encoding: gzip`. This eliminates silent corruption of CSE-encrypted downloads and of any stage object written by external tooling (`gsutil cp -Z`, BigQuery exports, customer ETL) that tags the object with gzip while the body is the natural-format payload.
- One-line behavioral change, scoped to the GCS storage HTTP client. No public API, protobuf, binding (Python / ODBC / JDBC), or `Cargo.toml` change. The shared TLS client (`tls/client.rs`), the control-plane / telemetry / OAuth clients, the Azure SAS client (`azure_transfer.rs`), and the CRL fetcher (`crl/cache.rs`) are intentionally untouched — gzip on control-plane JSON paths is still desirable.
- The upload-side `content-encoding: ""` strip in `upload_to_gcs` is unchanged and remains the PUT-side complement; driver-only round-trips are unaffected.

## Context

Design contract: [`--gcp--/2.6-response_gzip_workaround.md`](../blob/main/--gcp--/2.6-response_gzip_workaround.md). Master plan: [`--gcp--/IMPLEMENTATION_PLAN.md`](../blob/main/--gcp--/IMPLEMENTATION_PLAN.md) — this is Step 3 of the GCS PUT/GET gap-closure stack under `SNOW-3406389`.

**Why this must land before steps 4 and 5.** With auto-gunzip on, `Content-Length` (gap 2.5) compares the compressed wire size to the decompressed body length and fires spuriously, and the SHA-256 digest in `x-goog-meta-sfc-digest` (gap 2.3) is computed over stored bytes that no longer match what `download_from_gcs` sees. This step removes both blast-radius interactions before the dependent gaps land.

**Parity with reference drivers.**
- JDBC: `HttpUtil.disableContentCompression()` (`HttpUtil.java:420`), wired in via `SnowflakeGCSClient.java:237,:432` — direct analog.
- libsfclient: default libcurl behavior is no auto-decompression; the `CURLOPT_ACCEPT_ENCODING` opt-in at `http_perform.c:485` is gated to the chunk downloader, never to GCS file transfers.
- Python: `remove_content_encoding` urllib3 hook (`storage_client.py:54-59`) — the intent we mirror, though Python's connector installs the hook only on S3. sf_core now has the JDBC-strength defense.

## Test plan

```bash
cargo fmt --all -- --check                            # clean
cargo clippy -p sf_core --all-targets -- -D warnings  # clean
cargo test  -p sf_core --lib                          # 998 passed, 1 ignored
cargo test  -p sf_core --lib file_manager::gcs_transfer   # 36 passed
cargo test  -p sf_core --test integration_tests -- http:: # 34 passed
cargo test  -p sf_core --test integration_tests -- http::gcs   # 10 passed (6 existing + 4 new)
cargo test  -p sf_core --lib rest::snowflake::telemetry        # 3 passed
```

Four new wiremock-backed integration tests in `sf_core/tests/integration/http/gcs_retry.rs`:

| Test | Asserts |
|---|---|
| `gcs_download_content_encoding_gzip_with_non_gzip_body_is_returned_verbatim` | Response with `Content-Encoding: gzip` header and a non-gzip body succeeds and returns the wire bytes byte-for-byte (would error with "Invalid gzip header" before the fix). |
| `gcs_download_content_encoding_gzip_with_gzip_body_is_not_decoded` | Response with a valid gzip body and `Content-Encoding: gzip` returns the *compressed* wire bytes — positive byte-equality that proves the auto-decoder is off (would return the decoded payload before the fix). |
| `gcs_download_without_content_encoding_header_is_unchanged` | Happy-path regression guard — body returned verbatim when no `Content-Encoding` is present. |
| `gcs_download_does_not_advertise_gzip_accept_encoding` | The outbound `Accept-Encoding` header does not contain `gzip` (would contain `gzip` before the fix; `.no_gzip()` also suppresses reqwest's auto-injection). Guards against someone replacing `.no_gzip()` with `.gzip(true)` without also updating the body-side assertions. |

**Negative-case isolation check (per Step 3 prompt §8.5):** temporarily removed `.no_gzip()` from `create_gcs_client` and confirmed all three new no-gzip tests fail in the predicted way — one with a `reqwest::Error { kind: Decode, source: "Invalid gzip header" }`, one with a byte-mismatch between gzipped wire bytes and decoded payload, one with `accept-encoding: "gzip"` advertised on the wire. Restored the fix; full suite green again.

**Existing-test regression sweep:** `http::gcs_retry::*` (6 tests covering 401/403/400/404/503 retry paths) and `rest::snowflake::telemetry::*` (the `accept-encoding: gzip, deflate` assertion at `telemetry.rs:153` — proves the gzip feature stays globally enabled and only the GCS client opts out) all still pass.

## Drift report

Confirmed against the spec at the time of this PR:

- `sf_core/Cargo.toml:32` still declares `reqwest = { version = "0.12.23", features = ["json", "rustls-tls", "gzip"] }`. The gzip feature is on — `telemetry.rs:153` asserts `accept-encoding: gzip, deflate` is emitted live — so this is an **active** gap, not theoretical. The condition under which the prompt allowed a downgrade to a defensive `debug_assert!` does **not** apply; the full fix is shipped.
- `sf_core/src/file_manager/gcs_transfer.rs` `create_gcs_client` is at lines 284-289 as cited.
- `sf_core/src/file_manager/gcs_transfer.rs` upload-side `.header("content-encoding", "")` is at line 193 as cited; left untouched.
- Storage-client audit: `create_gcs_client` is the only reqwest builder in `sf_core/src/**` that touches GCS storage URLs. `connection.rs:2493` is a test helper for the control-plane client; `tls/client.rs` builds the shared TLS client (not used by GCS today); `crl/cache.rs:462` is the CRL fetcher; `azure_transfer.rs:254` is Azure (out of scope per spec §6 and §8 — tracked separately). No shared-client cross-bleed risk.
- Option taken: **Option A** (`.no_gzip()` on the storage `ClientBuilder`) per spec §5.4 recommendation. The reqwest 0.12.23 `ClientBuilder::no_gzip` symbol is present; the fallback to `.gzip(false) + Accept-Encoding: identity` (option B) was not needed.
- No `bindings/` changes (verified by inspecting the call chain `download_from_gcs` → `cursor.execute("GET …")`).

## Review deferrals

- **Arctic Owl rule-based review (`sf ai review run`):** clean — 0 comments, no eligible findings on the 2 changed files.
- **Arctic Owl agentic / Claude reviewer:** could not run from the agent's non-interactive shell because the local Snowhouse OAuth token is expired and `sfid` refresh requires a TTY for Okta. The change is one line of behavioral diff (`.no_gzip()`) plus a docstring and four wiremock tests; the rule-based pass, the manual self-review (scope, comment quality, negative-case isolation, parity with JDBC / libsfclient / Python) and the green regression sweep cover the residual risk. **No High/Medium findings deferred.**
- **ODBC-test reviewer:** N/A — no `bindings/odbc/**` changes (verified with `git diff main -- bindings/`, empty).
