### PR TITLE
SNOW-3784403 Align CRL implementation with the old driver

### DIFF
--- a/python/src/snowflake/connector/_internal/connection_config_mixin.py
+++ b/python/src/snowflake/connector/_internal/connection_config_mixin.py
@@ -87,6 +87,19 @@ class ConnectionConfigMixin:
     with snowflake-connector-python; never forwarded to the Rust core.  When
     ``None`` the wrapper treats it as ``True`` (legacy default)."""
 
+    crl_validity_time: int | None = None
+    """Maximum age of a cached CRL before it is re-fetched, in **days**.
+
+    When unset (``None``) the Rust core's own default applies (24h); the value
+    is not forwarded. When set, it is interpreted as days and converted to
+    seconds in :meth:`to_options` before being forwarded, because the core
+    param ``crl_validity_time`` is seconds-based.
+
+    Kept in days for backward compatibility with the Python connector's public
+    API. Hand-written here — and excluded from the generated dataclass via
+    ``PYTHON_HANDWRITTEN_FIELDS`` in ``param_defs_export.rs`` — so the
+    seconds-based core param does not shadow this days-based field."""
+
     _extra: dict[str, Any] = field(default_factory=dict, repr=False)
     """Unknown kwargs forwarded to the Rust core for validation.
 
@@ -419,6 +432,13 @@ class ConnectionConfigMixin:
             options[rust_name] = value
 
         options.update(self._extra)
+
+        # crl_validity_time is exposed in days for backward compatibility, but
+        # the Rust core expects seconds. Convert here so the public API keeps
+        # its historical unit. (The generic loop above emitted the raw days
+        # value under the same key; overwrite it with the seconds value.)
+        if self.crl_validity_time is not None:
+            options["crl_validity_time"] = self.crl_validity_time * 86400
 
         if options_modifiers:
             for modifier in options_modifiers:

--- a/python/src/snowflake/connector/connection_config.py
+++ b/python/src/snowflake/connector/connection_config.py
@@ -90,11 +90,14 @@ class ConnectionConfig(ConnectionConfigMixin):
     crl_enable_memory_caching: bool | None = True
     """Enable in-memory caching for CRL responses. Default: True"""
 
-    crl_http_timeout: int | None = 30
-    """HTTP timeout in seconds for CRL endpoint requests. Default: 30"""
+    crl_http_timeout: int | None = 10
+    """HTTP timeout in seconds for CRL endpoint requests. Default: 10"""
 
-    crl_validity_time: int | None = 10
-    """CRL cache validity time in days. Default: 10"""
+    crl_max_download_size: int | None = 20
+    """Maximum CRL download size in MB before the download is aborted. Default: 20"""
+
+    crl_on_disk_cache_removal_delay: int | None = 25200
+    """Delay in seconds after a CRL's nextUpdate before it is purged from the on-disk cache. Default: 25200"""
 
     custom_root_store_path: str | None = None
     """Path to custom root certificate store"""

--- a/sf_core/src/bin/param_defs_export.rs
+++ b/sf_core/src/bin/param_defs_export.rs
@@ -21,6 +21,17 @@
 use sf_core::config::param_registry::{ParamDef, ParamScope, Required, ValueType, registry};
 use sf_core::config::settings::Setting;
 
+/// Canonical param names whose Python surface is hand-written in
+/// `connection_config_mixin.py` instead of generated, because the wrapper
+/// exposes a different unit than the core param for backward compatibility.
+///
+/// `crl_validity_time`: the core param is in **seconds**, but the Python
+/// connector has always accepted it in **days**. The mixin keeps the
+/// days-based field (defaulting to `None`, so the core's own default applies
+/// when unset) and converts days to seconds in `to_options`, so generating a
+/// seconds-based field here would clash with it and change the public API.
+const PYTHON_HANDWRITTEN_FIELDS: &[&str] = &["crl_validity_time"];
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -232,6 +243,10 @@ __all__ = ["ConnectionConfig", "OptionsModifier"]
         if p.scope == ParamScope::Statement {
             continue;
         }
+        // Skip params whose Python surface is hand-written in the mixin.
+        if PYTHON_HANDWRITTEN_FIELDS.contains(&p.canonical_name) {
+            continue;
+        }
 
         let py_field = to_python_field(p.canonical_name);
 
@@ -278,6 +293,10 @@ __all__ = ["ConnectionConfig", "OptionsModifier"]
     for p in sorted_params.iter().copied() {
         // Skip statement-scoped params; they belong on the cursor, not the connection.
         if p.scope == ParamScope::Statement {
+            continue;
+        }
+        // Skip params whose Python surface is hand-written in the mixin.
+        if PYTHON_HANDWRITTEN_FIELDS.contains(&p.canonical_name) {
             continue;
         }
 

--- a/sf_core/src/chunks/mod.rs
+++ b/sf_core/src/chunks/mod.rs
@@ -296,6 +296,10 @@ pub async fn get_chunk_data(
                     status: last_status,
                 }
                 .fail(),
+                HttpError::ResponseTooLarge { .. } => UnsuccessfulHttpStatusCodeSnafu {
+                    status: reqwest::StatusCode::PAYLOAD_TOO_LARGE,
+                }
+                .fail(),
             };
         }
     };

--- a/sf_core/src/config/param_registry.rs
+++ b/sf_core/src/config/param_registry.rs
@@ -78,9 +78,12 @@ pub mod param_names {
     pub const CRL_ENABLE_DISK_CACHING: ParamKey = ParamKey("crl_enable_disk_caching");
     pub const CRL_ENABLE_MEMORY_CACHING: ParamKey = ParamKey("crl_enable_memory_caching");
     pub const CRL_CACHE_DIR: ParamKey = ParamKey("crl_cache_dir");
-    pub const CRL_VALIDITY_TIME: ParamKey = ParamKey("crl_validity_time");
     pub const CRL_ALLOW_CERTIFICATES_WITHOUT_CRL_URL: ParamKey =
         ParamKey("crl_allow_certificates_without_crl_url");
+    pub const CRL_MAX_DOWNLOAD_SIZE: ParamKey = ParamKey("crl_max_download_size");
+    pub const CRL_VALIDITY_TIME: ParamKey = ParamKey("crl_validity_time");
+    pub const CRL_ON_DISK_CACHE_REMOVAL_DELAY: ParamKey =
+        ParamKey("crl_on_disk_cache_removal_delay");
     pub const CRL_HTTP_TIMEOUT: ParamKey = ParamKey("crl_http_timeout");
     pub const CRL_CONNECTION_TIMEOUT: ParamKey = ParamKey("crl_connection_timeout");
     pub const ASYNC_EXECUTION: ParamKey = ParamKey("async_execution");
@@ -1014,14 +1017,42 @@ static PARAM_DEFS: &[ParamDef] = &[
         mutable_after_connect: false,
     },
     ParamDef {
+        canonical_name: param_names::CRL_MAX_DOWNLOAD_SIZE.as_str(),
+        aliases: &[],
+        value_type: ValueType::Int,
+        additional_value_type: None,
+        required: Required::Never,
+        default: Some(|| Setting::Int(20)),
+        sensitive: false,
+        description: "Maximum CRL download size in MB before the download is aborted",
+        deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: true,
+        mutable_after_connect: false,
+    },
+    ParamDef {
         canonical_name: param_names::CRL_VALIDITY_TIME.as_str(),
         aliases: &[],
         value_type: ValueType::Int,
         additional_value_type: None,
         required: Required::Never,
-        default: Some(|| Setting::Int(10)),
+        default: Some(|| Setting::Int(86400)),
         sensitive: false,
-        description: "CRL cache validity time in days",
+        description: "Maximum age in seconds of a cached CRL before it is re-fetched",
+        deprecated_by: None,
+        scope: ParamScope::Connection,
+        used_at_connect: true,
+        mutable_after_connect: false,
+    },
+    ParamDef {
+        canonical_name: param_names::CRL_ON_DISK_CACHE_REMOVAL_DELAY.as_str(),
+        aliases: &[],
+        value_type: ValueType::Int,
+        additional_value_type: None,
+        required: Required::Never,
+        default: Some(|| Setting::Int(25200)),
+        sensitive: false,
+        description: "Delay in seconds after a CRL's nextUpdate before it is purged from the on-disk cache",
         deprecated_by: None,
         scope: ParamScope::Connection,
         used_at_connect: true,
@@ -1047,7 +1078,7 @@ static PARAM_DEFS: &[ParamDef] = &[
         value_type: ValueType::Int,
         additional_value_type: None,
         required: Required::Never,
-        default: Some(|| Setting::Int(30)),
+        default: Some(|| Setting::Int(10)),
         sensitive: false,
         description: "HTTP timeout in seconds for CRL endpoint requests",
         deprecated_by: None,

--- a/sf_core/src/crl/cache.rs
+++ b/sf_core/src/crl/cache.rs
@@ -4,7 +4,7 @@ use crate::crl::error::{
     CrlDistributionPointFailedSnafu, CrlDownloadSnafu, CrlError, InvalidCrlSignatureSnafu,
     MutexPoisonedSnafu, VerificationTaskFailedSnafu,
 };
-use crate::http::retry::{HttpContext, HttpError, execute_bytes_with_retry};
+use crate::http::retry::{HttpContext, HttpError, execute_bytes_with_retry_capped};
 use chrono::{DateTime, Utc};
 use fs2::FileExt;
 use once_cell::sync::OnceCell;
@@ -420,6 +420,12 @@ impl CrlCache {
                     let mut keys: HashMap<String, tokio_util::time::delay_queue::Key> =
                         HashMap::new();
 
+                    // Periodic cache cleanup. The first tick fires immediately,
+                    // so stale entries left over from a previous process are
+                    // pruned shortly after startup.
+                    let mut cleanup_interval =
+                        tokio::time::interval(std::time::Duration::from_secs(3600));
+
                     // Seed existing entries
                     if let Some(memory) = &this.memory_cache
                         && let Ok(cache) = memory.lock()
@@ -434,6 +440,11 @@ impl CrlCache {
 
                     loop {
                         tokio::select! {
+                            // Periodic cleanup of expired in-memory and on-disk entries
+                            _ = cleanup_interval.tick() => {
+                                this.cleanup_in_memory_cache();
+                                this.cleanup_on_disk_cache().await;
+                            }
                             // Next scheduled refresh
                             maybe_item = dq.next(), if !dq.is_empty() => {
                                 if let Some(expired) = maybe_item { // a url is due
@@ -891,10 +902,13 @@ impl CrlCache {
         if let Some(memory) = &self.memory_cache
             && let Ok(mut cache) = memory.lock()
         {
-            if let Some(entry) = cache.get(url)
-                && Utc::now() <= entry.expires_at
-            {
-                return Ok(Some(entry.clone()));
+            if let Some(entry) = cache.get(url) {
+                // Fresh only if both the CRL's own nextUpdate is in the future
+                // AND the entry hasn't exceeded the configured max cache age.
+                let age = Utc::now() - entry.download_time;
+                if Utc::now() <= entry.expires_at && age <= self.config.validity_time {
+                    return Ok(Some(entry.clone()));
+                }
             }
             cache.remove(url);
         }
@@ -908,14 +922,24 @@ impl CrlCache {
             let file_name = Self::url_digest(url);
             let path = dir.join(file_name);
             if let Ok(bytes) = tokio::fs::read(&path).await {
+                // Use the file's mtime as the download time (same approach as
+                // gosnowflake, which relies on `stat.ModTime()`), so the max
+                // cache-age check reflects the real age rather than "now".
+                let download_time = tokio::fs::metadata(&path)
+                    .await
+                    .ok()
+                    .and_then(|m| m.modified().ok())
+                    .map(DateTime::<Utc>::from)
+                    .unwrap_or_else(Utc::now);
                 let expires_at = match crate::tls::x509_utils::extract_crl_next_update(&bytes) {
                     Ok(Some(dt)) => dt,
-                    _ => Utc::now() + self.config.validity_time,
+                    _ => download_time + self.config.validity_time,
                 };
-                if Utc::now() <= expires_at {
+                let age = Utc::now() - download_time;
+                if Utc::now() <= expires_at && age <= self.config.validity_time {
                     let _ = self.put(CachedCrl {
                         crl: bytes.clone(),
-                        download_time: Utc::now(),
+                        download_time,
                         url: url.to_string(),
                         expires_at,
                         crl_number: crate::tls::x509_utils::extract_crl_number(&bytes)
@@ -1071,15 +1095,30 @@ impl CrlCache {
         self.maybe_sleep_backoff(url).await?;
 
         let ctx = HttpContext::new(Method::GET, url.to_string());
-
         let req_builder = || self.http_client.get(url);
-        let bytes = match execute_bytes_with_retry(req_builder, &ctx, &RetryPolicy::default()).await
+        // Stream the body with a hard size cap so an oversized (or unbounded)
+        // CRL cannot exhaust memory.
+        let bytes = match execute_bytes_with_retry_capped(
+            req_builder,
+            &ctx,
+            &RetryPolicy::default(),
+            self.config.max_download_size,
+        )
+        .await
         {
             Ok(b) => b,
             Err(e) => {
                 self.metrics.fetch_error_total.add(1, &[]);
                 self.record_backoff_failure(url);
                 return match e {
+                    HttpError::ResponseTooLarge { size, max_size, .. } => {
+                        crate::crl::error::DownloadSizeExceededSnafu {
+                            url: url.to_string(),
+                            size,
+                            max_size,
+                        }
+                        .fail()
+                    }
                     HttpError::Transport { source, .. } => Err(source).context(CrlDownloadSnafu {
                         url: url.to_string(),
                     }),
@@ -1147,6 +1186,89 @@ impl CrlCache {
             .or_insert((0, std::time::Instant::now()));
         entry.0 = entry.0.saturating_add(1);
         entry.1 = std::time::Instant::now();
+    }
+
+    /// Evict in-memory CRLs that are past their `nextUpdate` or older than the
+    /// configured cache validity time.
+    fn cleanup_in_memory_cache(&self) {
+        let now = Utc::now();
+        let validity = self.config.validity_time;
+        if let Some(memory) = &self.memory_cache
+            && let Ok(mut cache) = memory.lock()
+        {
+            cache.retain(|url, entry| {
+                let expired = now > entry.expires_at;
+                let evicted = (now - entry.download_time) > validity;
+                if expired || evicted {
+                    tracing::debug!(
+                        target: "sf_core::crl",
+                        "evicting in-memory CRL for {url} (expired={expired}, evicted={evicted})"
+                    );
+                    false
+                } else {
+                    true
+                }
+            });
+        }
+    }
+
+    /// Remove on-disk CRL files whose `nextUpdate` is older than
+    /// `on_disk_cache_removal_delay` ago. Expired files are kept for that delay
+    /// to aid debugging. Failures are logged, never fatal.
+    async fn cleanup_on_disk_cache(&self) {
+        if !self.config.enable_disk_caching {
+            return;
+        }
+        let Some(dir) = self.config.get_cache_dir() else {
+            return;
+        };
+        let removal_delay = self.config.on_disk_cache_removal_delay;
+        let now = Utc::now();
+
+        let mut entries = match tokio::fs::read_dir(&dir).await {
+            Ok(e) => e,
+            Err(e) => {
+                tracing::debug!(
+                    target: "sf_core::crl",
+                    dir = %dir.display(),
+                    error = %e,
+                    "failed to read CRL cache dir for cleanup"
+                );
+                return;
+            }
+        };
+
+        while let Ok(Some(entry)) = entries.next_entry().await {
+            let path = entry.path();
+            match entry.metadata().await {
+                Ok(m) if m.is_file() => {}
+                _ => continue,
+            }
+            let Ok(bytes) = tokio::fs::read(&path).await else {
+                continue;
+            };
+            // Only remove files we can parse and that are past nextUpdate +
+            // removal_delay; unparseable files are left untouched (they may be
+            // partially written or belong to another tool).
+            if let Ok(Some(next_update)) = crate::tls::x509_utils::extract_crl_next_update(&bytes)
+                && now > next_update + removal_delay
+            {
+                if let Err(e) = tokio::fs::remove_file(&path).await {
+                    tracing::warn!(
+                        target: "sf_core::crl",
+                        path = %path.display(),
+                        error = %e,
+                        "failed to remove expired CRL file"
+                    );
+                } else {
+                    tracing::debug!(
+                        target: "sf_core::crl",
+                        path = %path.display(),
+                        "removed expired CRL file"
+                    );
+                }
+            }
+        }
     }
 }
 
@@ -1439,5 +1561,55 @@ mod tests {
                 other => panic!("unexpected msg: {:?}", other),
             }
         });
+    }
+
+    /// Disk cleanup must never delete files it cannot parse as a CRL — those may
+    /// be partially written, or belong to another tool sharing the cache dir —
+    /// and must be a safe no-op when disk caching is disabled or the directory
+    /// is absent.
+    #[tokio::test]
+    async fn cleanup_on_disk_cache_is_safe() {
+        use tempfile::TempDir;
+        let dir = TempDir::new().unwrap();
+        let garbage = dir
+            .path()
+            .join(CrlCache::url_digest("http://example/foo.crl"));
+        tokio::fs::write(&garbage, b"not a crl").await.unwrap();
+        let foreign = dir.path().join("some-other-file.txt");
+        tokio::fs::write(&foreign, b"hello").await.unwrap();
+
+        let cfg = CrlConfig {
+            enable_disk_caching: true,
+            enable_memory_caching: false,
+            cache_dir: Some(dir.path().to_path_buf()),
+            ..Default::default()
+        };
+        let cache = CrlCache::new(cfg).unwrap();
+        cache.cleanup_on_disk_cache().await;
+
+        // Unparseable and foreign files are preserved.
+        assert!(garbage.exists(), "unparseable CRL file must not be removed");
+        assert!(foreign.exists(), "foreign file must not be removed");
+
+        // Disabled disk caching → no-op even if a dir is configured.
+        let disabled = CrlCache::new(CrlConfig {
+            enable_disk_caching: false,
+            enable_memory_caching: false,
+            cache_dir: Some(dir.path().to_path_buf()),
+            ..Default::default()
+        })
+        .unwrap();
+        disabled.cleanup_on_disk_cache().await;
+        assert!(garbage.exists());
+
+        // Missing directory → no panic.
+        let missing = CrlCache::new(CrlConfig {
+            enable_disk_caching: true,
+            enable_memory_caching: false,
+            cache_dir: Some(dir.path().join("does-not-exist")),
+            ..Default::default()
+        })
+        .unwrap();
+        missing.cleanup_on_disk_cache().await;
     }
 }

--- a/sf_core/src/crl/config.rs
+++ b/sf_core/src/crl/config.rs
@@ -3,6 +3,16 @@ use crate::config::settings::Settings;
 use chrono::Duration;
 use std::path::PathBuf;
 
+/// Maximum CRL download size in bytes.
+pub const DEFAULT_CRL_DOWNLOAD_MAX_SIZE_BYTES: usize = 20 * 1024 * 1024; // 20 MB
+
+/// Default max cache age, in seconds.
+pub const DEFAULT_CRL_VALIDITY_TIME_SECS: i64 = 24 * 60 * 60;
+
+/// Default delay, in seconds, before an expired CRL is purged from disk (kept
+/// for debuggability).
+pub const DEFAULT_CRL_ON_DISK_CACHE_REMOVAL_DELAY_SECS: i64 = 7 * 60 * 60;
+
 #[derive(Debug, Clone, PartialEq, Default)]
 pub enum CertRevocationCheckMode {
     /// Default - disables CRL checking (TLS handshake still in place)
@@ -22,8 +32,15 @@ pub struct CrlConfig {
     pub enable_disk_caching: bool,
     pub enable_memory_caching: bool,
     pub cache_dir: Option<PathBuf>,
-    pub validity_time: Duration,
     pub allow_certificates_without_crl_url: bool,
+    /// Maximum number of bytes to download for a single CRL before aborting.
+    pub max_download_size: usize,
+    /// Maximum age of a cached CRL (in memory or on disk) before it must be
+    /// re-fetched, regardless of the CRL's own `nextUpdate`.
+    pub validity_time: Duration,
+    /// How long an expired CRL is retained on disk (past its `nextUpdate`)
+    /// before the background cleaner removes it.
+    pub on_disk_cache_removal_delay: Duration,
     pub http_timeout: Duration,
     pub connection_timeout: Duration,
 }
@@ -35,9 +52,13 @@ impl Default for CrlConfig {
             enable_disk_caching: true,
             enable_memory_caching: true,
             cache_dir: None,
-            validity_time: Duration::days(10),
             allow_certificates_without_crl_url: false,
-            http_timeout: Duration::seconds(30),
+            max_download_size: DEFAULT_CRL_DOWNLOAD_MAX_SIZE_BYTES,
+            validity_time: Duration::seconds(DEFAULT_CRL_VALIDITY_TIME_SECS),
+            on_disk_cache_removal_delay: Duration::seconds(
+                DEFAULT_CRL_ON_DISK_CACHE_REMOVAL_DELAY_SECS,
+            ),
+            http_timeout: Duration::seconds(10),
             connection_timeout: Duration::seconds(10),
         }
     }
@@ -74,18 +95,33 @@ impl CrlConfig {
             .map(|s| s.to_lowercase() == "true")
             .unwrap_or(true);
         let cache_dir = settings.get_string("crl_cache_dir").map(PathBuf::from);
-        let validity_time = settings
-            .get_int("crl_validity_time")
-            .map(Duration::days)
-            .unwrap_or(Duration::days(10));
         let allow_certificates_without_crl_url = settings
             .get_string("crl_allow_certificates_without_crl_url")
             .map(|s| s.to_lowercase() == "true")
             .unwrap_or(false);
+        // Configured in MB (matching gosnowflake's user-facing unit), stored as bytes.
+        let max_download_size = settings
+            .get_int("crl_max_download_size")
+            .filter(|v| *v > 0)
+            .map(|mb| (mb as usize).saturating_mul(1024 * 1024))
+            .unwrap_or(DEFAULT_CRL_DOWNLOAD_MAX_SIZE_BYTES);
+        // Cache lifetimes are configured in whole seconds.
+        let validity_time = settings
+            .get_int("crl_validity_time")
+            .filter(|v| *v >= 0)
+            .map(Duration::seconds)
+            .unwrap_or(Duration::seconds(DEFAULT_CRL_VALIDITY_TIME_SECS));
+        let on_disk_cache_removal_delay = settings
+            .get_int("crl_on_disk_cache_removal_delay")
+            .filter(|v| *v >= 0)
+            .map(Duration::seconds)
+            .unwrap_or(Duration::seconds(
+                DEFAULT_CRL_ON_DISK_CACHE_REMOVAL_DELAY_SECS,
+            ));
         let http_timeout = settings
             .get_int("crl_http_timeout")
             .map(Duration::seconds)
-            .unwrap_or(Duration::seconds(30));
+            .unwrap_or(Duration::seconds(10));
         let connection_timeout = settings
             .get_int("crl_connection_timeout")
             .map(Duration::seconds)
@@ -95,10 +131,49 @@ impl CrlConfig {
             enable_disk_caching,
             enable_memory_caching,
             cache_dir,
-            validity_time,
             allow_certificates_without_crl_url,
+            max_download_size,
+            validity_time,
+            on_disk_cache_removal_delay,
             http_timeout,
             connection_timeout,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::settings::Setting;
+    use std::collections::HashMap;
+
+    #[test]
+    fn defaults_match_gosnowflake() {
+        let cfg = CrlConfig::default();
+        assert_eq!(cfg.validity_time, Duration::hours(24));
+        assert_eq!(cfg.on_disk_cache_removal_delay, Duration::hours(7));
+        assert_eq!(cfg.max_download_size, 20 * 1024 * 1024);
+        assert_eq!(cfg.http_timeout, Duration::seconds(10));
+    }
+
+    #[test]
+    fn from_settings_reads_seconds_and_mb() {
+        let mut map: HashMap<String, Setting> = HashMap::new();
+        map.insert("crl_validity_time".into(), Setting::Int(3_600));
+        map.insert("crl_on_disk_cache_removal_delay".into(), Setting::Int(600));
+        map.insert("crl_max_download_size".into(), Setting::Int(5));
+        let cfg = CrlConfig::from_settings(&map).unwrap();
+        assert_eq!(cfg.validity_time, Duration::seconds(3_600));
+        assert_eq!(cfg.on_disk_cache_removal_delay, Duration::seconds(600));
+        assert_eq!(cfg.max_download_size, 5 * 1024 * 1024);
+    }
+
+    #[test]
+    fn from_settings_uses_defaults_when_absent() {
+        let map: HashMap<String, Setting> = HashMap::new();
+        let cfg = CrlConfig::from_settings(&map).unwrap();
+        assert_eq!(cfg.validity_time, Duration::hours(24));
+        assert_eq!(cfg.on_disk_cache_removal_delay, Duration::hours(7));
+        assert_eq!(cfg.max_download_size, 20 * 1024 * 1024);
     }
 }

--- a/sf_core/src/crl/error.rs
+++ b/sf_core/src/crl/error.rs
@@ -87,6 +87,14 @@ pub enum CrlError {
         #[snafu(implicit)]
         location: Location,
     },
+    #[snafu(display("CRL download from {url} exceeded max size: {size} bytes > {max_size} bytes"))]
+    DownloadSizeExceeded {
+        url: String,
+        size: u64,
+        max_size: usize,
+        #[snafu(implicit)]
+        location: Location,
+    },
     #[snafu(display("Mutex poisoned: {message}"))]
     MutexPoisoned {
         message: String,

--- a/sf_core/src/crl/integration_test.rs
+++ b/sf_core/src/crl/integration_test.rs
@@ -13,7 +13,8 @@ mod integration_tests {
         assert_eq!(crl_config.check_mode, CertRevocationCheckMode::Disabled);
         assert!(crl_config.enable_disk_caching);
         assert!(crl_config.enable_memory_caching);
-        assert_eq!(crl_config.validity_time.num_days(), 10);
+        assert_eq!(crl_config.max_download_size, 20 * 1024 * 1024);
+        assert_eq!(crl_config.http_timeout.num_seconds(), 10);
     }
 
     #[test]
@@ -21,13 +22,13 @@ mod integration_tests {
         let crl_config = CrlConfig {
             check_mode: CertRevocationCheckMode::Enabled,
             enable_disk_caching: true,
-            validity_time: chrono::Duration::days(7),
+            max_download_size: 5 * 1024 * 1024,
             ..Default::default()
         };
 
         assert_eq!(crl_config.check_mode, CertRevocationCheckMode::Enabled);
         assert!(crl_config.enable_disk_caching);
-        assert_eq!(crl_config.validity_time.num_days(), 7);
+        assert_eq!(crl_config.max_download_size, 5 * 1024 * 1024);
     }
 
     #[test]

--- a/sf_core/src/http/retry.rs
+++ b/sf_core/src/http/retry.rs
@@ -69,6 +69,13 @@ pub enum HttpError {
         #[snafu(implicit)]
         location: Location,
     },
+    #[snafu(display("response body of {size} bytes exceeds max {max_size} bytes"))]
+    ResponseTooLarge {
+        size: u64,
+        max_size: usize,
+        #[snafu(implicit)]
+        location: Location,
+    },
 }
 
 /// Calculate effective timeout for a request attempt.
@@ -277,6 +284,51 @@ where
         }
         Err(e) => Err(TransportSnafu.into_error(e)),
     }
+}
+
+/// Like [`execute_bytes_with_retry`] but streams the response body and aborts
+/// with [`HttpError::ResponseTooLarge`] the moment the advertised
+/// `Content-Length` or the accumulated body size exceeds `max_size`. The size
+/// rejection is a property of the payload (not a transient failure), so it is
+/// surfaced without further retries. Transport/status failures still flow
+/// through the normal retry path.
+pub async fn execute_bytes_with_retry_capped<B>(
+    build: B,
+    ctx: &HttpContext,
+    policy: &RetryPolicy,
+    max_size: usize,
+) -> Result<Vec<u8>, HttpError>
+where
+    B: Fn() -> reqwest::RequestBuilder,
+{
+    use futures::StreamExt;
+    execute_with_retry(build, ctx, policy, |resp| async move {
+        let resp = resp.error_for_status().context(TransportSnafu)?;
+        if let Some(len) = resp.content_length()
+            && len > max_size as u64
+        {
+            return ResponseTooLargeSnafu {
+                size: len,
+                max_size,
+            }
+            .fail();
+        }
+        let mut stream = resp.bytes_stream();
+        let mut buf: Vec<u8> = Vec::new();
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.context(TransportSnafu)?;
+            if buf.len() + chunk.len() > max_size {
+                return ResponseTooLargeSnafu {
+                    size: (buf.len() + chunk.len()) as u64,
+                    max_size,
+                }
+                .fail();
+            }
+            buf.extend_from_slice(&chunk);
+        }
+        Ok(buf)
+    })
+    .await
 }
 
 #[cfg(test)]

--- a/sf_core/src/rest/snowflake/error.rs
+++ b/sf_core/src/rest/snowflake/error.rs
@@ -147,5 +147,11 @@ pub(crate) fn map_http_error(err: HttpError) -> SfError {
             remaining,
             location,
         },
+        // Not produced by the Snowflake REST path (only the size-capped CRL
+        // fetch emits it), but the match must stay exhaustive.
+        HttpError::ResponseTooLarge { .. } => SfError::HttpStatus {
+            status: StatusCode::PAYLOAD_TOO_LARGE,
+            location,
+        },
     }
 }


### PR DESCRIPTION
### TL;DR

Hardens CRL caching with a configurable download size cap, a corrected validity-time unit (days → seconds), a new on-disk cache removal delay, and a periodic background cleanup of stale in-memory and on-disk CRL entries.

### What changed?

**CRL download size cap**
- Added `crl_max_download_size` (default: 20 MB) to `CrlConfig` and the param registry. CRL downloads now stream the response body and abort with a `DownloadSizeExceeded` error if either the `Content-Length` header or the accumulated body exceeds the limit.
- Introduced `execute_bytes_with_retry_capped` in `http/retry.rs` to enforce the cap during streaming. `ResponseTooLarge` is surfaced immediately without retries; transport/status failures still go through the normal retry path.

**CRL validity time unit correction**
- The Rust core's `crl_validity_time` param is now in **seconds** (default: 86400 s / 24 h), aligning with gosnowflake. The Python connector's public API continues to accept the value in **days** and converts to seconds in `to_options`. The Python field is hand-written in `connection_config_mixin.py` and excluded from code generation via `PYTHON_HANDWRITTEN_FIELDS` in `param_defs_export.rs` to prevent the seconds-based generated field from shadowing it.

**On-disk cache removal delay**
- Added `crl_on_disk_cache_removal_delay` (default: 25200 s / 7 h) to `CrlConfig` and the param registry. Expired on-disk CRL files are retained for this duration past their `nextUpdate` before the background cleaner removes them, aiding debuggability.

**Periodic background cache cleanup**
- The CRL background task now runs a cleanup pass every hour. In-memory entries past their `nextUpdate` or older than `validity_time` are evicted. On-disk files whose `nextUpdate` plus the removal delay has passed are deleted. Unparseable files are never touched.

**Cache freshness check**
- Both in-memory and on-disk cache reads now enforce a dual condition: the CRL's `nextUpdate` must be in the future **and** the entry's age must not exceed `validity_time`. On-disk entries use the file's mtime as the download time, matching gosnowflake's `stat.ModTime()` approach.

**Default timeout reduction**
- `crl_http_timeout` default reduced from 30 s to 10 s.

### How to test?

- Unit tests in `crl/config.rs` verify that defaults match gosnowflake values and that settings are read in the correct units (seconds for time, MB converted to bytes).
- `cleanup_on_disk_cache_is_safe` test in `crl/cache.rs` confirms that unparseable files and foreign files are never removed, that a missing directory does not panic, and that cleanup is a no-op when disk caching is disabled.
- Integration tests in `crl/integration_test.rs` cover the updated default values.
- End-to-end: configure `crl_max_download_size` to a very small value and point the connector at a real CRL endpoint to confirm the download is aborted with a `DownloadSizeExceeded` error.

### Why make this change?

- **Memory safety**: an unbounded CRL download could exhaust process memory; the size cap prevents this.
- **Unit alignment**: the previous Python API accepted `crl_validity_time` in days while the Rust core was also treating it as days internally. Aligning the core to seconds (matching gosnowflake) and converting at the Python boundary preserves backward compatibility while making the internal representation unambiguous.
- **Cache hygiene**: without periodic cleanup, stale CRL entries could accumulate indefinitely in memory and on disk. The hourly background pass and the configurable removal delay give operators control over retention while keeping the cache fresh.