### PR TITLE
feat(core): support in-band per-statement QUERY_TAG

### DIFF
--- a/sf_core/src/apis/database_driver_v1/statement.rs
+++ b/sf_core/src/apis/database_driver_v1/statement.rs
@@ -714,8 +714,10 @@ fn setting_to_json_value(setting: &Setting) -> serde_json::Value {
 
 /// Server-side parameter names forwarded in the query request.
 /// Each entry maps a local `ParamKey` to the Snowflake server-side parameter name.
-const QUERY_PARAMETER_NAMES: &[(ParamKey, &str)] =
-    &[(param_names::MULTI_STATEMENT_COUNT, "MULTI_STATEMENT_COUNT")];
+const QUERY_PARAMETER_NAMES: &[(ParamKey, &str)] = &[
+    (param_names::MULTI_STATEMENT_COUNT, "MULTI_STATEMENT_COUNT"),
+    (param_names::STATEMENT_QUERY_TAG, "QUERY_TAG"),
+];
 
 fn build_query_parameters(settings: &ParamStore) -> Option<HashMap<String, serde_json::Value>> {
     let mut params = HashMap::new();
@@ -1515,9 +1517,63 @@ mod tests {
             Some(&serde_json::Value::String("AUTO".to_string()))
         );
     }
-
     fn deserialize_query_response(json: &str) -> Data {
         serde_json::from_str(json).expect("test JSON must be valid query response Data")
+    }
+
+    #[test]
+    fn build_query_parameters_maps_statement_query_tag() {
+        let mut store = ParamStore::new();
+        store.insert(
+            param_names::STATEMENT_QUERY_TAG.as_str().to_string(),
+            Setting::String("etl_job_42".to_string()),
+        );
+        let params = build_query_parameters(&store).expect("expected a parameter map");
+        assert_eq!(
+            params.get("QUERY_TAG"),
+            Some(&serde_json::Value::String("etl_job_42".to_string()))
+        );
+        assert!(!params.contains_key("statement_query_tag"));
+    }
+
+    #[test]
+    fn statement_query_tag_serializes_into_request_parameters() {
+        use crate::rest::snowflake::query_request;
+        let mut store = ParamStore::new();
+        store.insert(
+            param_names::STATEMENT_QUERY_TAG.as_str().to_string(),
+            Setting::String("etl_job_42".to_string()),
+        );
+        let req = query_request::Request {
+            sql_text: "SELECT 1".to_string(),
+            async_exec: false,
+            sequence_id: 1,
+            query_submission_time: 0,
+            is_internal: false,
+            describe_only: None,
+            parameters: build_query_parameters(&store),
+            bindings: None,
+            bind_stage: None,
+            query_context: query_request::QueryContext { entries: None },
+        };
+        let json = serde_json::to_value(&req).expect("request must serialize");
+        assert_eq!(json["parameters"]["QUERY_TAG"], serde_json::json!("etl_job_42"));
+    }
+
+    #[tokio::test]
+    async fn statement_accepts_statement_query_tag_option() {
+        let ds = DatabaseDriverV1::new();
+        let ch = ds.connection_new();
+        let sh = ds.statement_new(ch).unwrap();
+        ds.statement_set_option(
+            sh,
+            param_names::STATEMENT_QUERY_TAG.as_str().into(),
+            Setting::String("etl_job_42".into()),
+        )
+        .await
+        .expect("statement_query_tag must be accepted as a statement-scoped option");
+        ds.statement_release(sh).unwrap();
+        ds.connection_release(ch).unwrap();
     }
 
     #[test]

--- a/sf_core/src/config/param_registry.rs
+++ b/sf_core/src/config/param_registry.rs
@@ -82,6 +82,11 @@ pub mod param_names {
     pub const CRL_CONNECTION_TIMEOUT: ParamKey = ParamKey("crl_connection_timeout");
     pub const ASYNC_EXECUTION: ParamKey = ParamKey("async_execution");
     pub const MULTI_STATEMENT_COUNT: ParamKey = ParamKey("multi_statement_count");
+    /// Per-statement QUERY_TAG, forwarded in-band in the query-request
+    /// `parameters` object. Deliberately distinct from the connection-level
+    /// `query_tag` passthrough: registering `query_tag` itself would, via
+    /// case-insensitive resolution, divert session-wide login forwarding.
+    pub const STATEMENT_QUERY_TAG: ParamKey = ParamKey("statement_query_tag");
     pub const AUTHENTICATION_TIMEOUT: ParamKey = ParamKey("authentication_timeout");
     pub const OKTA_USERNAME: ParamKey = ParamKey("okta_username");
     pub const DISABLE_SAML_URL_CHECK: ParamKey = ParamKey("disable_saml_url_check");
@@ -1098,6 +1103,20 @@ static PARAM_DEFS: &[ParamDef] = &[
         default: None,
         sensitive: false,
         description: "Exact number of statements in a multi-statement query",
+        deprecated_by: None,
+        scope: ParamScope::Statement,
+        used_at_connect: false,
+        mutable_after_connect: true,
+    },
+    ParamDef {
+        canonical_name: param_names::STATEMENT_QUERY_TAG.as_str(),
+        aliases: &[],
+        value_type: ValueType::String,
+        additional_value_type: None,
+        required: Required::Never,
+        default: None,
+        sensitive: false,
+        description: "Per-statement QUERY_TAG forwarded in-band in the query-request parameters",
         deprecated_by: None,
         scope: ParamScope::Statement,
         used_at_connect: false,


### PR DESCRIPTION
## Why

Setting a per-statement `QUERY_TAG` currently requires a separate
`ALTER SESSION SET QUERY_TAG = '...'` statement — an extra statement
handle and a network round-trip. Snowflake's `/queries/v1/query-request`
endpoint already accepts per-request session parameters in the
`parameters` object (the same path used today for `MULTI_STATEMENT_COUNT`
and `STATEMENT_TIMEOUT_IN_SECONDS`), so the tag can be sent in-band with
the statement it applies to.

This is consistent with the SQL API reference (`query_tag` is in the
per-request parameter allowlist) and with how gosnowflake
(`WithQueryTag`), snowflake-connector-python (`_statement_params`), and
snowflake-jdbc (`setParameter("QUERY_TAG", ...)`) all behave.

## What changed

- Added a statement-scoped `statement_query_tag` parameter to the param
  registry, mapped to the server-side `QUERY_TAG` key in the
  query-request `parameters` object via `QUERY_PARAMETER_NAMES`.
- Kept it deliberately distinct from the existing connection-level
  `query_tag` passthrough (an unregistered key forwarded as a session
  parameter at login). Because registry resolution is case-insensitive,
  registering `query_tag` itself would divert session-wide login
  forwarding and cause connection-string `QUERY_TAG` to be rejected as
  statement-scoped. A separate canonical key avoids that while still
  emitting the wire-level `QUERY_TAG`.
- Consumers set it per statement via `statement_set_option(s)`; it then
  serializes into the query body for both the sync and async execute
  paths through the existing `build_query_parameters` flow. No wrapper or
  protobuf changes — core layer only.

## Usage (core Rust consumer)

```rust
ds.statement_set_option(
    stmt,
    param_names::STATEMENT_QUERY_TAG.as_str().to_string(),
    Setting::String("etl_job_42".to_string()),
).await?;
// execute -> request body includes "parameters": { "QUERY_TAG": "etl_job_42" }
```

## Tests

- `build_query_parameters_maps_statement_query_tag` — maps the canonical
  key to `QUERY_TAG`.
- `statement_query_tag_serializes_into_request_parameters` — asserts the
  serialized request body contains `parameters.QUERY_TAG`.
- `statement_accepts_statement_query_tag_option` — accepted as a
  statement-scoped option.
- `collect_unknown_settings_returns_only_unregistered_keys` — existing
  connection-level `query_tag` login forwarding is unchanged (regression
  guard).

## Notes / scope

- A tag set via `statement_set_option` persists on the statement handle
  across re-executes until changed; strictly per-call scoping would be a
  follow-up.
- No language-wrapper surface added yet; this exposes the capability at
  the core layer only.
