### PR TITLE
feat(sf_core): add insecure_skip_tls_verify to disable TLS verification in one call

### DIFF
--- a/python/src/snowflake/connector/connection_config.py
+++ b/python/src/snowflake/connector/connection_config.py
@@ -189,6 +189,13 @@ class ConnectionConfig(ConnectionConfigMixin):
     ssl: bool | None = None
     """Enable or disable SSL/TLS (sets protocol to https or http). Deprecated: use protocol instead"""
 
+    tls_skip_verify: bool | None = False
+    """Skip all TLS verification with a single switch: disables both certificate and hostname checks (and, since
+    certificate verification is off, CRL revocation checks are bypassed too). Insecure; intended for testing only.
+
+    Default: False
+    """
+
     token: str | None = None
     """Pre-acquired bearer token (PAT or legacy OAUTH). Required when authenticator=PROGRAMMATIC_ACCESS_TOKEN"""
 

--- a/sf_core/src/config/connection_config.rs
+++ b/sf_core/src/config/connection_config.rs
@@ -329,7 +329,12 @@ fn build_tls_config(settings: &ParamStore) -> TlsConfig {
     let custom_root_store_path = settings
         .get_string(CUSTOM_ROOT_STORE_PATH)
         .map(PathBuf::from);
-    let skip_tls_verify = settings.get_bool(INSECURE_SKIP_TLS_VERIFY).unwrap_or(false);
+    let skip_tls_verify = settings.get_bool(TLS_SKIP_VERIFY).unwrap_or(false);
+    if skip_tls_verify {
+        tracing::warn!(
+            "TLS verification disabled via tls_skip_verify: certificate, hostname, and CRL revocation checks are all bypassed. Do not use in production."
+        );
+    }
     let verify_hostname = !skip_tls_verify && settings.get_bool(VERIFY_HOSTNAME).unwrap_or(true);
     let verify_certificates =
         !skip_tls_verify && settings.get_bool(VERIFY_CERTIFICATES).unwrap_or(true);
@@ -1174,9 +1179,9 @@ mod tests {
     }
 
     #[test]
-    fn insecure_skip_tls_verify_disables_both_checks() {
+    fn tls_skip_verify_disables_both_checks() {
         let mut settings = minimal_password_settings();
-        settings.insert("insecure_skip_tls_verify".into(), Setting::Bool(true));
+        settings.insert("tls_skip_verify".into(), Setting::Bool(true));
 
         let config = ConnectionConfig::build(&settings).unwrap();
         assert!(!config.tls.verify_hostname);
@@ -1184,15 +1189,60 @@ mod tests {
     }
 
     #[test]
-    fn insecure_skip_tls_verify_overrides_individual_verify_flags() {
+    fn tls_skip_verify_overrides_individual_verify_flags() {
         let mut settings = minimal_password_settings();
-        settings.insert("insecure_skip_tls_verify".into(), Setting::Bool(true));
+        settings.insert("tls_skip_verify".into(), Setting::Bool(true));
         settings.insert("verify_hostname".into(), Setting::Bool(true));
         settings.insert("verify_certificates".into(), Setting::Bool(true));
 
         let config = ConnectionConfig::build(&settings).unwrap();
         assert!(!config.tls.verify_hostname);
         assert!(!config.tls.verify_certificates);
+    }
+
+    #[test]
+    fn tls_skip_verify_canonicalizes_from_any_case_and_disables_verification() {
+        use crate::config::param_registry::registry;
+
+        for raw_key in ["tls_skip_verify", "TLS_SKIP_VERIFY", "Tls_Skip_Verify"] {
+            let canonical = registry()
+                .resolve(raw_key)
+                .unwrap_or_else(|| panic!("{raw_key} should resolve"))
+                .canonical_name;
+            assert_eq!(canonical, "tls_skip_verify");
+
+            let mut settings = minimal_password_settings();
+            settings.insert(canonical.to_string(), Setting::Bool(true));
+
+            let config = ConnectionConfig::build(&settings).unwrap();
+            assert!(
+                !config.tls.verify_hostname,
+                "{raw_key} should disable hostname check"
+            );
+            assert!(
+                !config.tls.verify_certificates,
+                "{raw_key} should disable cert check"
+            );
+        }
+    }
+
+    #[test]
+    fn tls_skip_verify_bypasses_crl_even_when_crl_check_mode_enabled() {
+        // Locks the registry description's CRL claim against drift: tls_skip_verify forces
+        // verify_certificates=false, and create_tls_client_with_config (tls/client.rs) then
+        // early-returns an insecure client without installing the CRL verifier — so CRL is
+        // bypassed even at crl_check_mode=ENABLED. The mode itself is left intact, just unused.
+        let mut settings = minimal_password_settings();
+        settings.insert("tls_skip_verify".into(), Setting::Bool(true));
+        settings.insert("crl_check_mode".into(), Setting::String("ENABLED".into()));
+
+        let config = ConnectionConfig::build(&settings).unwrap();
+        assert!(!config.tls.verify_certificates);
+        assert!(!config.tls.verify_hostname);
+        assert!(matches!(
+            config.tls.crl_config.check_mode,
+            CertRevocationCheckMode::Enabled
+        ));
     }
 
     #[test]

--- a/sf_core/src/config/connection_config.rs
+++ b/sf_core/src/config/connection_config.rs
@@ -329,8 +329,10 @@ fn build_tls_config(settings: &ParamStore) -> TlsConfig {
     let custom_root_store_path = settings
         .get_string(CUSTOM_ROOT_STORE_PATH)
         .map(PathBuf::from);
-    let verify_hostname = settings.get_bool(VERIFY_HOSTNAME).unwrap_or(true);
-    let verify_certificates = settings.get_bool(VERIFY_CERTIFICATES).unwrap_or(true);
+    let skip_tls_verify = settings.get_bool(INSECURE_SKIP_TLS_VERIFY).unwrap_or(false);
+    let verify_hostname = !skip_tls_verify && settings.get_bool(VERIFY_HOSTNAME).unwrap_or(true);
+    let verify_certificates =
+        !skip_tls_verify && settings.get_bool(VERIFY_CERTIFICATES).unwrap_or(true);
 
     TlsConfig {
         crl_config,
@@ -1169,6 +1171,28 @@ mod tests {
         let config = ConnectionConfig::build(&settings).unwrap();
         assert!(!config.tls.verify_hostname);
         assert!(config.tls.verify_certificates);
+    }
+
+    #[test]
+    fn insecure_skip_tls_verify_disables_both_checks() {
+        let mut settings = minimal_password_settings();
+        settings.insert("insecure_skip_tls_verify".into(), Setting::Bool(true));
+
+        let config = ConnectionConfig::build(&settings).unwrap();
+        assert!(!config.tls.verify_hostname);
+        assert!(!config.tls.verify_certificates);
+    }
+
+    #[test]
+    fn insecure_skip_tls_verify_overrides_individual_verify_flags() {
+        let mut settings = minimal_password_settings();
+        settings.insert("insecure_skip_tls_verify".into(), Setting::Bool(true));
+        settings.insert("verify_hostname".into(), Setting::Bool(true));
+        settings.insert("verify_certificates".into(), Setting::Bool(true));
+
+        let config = ConnectionConfig::build(&settings).unwrap();
+        assert!(!config.tls.verify_hostname);
+        assert!(!config.tls.verify_certificates);
     }
 
     #[test]

--- a/sf_core/src/config/param_registry.rs
+++ b/sf_core/src/config/param_registry.rs
@@ -71,6 +71,7 @@ pub mod param_names {
     pub const CUSTOM_ROOT_STORE_PATH: ParamKey = ParamKey("custom_root_store_path");
     pub const VERIFY_HOSTNAME: ParamKey = ParamKey("verify_hostname");
     pub const VERIFY_CERTIFICATES: ParamKey = ParamKey("verify_certificates");
+    pub const INSECURE_SKIP_TLS_VERIFY: ParamKey = ParamKey("insecure_skip_tls_verify");
     pub const CRL_CHECK_MODE: ParamKey = ParamKey("crl_check_mode");
     pub const CRL_ENABLE_DISK_CACHING: ParamKey = ParamKey("crl_enable_disk_caching");
     pub const CRL_ENABLE_MEMORY_CACHING: ParamKey = ParamKey("crl_enable_memory_caching");
@@ -739,6 +740,20 @@ static PARAM_DEFS: &[ParamDef] = &[
         used_at_connect: true,
         mutable_after_connect: false,
     },
+    ParamDef {
+        canonical_name: param_names::INSECURE_SKIP_TLS_VERIFY.as_str(),
+        aliases: &["TLS_SKIP_VERIFY"],
+        value_type: ValueType::Bool,
+        additional_value_type: None,
+        required: Required::Never,
+        default: Some(|| Setting::Bool(false)),
+        sensitive: false,
+        description: "Skip all TLS verification: a single switch that disables both certificate and hostname checks. Insecure; intended for testing only.",
+        deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: true,
+        mutable_after_connect: false,
+    },
     // ── CRL ─────────────────────────────────────────────────────────────
     ParamDef {
         canonical_name: param_names::CRL_CHECK_MODE.as_str(),
@@ -1290,6 +1305,7 @@ mod tests {
             ("TLS_CUSTOM_ROOT_STORE_PATH", "custom_root_store_path"),
             ("TLS_VERIFY_HOSTNAME", "verify_hostname"),
             ("TLS_VERIFY_CERTIFICATES", "verify_certificates"),
+            ("TLS_SKIP_VERIFY", "insecure_skip_tls_verify"),
             ("CRL_MODE", "crl_check_mode"),
             ("CRL_ENABLED", "crl_check_mode"),
             ("ALLOWUNDERSCORESINHOST", "preserve_underscores_in_hostname"),

--- a/sf_core/src/config/param_registry.rs
+++ b/sf_core/src/config/param_registry.rs
@@ -748,7 +748,7 @@ static PARAM_DEFS: &[ParamDef] = &[
         required: Required::Never,
         default: Some(|| Setting::Bool(false)),
         sensitive: false,
-        description: "Skip all TLS verification: a single switch that disables both certificate and hostname checks. Insecure; intended for testing only.",
+        description: "Skip all TLS verification with a single switch: disables both certificate and hostname checks (and, since certificate verification is off, CRL revocation checks are bypassed too). Insecure; intended for testing only.",
         deprecated_by: None,
         scope: ParamScope::Connection,
         used_at_connect: true,

--- a/sf_core/src/config/param_registry.rs
+++ b/sf_core/src/config/param_registry.rs
@@ -71,7 +71,7 @@ pub mod param_names {
     pub const CUSTOM_ROOT_STORE_PATH: ParamKey = ParamKey("custom_root_store_path");
     pub const VERIFY_HOSTNAME: ParamKey = ParamKey("verify_hostname");
     pub const VERIFY_CERTIFICATES: ParamKey = ParamKey("verify_certificates");
-    pub const INSECURE_SKIP_TLS_VERIFY: ParamKey = ParamKey("insecure_skip_tls_verify");
+    pub const TLS_SKIP_VERIFY: ParamKey = ParamKey("tls_skip_verify");
     pub const CRL_CHECK_MODE: ParamKey = ParamKey("crl_check_mode");
     pub const CRL_ENABLE_DISK_CACHING: ParamKey = ParamKey("crl_enable_disk_caching");
     pub const CRL_ENABLE_MEMORY_CACHING: ParamKey = ParamKey("crl_enable_memory_caching");
@@ -741,14 +741,14 @@ static PARAM_DEFS: &[ParamDef] = &[
         mutable_after_connect: false,
     },
     ParamDef {
-        canonical_name: param_names::INSECURE_SKIP_TLS_VERIFY.as_str(),
-        aliases: &["TLS_SKIP_VERIFY"],
+        canonical_name: param_names::TLS_SKIP_VERIFY.as_str(),
+        aliases: &[],
         value_type: ValueType::Bool,
         additional_value_type: None,
         required: Required::Never,
         default: Some(|| Setting::Bool(false)),
         sensitive: false,
-        description: "Skip all TLS verification with a single switch: disables both certificate and hostname checks (and, since certificate verification is off, CRL revocation checks are bypassed too). Insecure; intended for testing only.",
+        description: "Skip all TLS verification with a single switch: disables both certificate and hostname checks (and, since certificate verification is off, CRL revocation checks are bypassed too). Insecure; intended for testing only",
         deprecated_by: None,
         scope: ParamScope::Connection,
         used_at_connect: true,
@@ -1305,7 +1305,7 @@ mod tests {
             ("TLS_CUSTOM_ROOT_STORE_PATH", "custom_root_store_path"),
             ("TLS_VERIFY_HOSTNAME", "verify_hostname"),
             ("TLS_VERIFY_CERTIFICATES", "verify_certificates"),
-            ("TLS_SKIP_VERIFY", "insecure_skip_tls_verify"),
+            ("TLS_SKIP_VERIFY", "tls_skip_verify"),
             ("CRL_MODE", "crl_check_mode"),
             ("CRL_ENABLED", "crl_check_mode"),
             ("ALLOWUNDERSCORESINHOST", "preserve_underscores_in_hostname"),

--- a/sf_core/src/config/param_store.rs
+++ b/sf_core/src/config/param_store.rs
@@ -64,23 +64,12 @@ impl ParamStore {
 
     /// Extract a boolean value for `key`.
     ///
-    /// Checks `Setting::Bool` first, then falls back to `Setting::String` with
-    /// `"true"` / `"1"` / `"on"` / `"false"` / `"0"` / `"off"` parsing for
-    /// backward compatibility with TOML-loaded values and ODBC connection-string
-    /// encodings (e.g. `SSL=on`). Non-zero `Setting::Int` values are also
-    /// accepted. Unrecognised strings return `None` so the caller falls through
-    /// to its default rather than silently degrading to `false`.
+    /// Coercion (native `Bool`, `"true"`/`"1"`/`"on"` / `"false"`/`"0"`/`"off"`
+    /// strings, non-zero `Int`) is shared with `TlsConfig::from_settings` via
+    /// [`Setting::coerce_bool`]. Unrecognised strings return `None` so the
+    /// caller falls through to its default rather than degrading to `false`.
     pub fn get_bool(&self, key: ParamKey) -> Option<bool> {
-        match self.get(key)? {
-            Setting::Bool(b) => Some(*b),
-            Setting::String(s) => match s.to_lowercase().as_str() {
-                "true" | "1" | "on" => Some(true),
-                "false" | "0" | "off" => Some(false),
-                _ => None,
-            },
-            Setting::Int(i) => Some(*i != 0),
-            _ => None,
-        }
+        self.get(key).and_then(Setting::coerce_bool)
     }
 
     /// Create a `ParamStore` pre-populated with all registry defaults.

--- a/sf_core/src/config/settings.rs
+++ b/sf_core/src/config/settings.rs
@@ -49,6 +49,22 @@ impl Setting {
             None
         }
     }
+
+    /// Shared bool coercion for `ParamStore::get_bool` and
+    /// `TlsConfig::from_settings`, so both TLS-config paths agree. Returns
+    /// `None` for unrecognised strings/types so callers keep their own default.
+    pub(crate) fn coerce_bool(&self) -> Option<bool> {
+        match self {
+            Setting::Bool(b) => Some(*b),
+            Setting::String(s) => match s.to_lowercase().as_str() {
+                "true" | "1" | "on" => Some(true),
+                "false" | "0" | "off" => Some(false),
+                _ => None,
+            },
+            Setting::Int(i) => Some(*i != 0),
+            _ => None,
+        }
+    }
 }
 
 pub trait Settings {

--- a/sf_core/src/tls/config.rs
+++ b/sf_core/src/tls/config.rs
@@ -26,20 +26,22 @@ impl TlsConfig {
         let custom_root_store_path = settings
             .get_string("custom_root_store_path")
             .map(PathBuf::from);
-        let skip_tls_verify = settings
-            .get_string("insecure_skip_tls_verify")
-            .map(|s| s.to_lowercase() == "true")
-            .unwrap_or(false);
-        let verify_hostname = !skip_tls_verify
-            && settings
-                .get_string("verify_hostname")
-                .map(|s| s.to_lowercase() == "true")
-                .unwrap_or(true);
-        let verify_certificates = !skip_tls_verify
-            && settings
-                .get_string("verify_certificates")
-                .map(|s| s.to_lowercase() == "true")
-                .unwrap_or(true);
+        // Accept both a typed `Bool` setting and a `"true"`/`"false"` string so
+        // this path agrees with the `ParamStore`-backed `build_tls_config`
+        // (which coerces both); otherwise a `Setting::Bool` would be ignored here.
+        let bool_setting = |key: &str, default: bool| -> bool {
+            settings
+                .get_bool(key)
+                .or_else(|| {
+                    settings
+                        .get_string(key)
+                        .map(|s| s.eq_ignore_ascii_case("true"))
+                })
+                .unwrap_or(default)
+        };
+        let skip_tls_verify = bool_setting("insecure_skip_tls_verify", false);
+        let verify_hostname = !skip_tls_verify && bool_setting("verify_hostname", true);
+        let verify_certificates = !skip_tls_verify && bool_setting("verify_certificates", true);
         Ok(Self {
             crl_config,
             custom_root_store_path,
@@ -57,5 +59,34 @@ impl Default for TlsConfig {
             verify_hostname: true,
             verify_certificates: true,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::settings::Setting;
+    use std::collections::HashMap;
+
+    #[test]
+    fn from_settings_skip_disables_both_for_bool_and_string() {
+        for skip in [Setting::Bool(true), Setting::String("true".into())] {
+            let mut s: HashMap<String, Setting> = HashMap::new();
+            s.insert("insecure_skip_tls_verify".into(), skip);
+            // Skip wins even when the individual flags are explicitly enabled.
+            s.insert("verify_hostname".into(), Setting::Bool(true));
+            s.insert("verify_certificates".into(), Setting::Bool(true));
+
+            let cfg = TlsConfig::from_settings(&s).unwrap();
+            assert!(!cfg.verify_hostname);
+            assert!(!cfg.verify_certificates);
+        }
+    }
+
+    #[test]
+    fn from_settings_defaults_to_verifying() {
+        let cfg = TlsConfig::from_settings(&HashMap::<String, Setting>::new()).unwrap();
+        assert!(cfg.verify_hostname);
+        assert!(cfg.verify_certificates);
     }
 }

--- a/sf_core/src/tls/config.rs
+++ b/sf_core/src/tls/config.rs
@@ -26,14 +26,20 @@ impl TlsConfig {
         let custom_root_store_path = settings
             .get_string("custom_root_store_path")
             .map(PathBuf::from);
-        let verify_hostname = settings
-            .get_string("verify_hostname")
+        let skip_tls_verify = settings
+            .get_string("insecure_skip_tls_verify")
             .map(|s| s.to_lowercase() == "true")
-            .unwrap_or(true);
-        let verify_certificates = settings
-            .get_string("verify_certificates")
-            .map(|s| s.to_lowercase() == "true")
-            .unwrap_or(true);
+            .unwrap_or(false);
+        let verify_hostname = !skip_tls_verify
+            && settings
+                .get_string("verify_hostname")
+                .map(|s| s.to_lowercase() == "true")
+                .unwrap_or(true);
+        let verify_certificates = !skip_tls_verify
+            && settings
+                .get_string("verify_certificates")
+                .map(|s| s.to_lowercase() == "true")
+                .unwrap_or(true);
         Ok(Self {
             crl_config,
             custom_root_store_path,

--- a/sf_core/src/tls/config.rs
+++ b/sf_core/src/tls/config.rs
@@ -1,3 +1,9 @@
+use crate::config::ConfigError;
+use crate::config::param_names::{
+    CUSTOM_ROOT_STORE_PATH, TLS_SKIP_VERIFY, VERIFY_CERTIFICATES, VERIFY_HOSTNAME,
+};
+use crate::config::param_registry::{ParamKey, registry};
+use crate::config::settings::{Setting, Settings};
 use crate::crl::config::CrlConfig;
 use std::path::PathBuf;
 
@@ -19,29 +25,18 @@ impl TlsConfig {
         }
     }
 
-    pub fn from_settings(
-        settings: &dyn crate::config::settings::Settings,
-    ) -> Result<Self, crate::config::ConfigError> {
+    pub fn from_settings(settings: &dyn Settings) -> Result<Self, ConfigError> {
         let crl_config = CrlConfig::from_settings(settings)?;
-        let custom_root_store_path = settings
-            .get_string("custom_root_store_path")
+        let custom_root_store_path = lookup_setting(settings, CUSTOM_ROOT_STORE_PATH)
+            .and_then(|s| match s {
+                Setting::String(path) => Some(path),
+                _ => None,
+            })
             .map(PathBuf::from);
-        // Accept both a typed `Bool` setting and a `"true"`/`"false"` string so
-        // this path agrees with the `ParamStore`-backed `build_tls_config`
-        // (which coerces both); otherwise a `Setting::Bool` would be ignored here.
-        let bool_setting = |key: &str, default: bool| -> bool {
-            settings
-                .get_bool(key)
-                .or_else(|| {
-                    settings
-                        .get_string(key)
-                        .map(|s| s.eq_ignore_ascii_case("true"))
-                })
-                .unwrap_or(default)
-        };
-        let skip_tls_verify = bool_setting("insecure_skip_tls_verify", false);
-        let verify_hostname = !skip_tls_verify && bool_setting("verify_hostname", true);
-        let verify_certificates = !skip_tls_verify && bool_setting("verify_certificates", true);
+        let skip_tls_verify = lookup_bool(settings, TLS_SKIP_VERIFY, false);
+        let verify_hostname = !skip_tls_verify && lookup_bool(settings, VERIFY_HOSTNAME, true);
+        let verify_certificates =
+            !skip_tls_verify && lookup_bool(settings, VERIFY_CERTIFICATES, true);
         Ok(Self {
             crl_config,
             custom_root_store_path,
@@ -62,6 +57,24 @@ impl Default for TlsConfig {
     }
 }
 
+/// Read a setting by canonical `ParamKey`, falling back to any aliases the
+/// registry has for it. `build_tls_config` reads an already-canonicalized
+/// `ParamStore`; this path may get a raw settings bag, so resolving aliases
+/// here keeps both TLS-config builders honoring the same wrapper keys.
+fn lookup_setting(settings: &dyn Settings, key: ParamKey) -> Option<Setting> {
+    settings.get(key.as_str()).or_else(|| {
+        registry()
+            .resolve(key.as_str())
+            .and_then(|def| def.aliases.iter().find_map(|&alias| settings.get(alias)))
+    })
+}
+
+fn lookup_bool(settings: &dyn Settings, key: ParamKey, default: bool) -> bool {
+    lookup_setting(settings, key)
+        .and_then(|s| s.coerce_bool())
+        .unwrap_or(default)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -72,7 +85,7 @@ mod tests {
     fn from_settings_skip_disables_both_for_bool_and_string() {
         for skip in [Setting::Bool(true), Setting::String("true".into())] {
             let mut s: HashMap<String, Setting> = HashMap::new();
-            s.insert("insecure_skip_tls_verify".into(), skip);
+            s.insert("tls_skip_verify".into(), skip);
             // Skip wins even when the individual flags are explicitly enabled.
             s.insert("verify_hostname".into(), Setting::Bool(true));
             s.insert("verify_certificates".into(), Setting::Bool(true));
@@ -87,6 +100,18 @@ mod tests {
     fn from_settings_defaults_to_verifying() {
         let cfg = TlsConfig::from_settings(&HashMap::<String, Setting>::new()).unwrap();
         assert!(cfg.verify_hostname);
+        assert!(cfg.verify_certificates);
+    }
+
+    #[test]
+    fn from_settings_honors_registered_aliases() {
+        // Raw bag using the registered alias (TLS_VERIFY_HOSTNAME) instead of the
+        // canonical key must still take effect, matching the ParamStore path.
+        let mut s: HashMap<String, Setting> = HashMap::new();
+        s.insert("TLS_VERIFY_HOSTNAME".into(), Setting::Bool(false));
+
+        let cfg = TlsConfig::from_settings(&s).unwrap();
+        assert!(!cfg.verify_hostname);
         assert!(cfg.verify_certificates);
     }
 }


### PR DESCRIPTION
## Summary

Adds a single connection parameter to skip TLS verification, instead of requiring
`verify_certificates` and `verify_hostname` to be set separately.

## What's new

New `Bool` connection param **`tls_skip_verify`** (default `false`). When enabled it
forces **both** `verify_hostname` and `verify_certificates` to `false` in one call, and
takes precedence over the individual flags.

## Implementation

- Registered in `config/param_registry.rs` (`Bool`, default `false`, `Connection` scope,
  `used_at_connect`).
- Honored in **both** TLS-config builders, so every connection path respects it:
  - `connection_config::build_tls_config` (ParamStore-backed)
  - `TlsConfig::from_settings` (used via `rest_parameters`)
- `from_settings` resolves keys through the `param_names::*` constants and the registry's
  alias table (rather than hardcoded string literals), so it honors the same wrapper keys
  as the ParamStore path.
- Boolean coercion (`Bool` / `"true"`/`"1"`/`"on"` / `"false"`/`"0"`/`"off"` / non-zero
  `Int`) is shared via `Setting::coerce_bool`, so both builders provably agree.
- Emits a `tracing::warn!` on connect when verification is disabled.
- Downstream rustls / CRL verification already keys off `TlsConfig.verify_hostname` /
  `verify_certificates`; with `verify_certificates == false`, `create_tls_client_with_config`
  early-returns an insecure client without installing the CRL verifier, so CRL revocation
  checks are bypassed as well.

## Behavior

| `tls_skip_verify` | resulting `verify_hostname` / `verify_certificates` |
| --- | --- |
| `true` | both forced `false` (overrides the individual flags; CRL also bypassed) |
| `false` / unset | existing behavior — individual flags, default `true` |

Backward compatible: unset/`false` leaves current behavior unchanged.

## Tests

- `tls_skip_verify_disables_both_checks`
- `tls_skip_verify_overrides_individual_verify_flags`
- `tls_skip_verify_canonicalizes_from_any_case_and_disables_verification` (end-to-end via
  `ConnectionConfig::build`)
- `tls_skip_verify_bypasses_crl_even_when_crl_check_mode_enabled` (locks the registry's
  CRL claim against drift)
- `from_settings_honors_registered_aliases` (raw alias resolution in `from_settings`)
- `from_settings_skip_disables_both_for_bool_and_string`
- existing `build_tls_booleans_*` continue to pass

## Note

Named `tls_skip_verify` (per review). Insecure; intended for testing/development only.
The auto-generated `python/.../connection_config.py` binding is regenerated to include the
new field.