### PR TITLE
SNOW-3675196: thread async cancellation through the driver stack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2692,6 +2692,7 @@ dependencies = [
  "proto_utils",
  "sf_core",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
 ]
@@ -4117,6 +4118,9 @@ dependencies = [
 [[package]]
 name = "proto_utils"
 version = "0.1.0"
+dependencies = [
+ "tokio-util",
+]
 
 [[package]]
 name = "ptr_meta"

--- a/jdbc_bridge/Cargo.toml
+++ b/jdbc_bridge/Cargo.toml
@@ -17,6 +17,7 @@ proto_utils = { path = "../proto_utils" }
 tracing-subscriber = { version = "0.3.19", features = ["fmt", "env-filter"] }
 tracing = "0.1.41"
 tokio = { version = "1.50.0", features = ["rt"] }
+tokio-util = "0.7"
 
 [dependencies.jni]
 version = "0.21"

--- a/jdbc_bridge/src/lib.rs
+++ b/jdbc_bridge/src/lib.rs
@@ -64,6 +64,7 @@ impl JdbcBridge {
             service_name,
             method_name,
             request_bytes,
+            tokio_util::sync::CancellationToken::new(),
         ))
     }
 }

--- a/odbc/src/api/catalog.rs
+++ b/odbc/src/api/catalog.rs
@@ -17,7 +17,8 @@ use crate::api::error::{
 };
 use crate::api::runtime::global;
 use crate::api::statement::{
-    collect_nested_batch, execute_show_query_collect_batch, set_state_for_catalog,
+    arm_statement_cancel, collect_nested_batch, execute_show_query_collect_batch,
+    set_state_for_catalog,
 };
 use crate::api::utils::{catalog_arg_to_pattern, escape_like_wildcards};
 use crate::api::{
@@ -162,6 +163,8 @@ pub fn tables<E: OdbcEncoding>(
 
     validate_catalog_stmt_ready(&inner)?;
 
+    let (_cancel_guard, cancel) = arm_statement_cancel(&guard);
+
     let conn_handle = match &conn.state {
         ConnectionState::Connected { conn_handle, .. } => *conn_handle,
         ConnectionState::Disconnected => return DisconnectedSnafu.fail(),
@@ -186,6 +189,7 @@ pub fn tables<E: OdbcEncoding>(
             None,
             None,
             vec![],
+            cancel,
         );
     }
 
@@ -203,6 +207,7 @@ pub fn tables<E: OdbcEncoding>(
             None,
             None,
             vec![],
+            cancel,
         );
     }
 
@@ -224,7 +229,7 @@ pub fn tables<E: OdbcEncoding>(
     let catalog_raw = if metadata_id {
         catalog_raw
     } else {
-        resolve_null_catalog_to_connection_context(catalog_raw, conn_handle)?
+        resolve_null_catalog_to_connection_context(catalog_raw, conn_handle, cancel.clone())?
     };
     let catalog_pattern = catalog_arg_to_pattern(catalog_raw.as_deref(), metadata_id)?;
     let schema_pattern = catalog_arg_to_pattern(schema_raw.as_deref(), metadata_id)?;
@@ -241,6 +246,7 @@ pub fn tables<E: OdbcEncoding>(
         schema_pattern,
         table_pattern,
         table_types,
+        cancel,
     )
 }
 
@@ -257,6 +263,7 @@ pub fn tables<E: OdbcEncoding>(
 fn resolve_null_catalog_to_connection_context(
     catalog_raw: Option<String>,
     conn_handle: sf_core::protobuf::generated::database_driver_v1::ConnectionHandle,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> OdbcResult<Option<String>> {
     if catalog_raw.is_some() {
         return Ok(catalog_raw);
@@ -264,11 +271,14 @@ fn resolve_null_catalog_to_connection_context(
 
     let rt = global().context(OdbcRuntimeSnafu)?;
     let info = rt.block_on(async |c| {
-        c.connection_get_info(ConnectionGetInfoRequest {
-            conn_handle: Some(conn_handle),
-            info_codes: vec![],
-            include_master_token: false,
-        })
+        c.connection_get_info(
+            ConnectionGetInfoRequest {
+                conn_handle: Some(conn_handle),
+                info_codes: vec![],
+                include_master_token: false,
+            },
+            cancel,
+        )
         .await
     })?;
 
@@ -322,10 +332,12 @@ pub fn columns<E: OdbcEncoding>(
     let numeric_settings = conn.numeric_settings;
     drop(conn);
 
+    let (_cancel_guard, cancel) = arm_statement_cancel(&guard);
+
     let catalog_raw = if metadata_id {
         catalog_raw
     } else {
-        resolve_null_catalog_to_connection_context(catalog_raw, conn_handle)?
+        resolve_null_catalog_to_connection_context(catalog_raw, conn_handle, cancel.clone())?
     };
     let catalog_pattern = catalog_arg_to_pattern(catalog_raw.as_deref(), metadata_id)?;
     let schema_pattern = catalog_arg_to_pattern(schema_raw.as_deref(), metadata_id)?;
@@ -340,6 +352,7 @@ pub fn columns<E: OdbcEncoding>(
         schema_pattern,
         table_pattern,
         column_pattern,
+        cancel,
     )
 }
 
@@ -429,13 +442,17 @@ fn build_show_in_scope(catalog: Option<&str>, schema: Option<&str>, table: Optio
 
 fn metadata_request_use_connection_ctx(
     conn_handle: sf_core::protobuf::generated::database_driver_v1::ConnectionHandle,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> OdbcResult<bool> {
     let rt = global().context(OdbcRuntimeSnafu)?;
     let resp = rt.block_on(async |c| {
-        c.connection_get_parameter(ConnectionGetParameterRequest {
-            conn_handle: Some(conn_handle),
-            key: "CLIENT_METADATA_REQUEST_USE_CONNECTION_CTX".to_string(),
-        })
+        c.connection_get_parameter(
+            ConnectionGetParameterRequest {
+                conn_handle: Some(conn_handle),
+                key: "CLIENT_METADATA_REQUEST_USE_CONNECTION_CTX".to_string(),
+            },
+            cancel,
+        )
         .await
     });
     Ok(resp
@@ -449,13 +466,14 @@ fn resolve_show_identifiers(
     schema: Option<String>,
     table: Option<&str>,
     conn_handle: sf_core::protobuf::generated::database_driver_v1::ConnectionHandle,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> OdbcResult<(Option<String>, Option<String>)> {
     if catalog.is_some() && schema.is_some() {
         return Ok((catalog, schema));
     }
 
     let table_specified = table.is_some_and(|t| !t.is_empty());
-    let use_ctx = metadata_request_use_connection_ctx(conn_handle)?;
+    let use_ctx = metadata_request_use_connection_ctx(conn_handle, cancel.clone())?;
     let needs_info = catalog.is_none() || (schema.is_none() && (use_ctx || table_specified));
     if !needs_info {
         return Ok((catalog, schema));
@@ -463,11 +481,14 @@ fn resolve_show_identifiers(
 
     let rt = global().context(OdbcRuntimeSnafu)?;
     let info = rt.block_on(async |c| {
-        c.connection_get_info(ConnectionGetInfoRequest {
-            conn_handle: Some(conn_handle),
-            info_codes: vec![],
-            include_master_token: false,
-        })
+        c.connection_get_info(
+            ConnectionGetInfoRequest {
+                conn_handle: Some(conn_handle),
+                info_codes: vec![],
+                include_master_token: false,
+            },
+            cancel,
+        )
         .await
     })?;
 
@@ -726,6 +747,8 @@ pub fn primary_keys<E: OdbcEncoding>(
     let stmt_handle = guard.stmt_handle;
     drop(conn);
 
+    let (_cancel_guard, cancel) = arm_statement_cancel(&guard);
+
     if metadata_id {
         if catalog_raw.is_none() {
             return NullPointerSnafu.fail();
@@ -755,8 +778,13 @@ pub fn primary_keys<E: OdbcEncoding>(
         (catalog_raw, schema_raw, table_raw)
     };
 
-    let (catalog_raw, schema_raw) =
-        resolve_show_identifiers(catalog_raw, schema_raw, table_raw.as_deref(), conn_handle)?;
+    let (catalog_raw, schema_raw) = resolve_show_identifiers(
+        catalog_raw,
+        schema_raw,
+        table_raw.as_deref(),
+        conn_handle,
+        cancel.clone(),
+    )?;
 
     let scope = build_show_in_scope(
         catalog_raw.as_deref(),
@@ -765,7 +793,7 @@ pub fn primary_keys<E: OdbcEncoding>(
     );
     let sql = format!("SHOW PRIMARY KEYS IN {scope}");
 
-    let show_batch = match execute_show_query_collect_batch(stmt_handle, &sql) {
+    let show_batch = match execute_show_query_collect_batch(stmt_handle, &sql, cancel) {
         Ok(batch) => batch,
         Err(e) => {
             if e.server_sql_state()
@@ -1184,6 +1212,8 @@ pub fn foreign_keys<E: OdbcEncoding>(
     let stmt_handle = guard.stmt_handle;
     drop(conn);
 
+    let (_cancel_guard, cancel) = arm_statement_cancel(&guard);
+
     if metadata_id {
         // Only the side whose table was supplied carries required identifier
         // args; a single-sided query intentionally leaves the other side NULL.
@@ -1237,12 +1267,14 @@ pub fn foreign_keys<E: OdbcEncoding>(
         pk_schema_raw,
         pk_table_raw.as_deref(),
         conn_handle,
+        cancel.clone(),
     )?;
     let (fk_catalog_raw, fk_schema_raw) = resolve_show_identifiers(
         fk_catalog_raw,
         fk_schema_raw,
         fk_table_raw.as_deref(),
         conn_handle,
+        cancel.clone(),
     )?;
 
     let sql = build_show_foreign_keys_command(
@@ -1254,7 +1286,7 @@ pub fn foreign_keys<E: OdbcEncoding>(
         fk_table_raw.as_deref(),
     );
 
-    let show_batch = match execute_show_query_collect_batch(stmt_handle, &sql) {
+    let show_batch = match execute_show_query_collect_batch(stmt_handle, &sql, cancel) {
         Ok(batch) => batch,
         Err(e) => {
             if e.server_sql_state()
@@ -1390,10 +1422,14 @@ fn returns_table(data_type: &str) -> bool {
 /// Runs `SELECT database_name FROM information_schema.databases` to enumerate the
 /// databases to union over when the caller passes a NULL catalog without
 /// connection-context resolution (mirrors the reference `QueryDatabases`).
-fn enumerate_databases(stmt_handle: StatementHandle) -> OdbcResult<Vec<String>> {
+fn enumerate_databases(
+    stmt_handle: StatementHandle,
+    cancel: tokio_util::sync::CancellationToken,
+) -> OdbcResult<Vec<String>> {
     let batch = execute_show_query_collect_batch(
         stmt_handle,
         "select database_name from information_schema.databases",
+        cancel,
     )?;
     let mut dbs = Vec::with_capacity(batch.num_rows());
     for row in 0..batch.num_rows() {
@@ -1545,6 +1581,8 @@ pub fn procedures<E: OdbcEncoding>(
     let stmt_handle = guard.stmt_handle;
     drop(conn);
 
+    let (_cancel_guard, cancel) = arm_statement_cancel(&guard);
+
     // In identifier mode (SQL_ATTR_METADATA_ID = TRUE) every argument is a
     // required identifier: a NULL pointer is HY009.
     if metadata_id && (catalog_raw.is_none() || schema_raw.is_none() || proc_raw.is_none()) {
@@ -1565,14 +1603,17 @@ pub fn procedures<E: OdbcEncoding>(
     // NULL catalog under CLIENT_METADATA_REQUEST_USE_CONNECTION_CTX resolves to
     // the connection's current database (and schema, if schema is also NULL);
     // otherwise a NULL catalog enumerates every database (union all).
-    if catalog_raw.is_none() && metadata_request_use_connection_ctx(conn_handle)? {
+    if catalog_raw.is_none() && metadata_request_use_connection_ctx(conn_handle, cancel.clone())? {
         let rt = global().context(OdbcRuntimeSnafu)?;
         let info = rt.block_on(async |c| {
-            c.connection_get_info(ConnectionGetInfoRequest {
-                conn_handle: Some(conn_handle),
-                info_codes: vec![],
-                include_master_token: false,
-            })
+            c.connection_get_info(
+                ConnectionGetInfoRequest {
+                    conn_handle: Some(conn_handle),
+                    info_codes: vec![],
+                    include_master_token: false,
+                },
+                cancel.clone(),
+            )
             .await
         })?;
         db_name = info.database;
@@ -1583,7 +1624,7 @@ pub fn procedures<E: OdbcEncoding>(
 
     let db_names = match db_name {
         Some(db) => vec![db],
-        None => enumerate_databases(stmt_handle)?,
+        None => enumerate_databases(stmt_handle, cancel.clone())?,
     };
 
     if db_names.is_empty() {
@@ -1596,7 +1637,7 @@ pub fn procedures<E: OdbcEncoding>(
         proc_pattern.as_deref(),
     );
 
-    let batch = match execute_show_query_collect_batch(stmt_handle, &sql) {
+    let batch = match execute_show_query_collect_batch(stmt_handle, &sql, cancel) {
         Ok(batch) => batch,
         Err(e) => {
             if e.server_sql_state()
@@ -2216,6 +2257,8 @@ pub fn procedure_columns<E: OdbcEncoding>(
     let stmt_handle = guard.stmt_handle;
     drop(conn);
 
+    let (_cancel_guard, cancel) = arm_statement_cancel(&guard);
+
     // Identifier mode (SQL_ATTR_METADATA_ID = TRUE): catalog, schema, and proc
     // name are all required identifiers — a NULL pointer is HY009. ColumnName may
     // still be NULL (means "all columns").
@@ -2234,14 +2277,17 @@ pub fn procedure_columns<E: OdbcEncoding>(
     // the signature is parsed (the type strings never reach the server query).
     let column_pattern = catalog_arg_to_pattern(column_raw.as_deref(), metadata_id)?;
 
-    if catalog_raw.is_none() && metadata_request_use_connection_ctx(conn_handle)? {
+    if catalog_raw.is_none() && metadata_request_use_connection_ctx(conn_handle, cancel.clone())? {
         let rt = global().context(OdbcRuntimeSnafu)?;
         let info = rt.block_on(async |c| {
-            c.connection_get_info(ConnectionGetInfoRequest {
-                conn_handle: Some(conn_handle),
-                info_codes: vec![],
-                include_master_token: false,
-            })
+            c.connection_get_info(
+                ConnectionGetInfoRequest {
+                    conn_handle: Some(conn_handle),
+                    info_codes: vec![],
+                    include_master_token: false,
+                },
+                cancel.clone(),
+            )
             .await
         })?;
         db_name = info.database;
@@ -2252,7 +2298,7 @@ pub fn procedure_columns<E: OdbcEncoding>(
 
     let db_names = match db_name {
         Some(db) => vec![db],
-        None => enumerate_databases(stmt_handle)?,
+        None => enumerate_databases(stmt_handle, cancel.clone())?,
     };
 
     if db_names.is_empty() {
@@ -2265,7 +2311,7 @@ pub fn procedure_columns<E: OdbcEncoding>(
         proc_pattern.as_deref(),
     );
 
-    let batch = match execute_show_query_collect_batch(stmt_handle, &sql) {
+    let batch = match execute_show_query_collect_batch(stmt_handle, &sql, cancel) {
         Ok(batch) => batch,
         Err(e) => {
             if e.server_sql_state()
@@ -2304,19 +2350,23 @@ fn execute_get_objects_and_flatten(
     db_schema: Option<String>,
     table_name: Option<String>,
     table_type: Vec<String>,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> OdbcResult<()> {
     let rt = global().context(OdbcRuntimeSnafu)?;
 
     let response = rt.block_on(async |c| {
-        c.connection_get_objects(ConnectionGetObjectsRequest {
-            conn_handle: Some(conn_handle),
-            depth,
-            catalog,
-            db_schema,
-            table_name,
-            table_type,
-            column_name: None,
-        })
+        c.connection_get_objects(
+            ConnectionGetObjectsRequest {
+                conn_handle: Some(conn_handle),
+                depth,
+                catalog,
+                db_schema,
+                table_name,
+                table_type,
+                column_name: None,
+            },
+            cancel.clone(),
+        )
         .await
     })?;
 
@@ -2331,19 +2381,27 @@ fn execute_get_objects_and_flatten(
     // Fetch the Arrow stream from the result set handle
     let stream_ptr = {
         let stream_resp = rt.block_on(async |c| {
-            c.result_set_get_stream(ResultSetGetStreamRequest {
-                result_set_handle: Some(rs_handle),
-            })
-            .await
-        })?;
-        // Release is best-effort
-        let _ = rt.block_on(async |c| {
-            c.result_set_release(ResultSetReleaseRequest {
-                result_set_handle: Some(rs_handle),
-            })
+            c.result_set_get_stream(
+                ResultSetGetStreamRequest {
+                    result_set_handle: Some(rs_handle),
+                },
+                cancel.clone(),
+            )
             .await
         });
-        stream_resp
+        // Release before propagating any error so a failed/cancelled stream fetch
+        // does not leak the result set. Release is best-effort and must not reuse a
+        // possibly-cancelled token, or cancellation would skip cleanup.
+        let _ = rt.block_on(async |c| {
+            c.result_set_release(
+                ResultSetReleaseRequest {
+                    result_set_handle: Some(rs_handle),
+                },
+                tokio_util::sync::CancellationToken::new(),
+            )
+            .await
+        });
+        stream_resp?
             .stream
             .ok_or_else(|| crate::api::error::OdbcError::InternalError {
                 message: "ConnectionGetObjects: missing stream".to_string(),
@@ -2358,7 +2416,7 @@ fn execute_get_objects_and_flatten(
         .context(ArrowArrayStreamReaderCreationSnafu)?;
 
     // Read all batches from the nested Arrow stream
-    let nested_batch = collect_nested_batch(Box::new(reader))?;
+    let nested_batch = collect_nested_batch(Box::new(reader), cancel)?;
 
     // Flatten the nested batch into the flat 5-col ODBC result
     let flat_batch = flatten_to_odbc(nested_batch, depth)?;
@@ -2385,19 +2443,23 @@ fn execute_get_columns_and_flatten(
     db_schema: Option<String>,
     table_name: Option<String>,
     column_name: Option<String>,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> OdbcResult<()> {
     let rt = global().context(OdbcRuntimeSnafu)?;
 
     let response = rt.block_on(async |c| {
-        c.connection_get_objects(ConnectionGetObjectsRequest {
-            conn_handle: Some(conn_handle),
-            depth: DEPTH_COLUMNS,
-            catalog,
-            db_schema,
-            table_name,
-            table_type: vec![],
-            column_name,
-        })
+        c.connection_get_objects(
+            ConnectionGetObjectsRequest {
+                conn_handle: Some(conn_handle),
+                depth: DEPTH_COLUMNS,
+                catalog,
+                db_schema,
+                table_name,
+                table_type: vec![],
+                column_name,
+            },
+            cancel.clone(),
+        )
         .await
     })?;
 
@@ -2411,18 +2473,27 @@ fn execute_get_columns_and_flatten(
 
     let stream_ptr = {
         let stream_resp = rt.block_on(async |c| {
-            c.result_set_get_stream(ResultSetGetStreamRequest {
-                result_set_handle: Some(rs_handle),
-            })
-            .await
-        })?;
-        let _ = rt.block_on(async |c| {
-            c.result_set_release(ResultSetReleaseRequest {
-                result_set_handle: Some(rs_handle),
-            })
+            c.result_set_get_stream(
+                ResultSetGetStreamRequest {
+                    result_set_handle: Some(rs_handle),
+                },
+                cancel.clone(),
+            )
             .await
         });
-        stream_resp
+        // Release before propagating any error so a failed/cancelled stream fetch
+        // does not leak the result set. Release is best-effort and must not reuse a
+        // possibly-cancelled token, or cancellation would skip cleanup.
+        let _ = rt.block_on(async |c| {
+            c.result_set_release(
+                ResultSetReleaseRequest {
+                    result_set_handle: Some(rs_handle),
+                },
+                tokio_util::sync::CancellationToken::new(),
+            )
+            .await
+        });
+        stream_resp?
             .stream
             .ok_or_else(|| crate::api::error::OdbcError::InternalError {
                 message: "ConnectionGetObjects: missing stream".to_string(),
@@ -2435,7 +2506,7 @@ fn execute_get_columns_and_flatten(
     let reader = ArrowArrayStreamReader::try_new(owned_stream)
         .context(ArrowArrayStreamReaderCreationSnafu)?;
 
-    let nested_batch = collect_nested_batch(Box::new(reader))?;
+    let nested_batch = collect_nested_batch(Box::new(reader), cancel)?;
     let flat_batch = flatten_columns_to_odbc(nested_batch, &numeric_settings)?;
 
     let schema = flat_batch.schema();

--- a/odbc/src/api/connection.rs
+++ b/odbc/src/api/connection.rs
@@ -434,24 +434,33 @@ fn connect_with_params(
 
     let (db_handle, conn_handle) = global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
         let db_handle = c
-            .database_new(DatabaseNewRequest {})
+            .database_new(
+                DatabaseNewRequest {},
+                tokio_util::sync::CancellationToken::new(),
+            )
             .await?
             .db_handle
             .required("Database handle is required")?;
         let conn_handle = c
-            .connection_new(ConnectionNewRequest {})
+            .connection_new(
+                ConnectionNewRequest {},
+                tokio_util::sync::CancellationToken::new(),
+            )
             .await?
             .conn_handle
             .required("Connection handle is required")?;
 
         let response = c
-            .connection_set_options(ConnectionSetOptionsRequest {
-                conn_handle: Some(conn_handle),
-                options,
-                // ODBC always connects via a connection string / DSN, so there
-                // is no bare-connect default-profile fallback to trigger.
-                no_connection_details: false,
-            })
+            .connection_set_options(
+                ConnectionSetOptionsRequest {
+                    conn_handle: Some(conn_handle),
+                    options,
+                    // ODBC always connects via a connection string / DSN, so there
+                    // is no bare-connect default-profile fallback to trigger.
+                    no_connection_details: false,
+                },
+                tokio_util::sync::CancellationToken::new(),
+            )
             .await?;
 
         for warning in &response.warnings {
@@ -465,11 +474,14 @@ fn connect_with_params(
                 DEFAULT_LOGIN_TIMEOUT_SECS.to_string().into(),
             )]);
             let response = c
-                .connection_set_options(ConnectionSetOptionsRequest {
-                    conn_handle: Some(conn_handle),
-                    options: follow_up,
-                    no_connection_details: false,
-                })
+                .connection_set_options(
+                    ConnectionSetOptionsRequest {
+                        conn_handle: Some(conn_handle),
+                        options: follow_up,
+                        no_connection_details: false,
+                    },
+                    tokio_util::sync::CancellationToken::new(),
+                )
                 .await?;
             for warning in &response.warnings {
                 tracing::warn!("connection option warning: {}", warning.message);
@@ -478,18 +490,21 @@ fn connect_with_params(
 
         apply_pre_connection_runtime_attrs_async(c, &pre_connection_attrs, conn_handle).await?;
 
-        c.connection_init(ConnectionInitRequest {
-            conn_handle: Some(conn_handle),
-            db_handle: Some(db_handle),
-            wrapper_identity: Some(WrapperIdentity {
-                driver_name: Some(ODBC_DRIVER_NAME.to_string()),
-                driver_version: Some(ODBC_DRIVER_VERSION.to_string()),
-                // Set at compile time in `build.rs` (`SF_ODBC_*`) from Cargo / rustc.
-                language_runtime: Some(env!("SF_ODBC_WRAPPER_LANGUAGE_RUNTIME").to_string()),
-                language_version: Some(env!("SF_ODBC_BUILD_RUST_SEMVER").to_string()),
-                language_compiler: None,
-            }),
-        })
+        c.connection_init(
+            ConnectionInitRequest {
+                conn_handle: Some(conn_handle),
+                db_handle: Some(db_handle),
+                wrapper_identity: Some(WrapperIdentity {
+                    driver_name: Some(ODBC_DRIVER_NAME.to_string()),
+                    driver_version: Some(ODBC_DRIVER_VERSION.to_string()),
+                    // Set at compile time in `build.rs` (`SF_ODBC_*`) from Cargo / rustc.
+                    language_runtime: Some(env!("SF_ODBC_WRAPPER_LANGUAGE_RUNTIME").to_string()),
+                    language_version: Some(env!("SF_ODBC_BUILD_RUST_SEMVER").to_string()),
+                    language_compiler: None,
+                }),
+            },
+            tokio_util::sync::CancellationToken::new(),
+        )
         .await?;
 
         Ok::<_, crate::api::OdbcError>((db_handle, conn_handle))
@@ -510,11 +525,14 @@ fn connect_with_params(
         Ok(rt) => rt
             .block_on(async |c| {
                 let info = c
-                    .connection_get_info(ConnectionGetInfoRequest {
-                        conn_handle: Some(conn_handle),
-                        info_codes: vec![],
-                        include_master_token: false,
-                    })
+                    .connection_get_info(
+                        ConnectionGetInfoRequest {
+                            conn_handle: Some(conn_handle),
+                            info_codes: vec![],
+                            include_master_token: false,
+                        },
+                        tokio_util::sync::CancellationToken::new(),
+                    )
                     .await?;
                 Ok::<Option<String>, crate::api::OdbcError>(info.database)
             })
@@ -586,10 +604,13 @@ async fn apply_pre_connection_runtime_attrs_async(
         {
             Some(val) => {
                 client
-                    .connection_set_autocommit(ConnectionSetAutocommitRequest {
-                        conn_handle: Some(conn_handle),
-                        autocommit: matches!(val, AutocommitValue::On),
-                    })
+                    .connection_set_autocommit(
+                        ConnectionSetAutocommitRequest {
+                            conn_handle: Some(conn_handle),
+                            autocommit: matches!(val, AutocommitValue::On),
+                        },
+                        tokio_util::sync::CancellationToken::new(),
+                    )
                     .await?;
             }
             None => {
@@ -792,17 +813,26 @@ pub fn disconnect(connection_handle: sql::Handle) -> OdbcResult<()> {
     };
 
     global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
-        c.connection_close(ConnectionCloseRequest {
-            conn_handle: Some(conn_handle),
-        })
+        c.connection_close(
+            ConnectionCloseRequest {
+                conn_handle: Some(conn_handle),
+            },
+            tokio_util::sync::CancellationToken::new(),
+        )
         .await?;
-        c.connection_release(ConnectionReleaseRequest {
-            conn_handle: Some(conn_handle),
-        })
+        c.connection_release(
+            ConnectionReleaseRequest {
+                conn_handle: Some(conn_handle),
+            },
+            tokio_util::sync::CancellationToken::new(),
+        )
         .await?;
-        c.database_release(DatabaseReleaseRequest {
-            db_handle: Some(db_handle),
-        })
+        c.database_release(
+            DatabaseReleaseRequest {
+                db_handle: Some(db_handle),
+            },
+            tokio_util::sync::CancellationToken::new(),
+        )
         .await?;
         Ok::<_, crate::api::OdbcError>(())
     })?;
@@ -868,10 +898,13 @@ pub fn native_sql<E: OdbcEncoding>(
 fn get_session_parameter(conn_handle: &ConnectionHandle, key: &str) -> OdbcResult<Option<String>> {
     global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
         let resp = c
-            .connection_get_parameter(ConnectionGetParameterRequest {
-                conn_handle: Some(*conn_handle),
-                key: key.to_string(),
-            })
+            .connection_get_parameter(
+                ConnectionGetParameterRequest {
+                    conn_handle: Some(*conn_handle),
+                    key: key.to_string(),
+                },
+                tokio_util::sync::CancellationToken::new(),
+            )
             .await?;
         Ok(resp.value)
     })
@@ -971,15 +1004,21 @@ fn commit_or_rollback(dbc: &Dbc, op: TxnOp) -> OdbcResult<()> {
     g.block_on(async |c| -> OdbcResult<()> {
         match op {
             TxnOp::Commit => {
-                c.connection_commit(ConnectionCommitRequest {
-                    conn_handle: Some(conn_handle),
-                })
+                c.connection_commit(
+                    ConnectionCommitRequest {
+                        conn_handle: Some(conn_handle),
+                    },
+                    tokio_util::sync::CancellationToken::new(),
+                )
                 .await?;
             }
             TxnOp::Rollback => {
-                c.connection_rollback(ConnectionRollbackRequest {
-                    conn_handle: Some(conn_handle),
-                })
+                c.connection_rollback(
+                    ConnectionRollbackRequest {
+                        conn_handle: Some(conn_handle),
+                    },
+                    tokio_util::sync::CancellationToken::new(),
+                )
                 .await?;
             }
         }
@@ -1080,10 +1119,13 @@ pub fn set_connect_attr<E: OdbcEncoding>(
                     let autocommit_on = matches!(val, AutocommitValue::On);
                     drop(connection);
                     global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
-                        c.connection_set_autocommit(ConnectionSetAutocommitRequest {
-                            conn_handle: Some(conn_handle),
-                            autocommit: autocommit_on,
-                        })
+                        c.connection_set_autocommit(
+                            ConnectionSetAutocommitRequest {
+                                conn_handle: Some(conn_handle),
+                                autocommit: autocommit_on,
+                            },
+                            tokio_util::sync::CancellationToken::new(),
+                        )
                         .await
                     })?;
                     let mut connection = dbc.connection.lock();
@@ -1166,10 +1208,13 @@ pub fn set_connect_attr<E: OdbcEncoding>(
             global()
                 .context(OdbcRuntimeSnafu)?
                 .block_on(async |c| {
-                    c.connection_use_database(ConnectionUseDatabaseRequest {
-                        conn_handle: Some(conn_handle),
-                        database: catalog.clone(),
-                    })
+                    c.connection_use_database(
+                        ConnectionUseDatabaseRequest {
+                            conn_handle: Some(conn_handle),
+                            database: catalog.clone(),
+                        },
+                        tokio_util::sync::CancellationToken::new(),
+                    )
                     .await
                 })
                 .map_err(|e| -> crate::api::OdbcError {
@@ -1604,11 +1649,14 @@ fn current_database(dbc: &HandleGuard<Dbc>) -> OdbcResult<Option<String>> {
         Some(handle) => {
             let db = global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
                 let info = c
-                    .connection_get_info(ConnectionGetInfoRequest {
-                        conn_handle: Some(handle),
-                        info_codes: vec![],
-                        include_master_token: false,
-                    })
+                    .connection_get_info(
+                        ConnectionGetInfoRequest {
+                            conn_handle: Some(handle),
+                            info_codes: vec![],
+                            include_master_token: false,
+                        },
+                        tokio_util::sync::CancellationToken::new(),
+                    )
                     .await?;
                 Ok::<Option<String>, crate::api::OdbcError>(info.database)
             })?;
@@ -1686,9 +1734,12 @@ pub fn get_info<E: OdbcEncoding>(
             let version = match conn_handle {
                 Some(handle) => global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
                     let resp = c
-                        .connection_get_server_version(ConnectionGetServerVersionRequest {
-                            conn_handle: Some(handle),
-                        })
+                        .connection_get_server_version(
+                            ConnectionGetServerVersionRequest {
+                                conn_handle: Some(handle),
+                            },
+                            tokio_util::sync::CancellationToken::new(),
+                        )
                         .await?;
                     Ok::<Option<String>, crate::api::OdbcError>(resp.server_version)
                 })?,

--- a/odbc/src/api/error.rs
+++ b/odbc/src/api/error.rs
@@ -15,7 +15,8 @@ use odbc_sys as sql;
 use proto_utils::ProtoError;
 use sf_core::protobuf::generated::database_driver_v1::{
     ErrorTraceEntry, GenericError, InvalidParameterValue as ProtoInvalidParameterValue,
-    MissingParameter as ProtoMissingParameter, driver_error::ErrorType,
+    MissingParameter as ProtoMissingParameter, StatusCode as ProtoStatusCode,
+    driver_error::ErrorType,
 };
 
 use error_trace::ErrorTrace;
@@ -1098,20 +1099,28 @@ impl OdbcError {
         let loc = std::panic::Location::caller();
         let location = Location::new(loc.file(), loc.line(), loc.column());
         let core_error = match error {
-            ProtoError::Application(driver_exception) => CoreProtobufError::Application {
-                error: Box::new(
-                    driver_exception
-                        .error
-                        .and_then(|error| error.error_type)
-                        .unwrap_or(ErrorType::GenericError(GenericError {})),
-                ),
-                message: driver_exception.message,
-                status_code: driver_exception.status_code,
-                error_trace: driver_exception.error_trace,
-                sql_state: driver_exception.sql_state,
-                query_id: driver_exception.query_id,
-                location,
-            },
+            ProtoError::Application(driver_exception) => {
+                // A core-side cancellation must surface as OperationCanceled (HY008),
+                // not a generic CoreError (HY000); the status_code carries the
+                // classification the ApiError->protobuf boundary already erased.
+                if driver_exception.status_code == ProtoStatusCode::Cancelled as i32 {
+                    return OdbcError::OperationCanceled { location };
+                }
+                CoreProtobufError::Application {
+                    error: Box::new(
+                        driver_exception
+                            .error
+                            .and_then(|error| error.error_type)
+                            .unwrap_or(ErrorType::GenericError(GenericError {})),
+                    ),
+                    message: driver_exception.message,
+                    status_code: driver_exception.status_code,
+                    error_trace: driver_exception.error_trace,
+                    sql_state: driver_exception.sql_state,
+                    query_id: driver_exception.query_id,
+                    location,
+                }
+            }
             ProtoError::Transport(message) => CoreProtobufError::Transport { message, location },
         };
         OdbcError::CoreError {

--- a/odbc/src/api/handle_allocation.rs
+++ b/odbc/src/api/handle_allocation.rs
@@ -122,9 +122,12 @@ pub fn alloc_statement(input_handle: sql::Handle) -> OdbcResult<sql::Handle> {
     };
 
     let response = global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
-        c.statement_new(StatementNewRequest {
-            conn_handle: Some(conn_handle),
-        })
+        c.statement_new(
+            StatementNewRequest {
+                conn_handle: Some(conn_handle),
+            },
+            tokio_util::sync::CancellationToken::new(),
+        )
         .await
     })?;
 
@@ -204,9 +207,12 @@ fn cleanup_connection(dbc: &Dbc) -> OdbcResult<()> {
             ]
         };
         if let Err(e) = g.block_on(async |c| {
-            c.statement_release(StatementReleaseRequest {
-                stmt_handle: Some(stmt_handle),
-            })
+            c.statement_release(
+                StatementReleaseRequest {
+                    stmt_handle: Some(stmt_handle),
+                },
+                tokio_util::sync::CancellationToken::new(),
+            )
             .await
         }) {
             tracing::warn!("free_connection: failed to release statement {stmt_handle:?}: {e:?}");
@@ -297,9 +303,12 @@ pub fn free_statement(handle: sql::Handle) -> OdbcResult<()> {
     // Release the server-side handle first; only delete on success so that
     // free_connection's cleanup loop can still find the handle on failure.
     let release_result = g.block_on(async |c| {
-        c.statement_release(StatementReleaseRequest {
-            stmt_handle: Some(stmt_handle),
-        })
+        c.statement_release(
+            StatementReleaseRequest {
+                stmt_handle: Some(stmt_handle),
+            },
+            tokio_util::sync::CancellationToken::new(),
+        )
         .await?;
         Ok(())
     });

--- a/odbc/src/api/statement.rs
+++ b/odbc/src/api/statement.rs
@@ -169,7 +169,7 @@ fn exec_direct_impl(statement_handle: sql::Handle, statement_text: &str) -> Odbc
         let multi_statement_count = inner.multi_statement_count;
         let async_enabled = inner.async_enabled;
 
-        match run_cancellable(&guard, async_enabled, |client| async move {
+        match run_cancellable(&guard, async_enabled, |client, cancel| async move {
             let _bindings_owner = bindings_owner;
             if multi_statement_count >= 0 {
                 let mut options = std::collections::HashMap::new();
@@ -182,30 +182,39 @@ fn exec_direct_impl(statement_handle: sql::Handle, statement_text: &str) -> Odbc
                     },
                 );
                 client
-                    .statement_set_options(StatementSetOptionsRequest {
-                        stmt_handle: Some(stmt_handle),
-                        options,
-                    })
+                    .statement_set_options(
+                        StatementSetOptionsRequest {
+                            stmt_handle: Some(stmt_handle),
+                            options,
+                        },
+                        cancel.clone(),
+                    )
                     .await?;
             }
 
             client
-                .statement_set_sql_query(StatementSetSqlQueryRequest {
-                    stmt_handle: Some(stmt_handle),
-                    query: effective_query,
-                })
+                .statement_set_sql_query(
+                    StatementSetSqlQueryRequest {
+                        stmt_handle: Some(stmt_handle),
+                        query: effective_query,
+                    },
+                    cancel.clone(),
+                )
                 .await?;
 
             let response = client
-                .statement_execute_query(StatementExecuteQueryRequest {
-                    stmt_handle: Some(stmt_handle),
-                    bindings,
-                    timeout_seconds: if query_timeout > 0 {
-                        Some(query_timeout.min(u32::MAX as sql::ULen) as u32)
-                    } else {
-                        None
+                .statement_execute_query(
+                    StatementExecuteQueryRequest {
+                        stmt_handle: Some(stmt_handle),
+                        bindings,
+                        timeout_seconds: if query_timeout > 0 {
+                            Some(query_timeout.min(u32::MAX as sql::ULen) as u32)
+                        } else {
+                            None
+                        },
                     },
-                })
+                    cancel.clone(),
+                )
                 .await?;
             Ok(ExecDirectOutcome {
                 response,
@@ -230,6 +239,10 @@ fn exec_direct_impl(statement_handle: sql::Handle, statement_text: &str) -> Odbc
     };
 
     // === POST-PROCESSING (shared by poll and sync paths) ===
+    // Arm a fresh statement token so SQLCancel can interrupt result-stream
+    // materialization during finalization (run_cancellable's RPC token was
+    // already dropped). Sequential per-phase tokens avoid stale-cancel bleed.
+    let (_finalize_cancel_guard, finalize_cancel) = arm_statement_cancel(&guard);
     finalize_execute_response(
         &mut conn,
         &mut inner,
@@ -237,6 +250,7 @@ fn exec_direct_impl(statement_handle: sql::Handle, statement_text: &str) -> Odbc
         outcome.response,
         ExecutionOrigin::Direct,
         Some(statement_text),
+        finalize_cancel,
     )?;
     Ok(())
 }
@@ -254,8 +268,9 @@ fn finalize_execute_response(
     response: ExecuteQueryResponse,
     origin: ExecutionOrigin,
     last_sql: Option<&str>,
+    cancel: CancellationToken,
 ) -> OdbcResult<()> {
-    update_numeric_settings(&conn_handle, &mut conn.numeric_settings, last_sql)?;
+    update_numeric_settings(&conn_handle, &mut conn.numeric_settings, last_sql, cancel.clone())?;
 
     // Snapshot output pointers before passing `inner` into apply_execute_response.
     let param_set_size = inner.with_effective_apd(|apd| apd.array_size);
@@ -266,7 +281,7 @@ fn finalize_execute_response(
     // actually skipped.
     let param_operation_ptr = inner.with_effective_apd(|apd| apd.array_status_ptr);
 
-    let result = apply_execute_response(inner, conn_handle, response, origin);
+    let result = apply_execute_response(inner, conn_handle, response, origin, cancel);
     inner.rows_returned = 0;
 
     // Write PARAMS_PROCESSED and PARAM_STATUS regardless of result so the
@@ -306,14 +321,18 @@ fn update_numeric_settings(
     conn_handle: &ConnectionHandle,
     settings: &mut NumericSettings,
     last_sql: Option<&str>,
+    cancel: CancellationToken,
 ) -> OdbcResult<()> {
     let g = global().context(OdbcRuntimeSnafu)?;
     g.block_on(async |c| {
         if let Ok(resp) = c
-            .connection_get_parameter(ConnectionGetParameterRequest {
-                conn_handle: Some(*conn_handle),
-                key: "ODBC_TREAT_DECIMAL_AS_INT".to_string(),
-            })
+            .connection_get_parameter(
+                ConnectionGetParameterRequest {
+                    conn_handle: Some(*conn_handle),
+                    key: "ODBC_TREAT_DECIMAL_AS_INT".to_string(),
+                },
+                cancel.clone(),
+            )
             .await
             && let Some(value) = resp.value
         {
@@ -323,10 +342,13 @@ fn update_numeric_settings(
         }
 
         if let Ok(resp) = c
-            .connection_get_parameter(ConnectionGetParameterRequest {
-                conn_handle: Some(*conn_handle),
-                key: "ODBC_TREAT_BIG_NUMBER_AS_STRING".to_string(),
-            })
+            .connection_get_parameter(
+                ConnectionGetParameterRequest {
+                    conn_handle: Some(*conn_handle),
+                    key: "ODBC_TREAT_BIG_NUMBER_AS_STRING".to_string(),
+                },
+                cancel.clone(),
+            )
             .await
             && let Some(value) = resp.value
         {
@@ -336,10 +358,13 @@ fn update_numeric_settings(
         }
 
         if let Ok(resp) = c
-            .connection_get_parameter(ConnectionGetParameterRequest {
-                conn_handle: Some(*conn_handle),
-                key: "VARCHAR_AND_BINARY_MAX_SIZE_IN_RESULT".to_string(),
-            })
+            .connection_get_parameter(
+                ConnectionGetParameterRequest {
+                    conn_handle: Some(*conn_handle),
+                    key: "VARCHAR_AND_BINARY_MAX_SIZE_IN_RESULT".to_string(),
+                },
+                cancel.clone(),
+            )
             .await
             && let Some(value) = resp.value
             && let Ok(size) = value.parse::<u64>()
@@ -383,16 +408,25 @@ fn update_numeric_settings(
         // See PR #1068 review on `statement.rs:209`.
         if tz_format_needs_refresh(settings.tz_offset_format_cache, last_sql) {
             let rpc_result = c
-                .connection_get_parameter(ConnectionGetParameterRequest {
-                    conn_handle: Some(*conn_handle),
-                    key: "TIMESTAMP_TZ_OUTPUT_FORMAT".to_string(),
-                })
+                .connection_get_parameter(
+                    ConnectionGetParameterRequest {
+                        conn_handle: Some(*conn_handle),
+                        key: "TIMESTAMP_TZ_OUTPUT_FORMAT".to_string(),
+                    },
+                    cancel.clone(),
+                )
                 .await
                 .map(|resp| resp.value)
                 .map_err(|e| format!("{e:?}"));
             apply_tz_offset_format_update(&mut settings.tz_offset_format_cache, rpc_result);
         }
     });
+    // A cancelled settings refresh must surface as OperationCanceled rather than
+    // silently completing finalization; the per-RPC error-swallowing above is for
+    // genuine transient failures, not caller-initiated cancellation.
+    if cancel.is_cancelled() {
+        return OperationCanceledSnafu.fail();
+    }
     Ok(())
 }
 
@@ -827,48 +861,55 @@ fn prepare_impl(statement_handle: sql::Handle, query: &str) -> OdbcResult<()> {
 
         let query_owned = query.to_string();
 
-        let execution_outcome = run_cancellable(&guard, async_enabled, |client| async move {
-            client
-                .statement_set_sql_query(StatementSetSqlQueryRequest {
-                    stmt_handle: Some(stmt_handle),
-                    query: query_owned,
-                })
-                .await?;
+        let execution_outcome =
+            run_cancellable(&guard, async_enabled, |client, cancel| async move {
+                client
+                    .statement_set_sql_query(
+                        StatementSetSqlQueryRequest {
+                            stmt_handle: Some(stmt_handle),
+                            query: query_owned,
+                        },
+                        cancel.clone(),
+                    )
+                    .await?;
 
-            let prepare_response = client
-                .statement_prepare(StatementPrepareRequest {
-                    stmt_handle: Some(stmt_handle),
-                })
-                .await?;
+                let prepare_response = client
+                    .statement_prepare(
+                        StatementPrepareRequest {
+                            stmt_handle: Some(stmt_handle),
+                        },
+                        cancel.clone(),
+                    )
+                    .await?;
 
-            let result = prepare_response.result.required("Result is required")?;
-            let stream_ptr = result.stream.required("Stream is required")?;
-            let reader = reader_from_protobuf_stream(stream_ptr)?;
-            let schema = reader.schema();
+                let result = prepare_response.result.required("Result is required")?;
+                let stream_ptr = result.stream.required("Stream is required")?;
+                let reader = reader_from_protobuf_stream(stream_ptr)?;
+                let schema = reader.schema();
 
-            if result.number_of_binds < 0 {
-                tracing::warn!(
-                    "prepare: server reported negative bind count ({}), treating as 0",
-                    result.number_of_binds
-                );
-            }
-            let raw_bind_count = result.number_of_binds.max(0);
-            let param_count = u16::try_from(raw_bind_count).map_err(|_| {
-                crate::api::error::CountFieldIncorrectSnafu {
+                if result.number_of_binds < 0 {
+                    tracing::warn!(
+                        "prepare: server reported negative bind count ({}), treating as 0",
+                        result.number_of_binds
+                    );
+                }
+                let raw_bind_count = result.number_of_binds.max(0);
+                let param_count = u16::try_from(raw_bind_count).map_err(|_| {
+                    crate::api::error::CountFieldIncorrectSnafu {
                     reason: format!(
                         "server reported {raw_bind_count} parameter markers, exceeds maximum {}",
                         u16::MAX
                     ),
                 }
                 .build()
-            })?;
+                })?;
 
-            Ok(PrepareOutcome {
-                number_of_binds: param_count,
-                schema,
-                array_bind_supported: result.array_bind_supported,
-            })
-        })?;
+                Ok(PrepareOutcome {
+                    number_of_binds: param_count,
+                    schema,
+                    array_bind_supported: result.array_bind_supported,
+                })
+            })?;
         match execution_outcome {
             Execution::Completed(outcome) => outcome,
             Execution::Spawned(join_handle) => {
@@ -1035,7 +1076,7 @@ pub fn execute(statement_handle: sql::Handle) -> OdbcResult<()> {
         let multi_statement_count = inner.multi_statement_count;
         let async_enabled = inner.async_enabled;
 
-        let outcome = match run_cancellable(&guard, async_enabled, |client| async move {
+        let outcome = match run_cancellable(&guard, async_enabled, |client, cancel| async move {
             let _bindings_owner = bindings_owner;
             if multi_statement_count >= 0 {
                 let mut options = std::collections::HashMap::new();
@@ -1048,22 +1089,28 @@ pub fn execute(statement_handle: sql::Handle) -> OdbcResult<()> {
                     },
                 );
                 client
-                    .statement_set_options(StatementSetOptionsRequest {
-                        stmt_handle: Some(stmt_handle),
-                        options,
-                    })
+                    .statement_set_options(
+                        StatementSetOptionsRequest {
+                            stmt_handle: Some(stmt_handle),
+                            options,
+                        },
+                        cancel.clone(),
+                    )
                     .await?;
             }
             let response = client
-                .statement_execute_query(StatementExecuteQueryRequest {
-                    stmt_handle: Some(stmt_handle),
-                    bindings,
-                    timeout_seconds: if query_timeout > 0 {
-                        Some(query_timeout.min(u32::MAX as sql::ULen) as u32)
-                    } else {
-                        None
+                .statement_execute_query(
+                    StatementExecuteQueryRequest {
+                        stmt_handle: Some(stmt_handle),
+                        bindings,
+                        timeout_seconds: if query_timeout > 0 {
+                            Some(query_timeout.min(u32::MAX as sql::ULen) as u32)
+                        } else {
+                            None
+                        },
                     },
-                })
+                    cancel.clone(),
+                )
                 .await?;
             Ok(ExecuteOutcome {
                 response,
@@ -1097,6 +1144,10 @@ pub fn execute(statement_handle: sql::Handle) -> OdbcResult<()> {
     // RPC. An `ALTER SESSION` issued via prepare/execute (very rare) is
     // the documented edge case where the new format won't take effect
     // until the next `SQLExecDirect` runs.
+    // Arm a fresh statement token so SQLCancel can interrupt result-stream
+    // materialization during finalization (run_cancellable's RPC token was
+    // already dropped). Sequential per-phase tokens avoid stale-cancel bleed.
+    let (_finalize_cancel_guard, finalize_cancel) = arm_statement_cancel(&guard);
     finalize_execute_response(
         &mut conn,
         &mut inner,
@@ -1104,6 +1155,7 @@ pub fn execute(statement_handle: sql::Handle) -> OdbcResult<()> {
         outcome.response,
         origin,
         None,
+        finalize_cancel,
     )?;
     Ok(())
 }
@@ -1139,6 +1191,7 @@ fn apply_execute_response(
     conn_handle: ConnectionHandle,
     response: ExecuteQueryResponse,
     origin: ExecutionOrigin,
+    cancel: CancellationToken,
 ) -> OdbcResult<()> {
     let result = response.result.required("Execute result is required")?;
 
@@ -1155,7 +1208,7 @@ fn apply_execute_response(
                 .result_set_handle
                 .required("ResultSet handle is required")?;
             let query_id = descriptor.query_id.clone();
-            let stream = fetch_stream_and_release(rs_handle)?;
+            let stream = fetch_stream_and_release(rs_handle, cancel)?;
             let execute_state = create_execute_state_from_stream(
                 stream,
                 descriptor.statement_type_id,
@@ -1199,14 +1252,14 @@ fn apply_execute_response(
 
             // Fetch and apply the first child result set.
             let first_id = &stmt.multi_query_ids[0];
-            let rs = fetch_result_set_by_query_id(conn_handle, first_id)?;
+            let rs = fetch_result_set_by_query_id(conn_handle, first_id, cancel.clone())?;
             let descriptor = rs.result_descriptor.as_ref();
             let statement_type_id = descriptor.and_then(|d| d.statement_type_id);
             let rows_affected = descriptor.and_then(|d| d.rows_affected);
             let rs_handle = rs
                 .result_set_handle
                 .required("ResultSet handle is required")?;
-            let stream = fetch_stream_and_release(rs_handle)?;
+            let stream = fetch_stream_and_release(rs_handle, cancel)?;
             let execute_state =
                 create_execute_state_from_stream(stream, statement_type_id, rows_affected, origin)?;
             stmt.multi_current_idx = 1;
@@ -1220,12 +1273,16 @@ fn apply_execute_response(
 fn fetch_result_set_by_query_id(
     conn_handle: ConnectionHandle,
     query_id: &str,
+    cancel: CancellationToken,
 ) -> OdbcResult<ResultSetResponse> {
     let response = global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
-        c.connection_get_result_set(ConnectionGetResultSetRequest {
-            conn_handle: Some(conn_handle),
-            query_id: query_id.to_string(),
-        })
+        c.connection_get_result_set(
+            ConnectionGetResultSetRequest {
+                conn_handle: Some(conn_handle),
+                query_id: query_id.to_string(),
+            },
+            cancel,
+        )
         .await
     })?;
     Ok(response)
@@ -1235,26 +1292,35 @@ fn fetch_result_set_by_query_id(
 ///
 /// `result_set_get_stream` takes ownership of the prebuilt stream (one-shot),
 /// so the handle is no longer useful after this call.
-fn fetch_stream_and_release(rs_handle: ResultSetHandle) -> OdbcResult<ArrowArrayStreamPtr> {
-    let stream = {
-        let response = global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
-            c.result_set_get_stream(ResultSetGetStreamRequest {
+fn fetch_stream_and_release(
+    rs_handle: ResultSetHandle,
+    cancel: CancellationToken,
+) -> OdbcResult<ArrowArrayStreamPtr> {
+    let fetch_result = global().context(OdbcRuntimeSnafu)?.block_on(async |c| {
+        c.result_set_get_stream(
+            ResultSetGetStreamRequest {
                 result_set_handle: Some(rs_handle),
-            })
-            .await
-        })?;
-        response.stream.required("Stream is required")?
-    };
+            },
+            cancel,
+        )
+        .await
+    });
+    // Release the handle whether or not the fetch succeeded — an error (including
+    // cancellation) must not leak the result set and its stored rowset data.
     release_result_set(rs_handle);
+    let stream = fetch_result?.stream.required("Stream is required")?;
     Ok(stream)
 }
 
 fn release_result_set(rs_handle: ResultSetHandle) {
     if let Ok(rt) = global() {
         let _ = rt.block_on(async |c| {
-            c.result_set_release(ResultSetReleaseRequest {
-                result_set_handle: Some(rs_handle),
-            })
+            c.result_set_release(
+                ResultSetReleaseRequest {
+                    result_set_handle: Some(rs_handle),
+                },
+                tokio_util::sync::CancellationToken::new(),
+            )
             .await
         });
     }
@@ -1262,11 +1328,28 @@ fn release_result_set(rs_handle: ResultSetHandle) {
 
 pub(crate) fn collect_nested_batch(
     mut reader: Box<dyn RecordBatchReader + Send>,
+    cancel: CancellationToken,
 ) -> OdbcResult<RecordBatch> {
     let schema = reader.schema();
     let mut batches = vec![];
     for b in &mut *reader {
-        let batch = b.context(ArrowBatchReadSnafu)?;
+        // Check on the success path too: a reader draining already-buffered
+        // batches yields no error, so an error-only check would let SQLCancel
+        // slip through and the operation complete instead of returning HY008.
+        if cancel.is_cancelled() {
+            return OperationCanceledSnafu.fail();
+        }
+        let batch = match b {
+            Ok(batch) => batch,
+            // Draining the reader materializes external chunks; if SQLCancel
+            // fired during that blocking read, classify it as OperationCanceled
+            // (HY008) rather than a generic ArrowBatchRead error.
+            Err(e) if cancel.is_cancelled() => {
+                tracing::debug!(error = %e, "reader drain cancelled");
+                return OperationCanceledSnafu.fail();
+            }
+            Err(e) => return Err(e).context(ArrowBatchReadSnafu),
+        };
         batches.push(batch);
     }
     if batches.is_empty() {
@@ -1282,19 +1365,26 @@ pub(crate) fn collect_nested_batch(
 pub(crate) fn execute_show_query_collect_batch(
     stmt_handle: StatementHandle,
     sql: &str,
+    cancel: CancellationToken,
 ) -> OdbcResult<RecordBatch> {
     let rt = global().context(OdbcRuntimeSnafu)?;
     let response = rt.block_on(async |c| {
-        c.statement_set_sql_query(StatementSetSqlQueryRequest {
-            stmt_handle: Some(stmt_handle),
-            query: sql.to_string(),
-        })
+        c.statement_set_sql_query(
+            StatementSetSqlQueryRequest {
+                stmt_handle: Some(stmt_handle),
+                query: sql.to_string(),
+            },
+            cancel.clone(),
+        )
         .await?;
-        c.statement_execute_query(StatementExecuteQueryRequest {
-            stmt_handle: Some(stmt_handle),
-            bindings: None,
-            timeout_seconds: None,
-        })
+        c.statement_execute_query(
+            StatementExecuteQueryRequest {
+                stmt_handle: Some(stmt_handle),
+                bindings: None,
+                timeout_seconds: None,
+            },
+            cancel.clone(),
+        )
         .await
     })?;
 
@@ -1314,9 +1404,9 @@ pub(crate) fn execute_show_query_collect_batch(
         }
     };
 
-    let stream = fetch_stream_and_release(rs_handle)?;
+    let stream = fetch_stream_and_release(rs_handle, cancel.clone())?;
     let reader = reader_from_protobuf_stream(stream)?;
-    collect_nested_batch(Box::new(reader))
+    collect_nested_batch(Box::new(reader), cancel)
 }
 
 fn create_execute_state_from_stream(
@@ -1499,10 +1589,13 @@ fn get_session_parameter(conn_handle: &ConnectionHandle, key: &str) -> OdbcResul
         .context(OdbcRuntimeSnafu)?
         .block_on(async |c| {
             let resp = c
-                .connection_get_parameter(ConnectionGetParameterRequest {
-                    conn_handle: Some(*conn_handle),
-                    key: key.to_string(),
-                })
+                .connection_get_parameter(
+                    ConnectionGetParameterRequest {
+                        conn_handle: Some(*conn_handle),
+                        key: key.to_string(),
+                    },
+                    tokio_util::sync::CancellationToken::new(),
+                )
                 .await?;
             Ok(resp.value)
         })
@@ -2956,7 +3049,7 @@ fn accumulate_put_data(
 
 /// Sets `cancel_token` on creation and clears it on drop, so every exit
 /// path (including early returns and panics) releases the token.
-struct CancelTokenGuard<'a> {
+pub(crate) struct CancelTokenGuard<'a> {
     slot: &'a parking_lot::Mutex<Option<CancellationToken>>,
 }
 
@@ -2975,6 +3068,20 @@ impl Drop for CancelTokenGuard<'_> {
         *self.slot.lock() = None;
     }
 }
+
+/// Arms a fresh cancellation token on the statement so `SQLCancel` can abort
+/// the in-flight operation, returning the RAII guard (clears the slot on every
+/// exit path) and a clone of the token to thread into the operation's RPCs.
+/// The token slot is a separate mutex from `StatementInner`, so `SQLCancel`
+/// reaches it without contending on the lock a running operation holds.
+pub(crate) fn arm_statement_cancel(
+    stmt: &crate::api::Statement,
+) -> (CancelTokenGuard<'_>, CancellationToken) {
+    let token = CancellationToken::new();
+    let guard = CancelTokenGuard::arm(&stmt.cancel_token, token.clone());
+    (guard, token)
+}
+
 
 /// Awaits a finished `JoinHandle` and translates panics into internal errors.
 fn poll_join_handle<T>(join_handle: tokio::task::JoinHandle<OdbcResult<T>>) -> OdbcResult<T> {
@@ -3032,6 +3139,7 @@ fn run_cancellable<T, F>(
     async_enabled: bool,
     f: impl FnOnce(
         std::sync::Arc<sf_core::protobuf::apis::database_driver_v1::DatabaseDriverClient>,
+        CancellationToken,
     ) -> F,
 ) -> OdbcResult<Execution<T>>
 where
@@ -3044,7 +3152,11 @@ where
 
     if async_enabled {
         let token_clone = token.clone();
-        let future = f(client);
+        let future = f(client, token.clone());
+        // Publish the token BEFORE spawning so a concurrent SQLCancel cannot
+        // observe an empty slot while the task is already running (TOCTOU race).
+        // The async cleanup path clears the slot on poll completion / free.
+        *stmt.cancel_token.lock() = Some(token);
         let join_handle = g.spawn(async move {
             tokio::select! {
                 biased;
@@ -3052,12 +3164,11 @@ where
                 result = future => result,
             }
         });
-        *stmt.cancel_token.lock() = Some(token);
         return Ok(Execution::Spawned(join_handle));
     }
 
     let _cancel_guard = CancelTokenGuard::arm(&stmt.cancel_token, token.clone());
-    let future = f(client);
+    let future = f(client, token.clone());
     let result = g.block_on(async move |_c| {
         tokio::select! {
             biased;
@@ -3211,6 +3322,7 @@ fn execute_dae(
         Ok(globals) => globals,
     };
     let response = globals.block_on(async |c| {
+        let rpc_token = token.clone();
         tokio::select! {
             biased;
             _ = token.cancelled() => OperationCanceledSnafu.fail(),
@@ -3219,7 +3331,7 @@ fn execute_dae(
                     c.statement_set_sql_query(StatementSetSqlQueryRequest {
                         stmt_handle: Some(stmt_handle),
                         query,
-                    })
+                    }, rpc_token.clone())
                     .await?;
                 }
                 c.statement_execute_query(StatementExecuteQueryRequest {
@@ -3230,7 +3342,7 @@ fn execute_dae(
                     } else {
                         None
                     },
-                })
+                }, rpc_token.clone())
                 .await
             } => result.map_err(Into::into),
         }
@@ -3252,11 +3364,12 @@ fn execute_dae(
         &conn_handle,
         &mut conn.numeric_settings,
         last_sql.as_deref(),
+        token.clone(),
     ) {
         inner.state.set(restored);
         return Err(e);
     }
-    apply_execute_response(inner, conn_handle, response, origin)?;
+    apply_execute_response(inner, conn_handle, response, origin, token.clone())?;
     inner.rows_returned = 0;
     Ok(())
 }
@@ -3344,14 +3457,18 @@ pub fn more_results(statement_handle: sql::Handle) -> OdbcResult<()> {
     };
     drop(conn);
 
-    let rs = fetch_result_set_by_query_id(conn_handle, &query_id)?;
+    // Arm the statement token so a concurrent SQLCancel can interrupt the
+    // blocking result-set/stream fetch for the next child result set.
+    let (_cancel_guard, cancel) = arm_statement_cancel(&guard);
+
+    let rs = fetch_result_set_by_query_id(conn_handle, &query_id, cancel.clone())?;
     let descriptor = rs.result_descriptor.as_ref();
     let statement_type_id = descriptor.and_then(|d| d.statement_type_id);
     let rows_affected = descriptor.and_then(|d| d.rows_affected);
     let rs_handle = rs
         .result_set_handle
         .required("ResultSet handle is required")?;
-    let stream = fetch_stream_and_release(rs_handle)?;
+    let stream = fetch_stream_and_release(rs_handle, cancel)?;
     let execute_state =
         create_execute_state_from_stream(stream, statement_type_id, rows_affected, origin)?;
     set_state(&mut inner, execute_state);

--- a/odbc/src/api/telemetry.rs
+++ b/odbc/src/api/telemetry.rs
@@ -24,13 +24,16 @@ pub fn record_api_usage(
     let Ok(globals) = global() else { return };
     let result = globals.block_on(async |client| {
         client
-            .telemetry_send_api_usage(TelemetrySendApiUsageRequest {
-                conn_handle: Some(conn_handle),
-                api_method: api_method.to_string(),
-                // ODBC records bare entry-point names; argument capture is a
-                // wrapper-level concern that ODBC does not implement.
-                passed_arguments: Vec::new(),
-            })
+            .telemetry_send_api_usage(
+                TelemetrySendApiUsageRequest {
+                    conn_handle: Some(conn_handle),
+                    api_method: api_method.to_string(),
+                    // ODBC records bare entry-point names; argument capture is a
+                    // wrapper-level concern that ODBC does not implement.
+                    passed_arguments: Vec::new(),
+                },
+                tokio_util::sync::CancellationToken::new(),
+            )
             .await
     });
     if let Err(e) = result {
@@ -53,11 +56,14 @@ pub fn record_wrapper_error(handle_type: sql::HandleType, handle: sql::Handle, e
     let error_source: &'static str = error_source.into();
     let result = globals.block_on(async |client| {
         client
-            .telemetry_send_wrapper_error(TelemetrySendWrapperErrorRequest {
-                conn_handle: Some(conn_handle),
-                exception_type: exception_type.to_string(),
-                error_source: error_source.to_string(),
-            })
+            .telemetry_send_wrapper_error(
+                TelemetrySendWrapperErrorRequest {
+                    conn_handle: Some(conn_handle),
+                    exception_type: exception_type.to_string(),
+                    error_source: error_source.to_string(),
+                },
+                tokio_util::sync::CancellationToken::new(),
+            )
             .await
     });
     if let Err(e) = result {

--- a/proto_generator/src/generators/rust_generator.rs
+++ b/proto_generator/src/generators/rust_generator.rs
@@ -102,6 +102,7 @@ impl RustGenerator {
         r#"
 use proto_utils::*;
 use prost::Message;
+use tokio_util::sync::CancellationToken;
 "#
         .to_string()
     }
@@ -165,13 +166,13 @@ use prost::Message;
         match method_error {
             Some(error) => {
                 format!(
-                    r#"	fn {name}(&self, input: {input_type}) -> impl std::future::Future<Output = Result<{output_type}, {error}>> + Send;
+                    r#"	fn {name}(&self, input: {input_type}, cancel: CancellationToken) -> impl std::future::Future<Output = Result<{output_type}, {error}>> + Send;
 "#
                 )
             }
             None => {
                 format!(
-                    r#"	fn {name}(&self, input: {input_type}) -> impl std::future::Future<Output = {output_type}> + Send;
+                    r#"	fn {name}(&self, input: {input_type}, cancel: CancellationToken) -> impl std::future::Future<Output = {output_type}> + Send;
 "#
                 )
             }
@@ -194,7 +195,7 @@ use prost::Message;
 
         let mut content = format!(
             r#"pub trait {service_name}Server : {service_name} {{
-	fn handle_message(&self, method: &str, message: Vec<u8>) -> impl std::future::Future<Output = Result<Vec<u8>, ProtoError<Vec<u8>>>> + Send where Self: Sync {{ async move {{
+	fn handle_message(&self, method: &str, message: Vec<u8>, cancel: CancellationToken) -> impl std::future::Future<Output = Result<Vec<u8>, ProtoError<Vec<u8>>>> + Send where Self: Sync {{ async move {{
 		match method {{
 "#
         );
@@ -230,7 +231,7 @@ use prost::Message;
 					Ok(input) => input,
 					Err(e) => return Err(ProtoError::Transport(e.to_string())),
 				}};
-				let result = Box::pin(self.{name}(input)).await;
+				let result = Box::pin(self.{name}(input, cancel.clone())).await;
 				match result {{
 				Ok(output) => Ok(output.encode_to_vec()),
 				Err(e) => Err(ProtoError::Application(e.encode_to_vec())),
@@ -307,8 +308,8 @@ impl<T: Transport> {service_name}Client<T> {{
             Some(error) => {
                 format!(
                     r#"
-    pub async fn {name}(&self, input: {input_type}) -> Result<{output_type}, ProtoError<{error}>> {{
-        let result = self.transport.handle_message("{service_name}", "{name}", input.encode_to_vec()).await;
+    pub async fn {name}(&self, input: {input_type}, cancel: CancellationToken) -> Result<{output_type}, ProtoError<{error}>> {{
+        let result = self.transport.handle_message("{service_name}", "{name}", input.encode_to_vec(), cancel).await;
         match result {{
             Ok(output) => {{
                 let output = {output_type}::decode(&output[..]);
@@ -333,8 +334,8 @@ impl<T: Transport> {service_name}Client<T> {{
             None => {
                 format!(
                     r#"
-    pub async fn {name}(&self, input: {input_type}) -> Result<{output_type}, ProtoError<()>> {{
-        let result = self.transport.handle_message("{service_name}", "{name}", input.encode_to_vec()).await;
+    pub async fn {name}(&self, input: {input_type}, cancel: CancellationToken) -> Result<{output_type}, ProtoError<()>> {{
+        let result = self.transport.handle_message("{service_name}", "{name}", input.encode_to_vec(), cancel).await;
         match result {{
             Ok(output) => {{
                 let output = {output_type}::decode(&output[..]);

--- a/proto_utils/Cargo.toml
+++ b/proto_utils/Cargo.toml
@@ -6,3 +6,6 @@ edition = "2024"
 [lib]
 name = "proto_utils"
 
+[dependencies]
+tokio-util = "0.7"
+

--- a/proto_utils/src/lib.rs
+++ b/proto_utils/src/lib.rs
@@ -10,5 +10,6 @@ pub trait Transport {
         service: &str,
         method: &str,
         message: Vec<u8>,
+        cancel: tokio_util::sync::CancellationToken,
     ) -> impl std::future::Future<Output = Result<Vec<u8>, ProtoError<Vec<u8>>>> + Send;
 }

--- a/sf_core/benches/prefetch_bench.rs
+++ b/sf_core/benches/prefetch_bench.rs
@@ -223,6 +223,7 @@ fn bench_arrow_prefetch(c: &mut Criterion) {
                             downloader,
                             parser,
                             &config,
+                            tokio_util::sync::CancellationToken::new(),
                         ))
                         .expect("failed to create prefetch reader");
 
@@ -324,6 +325,7 @@ fn bench_json_prefetch(c: &mut Criterion) {
                             downloader,
                             parser,
                             &config,
+                            tokio_util::sync::CancellationToken::new(),
                         ))
                         .expect("failed to create prefetch reader");
 

--- a/sf_core/src/apis/database_driver_v1/connection.rs
+++ b/sf_core/src/apis/database_driver_v1/connection.rs
@@ -63,6 +63,7 @@ impl DatabaseDriverV1 {
         &self,
         conn_handle: Handle,
         autocommit: bool,
+        cancel: tokio_util::sync::CancellationToken,
     ) -> Result<(), ApiError> {
         match self.connections.get_obj(conn_handle) {
             Some(conn_ptr) => {
@@ -73,7 +74,7 @@ impl DatabaseDriverV1 {
                     } else {
                         "ALTER SESSION SET AUTOCOMMIT = FALSE"
                     };
-                    self.execute_session_sql(&conn, sql, SessionStateRefresh::Apply)
+                    self.execute_session_sql(&conn, sql, SessionStateRefresh::Apply, cancel)
                         .await
                 } else {
                     conn.init_session_parameters
@@ -96,6 +97,7 @@ impl DatabaseDriverV1 {
         &self,
         conn_handle: Handle,
         database: &str,
+        cancel: tokio_util::sync::CancellationToken,
     ) -> Result<(), ApiError> {
         let db = database.trim();
         if db.is_empty() {
@@ -117,7 +119,7 @@ impl DatabaseDriverV1 {
                     }
                     .fail();
                 }
-                self.execute_session_sql(&conn, &sql, SessionStateRefresh::Apply)
+                self.execute_session_sql(&conn, &sql, SessionStateRefresh::Apply, cancel)
                     .await
             }
             None => InvalidArgumentSnafu {
@@ -129,15 +131,23 @@ impl DatabaseDriverV1 {
 
     /// Commit the open transaction on the given connection by executing `COMMIT`.
     /// Must only be called after the connection is initialised (`is_post_connect()`).
-    pub async fn connection_commit(&self, conn_handle: Handle) -> Result<(), ApiError> {
-        self.execute_transaction_control(conn_handle, "COMMIT")
+    pub async fn connection_commit(
+        &self,
+        conn_handle: Handle,
+        cancel: tokio_util::sync::CancellationToken,
+    ) -> Result<(), ApiError> {
+        self.execute_transaction_control(conn_handle, "COMMIT", cancel)
             .await
     }
 
     /// Roll back the open transaction on the given connection by executing `ROLLBACK`.
     /// Must only be called after the connection is initialised (`is_post_connect()`).
-    pub async fn connection_rollback(&self, conn_handle: Handle) -> Result<(), ApiError> {
-        self.execute_transaction_control(conn_handle, "ROLLBACK")
+    pub async fn connection_rollback(
+        &self,
+        conn_handle: Handle,
+        cancel: tokio_util::sync::CancellationToken,
+    ) -> Result<(), ApiError> {
+        self.execute_transaction_control(conn_handle, "ROLLBACK", cancel)
             .await
     }
 
@@ -147,6 +157,7 @@ impl DatabaseDriverV1 {
         &self,
         conn_handle: Handle,
         sql: &str,
+        cancel: tokio_util::sync::CancellationToken,
     ) -> Result<(), ApiError> {
         match self.connections.get_obj(conn_handle) {
             Some(conn_ptr) => {
@@ -160,7 +171,7 @@ impl DatabaseDriverV1 {
                 // COMMIT/ROLLBACK do not change session parameters or
                 // current database/schema/warehouse/role, so skip the
                 // session-state cache refresh.
-                self.execute_session_sql(&conn, sql, SessionStateRefresh::Skip)
+                self.execute_session_sql(&conn, sql, SessionStateRefresh::Skip, cancel)
                     .await
             }
             None => InvalidArgumentSnafu {
@@ -177,6 +188,7 @@ impl DatabaseDriverV1 {
         &self,
         conn_handle: Handle,
         schema: &str,
+        cancel: tokio_util::sync::CancellationToken,
     ) -> Result<(), ApiError> {
         let schema = schema.trim();
         if schema.is_empty() {
@@ -198,7 +210,7 @@ impl DatabaseDriverV1 {
                 }
                 let database = resolve_session_database(&conn)?;
                 let sql = build_use_schema_sql(database.as_deref(), schema);
-                self.execute_session_sql(&conn, &sql, SessionStateRefresh::Apply)
+                self.execute_session_sql(&conn, &sql, SessionStateRefresh::Apply, cancel)
                     .await
             }
             None => InvalidArgumentSnafu {
@@ -222,6 +234,7 @@ impl DatabaseDriverV1 {
         conn: &Connection,
         sql: &str,
         refresh: SessionStateRefresh,
+        cancel: tokio_util::sync::CancellationToken,
     ) -> Result<(), ApiError> {
         let query_input = QueryInput {
             sql: sql.to_string(),
@@ -248,6 +261,7 @@ impl DatabaseDriverV1 {
                 query_input.clone(),
                 &retry_policy,
                 QueryExecutionMode::Blocking,
+                cancel.clone(),
             )
             .await
             {
@@ -277,6 +291,7 @@ impl DatabaseDriverV1 {
         &self,
         conn_handle: Handle,
         _db_handle: Handle,
+        cancel: tokio_util::sync::CancellationToken,
     ) -> Result<(), ApiError> {
         match self.connections.get_obj(conn_handle) {
             Some(conn_ptr) => {
@@ -454,6 +469,7 @@ impl DatabaseDriverV1 {
                     token_cache.map(|c| c as &dyn TokenCache),
                     Some(&self.prompt_locks),
                     &retry_policy,
+                    cancel,
                 );
 
                 let login_result = if let Some(budget) = timeout_config.login_timeout {
@@ -1902,6 +1918,7 @@ impl DatabaseDriverV1 {
         &self,
         conn_handle: Handle,
         query_id: &str,
+        cancel: tokio_util::sync::CancellationToken,
     ) -> Result<snowflake::QueryStatusResult, ApiError> {
         if query_id.is_empty() {
             return InvalidArgumentSnafu {
@@ -1938,6 +1955,7 @@ impl DatabaseDriverV1 {
             let server_url = &server_url;
             let client_info = &client_info;
             let retry_policy = &retry_policy;
+            let cancel = cancel.clone();
             async move {
                 snowflake::get_query_status(
                     http_client,
@@ -1946,6 +1964,7 @@ impl DatabaseDriverV1 {
                     &token,
                     query_id,
                     retry_policy,
+                    cancel,
                 )
                 .await
             }
@@ -2432,7 +2451,11 @@ impl DatabaseDriverV1 {
     ///
     /// This design matches all existing Snowflake drivers (Python, Go, JDBC, .NET, Node.js)
     /// which configure logout behavior at connection initialization, not at close time.
-    pub async fn connection_close(&self, conn_handle: Handle) -> Result<(), ApiError> {
+    pub async fn connection_close(
+        &self,
+        conn_handle: Handle,
+        cancel: tokio_util::sync::CancellationToken,
+    ) -> Result<(), ApiError> {
         let conn_ptr = self
             .connections
             .get_obj(conn_handle)
@@ -2482,7 +2505,8 @@ impl DatabaseDriverV1 {
         self.flush_connection_telemetry(conn_handle).await;
 
         // Execute logout — network I/O, lock must not be held
-        let logout_result = logout::execute_logout_with_strategy(logout_data, error_strategy).await;
+        let logout_result =
+            logout::execute_logout_with_strategy(logout_data, error_strategy, cancel).await;
 
         // Cleanup connection resources (separate lock acquisition after I/O)
         cleanup_connection(&conn_ptr).await?;

--- a/sf_core/src/apis/database_driver_v1/database.rs
+++ b/sf_core/src/apis/database_driver_v1/database.rs
@@ -62,6 +62,7 @@ impl DatabaseDriverV1 {
         chunk_format: ChunkFormatKind,
         nullable_flags: &[bool],
         row_types: Vec<RowType>,
+        cancel: tokio_util::sync::CancellationToken,
     ) -> Result<Box<FFI_ArrowArrayStream>, ApiError> {
         let (client, prefetch_config) = match conn_handle {
             Some(conn_handle) => {
@@ -99,6 +100,7 @@ impl DatabaseDriverV1 {
             nullable_flags,
             client,
             &prefetch_config,
+            cancel,
         )
         .await
         .context(ChunkFetchSnafu)?;

--- a/sf_core/src/apis/database_driver_v1/error.rs
+++ b/sf_core/src/apis/database_driver_v1/error.rs
@@ -203,4 +203,27 @@ pub enum ApiError {
         #[snafu(implicit)]
         location: Location,
     },
+    #[snafu(display("Operation cancelled"))]
+    Cancelled {
+        #[snafu(implicit)]
+        location: Location,
+    },
+}
+
+impl ApiError {
+    pub(crate) fn is_cancelled(&self) -> bool {
+        match self {
+            ApiError::Cancelled { .. } => true,
+            ApiError::Login { source, .. }
+            | ApiError::Query { source, .. }
+            | ApiError::TokenRequest { source, .. }
+            | ApiError::SessionRefresh { source, .. } => source.is_cancelled(),
+            ApiError::ChunkFetch { source, .. } | ApiError::InlineJsonEncode { source, .. } => {
+                source.is_cancelled()
+            }
+            ApiError::QueryResponseProcess { source, .. } => source.is_cancelled(),
+            ApiError::StageBinding { source, .. } => source.is_cancelled(),
+            _ => false,
+        }
+    }
 }

--- a/sf_core/src/apis/database_driver_v1/get_objects.rs
+++ b/sf_core/src/apis/database_driver_v1/get_objects.rs
@@ -25,6 +25,7 @@ use arrow::array::{
 };
 use arrow::buffer::{NullBuffer, OffsetBuffer, ScalarBuffer};
 use arrow::datatypes::{DataType, Field, Fields, Schema, SchemaRef};
+use arrow::error::ArrowError;
 use snafu::{OptionExt, ResultExt};
 use tokio::sync::Mutex;
 
@@ -32,7 +33,7 @@ use super::connection::{Connection, with_valid_session};
 use super::error::*;
 use super::global_state::DatabaseDriverV1;
 use super::like_pattern;
-use crate::chunks::PrefetchConfig;
+use crate::chunks::{ChunkError, PrefetchConfig};
 use crate::handle_manager::Handle;
 use crate::rest::snowflake::{
     QueryExecutionMode, QueryInput, RestError, snowflake_query_with_client,
@@ -204,6 +205,7 @@ impl DatabaseDriverV1 {
     pub async fn connection_get_objects(
         &self,
         req: GetObjectsRequest,
+        cancel: tokio_util::sync::CancellationToken,
     ) -> Result<super::result_set::ResultSetInfo, ApiError> {
         let conn_ptr = self
             .connections
@@ -221,12 +223,15 @@ impl DatabaseDriverV1 {
         // explicitly; reject COLUMNS (deferred) and unknown values rather than
         // letting them fall through to a TABLES catch-all.
         let batch = match req.depth {
-            DEPTH_CATALOGS => fetch_catalogs(&conn_ptr, catalog_filter.as_deref()).await?,
+            DEPTH_CATALOGS => {
+                fetch_catalogs(&conn_ptr, catalog_filter.as_deref(), cancel.clone()).await?
+            }
             DEPTH_DB_SCHEMAS => {
                 fetch_schemas(
                     &conn_ptr,
                     catalog_filter.as_deref(),
                     schema_filter.as_deref(),
+                    cancel.clone(),
                 )
                 .await?
             }
@@ -238,6 +243,7 @@ impl DatabaseDriverV1 {
                     schema_filter.as_deref(),
                     req.table_name.as_deref(),
                     &table_types,
+                    cancel.clone(),
                 )
                 .await?
             }
@@ -248,6 +254,7 @@ impl DatabaseDriverV1 {
                     schema_filter.as_deref(),
                     req.table_name.as_deref(),
                     req.column_name.as_deref(),
+                    cancel,
                 )
                 .await?
             }
@@ -307,9 +314,10 @@ async fn apply_connection_context(
 async fn fetch_catalogs(
     conn_ptr: &Arc<Mutex<Connection>>,
     catalog_filter: Option<&str>,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<RecordBatch, ApiError> {
     let sql = "SHOW DATABASES IN ACCOUNT".to_string();
-    let rows = execute_show(conn_ptr, &sql).await?;
+    let rows = execute_show(conn_ptr, &sql, cancel).await?;
 
     let catalog_names: Vec<Option<String>> = rows
         .iter()
@@ -335,6 +343,7 @@ async fn fetch_schemas(
     conn_ptr: &Arc<Mutex<Connection>>,
     catalog_filter: Option<&str>,
     schema_filter: Option<&str>,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<RecordBatch, ApiError> {
     // Pick tightest scope: exact catalog -> IN DATABASE "db", else IN ACCOUNT
     let sql = if let Some(pattern) = catalog_filter {
@@ -351,7 +360,7 @@ async fn fetch_schemas(
         "SHOW SCHEMAS IN ACCOUNT".to_string()
     };
 
-    let rows = execute_show(conn_ptr, &sql).await?;
+    let rows = execute_show(conn_ptr, &sql, cancel).await?;
 
     let mut by_catalog: BTreeMap<String, Vec<String>> = BTreeMap::new();
 
@@ -421,6 +430,7 @@ async fn fetch_tables(
     schema_filter: Option<&str>,
     table_name_filter: Option<&str>,
     table_types: &TableTypeFilter,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<RecordBatch, ApiError> {
     if matches!(table_types, TableTypeFilter::Unsupported) {
         return build_tables_batch(BTreeMap::new());
@@ -453,6 +463,7 @@ async fn fetch_tables(
     let rows = execute_show(
         conn_ptr,
         &format_show_sql("SHOW OBJECTS", &like_clause, &scope),
+        cancel,
     )
     .await?;
 
@@ -575,6 +586,7 @@ fn map_execute_show_error(
 async fn execute_show(
     conn_ptr: &Arc<Mutex<Connection>>,
     sql: &str,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<Vec<Vec<(String, String)>>, ApiError> {
     let (query_parameters, http_client, retry_policy, prefetch_config) = {
         let conn = conn_ptr.lock().await;
@@ -603,6 +615,7 @@ async fn execute_show(
         let query_parameters = query_parameters.clone();
         let query_input = query_input.clone();
         let retry_policy = retry_policy.clone();
+        let cancel = cancel.clone();
         async move {
             snowflake_query_with_client(
                 &http_client,
@@ -611,6 +624,7 @@ async fn execute_show(
                 query_input,
                 &retry_policy,
                 QueryExecutionMode::Blocking,
+                cancel,
             )
             .await
         }
@@ -629,18 +643,22 @@ async fn execute_show(
     // Account-wide `SHOW OBJECTS` spills to external chunks; parsing only the
     // inline rowset here would silently drop most rows.
     let rowset_data = response.data.into_rowset_data();
-    let reader = super::query::read_batches(&rowset_data, http_client, &prefetch_config, None)
-        .await
-        .map_err(|e| {
-            InvalidArgumentSnafu {
-                argument: format!("SHOW result read failed: {e}"),
-            }
-            .build()
-        })?;
+    let reader =
+        super::query::read_batches(&rowset_data, http_client, &prefetch_config, None, cancel.clone())
+            .await
+            .map_err(|e| {
+                if e.is_cancelled() {
+                    return CancelledSnafu.build();
+                }
+                InvalidArgumentSnafu {
+                    argument: format!("SHOW result read failed: {e}"),
+                }
+                .build()
+            })?;
     // The reader drains chunks via `blocking_recv`, which panics if polled on a
     // runtime worker; drain it on a blocking thread while downloads progress on
     // the async workers.
-    let parsed = tokio::task::spawn_blocking(move || rows_from_reader(reader))
+    let parsed = tokio::task::spawn_blocking(move || rows_from_reader(reader, cancel))
         .await
         .map_err(|e| {
             InvalidArgumentSnafu {
@@ -665,10 +683,24 @@ async fn execute_show(
 /// metadata) and consumer (`get_column`) never drift.
 fn rows_from_reader(
     reader: Box<dyn RecordBatchReader + Send>,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<Vec<Vec<(String, String)>>, ApiError> {
     let mut rows = Vec::new();
     for batch_result in reader {
-        let batch = batch_result.context(ArrowParseSnafu)?;
+        // Check on the success path too: draining already-buffered batches
+        // yields no error, so an error-only check would let cancellation slip
+        // through and the SHOW parse complete instead of surfacing CANCELLED.
+        if cancel.is_cancelled() {
+            return CancelledSnafu.fail();
+        }
+        let batch = match batch_result {
+            Ok(batch) => batch,
+            // A cancelled chunk download reaches the reader as a `ChunkError::Cancelled`
+            // boxed inside `ArrowError::ExternalError`; unwrap it so cancellation surfaces
+            // as CANCELLED instead of being flattened into `ApiError::ArrowParse`.
+            Err(e) if arrow_error_is_cancelled(&e) => return CancelledSnafu.fail(),
+            Err(e) => return Err(e).context(ArrowParseSnafu),
+        };
         let names: Vec<String> = batch
             .schema()
             .fields()
@@ -687,6 +719,16 @@ fn rows_from_reader(
         }
     }
     Ok(rows)
+}
+
+fn arrow_error_is_cancelled(err: &ArrowError) -> bool {
+    matches!(
+        err,
+        ArrowError::ExternalError(source)
+            if source
+                .downcast_ref::<ChunkError>()
+                .is_some_and(ChunkError::is_cancelled)
+    )
 }
 
 fn cell_as_string(column: &dyn Array, row_idx: usize) -> Option<String> {
@@ -1123,6 +1165,7 @@ async fn fetch_columns(
     schema_filter: Option<&str>,
     table_name_filter: Option<&str>,
     column_name_filter: Option<&str>,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<RecordBatch, ApiError> {
     // Empty string means "match nothing".
     if matches!(table_name_filter, Some("")) || matches!(column_name_filter, Some("")) {
@@ -1158,7 +1201,7 @@ async fn fetch_columns(
     };
 
     let sql = format_show_sql("SHOW COLUMNS", &col_like_clause, &scope);
-    let rows = execute_show(conn_ptr, &sql).await?;
+    let rows = execute_show(conn_ptr, &sql, cancel).await?;
 
     // Group columns by (catalog, schema, table), preserving SHOW row order for
     // ordinal_position assignment. BTreeMap gives deterministic lexicographic sort.
@@ -1376,6 +1419,105 @@ fn build_full_columns_schema_list_array(
 mod tests {
     use super::*;
     use arrow::ipc::reader::StreamReader;
+
+    struct OneErrorReader {
+        schema: SchemaRef,
+        err: Option<ArrowError>,
+    }
+
+    impl Iterator for OneErrorReader {
+        type Item = Result<RecordBatch, ArrowError>;
+        fn next(&mut self) -> Option<Self::Item> {
+            self.err.take().map(Err)
+        }
+    }
+
+    impl RecordBatchReader for OneErrorReader {
+        fn schema(&self) -> SchemaRef {
+            self.schema.clone()
+        }
+    }
+
+    fn one_error_reader(err: ArrowError) -> Box<dyn RecordBatchReader + Send> {
+        let schema = Arc::new(Schema::new(vec![Field::new("name", DataType::Utf8, true)]));
+        Box::new(OneErrorReader {
+            schema,
+            err: Some(err),
+        })
+    }
+
+    struct OkBatchReader {
+        schema: SchemaRef,
+        batch: Option<RecordBatch>,
+    }
+
+    impl Iterator for OkBatchReader {
+        type Item = Result<RecordBatch, ArrowError>;
+        fn next(&mut self) -> Option<Self::Item> {
+            self.batch.take().map(Ok)
+        }
+    }
+
+    impl RecordBatchReader for OkBatchReader {
+        fn schema(&self) -> SchemaRef {
+            self.schema.clone()
+        }
+    }
+
+    #[test]
+    fn rows_from_reader_maps_cancelled_chunk_to_cancelled() {
+        let cancelled = ChunkError::Cancelled {
+            location: snafu::Location::default(),
+        };
+        let reader = one_error_reader(ArrowError::ExternalError(Box::new(cancelled)));
+
+        let err = rows_from_reader(reader, tokio_util::sync::CancellationToken::new())
+            .expect_err("cancelled drain must surface an error");
+
+        assert!(
+            matches!(err, ApiError::Cancelled { .. }),
+            "expected ApiError::Cancelled, got {err:?}"
+        );
+        assert!(err.is_cancelled());
+    }
+
+    #[test]
+    fn rows_from_reader_maps_other_arrow_error_to_arrow_parse() {
+        let reader = one_error_reader(ArrowError::ComputeError("boom".to_string()));
+
+        let err = rows_from_reader(reader, tokio_util::sync::CancellationToken::new())
+            .expect_err("reader error must surface");
+
+        assert!(
+            matches!(err, ApiError::ArrowParse { .. }),
+            "expected ApiError::ArrowParse, got {err:?}"
+        );
+        assert!(!err.is_cancelled());
+    }
+
+    #[test]
+    fn rows_from_reader_cancelled_token_during_successful_drain() {
+        let schema = Arc::new(Schema::new(vec![Field::new("name", DataType::Utf8, true)]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(StringArray::from(vec!["a", "b"])) as ArrayRef],
+        )
+        .unwrap();
+        let reader = Box::new(OkBatchReader {
+            schema,
+            batch: Some(batch),
+        });
+
+        let cancel = tokio_util::sync::CancellationToken::new();
+        cancel.cancel();
+        let err = rows_from_reader(reader, cancel)
+            .expect_err("cancelled token must surface even on a successful drain");
+
+        assert!(
+            matches!(err, ApiError::Cancelled { .. }),
+            "expected ApiError::Cancelled, got {err:?}"
+        );
+    }
 
     // --- Schema contract ---
 
@@ -1665,7 +1807,7 @@ mod tests {
         }
         let chunk_base64 = BASE64.encode(&buf);
         let reader = single_chunk_reader(&chunk_base64, None).unwrap();
-        let rows = rows_from_reader(reader).unwrap();
+        let rows = rows_from_reader(reader, tokio_util::sync::CancellationToken::new()).unwrap();
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0][0].1, "MY_TABLE");
         assert_eq!(rows[0][1].1, "DB");

--- a/sf_core/src/apis/database_driver_v1/logout.rs
+++ b/sf_core/src/apis/database_driver_v1/logout.rs
@@ -221,7 +221,10 @@ pub(super) fn prepare_logout_from_conn(
 /// Uses `RefreshContext::execute_with_refresh` — the shared refresh-retry loop.
 /// Calls `execute_with_refresh` directly (not `with_valid_session`) because logout
 /// uses `RefreshContext::new()` (no `is_closed` check — logout runs after close).
-pub(super) async fn send_logout_request(data: LogoutData) -> Result<(), ApiError> {
+pub(super) async fn send_logout_request(
+    data: LogoutData,
+    cancel: tokio_util::sync::CancellationToken,
+) -> Result<(), ApiError> {
     let mut ctx = data.refresh_ctx;
 
     let result = ctx
@@ -230,12 +233,17 @@ pub(super) async fn send_logout_request(data: LogoutData) -> Result<(), ApiError
             let url = &data.url;
             let info = &data.info;
             let retry_policy = &data.retry_policy;
-            async move { logout_session(client, url, &token, info, retry_policy).await }
+            let cancel = cancel.clone();
+            async move { logout_session(client, url, &token, info, retry_policy, cancel).await }
         })
         .await;
 
-    // Remap ApiError::Query (from RefreshContext) to ApiError::Logout
+    // Remap ApiError::Query (from RefreshContext) to ApiError::Logout, but
+    // preserve cancellation classification: a cancelled logout must surface as
+    // ApiError::Cancelled rather than being flattened into ApiError::Logout
+    // (which maps to InternalError).
     result.map_err(|e| match e {
+        e if e.is_cancelled() => CancelledSnafu.build(),
         ApiError::Query { source, .. } => LogoutSnafu {
             message: format!("{source}"),
         }
@@ -255,10 +263,11 @@ pub(super) async fn send_logout_request(data: LogoutData) -> Result<(), ApiError
 pub(super) async fn execute_logout_with_strategy(
     logout_data: Option<LogoutData>,
     error_strategy: crate::config::logout::ErrorStrategy,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<(), ApiError> {
     let logout_result = match logout_data {
         Some(data) => {
-            let result = send_logout_request(data).await;
+            let result = send_logout_request(data, cancel).await;
             if result.is_ok() {
                 tracing::info!("Logout completed successfully");
             }
@@ -270,6 +279,13 @@ pub(super) async fn execute_logout_with_strategy(
             Ok(())
         }
     };
+
+    // Cancellation is a caller-initiated abort, not an unrecoverable logout
+    // failure, so it must surface as CANCELLED even under BestEffort (which
+    // would otherwise suppress it into Ok(())).
+    if logout_result.as_ref().is_err_and(|e| e.is_cancelled()) {
+        return logout_result;
+    }
 
     error_strategy.handle_failed_logout(logout_result)
 }

--- a/sf_core/src/apis/database_driver_v1/query.rs
+++ b/sf_core/src/apis/database_driver_v1/query.rs
@@ -53,6 +53,7 @@ pub struct StageInfoRefreshContext {
     pub sql: String,
     pub query_parameters: crate::config::rest_parameters::QueryParameters,
     pub conn: Arc<Mutex<Connection>>,
+    pub cancel: tokio_util::sync::CancellationToken,
 }
 
 /// Executes a PUT/GET file transfer and returns a `RowsetData` variant holding the results.
@@ -87,6 +88,7 @@ pub(super) async fn perform_put_get_transfer(
     unsafe_file_write: bool,
     tls_config: crate::tls::config::TlsConfig,
     crl_worker: crate::crl::worker::SharedCrlWorker,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<RowsetData, QueryResponseProcessingError> {
     // Seed the refresher's cache with the initial snapshot.
     let initial_snapshot = data
@@ -111,9 +113,10 @@ pub(super) async fn perform_put_get_transfer(
                 .context(FileTransferPreparationSnafu)?;
             file_upload_data.stage_info.tls_config = tls_config.clone();
             file_upload_data.stage_info.crl_worker = crl_worker.clone();
-            let upload_results = upload_files(&file_upload_data, retry_policy, refresher_handle)
-                .await
-                .context(FileUploadSnafu)?;
+            let upload_results =
+                upload_files(&file_upload_data, retry_policy, refresher_handle, cancel)
+                    .await
+                    .context(FileUploadSnafu)?;
             Ok(RowsetData::Upload(upload_results))
         }
         "DOWNLOAD" => {
@@ -133,7 +136,7 @@ pub(super) async fn perform_put_get_transfer(
             file_download_data.stage_info.tls_config = tls_config;
             file_download_data.stage_info.crl_worker = crl_worker;
             let download_results =
-                download_files(file_download_data, retry_policy, refresher_handle)
+                download_files(file_download_data, retry_policy, refresher_handle, cancel)
                     .await
                     .context(FileDownloadSnafu)?;
             Ok(RowsetData::Download(download_results))
@@ -162,6 +165,7 @@ pub(super) async fn perform_stream_upload(
     use_s3_regional_url_session_param: bool,
     put_get_policy: &RetryPolicy,
     bytes: Vec<u8>,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<RowsetData, QueryResponseProcessingError> {
     let upload_data = data
         .to_file_upload_data(
@@ -209,9 +213,10 @@ pub(super) async fn perform_stream_upload(
         multipart: upload_data.multipart,
     };
 
-    let result = upload_in_memory_file(bytes, single, put_get_policy, &mut refresher_handle)
-        .await
-        .context(FileUploadSnafu)?;
+    let result =
+        upload_in_memory_file(bytes, single, put_get_policy, &mut refresher_handle, cancel)
+            .await
+            .context(FileUploadSnafu)?;
 
     Ok(RowsetData::Upload(vec![result]))
 }
@@ -430,6 +435,7 @@ async fn fetch_fresh_stage_info_with_sql(
             let http_client = http_client.clone();
             let query_parameters = ctx.query_parameters.clone();
             let query_input = query_input.clone();
+            let cancel = ctx.cancel.clone();
             async move {
                 rest::snowflake::snowflake_query_with_client(
                     &http_client,
@@ -438,6 +444,7 @@ async fn fetch_fresh_stage_info_with_sql(
                     query_input,
                     &crate::config::retry::RetryPolicy::default(),
                     rest::snowflake::QueryExecutionMode::Blocking,
+                    cancel,
                 )
                 .await
             }
@@ -470,6 +477,7 @@ pub(super) async fn build_reader_from_rowset_data(
     prefetch_config: &PrefetchConfig,
     wrapper_presets: &WrapperPresets,
     nullable_flags: Option<&[bool]>,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<Box<dyn RecordBatchReader + Send>, QueryResponseProcessingError> {
     match data {
         RowsetData::Upload(results) => {
@@ -477,7 +485,7 @@ pub(super) async fn build_reader_from_rowset_data(
         }
         RowsetData::Download(results) => download_results_reader(results, wrapper_presets)
             .context(DownloadResultsConversionSnafu),
-        _ => read_batches(data, http_client, prefetch_config, nullable_flags)
+        _ => read_batches(data, http_client, prefetch_config, nullable_flags, cancel)
             .await
             .context(BatchReadSnafu),
     }
@@ -488,6 +496,7 @@ pub(super) async fn read_batches(
     http_client: Client,
     prefetch_config: &PrefetchConfig,
     nullable_flags: Option<&[bool]>,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<Box<dyn RecordBatchReader + Send>, ReadBatchesError> {
     tracing::debug!("read_batches called {:?}", data);
     match data {
@@ -503,6 +512,7 @@ pub(super) async fn read_batches(
             http_client.clone(),
             prefetch_config,
             nullable_flags,
+            cancel,
         )
         .await
         .context(ChunkReadSnafu),
@@ -519,6 +529,7 @@ pub(super) async fn read_batches(
                 Vec::new(),
                 http_client.clone(),
                 prefetch_config,
+                cancel,
             )
             .await
             .context(ChunkReadSnafu)
@@ -537,6 +548,7 @@ pub(super) async fn read_batches(
                 chunk_download_data.clone(),
                 http_client.clone(),
                 prefetch_config,
+                cancel,
             )
             .await
             .context(ChunkReadSnafu)
@@ -808,6 +820,17 @@ pub enum QueryResponseProcessingError {
     },
 }
 
+impl QueryResponseProcessingError {
+    pub(crate) fn is_cancelled(&self) -> bool {
+        match self {
+            QueryResponseProcessingError::BatchRead { source, .. } => source.is_cancelled(),
+            QueryResponseProcessingError::FileUpload { source, .. } => source.is_cancelled(),
+            QueryResponseProcessingError::FileDownload { source, .. } => source.is_cancelled(),
+            _ => false,
+        }
+    }
+}
+
 #[derive(Debug, Snafu, error_trace::ErrorTrace)]
 pub enum ReadBatchesError {
     #[snafu(display(
@@ -848,6 +871,12 @@ pub enum ReadBatchesError {
         #[snafu(implicit)]
         location: Location,
     },
+}
+
+impl ReadBatchesError {
+    pub(crate) fn is_cancelled(&self) -> bool {
+        matches!(self, ReadBatchesError::ChunkRead { source, .. } if source.is_cancelled())
+    }
 }
 
 #[cfg(test)]

--- a/sf_core/src/apis/database_driver_v1/result_set.rs
+++ b/sf_core/src/apis/database_driver_v1/result_set.rs
@@ -315,6 +315,7 @@ pub(super) async fn resolve_reader_ctx(
 pub(super) async fn fetch_query_response_data(
     conn_ptr: &Arc<Mutex<Connection>>,
     query_id: &str,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<Data, ApiError> {
     let (query_parameters, http_client, retry_policy) = {
         let conn = conn_ptr.lock().await;
@@ -338,6 +339,7 @@ pub(super) async fn fetch_query_response_data(
                 session_token.reveal(),
                 query_id,
                 &retry_policy,
+                cancel.clone(),
             )
             .await
             {
@@ -403,6 +405,7 @@ impl DatabaseDriverV1 {
     pub async fn result_set_get_stream(
         &self,
         result_handle: Handle,
+        cancel: tokio_util::sync::CancellationToken,
     ) -> Result<Box<dyn RecordBatchReader + Send>, ApiError> {
         let rs_ptr = self
             .results
@@ -424,6 +427,7 @@ impl DatabaseDriverV1 {
             &prefetch_config,
             &self.wrapper_presets,
             flags,
+            cancel,
         )
         .await
         .context(QueryResponseProcessSnafu)?;
@@ -550,6 +554,7 @@ impl DatabaseDriverV1 {
         &self,
         conn_handle: Handle,
         query_id: String,
+        cancel: tokio_util::sync::CancellationToken,
     ) -> Result<ResultSetInfo, ApiError> {
         let conn_ptr =
             self.connections
@@ -558,7 +563,7 @@ impl DatabaseDriverV1 {
                     argument: "Connection handle not found".to_string(),
                 })?;
 
-        let data = fetch_query_response_data(&conn_ptr, &query_id).await?;
+        let data = fetch_query_response_data(&conn_ptr, &query_id, cancel).await?;
         let descriptor = response_to_descriptor(&data, &self.wrapper_presets);
         let reader_ctx = resolve_reader_ctx(&conn_ptr).await?;
         let handle =
@@ -667,7 +672,9 @@ mod tests {
 
         let runtime = tokio::runtime::Runtime::new().expect("failed to build tokio runtime");
         let reader: Box<dyn RecordBatchReader + Send> = runtime
-            .block_on(driver.result_set_get_stream(handle))
+            .block_on(
+                driver.result_set_get_stream(handle, tokio_util::sync::CancellationToken::new()),
+            )
             .expect("result_set_get_stream should succeed for an inline JSON rowset");
 
         assert_id_name_reader(reader);
@@ -697,7 +704,9 @@ mod tests {
 
         let runtime = tokio::runtime::Runtime::new().expect("failed to build tokio runtime");
         let reader: Box<dyn RecordBatchReader + Send> = runtime
-            .block_on(driver.result_set_get_stream(handle))
+            .block_on(
+                driver.result_set_get_stream(handle, tokio_util::sync::CancellationToken::new()),
+            )
             .expect("result_set_get_stream should succeed for an inline Arrow rowset");
 
         assert_id_name_reader(reader);

--- a/sf_core/src/apis/database_driver_v1/statement.rs
+++ b/sf_core/src/apis/database_driver_v1/statement.rs
@@ -204,11 +204,15 @@ pub struct PrepareResult {
 }
 
 impl DatabaseDriverV1 {
-    pub async fn statement_prepare(&self, stmt_handle: Handle) -> Result<PrepareResult, ApiError> {
+    pub async fn statement_prepare(
+        &self,
+        stmt_handle: Handle,
+        cancel: tokio_util::sync::CancellationToken,
+    ) -> Result<PrepareResult, ApiError> {
         let session_id = self.session_id_for_stmt(stmt_handle).await;
         async {
             let result = self
-                .execute_query_internal(stmt_handle, None, Some(true), None)
+                .execute_query_internal(stmt_handle, None, Some(true), None, cancel.clone())
                 .await?;
 
             // Multi-statement query prepare is not supported.
@@ -218,8 +222,11 @@ impl DatabaseDriverV1 {
                 }
                 .fail();
             };
-            let stream = self.result_set_get_stream(rs_info.handle).await?;
+            // Release the handle whether or not the stream fetch succeeded — a
+            // cancelled or failed fetch must not leak the result set's rowset data.
+            let stream_result = self.result_set_get_stream(rs_info.handle, cancel).await;
             self.result_set_release(rs_info.handle)?;
+            let stream = stream_result?;
 
             let stmt_ptr =
                 self.statements
@@ -254,9 +261,10 @@ impl DatabaseDriverV1 {
         stmt_handle: Handle,
         bindings: Option<BindingType<'a>>,
         timeout_seconds: Option<u32>,
+        cancel: tokio_util::sync::CancellationToken,
     ) -> Result<ExecuteQueryResult, ApiError> {
         let session_id = self.session_id_for_stmt(stmt_handle).await;
-        self.execute_query_internal(stmt_handle, bindings, None, timeout_seconds)
+        self.execute_query_internal(stmt_handle, bindings, None, timeout_seconds, cancel)
             .instrument(crate::snowflake_op_span!(
                 "statement_execute_query",
                 session_id
@@ -271,6 +279,7 @@ impl DatabaseDriverV1 {
         query_parameters: &QueryParameters,
         retry_policy: &RetryPolicy,
         csv_bytes: &[u8],
+        cancel: tokio_util::sync::CancellationToken,
     ) -> Result<String, ApiError> {
         let (use_s3_regional_url_session_param, flags, put_get_policy) = {
             let conn = conn_arc.lock().await;
@@ -294,7 +303,7 @@ impl DatabaseDriverV1 {
             use_s3_regional_url_session_param,
         };
         let request_id = uuid::Uuid::new_v4();
-        crate::stage_binding::upload_csv_bindings(&stage_ctx, &flags, request_id, csv_bytes)
+        crate::stage_binding::upload_csv_bindings(&stage_ctx, &flags, request_id, csv_bytes, cancel)
             .await
             .context(StageBindingSnafu)
     }
@@ -305,6 +314,7 @@ impl DatabaseDriverV1 {
         bindings: Option<BindingType<'a>>,
         describe_only: Option<bool>,
         timeout_seconds: Option<u32>,
+        cancel: tokio_util::sync::CancellationToken,
     ) -> Result<ExecuteQueryResult, ApiError> {
         let stmt_ptr =
             self.statements
@@ -336,6 +346,7 @@ impl DatabaseDriverV1 {
                     &query_parameters,
                     &retry_policy,
                     bytes,
+                    cancel.clone(),
                 )
                 .await?;
             inject_timestamp_input_format_auto(&mut query_parameter_map);
@@ -372,6 +383,7 @@ impl DatabaseDriverV1 {
                     query_input.clone(),
                     &retry_policy,
                     execution_mode,
+                    cancel.clone(),
                 );
                 let result = if let Some((budget, deadline)) = query_deadline {
                     match tokio::time::timeout_at(deadline, query_call).await {
@@ -423,6 +435,7 @@ impl DatabaseDriverV1 {
                 data,
                 Some((query, query_parameters)),
                 skip_upload_on_content_match,
+                cancel,
             )
             .await?;
         let reader_ctx = resolve_reader_ctx(&conn_arc).await?;
@@ -442,6 +455,7 @@ impl DatabaseDriverV1 {
         data: query_response::Data,
         refresh_sql: Option<(String, QueryParameters)>,
         skip_upload_on_content_match: bool,
+        cancel: tokio_util::sync::CancellationToken,
     ) -> Result<query_response::RowsetData, ApiError> {
         match data.command.as_deref() {
             Some(command) => {
@@ -452,6 +466,7 @@ impl DatabaseDriverV1 {
                         sql,
                         query_parameters,
                         conn: conn.clone(),
+                        cancel: cancel.clone(),
                     });
                 // Late-bind connection params so post-init `set_option`
                 // overrides take effect (mirrors `LogoutConfig`).
@@ -480,6 +495,7 @@ impl DatabaseDriverV1 {
                     unsafe_file_write,
                     tls_config,
                     self.crl_worker.clone(),
+                    cancel,
                 )
                 .await
                 .context(QueryResponseProcessSnafu)
@@ -493,6 +509,7 @@ impl DatabaseDriverV1 {
         &self,
         stmt_handle: Handle,
         bindings: Option<BindingType<'a>>,
+        cancel: tokio_util::sync::CancellationToken,
     ) -> Result<AsyncExecuteResult, ApiError> {
         let stmt_ptr =
             self.statements
@@ -518,6 +535,7 @@ impl DatabaseDriverV1 {
                     &query_parameters,
                     &retry_policy,
                     bytes,
+                    cancel.clone(),
                 )
                 .await?;
             inject_timestamp_input_format_auto(&mut query_parameter_map);
@@ -547,6 +565,7 @@ impl DatabaseDriverV1 {
                     &query_input,
                     request_id,
                     &retry_policy,
+                    cancel.clone(),
                 )
                 .await
                 {
@@ -576,6 +595,7 @@ impl DatabaseDriverV1 {
         &self,
         conn_handle: Handle,
         query_id: String,
+        cancel: tokio_util::sync::CancellationToken,
     ) -> Result<ExecuteQueryResult, ApiError> {
         let session_id = self.session_id_for_conn(conn_handle).await;
         async {
@@ -585,7 +605,7 @@ impl DatabaseDriverV1 {
                 }
             })?;
 
-            let data = fetch_query_response_data(&conn_ptr, &query_id).await?;
+            let data = fetch_query_response_data(&conn_ptr, &query_id, cancel.clone()).await?;
             let descriptor = response_to_descriptor(&data, &self.wrapper_presets);
             if let Some(multi) = multistatement::try_into_multi_result(&data, descriptor.clone()) {
                 return Ok(multi);
@@ -616,7 +636,7 @@ impl DatabaseDriverV1 {
             // this async result-fetch path is not normally reached for file
             // transfers; pass skip_upload_on_content_match=false defensively.
             let rowset_data = self
-                .extract_rowset_data(&conn_ptr, data, refresh_sql, false)
+                .extract_rowset_data(&conn_ptr, data, refresh_sql, false, cancel)
                 .await?;
             let reader_ctx = resolve_reader_ctx(&conn_ptr).await?;
             Ok(self.build_execute_result(rowset_data, descriptor, reader_ctx))

--- a/sf_core/src/apis/database_driver_v1/stream_transfer.rs
+++ b/sf_core/src/apis/database_driver_v1/stream_transfer.rs
@@ -48,6 +48,7 @@ impl DatabaseDriverV1 {
         conn_handle: Handle,
         sql: String,
         data: Vec<u8>,
+        cancel: tokio_util::sync::CancellationToken,
     ) -> Result<ResultSetInfo, ApiError> {
         let session_id = self.session_id_for_conn(conn_handle).await;
         async {
@@ -75,6 +76,7 @@ impl DatabaseDriverV1 {
                 &query_parameters,
                 &retry_policy,
                 sql.clone(),
+                cancel.clone(),
             )
             .await?;
 
@@ -99,6 +101,7 @@ impl DatabaseDriverV1 {
                 sql: sql.clone(),
                 query_parameters: query_parameters.clone(),
                 conn: conn_ptr.clone(),
+                cancel: cancel.clone(),
             };
             let use_s3_regional_url = conn_ptr
                 .lock()
@@ -120,6 +123,7 @@ impl DatabaseDriverV1 {
                 use_s3_regional_url,
                 &put_get_policy,
                 data,
+                cancel,
             )
             .await
             .context(QueryResponseProcessSnafu)?;
@@ -144,6 +148,7 @@ impl DatabaseDriverV1 {
         stage_name: &str,
         source_filename: &str,
         decompress: bool,
+        cancel: tokio_util::sync::CancellationToken,
     ) -> Result<Vec<u8>, ApiError> {
         let session_id = self.session_id_for_conn(conn_handle).await;
         async {
@@ -179,6 +184,7 @@ impl DatabaseDriverV1 {
                 &query_parameters,
                 &retry_policy,
                 get_sql.clone(),
+                cancel.clone(),
             )
             .await?;
 
@@ -238,6 +244,7 @@ impl DatabaseDriverV1 {
                 sql: get_sql,
                 query_parameters,
                 conn: conn_ptr.clone(),
+                cancel: cancel.clone(),
             };
             let mut refresher = stream_stage_info_refresher(refresh_ctx, initial_snapshot);
 
@@ -265,14 +272,23 @@ impl DatabaseDriverV1 {
 
             let mut refresher_dyn: Option<&mut dyn file_manager::StageInfoRefresher> =
                 Some(&mut refresher);
-            download_single_file(single_download, &put_get_policy, 0, &mut refresher_dyn)
-                .await
-                .map_err(|e| {
-                    InvalidArgumentSnafu {
-                        argument: format!("Download failed: {e}"),
-                    }
-                    .build()
-                })?;
+            download_single_file(
+                single_download,
+                &put_get_policy,
+                0,
+                &mut refresher_dyn,
+                cancel,
+            )
+            .await
+            .map_err(|e| {
+                if e.is_cancelled() {
+                    return CancelledSnafu.build();
+                }
+                InvalidArgumentSnafu {
+                    argument: format!("Download failed: {e}"),
+                }
+                .build()
+            })?;
 
             // The downloaded file lives at `<tmp_dir>/<basename(source_filename)>`.
             // Read the first regular file we find — there will be exactly one.
@@ -346,6 +362,7 @@ async fn run_sql_against_gs(
     query_parameters: &QueryParameters,
     retry_policy: &crate::config::retry::RetryPolicy,
     sql: String,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<query_response::Response, ApiError> {
     let query_input = QueryInput::new(sql);
 
@@ -360,6 +377,7 @@ async fn run_sql_against_gs(
             query_input.clone(),
             retry_policy,
             QueryExecutionMode::Blocking,
+            cancel.clone(),
         )
         .await
         {

--- a/sf_core/src/bin/collect_chunk_data.rs
+++ b/sf_core/src/bin/collect_chunk_data.rs
@@ -191,7 +191,12 @@ async fn save_arrow_data(
         let row_count = chunk.row_count;
         let uncompressed_size = chunk.uncompressed_size;
         let compressed_size = chunk.compressed_size;
-        let bytes = get_chunk_data(client.clone(), chunk).await?;
+        let bytes = get_chunk_data(
+            client.clone(),
+            chunk,
+            tokio_util::sync::CancellationToken::new(),
+        )
+        .await?;
         let saved_size = bytes.len() as u64;
         let path = output_dir.join(format!("chunk_{i}.bin"));
         tokio::fs::write(&path, &bytes).await?;
@@ -264,7 +269,12 @@ async fn save_json_data(
         let row_count = chunk.row_count;
         let uncompressed_size = chunk.uncompressed_size;
         let compressed_size = chunk.compressed_size;
-        let bytes = get_chunk_data(client.clone(), chunk).await?;
+        let bytes = get_chunk_data(
+            client.clone(),
+            chunk,
+            tokio_util::sync::CancellationToken::new(),
+        )
+        .await?;
         let saved_size = bytes.len() as u64;
         let path = output_dir.join(format!("chunk_{i}.bin"));
         tokio::fs::write(&path, &bytes).await?;
@@ -360,7 +370,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let login_params = build_login_params(&params, client_info.clone(), server_url.clone())?;
 
     println!("Logging in to Snowflake...");
-    let login_result = snowflake_login(&login_params, None, crl_worker.clone()).await?;
+    let login_result = snowflake_login(
+        &login_params,
+        None,
+        crl_worker.clone(),
+        tokio_util::sync::CancellationToken::new(),
+    )
+    .await?;
     println!(
         "Login successful (session_id={})",
         login_result.tokens.session_id
@@ -386,6 +402,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         QueryInput::new(alter_sql),
         QueryExecutionMode::Blocking,
         crl_worker.clone(),
+        tokio_util::sync::CancellationToken::new(),
     )
     .await?;
 
@@ -401,6 +418,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         QueryInput::new(cli.sql.clone()),
         QueryExecutionMode::Blocking,
         crl_worker.clone(),
+        tokio_util::sync::CancellationToken::new(),
     )
     .await?;
 

--- a/sf_core/src/chunks/error.rs
+++ b/sf_core/src/chunks/error.rs
@@ -70,4 +70,15 @@ pub enum ChunkError {
         #[snafu(implicit)]
         location: Location,
     },
+    #[snafu(display("operation cancelled"))]
+    Cancelled {
+        #[snafu(implicit)]
+        location: Location,
+    },
+}
+
+impl ChunkError {
+    pub(crate) fn is_cancelled(&self) -> bool {
+        matches!(self, ChunkError::Cancelled { .. })
+    }
 }

--- a/sf_core/src/chunks/http_downloader.rs
+++ b/sf_core/src/chunks/http_downloader.rs
@@ -16,8 +16,12 @@ impl DownloadChunk for HttpChunkDownloader {
         level = "trace",
         skip_all
     )]
-    async fn download_chunk(&self, chunk: ChunkDownloadData) -> Result<Vec<u8>, ArrowError> {
-        get_chunk_data(self.client.clone(), chunk)
+    async fn download_chunk(
+        &self,
+        chunk: ChunkDownloadData,
+        cancel: tokio_util::sync::CancellationToken,
+    ) -> Result<Vec<u8>, ArrowError> {
+        get_chunk_data(self.client.clone(), chunk, cancel)
             .await
             .map_err(|e| ArrowError::ExternalError(Box::new(e)))
     }

--- a/sf_core/src/chunks/mock.rs
+++ b/sf_core/src/chunks/mock.rs
@@ -9,7 +9,11 @@ use super::prefetch::DownloadChunk;
 pub struct FileChunkDownloader;
 
 impl DownloadChunk for FileChunkDownloader {
-    async fn download_chunk(&self, chunk: ChunkDownloadData) -> Result<Vec<u8>, ArrowError> {
+    async fn download_chunk(
+        &self,
+        chunk: ChunkDownloadData,
+        _cancel: tokio_util::sync::CancellationToken,
+    ) -> Result<Vec<u8>, ArrowError> {
         let path = PathBuf::from(&chunk.url);
         tokio::fs::read(&path)
             .await

--- a/sf_core/src/chunks/mod.rs
+++ b/sf_core/src/chunks/mod.rs
@@ -73,6 +73,7 @@ pub async fn json_prefetch_reader(
     chunk_download_data: Vec<ChunkDownloadData>,
     client: Client,
     config: &PrefetchConfig,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<Box<dyn RecordBatchReader + Send>, ChunkError> {
     let initial_reader = convert_string_rowset_to_arrow_reader(initial_rowset, &row_types)?;
     json_chunks_reader(
@@ -81,6 +82,7 @@ pub async fn json_prefetch_reader(
         chunk_download_data,
         client,
         config,
+        cancel,
     )
     .await
 }
@@ -91,6 +93,7 @@ async fn json_chunks_reader(
     chunk_download_data: Vec<ChunkDownloadData>,
     client: Client,
     config: &PrefetchConfig,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<Box<dyn RecordBatchReader + Send>, ChunkError> {
     let downloader = HttpChunkDownloader { client };
     let parser = JsonChunkParser {
@@ -102,6 +105,7 @@ async fn json_chunks_reader(
         downloader,
         parser,
         config,
+        cancel,
     )
     .await
 }
@@ -112,9 +116,11 @@ pub async fn arrow_prefetch_reader(
     client: Client,
     config: &PrefetchConfig,
     nullable_flags: Option<&[bool]>,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<Box<dyn RecordBatchReader + Send>, ChunkError> {
     let initial_reader =
-        get_initial_chunk_reader(initial_base64_opt, &mut chunk_download_data, &client).await?;
+        get_initial_chunk_reader(initial_base64_opt, &mut chunk_download_data, &client, cancel.clone())
+            .await?;
     let downloader = HttpChunkDownloader { client };
     let parser = ArrowChunkParser;
     let reader = PrefetchChunkReader::reader(
@@ -123,6 +129,7 @@ pub async fn arrow_prefetch_reader(
         downloader,
         parser,
         config,
+        cancel,
     )
     .await?;
     Ok(maybe_inject_nullable(reader, nullable_flags))
@@ -132,6 +139,7 @@ async fn get_initial_chunk_reader(
     initial_base64_opt: Option<&str>,
     chunk_download_data: &mut VecDeque<ChunkDownloadData>,
     client: &Client,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<StreamReader<Cursor<Vec<u8>>>, ChunkError> {
     Ok(if let Some(initial_base64) = initial_base64_opt {
         let bytes = BASE64.decode(initial_base64).context(Base64DecodeSnafu)?;
@@ -141,7 +149,7 @@ async fn get_initial_chunk_reader(
         let first = chunk_download_data
             .pop_front()
             .context(MissingInitialChunkSnafu)?;
-        let bytes = get_chunk_data(client.clone(), first).await?;
+        let bytes = get_chunk_data(client.clone(), first, cancel).await?;
         let cursor = io::Cursor::new(bytes);
         StreamReader::try_new(cursor, None).context(ChunkReadSnafu)?
     })
@@ -253,6 +261,7 @@ pub async fn fetch_chunks_reader(
     nullable_flags: &[bool],
     client: Client,
     prefetch_config: &PrefetchConfig,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<Box<dyn RecordBatchReader + Send>, ChunkError> {
     let mut initial_base64_opt = None;
     let mut remote_chunks = VecDeque::new();
@@ -278,6 +287,7 @@ pub async fn fetch_chunks_reader(
                 client,
                 prefetch_config,
                 Some(nullable_flags),
+                cancel,
             )
             .await
         }
@@ -286,6 +296,7 @@ pub async fn fetch_chunks_reader(
                 initial_base64_opt.as_deref(),
                 &mut remote_chunks,
                 &client,
+                cancel.clone(),
             )
             .await?;
             json_chunks_reader(
@@ -294,6 +305,7 @@ pub async fn fetch_chunks_reader(
                 Vec::from(remote_chunks),
                 client,
                 prefetch_config,
+                cancel,
             )
             .await
         }
@@ -346,6 +358,7 @@ pub struct InitialChunkData {
 pub async fn get_chunk_data(
     client: Client,
     chunk: ChunkDownloadData,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<Vec<u8>, ChunkError> {
     let url = &chunk.url;
     let mut headers = HeaderMap::new();
@@ -366,6 +379,7 @@ pub async fn get_chunk_data(
         &ctx,
         &policy,
         |r| async move { Ok(r) },
+        cancel.clone(),
     )
     .await
     {
@@ -387,6 +401,7 @@ pub async fn get_chunk_data(
                     status: reqwest::StatusCode::PAYLOAD_TOO_LARGE,
                 }
                 .fail(),
+                HttpError::Cancelled { .. } => CancelledSnafu.fail(),
             };
         }
     };
@@ -398,7 +413,11 @@ pub async fn get_chunk_data(
         .fail()?;
     }
 
-    let body = response.bytes().await.context(CommunicationSnafu)?;
+    let body = tokio::select! {
+        biased;
+        _ = cancel.cancelled() => return CancelledSnafu.fail(),
+        body = response.bytes() => body.context(CommunicationSnafu)?,
+    };
     let bytes = body.to_vec();
     // gzip inflate is CPU-bound; run it on the blocking pool so a large chunk
     // body doesn't stall this runtime worker.
@@ -442,6 +461,7 @@ mod tests {
             &[],
             Client::new(),
             &PrefetchConfig::default(),
+            tokio_util::sync::CancellationToken::new(),
         )
         .await;
 

--- a/sf_core/src/chunks/prefetch.rs
+++ b/sf_core/src/chunks/prefetch.rs
@@ -20,6 +20,7 @@ pub trait DownloadChunk: Send + Sync + Clone + 'static {
     fn download_chunk(
         &self,
         chunk: ChunkDownloadData,
+        cancel: tokio_util::sync::CancellationToken,
     ) -> impl Future<Output = Result<Vec<u8>, ArrowError>> + Send;
 }
 
@@ -63,6 +64,7 @@ impl<D: DownloadChunk, P: ParseChunk> PrefetchChunkReader<D, P> {
         downloader: D,
         parser: P,
         config: &PrefetchConfig,
+        cancel: tokio_util::sync::CancellationToken,
     ) -> Result<Box<dyn RecordBatchReader + Send>, ChunkError> {
         let schema = initial.schema();
         let initial = initial
@@ -83,6 +85,7 @@ impl<D: DownloadChunk, P: ParseChunk> PrefetchChunkReader<D, P> {
                 tx,
                 prefetch_concurrency,
                 memory_budget,
+                cancel,
             )
             .with_current_subscriber(),
         );
@@ -103,6 +106,7 @@ impl<D: DownloadChunk, P: ParseChunk> PrefetchChunkReader<D, P> {
         tx: tokio::sync::mpsc::Sender<Result<Chunk, ArrowError>>,
         prefetch_concurrency: usize,
         memory_budget: MemoryBudget,
+        cancel: tokio_util::sync::CancellationToken,
     ) -> Result<(), SendError<Result<Chunk, ArrowError>>> {
         let send = |msg: Result<Chunk, ArrowError>| {
             let tx = &tx;
@@ -133,8 +137,9 @@ impl<D: DownloadChunk, P: ParseChunk> PrefetchChunkReader<D, P> {
 
                 let d = downloader.clone();
                 let p = parser.clone();
+                let task_cancel = cancel.clone();
                 chunk_tasks.push_back(tokio::task::spawn(
-                    get_chunk(d, p, data, ticket).with_current_subscriber(),
+                    get_chunk(d, p, data, ticket, task_cancel).with_current_subscriber(),
                 ));
             }
         }
@@ -158,8 +163,9 @@ impl<D: DownloadChunk, P: ParseChunk> PrefetchChunkReader<D, P> {
 
                 let d = downloader.clone();
                 let p = parser.clone();
+                let task_cancel = cancel.clone();
                 chunk_tasks.push_back(tokio::task::spawn(
-                    get_chunk(d, p, data, ticket).with_current_subscriber(),
+                    get_chunk(d, p, data, ticket, task_cancel).with_current_subscriber(),
                 ));
             }
         }
@@ -173,8 +179,9 @@ async fn get_chunk(
     parser: impl ParseChunk,
     data: ChunkDownloadData,
     ticket: MemoryTicket,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<Chunk, ArrowError> {
-    let bytes = downloader.download_chunk(data).await?;
+    let bytes = downloader.download_chunk(data, cancel).await?;
     // Arrow IPC / JSON→Arrow decode is CPU-bound; run it on the blocking pool so
     // it doesn't occupy this runtime worker (result chunks are routinely multi-MB).
     let batches = tokio::task::spawn_blocking(move || parser.parse_chunk(bytes))

--- a/sf_core/src/crl/cache.rs
+++ b/sf_core/src/crl/cache.rs
@@ -1168,6 +1168,7 @@ impl CrlCache {
             &ctx,
             &RetryPolicy::default(),
             self.config.max_download_size,
+            tokio_util::sync::CancellationToken::new(),
         )
         .await
         {
@@ -1189,9 +1190,8 @@ impl CrlCache {
                     }),
                     HttpError::DeadlineExceeded { .. }
                     | HttpError::RetryAfterExceeded { .. }
-                    | HttpError::MaxAttempts { .. } => {
-                        crate::crl::error::HttpTimeoutSnafu {}.fail()
-                    }
+                    | HttpError::MaxAttempts { .. }
+                    | HttpError::Cancelled { .. } => crate::crl::error::HttpTimeoutSnafu {}.fail(),
                 };
             }
         };

--- a/sf_core/src/file_manager/azure_transfer.rs
+++ b/sf_core/src/file_manager/azure_transfer.rs
@@ -43,6 +43,7 @@ pub(super) async fn upload_to_azure_or_skip(
     skip_upload_on_content_match: bool,
     multipart: MultipartParams,
     policy: &RetryPolicy,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<UploadStatus, AzureUploadError> {
     let client = create_azure_client(stage_info)?;
     let key = format!("{}{filename}", stage_info.key_prefix);
@@ -50,7 +51,7 @@ pub(super) async fn upload_to_azure_or_skip(
 
     let head_needed = !overwrite || skip_upload_on_content_match;
     let remote = if head_needed {
-        match send_head_to_azure_blob(&client, &url, sas_token, policy).await {
+        match send_head_to_azure_blob(&client, &url, sas_token, policy, cancel.clone()).await {
             Ok(remote) => remote,
             Err(e) if !overwrite => {
                 // Cannot verify whether the blob exists; fail-CLOSED to
@@ -87,9 +88,13 @@ pub(super) async fn upload_to_azure_or_skip(
         SkipDecision::Upload => {}
     }
 
-    let body_len = multipart::upload_body_len(&prepared)
-        .await
-        .context(azure_upload_error::SourceIoSnafu)?;
+    let body_len = tokio::select! {
+        biased;
+        _ = cancel.cancelled() => return azure_upload_error::CancelledSnafu.fail(),
+        len = multipart::upload_body_len(&prepared) => {
+            len.context(azure_upload_error::SourceIoSnafu)?
+        }
+    };
     if body_len >= multipart.threshold.bytes() {
         azure_multipart_upload(
             &client,
@@ -99,10 +104,11 @@ pub(super) async fn upload_to_azure_or_skip(
             body_len,
             multipart.concurrency,
             policy,
+            cancel,
         )
         .await?;
     } else {
-        upload_to_azure(&client, &url, sas_token, prepared, policy).await?;
+        upload_to_azure(&client, &url, sas_token, prepared, policy, cancel).await?;
     }
     Ok(UploadStatus::Uploaded)
 }
@@ -158,6 +164,7 @@ pub async fn download_from_azure(
     stage_info: &StageInfo,
     filename: &str,
     policy: &RetryPolicy,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<DownloadResponse, AzureDownloadError> {
     let client = create_azure_client(stage_info)?;
     let key = format!("{}{filename}", stage_info.key_prefix);
@@ -166,19 +173,22 @@ pub async fn download_from_azure(
         || client.get(build_sas_url(&url, sas_token.reveal())),
         Method::GET,
         policy,
+        cancel.clone(),
     )
     .await?;
 
     // Extract metadata from response headers
     let (digest, file_metadata) = parse_azure_file_metadata(response.headers())?;
 
-    let data = response
-        .bytes()
-        .await
-        .map_err(|e| AzureRequestError::Http {
-            detail: sanitize_sas(e.to_string()),
-        })?
-        .to_vec();
+    let data = tokio::select! {
+        biased;
+        _ = cancel.cancelled() => return azure_download_error::CancelledSnafu.fail(),
+        bytes = response.bytes() => bytes
+            .map_err(|e| AzureRequestError::Http {
+                detail: sanitize_sas(e.to_string()),
+            })?
+            .to_vec(),
+    };
     let cloud_byte_count = data.len() as i64;
 
     Ok(DownloadResponse {
@@ -217,11 +227,13 @@ async fn send_head_to_azure_blob(
     url: &str,
     sas_token: &SensitiveString,
     policy: &RetryPolicy,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<Option<RemoteBlobHeader>, AzureUploadError> {
     match azure_request_with_retry(
         || client.head(build_sas_url(url, sas_token.reveal())),
         Method::HEAD,
         policy,
+        cancel.clone(),
     )
     .await
     {
@@ -262,6 +274,7 @@ async fn upload_to_azure(
     sas_token: &SensitiveString,
     prepared: PreparedUpload,
     policy: &RetryPolicy,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<(), AzureUploadError> {
     // `body_for` re-opens the source per retry; `prepared`'s gzip-tempfile guard
     // (if any) lives inside `prepared.source` and outlives this fn. CSE params
@@ -332,6 +345,7 @@ async fn upload_to_azure(
         &Method::PUT,
         url,
         policy,
+        cancel,
     )
     .await?;
 
@@ -355,6 +369,7 @@ async fn azure_multipart_upload(
     body_len: u64,
     concurrency: usize,
     policy: &RetryPolicy,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<(), AzureUploadError> {
     let chunk_size = multipart::compute_part_size(body_len, &MultipartConfig::AZURE)
         .context(azure_upload_error::FileTooLargeSnafu)?;
@@ -378,11 +393,14 @@ async fn azure_multipart_upload(
         multipart::spawn_part_reader(source, encryptor, chunk_size as usize, concurrency);
 
     let mut block_numbers: Vec<i32> = ReceiverStream::new(parts_rx)
-        .map(|part| async move {
-            let part = part.context(azure_upload_error::SourceIoSnafu)?;
-            let number = part.number;
-            azure_put_block(client, full_url, part, policy).await?;
-            Ok::<i32, AzureUploadError>(number)
+        .map(|part| {
+            let cancel = cancel.clone();
+            async move {
+                let part = part.context(azure_upload_error::SourceIoSnafu)?;
+                let number = part.number;
+                azure_put_block(client, full_url, part, policy, cancel).await?;
+                Ok::<i32, AzureUploadError>(number)
+            }
         })
         .buffer_unordered(concurrency)
         .try_collect()
@@ -413,6 +431,7 @@ async fn azure_multipart_upload(
         encryption_data_str.as_deref(),
         mat_desc_str.as_deref(),
         policy,
+        cancel,
     )
     .await?;
 
@@ -436,6 +455,7 @@ async fn azure_put_block(
     full_url: &str,
     part: multipart::UploadPart,
     policy: &RetryPolicy,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<(), AzureUploadError> {
     let block_id = azure_block_id(part.number);
     let body = part.body;
@@ -456,6 +476,7 @@ async fn azure_put_block(
         &Method::PUT,
         full_url,
         policy,
+        cancel,
     )
     .await
 }
@@ -470,6 +491,7 @@ async fn azure_put_block_list(
     encryption_data_str: Option<&str>,
     mat_desc_str: Option<&str>,
     policy: &RetryPolicy,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<(), AzureUploadError> {
     let body = build_block_list_xml(block_numbers);
     // Own everything the per-attempt async closure touches so the future is
@@ -497,6 +519,7 @@ async fn azure_put_block_list(
         &Method::PUT,
         full_url,
         policy,
+        cancel,
     )
     .await
 }
@@ -556,15 +579,22 @@ async fn azure_request_with_retry<F>(
     build_request: F,
     method: Method,
     policy: &RetryPolicy,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<reqwest::Response, AzureRequestError>
 where
     F: Fn() -> reqwest::RequestBuilder,
 {
     let ctx = HttpContext::new(method, "azure-transfer");
 
-    let response = http_execute_with_retry(build_request, &ctx, policy, |r| async move { Ok(r) })
-        .await
-        .map_err(map_http_error)?;
+    let response = http_execute_with_retry(
+        build_request,
+        &ctx,
+        policy,
+        |r| async move { Ok(r) },
+        cancel,
+    )
+    .await
+    .map_err(map_http_error)?;
 
     tracing::info!(status = response.status().as_u16(), "HTTP response");
 
@@ -621,6 +651,10 @@ impl UploadRetryAdapter for AzureUploadRetry {
         }
         .build()
     }
+
+    fn on_cancelled(&self) -> AzureUploadError {
+        azure_upload_error::CancelledSnafu.build()
+    }
 }
 
 /// Executes an Azure upload with retry, accepting a **fallible** request-builder closure.
@@ -636,15 +670,17 @@ async fn azure_upload_with_retry<F>(
     method: &reqwest::Method,
     url: &str,
     policy: &RetryPolicy,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<(), AzureUploadError>
 where
     F: AsyncFn() -> Result<reqwest::RequestBuilder, AzureUploadError>,
 {
-    cloud_http::upload_with_retry(policy, &AzureUploadRetry, method, url, build_request).await
+    cloud_http::upload_with_retry(policy, &AzureUploadRetry, method, url, build_request, cancel).await
 }
 
 fn map_http_error(e: HttpError) -> AzureRequestError {
     match e {
+        HttpError::Cancelled { .. } => AzureRequestError::Cancelled,
         HttpError::Transport { source, .. } => AzureRequestError::Http {
             detail: sanitize_sas(source.to_string()),
         },
@@ -824,6 +860,7 @@ pub async fn download_from_azure_streaming(
     multipart: MultipartParams,
     policy: &RetryPolicy,
     spill_target: cloud_http::CloudSpillTarget<'_>,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<CloudStreamingDownload, AzureDownloadError> {
     let client = create_azure_client(stage_info)?;
     let key = format!("{}{filename}", stage_info.key_prefix);
@@ -831,7 +868,9 @@ pub async fn download_from_azure_streaming(
     let full_url = build_sas_url(&url, sas_token.reveal());
 
     // HEAD (Get Blob Properties) for size + metadata, to route single vs ranged.
-    let head = azure_request_with_retry(|| client.head(&full_url), Method::HEAD, policy).await?;
+    let head =
+        azure_request_with_retry(|| client.head(&full_url), Method::HEAD, policy, cancel.clone())
+            .await?;
     // Read the size from the Content-Length header rather than reqwest's
     // `content_length()`, which is unreliable for HEAD responses (no body to
     // measure). Real Azure always sends Content-Length on Get Blob Properties.
@@ -877,6 +916,7 @@ pub async fn download_from_azure_streaming(
             multipart.concurrency,
             policy,
             spill_target,
+            cancel,
         )
         .await?;
         // Ranged path: size came from HEAD, so no wire-byte tracking is needed.
@@ -886,8 +926,9 @@ pub async fn download_from_azure_streaming(
         )
     } else {
         let response =
-            azure_request_with_retry(|| client.get(&full_url), Method::GET, policy).await?;
-        let reader = cloud_http::spawn_byte_stream_producer(response);
+            azure_request_with_retry(|| client.get(&full_url), Method::GET, policy, cancel.clone())
+                .await?;
+        let reader = cloud_http::spawn_byte_stream_producer(response, cancel);
         let handle = reader.bytes_read_handle();
         (
             cloud_http::CloudDownloadBody::Streamed(Box::new(reader)),
@@ -927,6 +968,7 @@ async fn azure_range_download(
     concurrency: usize,
     policy: &RetryPolicy,
     target: cloud_http::CloudSpillTarget<'_>,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<cloud_http::CloudSpilledBody, AzureDownloadError> {
     let mk_temp_err = |e: std::io::Error| {
         azure_download_error::TempFileSnafu {
@@ -982,8 +1024,9 @@ async fn azure_range_download(
     let results: Vec<Result<(), AzureDownloadError>> = futures::stream::iter(ranges)
         .map(|range| {
             let file = Arc::clone(&file);
+            let cancel = cancel.clone();
             async move {
-                let bytes = azure_get_range(client, full_url, &range, policy).await?;
+                let bytes = azure_get_range(client, full_url, &range, policy, cancel).await?;
                 tokio::task::spawn_blocking(move || multipart::write_at(&file, range.start, &bytes))
                     .await
                     .map_err(|e| {
@@ -1033,6 +1076,7 @@ async fn azure_get_range(
     full_url: &str,
     range: &multipart::DownloadRange,
     policy: &RetryPolicy,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<Bytes, AzureDownloadError> {
     let range_header = format!("bytes={}-{}", range.start, range.end);
     let response = azure_request_with_retry(
@@ -1043,6 +1087,7 @@ async fn azure_get_range(
         },
         Method::GET,
         policy,
+        cancel,
     )
     .await?;
     // A body-read failure after a successful response maps to the same
@@ -1106,6 +1151,8 @@ enum AzureRequestError {
     MissingMetadata { field: String },
     #[snafu(display("Azure retry exhausted: {detail}"))]
     RetryExhausted { detail: String },
+    #[snafu(display("Operation cancelled"))]
+    Cancelled,
 }
 
 impl From<AzureRequestError> for AzureUploadError {
@@ -1124,6 +1171,7 @@ impl From<AzureRequestError> for AzureUploadError {
             AzureRequestError::RetryExhausted { detail } => {
                 azure_upload_error::RetryExhaustedSnafu { detail }.build()
             }
+            AzureRequestError::Cancelled => azure_upload_error::CancelledSnafu.build(),
         }
     }
 }
@@ -1146,6 +1194,7 @@ impl From<AzureRequestError> for AzureDownloadError {
             AzureRequestError::RetryExhausted { detail } => {
                 azure_download_error::RetryExhaustedSnafu { detail }.build()
             }
+            AzureRequestError::Cancelled => azure_download_error::CancelledSnafu.build(),
         }
     }
 }
@@ -1202,6 +1251,17 @@ pub enum AzureUploadError {
         #[snafu(implicit)]
         location: Location,
     },
+    #[snafu(display("Operation cancelled"))]
+    Cancelled {
+        #[snafu(implicit)]
+        location: Location,
+    },
+}
+
+impl AzureUploadError {
+    pub(crate) fn is_cancelled(&self) -> bool {
+        matches!(self, AzureUploadError::Cancelled { .. })
+    }
 }
 
 #[derive(Snafu, Debug, error_trace::ErrorTrace)]
@@ -1262,6 +1322,17 @@ pub enum AzureDownloadError {
         #[snafu(implicit)]
         location: Location,
     },
+    #[snafu(display("Operation cancelled"))]
+    Cancelled {
+        #[snafu(implicit)]
+        location: Location,
+    },
+}
+
+impl AzureDownloadError {
+    pub(crate) fn is_cancelled(&self) -> bool {
+        matches!(self, AzureDownloadError::Cancelled { .. })
+    }
 }
 
 // --- Unit tests ---
@@ -1642,6 +1713,7 @@ mod tests {
             /* skip_upload_on_content_match */ false,
             MultipartParams::default(),
             &test_policy(DEFAULT_PUT_GET_MAX_ATTEMPTS),
+            tokio_util::sync::CancellationToken::new(),
         )
         .await
         .expect("upload-or-skip should succeed");
@@ -1676,6 +1748,7 @@ mod tests {
             /* skip_upload_on_content_match */ false,
             MultipartParams::default(),
             &test_policy(DEFAULT_PUT_GET_MAX_ATTEMPTS),
+            tokio_util::sync::CancellationToken::new(),
         )
         .await
         .expect("upload should succeed against the mock");
@@ -1722,6 +1795,7 @@ mod tests {
             /* skip_upload_on_content_match */ true,
             MultipartParams::default(),
             &test_policy(DEFAULT_PUT_GET_MAX_ATTEMPTS),
+            tokio_util::sync::CancellationToken::new(),
         )
         .await
         .expect("upload-or-skip should succeed");
@@ -1756,6 +1830,7 @@ mod tests {
             /* skip_upload_on_content_match */ true,
             MultipartParams::default(),
             &test_policy(DEFAULT_PUT_GET_MAX_ATTEMPTS),
+            tokio_util::sync::CancellationToken::new(),
         )
         .await
         .expect("upload should succeed against the mock");
@@ -1787,6 +1862,7 @@ mod tests {
             /* skip_upload_on_content_match */ true,
             MultipartParams::default(),
             &test_policy(DEFAULT_PUT_GET_MAX_ATTEMPTS),
+            tokio_util::sync::CancellationToken::new(),
         )
         .await
         .expect("upload should succeed against the mock");
@@ -1820,6 +1896,7 @@ mod tests {
             /* skip_upload_on_content_match */ true,
             MultipartParams::default(),
             &test_policy(DEFAULT_PUT_GET_MAX_ATTEMPTS),
+            tokio_util::sync::CancellationToken::new(),
         )
         .await
         .expect("upload should succeed against the mock");
@@ -1943,6 +2020,7 @@ mod tests {
             /* skip_upload_on_content_match */ true,
             MultipartParams::default(),
             &test_policy(DEFAULT_PUT_GET_MAX_ATTEMPTS),
+            tokio_util::sync::CancellationToken::new(),
         )
         .await
         .expect("upload should succeed against the mock");
@@ -2000,6 +2078,7 @@ mod tests {
             /* skip_upload_on_content_match */ true,
             MultipartParams::default(),
             &test_policy(DEFAULT_PUT_GET_MAX_ATTEMPTS),
+            tokio_util::sync::CancellationToken::new(),
         )
         .await;
         assert!(
@@ -2049,6 +2128,7 @@ mod tests {
             false,
             MultipartParams::default(),
             &test_policy(DEFAULT_PUT_GET_MAX_ATTEMPTS),
+            tokio_util::sync::CancellationToken::new(),
         )
         .await
         .expect("upload should succeed against the mock");
@@ -2133,6 +2213,7 @@ mod tests {
             /* skip_upload_on_content_match */ false,
             MultipartParams::default(),
             &test_policy(DEFAULT_PUT_GET_MAX_ATTEMPTS),
+            tokio_util::sync::CancellationToken::new(),
         )
         .await
         .expect("retry should recover and existence skip should fire");
@@ -2164,6 +2245,7 @@ mod tests {
             /* skip_upload_on_content_match */ false,
             MultipartParams::default(),
             &test_policy(DEFAULT_PUT_GET_MAX_ATTEMPTS),
+            tokio_util::sync::CancellationToken::new(),
         )
         .await;
         assert!(
@@ -2203,6 +2285,7 @@ mod tests {
             /* skip_upload_on_content_match */ true,
             MultipartParams::default(),
             &test_policy(DEFAULT_PUT_GET_MAX_ATTEMPTS),
+            tokio_util::sync::CancellationToken::new(),
         )
         .await
         .expect("skip_match path should fail-OPEN to PUT after HEAD retry exhaustion");
@@ -2235,6 +2318,7 @@ mod tests {
             /* skip_upload_on_content_match */ false,
             MultipartParams::default(),
             &test_policy(DEFAULT_PUT_GET_MAX_ATTEMPTS),
+            tokio_util::sync::CancellationToken::new(),
         )
         .await;
         assert!(
@@ -2272,6 +2356,7 @@ mod tests {
             /* skip_upload_on_content_match */ false,
             MultipartParams::default(),
             &test_policy(DEFAULT_PUT_GET_MAX_ATTEMPTS),
+            tokio_util::sync::CancellationToken::new(),
         )
         .await;
         assert!(
@@ -2346,6 +2431,7 @@ mod tests {
             false,
             always_multipart(),
             &test_policy(DEFAULT_PUT_GET_MAX_ATTEMPTS),
+            tokio_util::sync::CancellationToken::new(),
         )
         .await
         .expect("block-blob upload should succeed against the mock");
@@ -2403,6 +2489,7 @@ mod tests {
             always_multipart(),
             &test_policy(DEFAULT_PUT_GET_MAX_ATTEMPTS),
             cloud_http::CloudSpillTarget::Temp(spill.path()),
+            tokio_util::sync::CancellationToken::new(),
         )
         .await
         .expect("ranged download should succeed against the mock");
@@ -2448,6 +2535,7 @@ mod tests {
             always_multipart(),
             &test_policy(DEFAULT_PUT_GET_MAX_ATTEMPTS),
             cloud_http::CloudSpillTarget::Part(&part_path),
+            tokio_util::sync::CancellationToken::new(),
         )
         .await
         .expect("ranged download should succeed against the mock");
@@ -2494,6 +2582,7 @@ mod tests {
             always_multipart(),
             &test_policy(DEFAULT_PUT_GET_MAX_ATTEMPTS),
             cloud_http::CloudSpillTarget::Part(&part_path),
+            tokio_util::sync::CancellationToken::new(),
         )
         .await;
 

--- a/sf_core/src/file_manager/cloud_http.rs
+++ b/sf_core/src/file_manager/cloud_http.rs
@@ -19,6 +19,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
+use tokio_util::sync::CancellationToken;
 
 /// Read-buffer size in bytes for the streaming upload producer — one channel chunk.
 const UPLOAD_CHUNK_SIZE_BYTES: usize = 64 * 1024;
@@ -27,6 +28,8 @@ const UPLOAD_CHUNK_SIZE_BYTES: usize = 64 * 1024;
 /// 300s cap; the retry budget (`policy.max_elapsed`) must exceed this so at
 /// least one full attempt can complete.
 const REQUEST_TIMEOUT_SECS: u64 = 300;
+
+pub(super) const STREAM_CANCELLED_MESSAGE: &str = "download cancelled";
 
 use std::collections::BTreeSet;
 
@@ -129,12 +132,29 @@ impl std::io::Read for StreamReader {
 /// scope; revisit if Range-resume becomes a requirement. The
 /// `gcs_streaming_mid_body_disconnect_surfaces_error` test pins this
 /// behaviour.
-pub(super) fn spawn_byte_stream_producer(response: reqwest::Response) -> StreamReader {
+pub(super) fn spawn_byte_stream_producer(
+    response: reqwest::Response,
+    cancel: CancellationToken,
+) -> StreamReader {
     let (tx, rx) = std::sync::mpsc::sync_channel::<std::io::Result<Bytes>>(8);
     let stream = response.bytes_stream();
     tokio::spawn(async move {
         let mut stream = stream;
-        while let Some(chunk_result) = stream.next().await {
+        loop {
+            let chunk_result = tokio::select! {
+                biased;
+                _ = cancel.cancelled() => {
+                    let _ = tx.send(Err(std::io::Error::new(
+                        std::io::ErrorKind::Interrupted,
+                        STREAM_CANCELLED_MESSAGE,
+                    )));
+                    break;
+                }
+                chunk_result = stream.next() => chunk_result,
+            };
+            let Some(chunk_result) = chunk_result else {
+                break;
+            };
             let mapped = chunk_result.map_err(std::io::Error::other);
             // If the consumer dropped (decryption finished/errored) while we
             // had a pending error, the error is silently lost — the consumer
@@ -376,6 +396,7 @@ pub(super) trait UploadRetryAdapter {
     fn on_http_failure(&self, status: u16, body: String) -> Self::Err;
     fn on_transport(&self, e: reqwest::Error) -> Self::Err;
     fn on_exhausted(&self, detail: String) -> Self::Err;
+    fn on_cancelled(&self) -> Self::Err;
 }
 
 /// Shared retry/backoff loop for the cloud upload paths. The async closure
@@ -392,6 +413,7 @@ pub(super) async fn upload_with_retry<F, M>(
     method: &reqwest::Method,
     url: &str,
     build_request: F,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<(), M::Err>
 where
     F: AsyncFn() -> Result<reqwest::RequestBuilder, M::BuildErr>,
@@ -406,6 +428,9 @@ where
     let log_path = url.split(['?', '#']).next().unwrap_or("");
 
     for attempt in 1..=max_attempts {
+        if cancel.is_cancelled() {
+            return Err(adapter.on_cancelled());
+        }
         let remaining = if let Some(budget) = policy.max_elapsed {
             let elapsed = start.elapsed();
             if elapsed >= budget {
@@ -424,14 +449,24 @@ where
             (None, None) => Duration::from_secs(REQUEST_TIMEOUT_SECS),
         };
 
-        let req = match build_request().await {
+        let build = tokio::select! {
+            biased;
+            _ = cancel.cancelled() => return Err(adapter.on_cancelled()),
+            b = build_request() => b,
+        };
+        let req = match build {
             Ok(r) => r.timeout(timeout),
             Err(e) => return Err(adapter.on_build_err(e)),
         };
 
         tracing::info!(method = %method, path = %log_path, attempt, "outbound HTTP call");
 
-        match req.send().await {
+        let send_result = tokio::select! {
+            biased;
+            _ = cancel.cancelled() => return Err(adapter.on_cancelled()),
+            r = req.send() => r,
+        };
+        match send_result {
             Ok(resp) => {
                 tracing::info!(status = resp.status().as_u16(), "HTTP response");
                 if resp.status().is_success() {
@@ -443,12 +478,20 @@ where
                 let status_code = resp.status().as_u16();
                 let retryable = is_retryable_status(status_code, &policy.extra_retryable_statuses);
                 if !retryable || attempt >= max_attempts {
-                    let body = read_error_body(resp).await;
+                    let body = tokio::select! {
+                        biased;
+                        _ = cancel.cancelled() => return Err(adapter.on_cancelled()),
+                        b = read_error_body(resp) => b,
+                    };
                     return Err(adapter.on_http_failure(status_code, body));
                 }
                 let delay = Duration::from_millis(sleep_ms as u64);
                 sleep_ms = next_delay_ms(sleep_ms, &policy.backoff);
-                tokio::time::sleep(delay).await;
+                tokio::select! {
+                    biased;
+                    _ = cancel.cancelled() => return Err(adapter.on_cancelled()),
+                    _ = tokio::time::sleep(delay) => {}
+                }
             }
             Err(e) => {
                 if attempt >= max_attempts {
@@ -456,7 +499,11 @@ where
                 }
                 let delay = Duration::from_millis(sleep_ms as u64);
                 sleep_ms = next_delay_ms(sleep_ms, &policy.backoff);
-                tokio::time::sleep(delay).await;
+                tokio::select! {
+                    biased;
+                    _ = cancel.cancelled() => return Err(adapter.on_cancelled()),
+                    _ = tokio::time::sleep(delay) => {}
+                }
             }
         }
     }

--- a/sf_core/src/file_manager/gcs_transfer.rs
+++ b/sf_core/src/file_manager/gcs_transfer.rs
@@ -53,6 +53,7 @@ pub async fn upload_to_gcs_or_skip(
     overwrite: bool,
     policy: &RetryPolicy,
     refresher: &mut Option<&mut dyn StageInfoRefresher>,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<UploadStatus, GcsUploadError> {
     let client = create_gcs_client(stage_info)?;
     let key = format!("{}{filename}", stage_info.key_prefix);
@@ -85,17 +86,21 @@ pub async fn upload_to_gcs_or_skip(
         let key = key.clone();
         let client = client.clone();
         let wire_policy = wire_policy.clone();
+        let attempt_factory_cancel = cancel.clone();
         move |snapshot: super::types::StageInfoSnapshot| {
             let stage_info = base.with_snapshot(snapshot);
             let prepared = prepared.clone();
             let key = key.clone();
             let client = client.clone();
             let wire_policy = wire_policy.clone();
+            let attempt_cancel = attempt_factory_cancel.clone();
             async move {
                 let (url, token) = resolve_url_and_token(&stage_info, &key, None)
                     .map_err(map_gcs_request_error_for_attempt)?;
 
-                let head = check_file_exists_gcs(&client, &url, token).await;
+                let head = check_file_exists_gcs(&client, &url, token, &attempt_cancel)
+                    .await
+                    .map_err(map_gcs_request_error_for_attempt)?;
 
                 if !overwrite && matches!(head, GcsHeadResult::Found { .. }) {
                     tracing::info!("File already exists in GCS: {key}");
@@ -118,7 +123,7 @@ pub async fn upload_to_gcs_or_skip(
                     return Ok(UploadStatus::Skipped);
                 }
 
-                upload_to_gcs(&client, &url, token, prepared, &wire_policy)
+                upload_to_gcs(&client, &url, token, prepared, &wire_policy, attempt_cancel)
                     .await
                     .map_err(map_gcs_request_error_for_attempt)?;
                 Ok(UploadStatus::Uploaded)
@@ -237,6 +242,7 @@ async fn gcs_get_with_refresh(
     policy: &RetryPolicy,
     per_file_index: usize,
     refresher: &mut Option<&mut dyn StageInfoRefresher>,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<reqwest::Response, GcsDownloadError> {
     let client = create_gcs_client(stage_info)?;
     let key = format!("{}{filename}", stage_info.key_prefix);
@@ -269,12 +275,14 @@ async fn gcs_get_with_refresh(
         let key = key.clone();
         let client = client.clone();
         let wire_policy = wire_policy.clone();
+        let cancel = cancel.clone();
         move |snapshot: super::types::StageInfoSnapshot| {
             let stage_info = base.with_snapshot(snapshot);
             let key = key.clone();
             let client = client.clone();
             let per_file_url = per_file_url.clone();
             let wire_policy = wire_policy.clone();
+            let cancel = cancel.clone();
             async move {
                 let (url, token) =
                     resolve_url_and_token(&stage_info, &key, per_file_url.as_deref())
@@ -290,6 +298,7 @@ async fn gcs_get_with_refresh(
                     },
                     Method::GET,
                     &wire_policy,
+                    cancel,
                 )
                 .await
                 .map_err(map_gcs_request_error_for_attempt)
@@ -389,6 +398,7 @@ pub async fn download_from_gcs(
     policy: &RetryPolicy,
     per_file_index: usize,
     refresher: &mut Option<&mut dyn StageInfoRefresher>,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<DownloadResponse, GcsDownloadError> {
     let response = gcs_get_with_refresh(
         stage_info,
@@ -397,6 +407,7 @@ pub async fn download_from_gcs(
         policy,
         per_file_index,
         refresher,
+        cancel.clone(),
     )
     .await?;
 
@@ -439,11 +450,13 @@ pub async fn download_from_gcs(
         None => None,
     };
 
-    let data = response
-        .bytes()
-        .await
-        .map_err(|source| GcsRequestError::Http { source })?
-        .to_vec();
+    let data = tokio::select! {
+        biased;
+        _ = cancel.cancelled() => return gcs_download_error::CancelledSnafu.fail(),
+        bytes = response.bytes() => bytes
+            .map_err(|source| GcsRequestError::Http { source })?
+            .to_vec(),
+    };
     let actual_len = data.len() as u64;
 
     if let Some(expected) = expected_length {
@@ -489,7 +502,7 @@ enum GcsHeadResult {
 /// Issue a HEAD against the GCS object and return `Found { digest }` on
 /// 200, or `NotFound` otherwise.
 ///
-/// Any non-200 status (including 403 / unexpected codes) and any
+/// Any non-200 status (including 403 / unexpected codes) and any non-cancel
 /// transport-level error are treated as `NotFound` — the caller falls
 /// through to a PUT. A malformed sfc-digest header yields
 /// `Found { digest: None }`; the digest comparison then misses and the
@@ -498,13 +511,20 @@ async fn check_file_exists_gcs(
     client: &reqwest::Client,
     url: &str,
     token: Option<&str>,
-) -> GcsHeadResult {
+    cancel: &tokio_util::sync::CancellationToken,
+) -> Result<GcsHeadResult, GcsRequestError> {
     let mut request = client.head(url);
     if let Some(t) = token {
         request = request.bearer_auth(t);
     }
 
-    match request.send().await {
+    let send_result = tokio::select! {
+        biased;
+        _ = cancel.cancelled() => return Err(GcsRequestError::Cancelled),
+        result = request.send() => result,
+    };
+
+    let head = match send_result {
         Ok(resp) => match resp.status() {
             StatusCode::OK => {
                 let digest = match try_get_header(resp.headers(), GCS_META_SFC_DIGEST) {
@@ -543,7 +563,8 @@ async fn check_file_exists_gcs(
             );
             GcsHeadResult::NotFound
         }
-    }
+    };
+    Ok(head)
 }
 
 /// Upload data to GCS with retry logic.
@@ -568,6 +589,7 @@ async fn upload_to_gcs(
     token: Option<&str>,
     prepared: PreparedUpload,
     policy: &RetryPolicy,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<(), GcsRequestError> {
     // `body_for` re-opens the source per retry (a `Path` re-open or an O(1)
     // `Bytes` refcount clone). `prepared` is held until this fn returns, so a
@@ -649,6 +671,7 @@ async fn upload_to_gcs(
         &Method::PUT,
         url,
         policy,
+        cancel,
     )
     .await?;
 
@@ -703,15 +726,22 @@ async fn gcs_request_with_retry<F>(
     build_request: F,
     method: Method,
     policy: &RetryPolicy,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<reqwest::Response, GcsRequestError>
 where
     F: Fn() -> reqwest::RequestBuilder,
 {
     let ctx = HttpContext::new(method, "gcs-transfer");
 
-    let response = http_execute_with_retry(build_request, &ctx, policy, |r| async move { Ok(r) })
-        .await
-        .map_err(map_http_error)?;
+    let response = http_execute_with_retry(
+        build_request,
+        &ctx,
+        policy,
+        |r| async move { Ok(r) },
+        cancel,
+    )
+    .await
+    .map_err(map_http_error)?;
 
     if response.status().is_success() {
         return Ok(response);
@@ -759,6 +789,10 @@ impl UploadRetryAdapter for GcsUploadRetry {
             detail: format!("GCS upload {detail}"),
         }
     }
+
+    fn on_cancelled(&self) -> GcsRequestError {
+        GcsRequestError::Cancelled
+    }
 }
 
 /// Executes a GCS upload with retry, accepting a **fallible** request-builder closure.
@@ -779,15 +813,17 @@ async fn gcs_upload_with_retry<F>(
     method: &Method,
     url: &str,
     policy: &RetryPolicy,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<(), GcsRequestError>
 where
     F: AsyncFn() -> Result<reqwest::RequestBuilder, GcsRequestError>,
 {
-    cloud_http::upload_with_retry(policy, &GcsUploadRetry, method, url, build_request).await
+    cloud_http::upload_with_retry(policy, &GcsUploadRetry, method, url, build_request, cancel).await
 }
 
 fn map_http_error(e: HttpError) -> GcsRequestError {
     match e {
+        HttpError::Cancelled { .. } => GcsRequestError::Cancelled,
         HttpError::Transport { source, .. } => GcsRequestError::Http { source },
         other => GcsRequestError::RetryExhausted {
             detail: other.to_string(),
@@ -949,6 +985,7 @@ pub async fn download_from_gcs_streaming(
     policy: &RetryPolicy,
     per_file_index: usize,
     refresher: &mut Option<&mut dyn StageInfoRefresher>,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<CloudStreamingDownload, GcsDownloadError> {
     let response = gcs_get_with_refresh(
         stage_info,
@@ -957,6 +994,7 @@ pub async fn download_from_gcs_streaming(
         policy,
         per_file_index,
         refresher,
+        cancel.clone(),
     )
     .await?;
 
@@ -1004,7 +1042,7 @@ pub async fn download_from_gcs_streaming(
         (None, _) => None,
     };
 
-    let reader = cloud_http::spawn_byte_stream_producer(response);
+    let reader = cloud_http::spawn_byte_stream_producer(response, cancel);
     let cloud_bytes_read = reader.bytes_read_handle();
     Ok(CloudStreamingDownload {
         cloud_byte_count,
@@ -1201,6 +1239,8 @@ enum GcsRequestError {
     ClientSetup { detail: String },
     #[snafu(display("Failed to serialize GCS metadata"))]
     Serialization { source: serde_json::Error },
+    #[snafu(display("Operation cancelled"))]
+    Cancelled,
 }
 
 impl From<GcsRequestError> for GcsUploadError {
@@ -1229,6 +1269,7 @@ impl From<GcsRequestError> for GcsUploadError {
             GcsRequestError::Serialization { source } => {
                 gcs_upload_error::SerializationSnafu.into_error(source)
             }
+            GcsRequestError::Cancelled => gcs_upload_error::CancelledSnafu.build(),
         }
     }
 }
@@ -1264,6 +1305,7 @@ impl From<GcsRequestError> for GcsDownloadError {
             GcsRequestError::Serialization { source } => {
                 gcs_download_error::DeserializationSnafu.into_error(source)
             }
+            GcsRequestError::Cancelled => gcs_download_error::CancelledSnafu.build(),
         }
     }
 }
@@ -1333,6 +1375,17 @@ pub enum GcsUploadError {
         #[snafu(implicit)]
         location: Location,
     },
+    #[snafu(display("Operation cancelled"))]
+    Cancelled {
+        #[snafu(implicit)]
+        location: Location,
+    },
+}
+
+impl GcsUploadError {
+    pub(crate) fn is_cancelled(&self) -> bool {
+        matches!(self, GcsUploadError::Cancelled { .. })
+    }
 }
 
 #[derive(Snafu, Debug, error_trace::ErrorTrace)]
@@ -1414,6 +1467,17 @@ pub enum GcsDownloadError {
         #[snafu(implicit)]
         location: Location,
     },
+    #[snafu(display("Operation cancelled"))]
+    Cancelled {
+        #[snafu(implicit)]
+        location: Location,
+    },
+}
+
+impl GcsDownloadError {
+    pub(crate) fn is_cancelled(&self) -> bool {
+        matches!(self, GcsDownloadError::Cancelled { .. })
+    }
 }
 
 // --- Unit tests ---
@@ -2143,7 +2207,10 @@ mod tests {
 
         let client = create_gcs_client(&make_stage_for_mock(&server.uri())).unwrap();
         let url = format!("{}/my-bucket/prefix/file.csv", server.uri());
-        let result = check_file_exists_gcs(&client, &url, Some("token")).await;
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let result = check_file_exists_gcs(&client, &url, Some("token"), &cancel)
+            .await
+            .unwrap();
 
         assert_eq!(
             result,
@@ -2164,7 +2231,10 @@ mod tests {
 
         let client = create_gcs_client(&make_stage_for_mock(&server.uri())).unwrap();
         let url = format!("{}/my-bucket/prefix/file.csv", server.uri());
-        let result = check_file_exists_gcs(&client, &url, Some("token")).await;
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let result = check_file_exists_gcs(&client, &url, Some("token"), &cancel)
+            .await
+            .unwrap();
 
         // Older objects (pre-`sfc-digest`-write era, libsfclient-S3-style
         // uploads, etc.) lack the header; the conservative fall-through
@@ -2186,7 +2256,10 @@ mod tests {
 
         let client = create_gcs_client(&make_stage_for_mock(&server.uri())).unwrap();
         let url = format!("{}/my-bucket/prefix/file.csv", server.uri());
-        let result = check_file_exists_gcs(&client, &url, Some("token")).await;
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let result = check_file_exists_gcs(&client, &url, Some("token"), &cancel)
+            .await
+            .unwrap();
 
         assert_eq!(result, GcsHeadResult::NotFound);
     }
@@ -2202,7 +2275,10 @@ mod tests {
 
         let client = create_gcs_client(&make_stage_for_mock(&server.uri())).unwrap();
         let url = format!("{}/my-bucket/prefix/file.csv", server.uri());
-        let result = check_file_exists_gcs(&client, &url, Some("token")).await;
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let result = check_file_exists_gcs(&client, &url, Some("token"), &cancel)
+            .await
+            .unwrap();
 
         // 403 indicates limited credentials (e.g. PUT-only); proceed
         // with upload rather than surface a hard error — the worst
@@ -2221,7 +2297,10 @@ mod tests {
 
         let client = create_gcs_client(&make_stage_for_mock(&server.uri())).unwrap();
         let url = format!("{}/my-bucket/prefix/file.csv", server.uri());
-        let result = check_file_exists_gcs(&client, &url, Some("token")).await;
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let result = check_file_exists_gcs(&client, &url, Some("token"), &cancel)
+            .await
+            .unwrap();
 
         assert_eq!(result, GcsHeadResult::NotFound);
     }
@@ -2244,7 +2323,10 @@ mod tests {
 
         let client = create_gcs_client(&make_stage_for_mock(&server.uri())).unwrap();
         let url = format!("{}/my-bucket/prefix/file.csv", server.uri());
-        let result = check_file_exists_gcs(&client, &url, Some("token")).await;
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let result = check_file_exists_gcs(&client, &url, Some("token"), &cancel)
+            .await
+            .unwrap();
 
         assert_eq!(result, GcsHeadResult::Found { digest: None });
     }
@@ -2349,6 +2431,7 @@ mod tests {
             true,
             &test_policy(false, DEFAULT_PUT_GET_MAX_ATTEMPTS),
             &mut None,
+            tokio_util::sync::CancellationToken::new(),
         )
         .await
         .unwrap();
@@ -2380,6 +2463,7 @@ mod tests {
             false,
             &test_policy(false, DEFAULT_PUT_GET_MAX_ATTEMPTS),
             &mut None,
+            tokio_util::sync::CancellationToken::new(),
         )
         .await
         .unwrap();
@@ -2406,6 +2490,7 @@ mod tests {
             true,
             &test_policy(false, DEFAULT_PUT_GET_MAX_ATTEMPTS),
             &mut None,
+            tokio_util::sync::CancellationToken::new(),
         )
         .await
         .unwrap();
@@ -2431,6 +2516,7 @@ mod tests {
             true,
             &test_policy(false, DEFAULT_PUT_GET_MAX_ATTEMPTS),
             &mut None,
+            tokio_util::sync::CancellationToken::new(),
         )
         .await
         .unwrap();
@@ -2456,6 +2542,7 @@ mod tests {
             false,
             &test_policy(false, DEFAULT_PUT_GET_MAX_ATTEMPTS),
             &mut None,
+            tokio_util::sync::CancellationToken::new(),
         )
         .await
         .unwrap();
@@ -2477,6 +2564,7 @@ mod tests {
             false,
             &test_policy(false, DEFAULT_PUT_GET_MAX_ATTEMPTS),
             &mut None,
+            tokio_util::sync::CancellationToken::new(),
         )
         .await
         .unwrap();
@@ -2508,6 +2596,7 @@ mod tests {
             true,
             &test_policy(false, DEFAULT_PUT_GET_MAX_ATTEMPTS),
             &mut None,
+            tokio_util::sync::CancellationToken::new(),
         )
         .await
         .unwrap();
@@ -2537,6 +2626,7 @@ mod tests {
             true,
             &test_policy(false, DEFAULT_PUT_GET_MAX_ATTEMPTS),
             &mut None,
+            tokio_util::sync::CancellationToken::new(),
         )
         .await
         .unwrap();
@@ -2573,6 +2663,7 @@ mod tests {
             true,
             &test_policy(false, DEFAULT_PUT_GET_MAX_ATTEMPTS),
             &mut None,
+            tokio_util::sync::CancellationToken::new(),
         )
         .await
         .unwrap();

--- a/sf_core/src/file_manager/mod.rs
+++ b/sf_core/src/file_manager/mod.rs
@@ -114,6 +114,7 @@ pub async fn upload_files(
     data: &UploadData,
     policy: &RetryPolicy,
     mut refresher: Option<&mut dyn StageInfoRefresher>,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<Vec<UploadResult>, FileManagerError> {
     let file_locations =
         expand_filenames(&data.src_location_pattern).context(PathExpansionSnafu)?;
@@ -151,7 +152,8 @@ pub async fn upload_files(
             multipart: data.multipart,
         };
 
-        let result = upload_single_file(single_upload_data, policy, &mut refresher).await?;
+        let result =
+            upload_single_file(single_upload_data, policy, &mut refresher, cancel.clone()).await?;
         results.push(result);
     }
 
@@ -172,6 +174,22 @@ fn current_stage_info(base: &StageInfo, refresher: Option<&dyn StageInfoRefreshe
     )
 }
 
+fn is_stream_cancelled_error(err: &FileManagerError) -> bool {
+    fn is_cancelled_io(source: &std::io::Error) -> bool {
+        source.kind() == std::io::ErrorKind::Interrupted
+            && source.to_string() == cloud_http::STREAM_CANCELLED_MESSAGE
+    }
+
+    match err {
+        FileManagerError::Io { source, .. } => is_cancelled_io(source),
+        FileManagerError::Decryption {
+            source: EncryptionError::Io { source, .. },
+            ..
+        } => is_cancelled_io(source),
+        _ => false,
+    }
+}
+
 /// Uploads one file. The `refresher` (if any) is used to refresh stage info
 /// on recoverable errors:
 /// - S3 stages: AWS `ExpiredToken` triggers a creds refresh
@@ -186,10 +204,11 @@ pub async fn upload_single_file(
     data: SingleUploadData,
     policy: &RetryPolicy,
     refresher: &mut Option<&mut dyn StageInfoRefresher>,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<UploadResult, FileManagerError> {
     // `preprocess_file_before_upload` reads a `ByteSource::Path` itself
     // (streaming), so `upload_single_file` no longer pre-reads the file.
-    upload_prepared_source(data.source.clone(), data, policy, refresher).await
+    upload_prepared_source(data.source.clone(), data, policy, refresher, cancel).await
 }
 
 /// Uploads an in-memory byte buffer to the stage location described by
@@ -207,8 +226,16 @@ pub async fn upload_in_memory_file(
     data: SingleUploadData,
     policy: &RetryPolicy,
     refresher: &mut Option<&mut dyn StageInfoRefresher>,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<UploadResult, FileManagerError> {
-    upload_prepared_source(ByteSource::Bytes(buffer.into()), data, policy, refresher).await
+    upload_prepared_source(
+        ByteSource::Bytes(buffer.into()),
+        data,
+        policy,
+        refresher,
+        cancel,
+    )
+    .await
 }
 
 /// Shared core of the upload path used by both `upload_single_file` (file
@@ -220,6 +247,7 @@ async fn upload_prepared_source(
     data: SingleUploadData,
     policy: &RetryPolicy,
     refresher: &mut Option<&mut dyn StageInfoRefresher>,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<UploadResult, FileManagerError> {
     // `preprocess_file_before_upload` reads the source file from disk and
     // AES-encrypts it (blocking I/O + CPU-bound); run it off the async executor
@@ -242,6 +270,7 @@ async fn upload_prepared_source(
             policy,
             data.multipart,
             refresher,
+            cancel,
         )
         .await
         .context(S3UploadSnafu)?,
@@ -252,6 +281,7 @@ async fn upload_prepared_source(
             data.overwrite,
             &gcs_retry_policy(data.stage_info.presigned_url.is_some(), policy),
             refresher,
+            cancel,
         )
         .await
         .context(GcsUploadSnafu)?,
@@ -263,6 +293,7 @@ async fn upload_prepared_source(
             data.skip_upload_on_content_match,
             data.multipart,
             &azure_retry_policy(policy),
+            cancel,
         )
         .await
         .context(AzureUploadSnafu)?,
@@ -522,6 +553,7 @@ pub async fn download_files(
     mut data: DownloadData,
     policy: &RetryPolicy,
     mut refresher: Option<&mut dyn StageInfoRefresher>,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<Vec<DownloadResult>, FileManagerError> {
     let mut results = Vec::new();
 
@@ -553,8 +585,14 @@ pub async fn download_files(
             unsafe_file_write: data.unsafe_file_write,
         };
 
-        let result =
-            download_single_file(single_download_data, policy, index, &mut refresher).await?;
+        let result = download_single_file(
+            single_download_data,
+            policy,
+            index,
+            &mut refresher,
+            cancel.clone(),
+        )
+        .await?;
         results.push(result);
     }
 
@@ -654,6 +692,7 @@ pub async fn download_single_file(
     policy: &RetryPolicy,
     per_file_index: usize,
     refresher: &mut Option<&mut dyn StageInfoRefresher>,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<DownloadResult, FileManagerError> {
     // Blocking FS syscalls (create_dir_all/canonicalize); keep off the async executor.
     let (output_path, partial_path) = {
@@ -721,6 +760,7 @@ pub async fn download_single_file(
                 data.multipart,
                 refresher,
                 spill_target,
+                cancel.clone(),
             )
             .await
             .context(S3DownloadSnafu)?;
@@ -801,6 +841,20 @@ pub async fn download_single_file(
             .await
             .context(BlockingTaskSnafu)??;
 
+            // Cancelled after the blocking write but before publish: abandon the
+            // artifact and report cancellation rather than publishing a completed
+            // file (mirrors the GCS/Azure arms). The git-stage spilled temp
+            // auto-deletes on drop; only the `.part` path needs explicit removal.
+            if cancel.is_cancelled() {
+                if spilled_temp.is_none() {
+                    warn_remove_partial(&partial_path);
+                }
+                return Err(DownloadFileError::Cancelled {
+                    location: Location::new(file!(), line!(), 0),
+                })
+                .context(S3DownloadSnafu);
+            }
+
             // Atomic publish: rename into place after the .await cancellation point.
             // `Some(temp)` (git-stage ranged download): the raw temp is renamed
             // directly to output — single same-FS rename.
@@ -857,6 +911,7 @@ pub async fn download_single_file(
                 ),
                 per_file_index,
                 refresher,
+                cancel.clone(),
             )
             .await
             .context(GcsDownloadSnafu)?;
@@ -873,7 +928,7 @@ pub async fn download_single_file(
             // Rename happens after the `.await` (see below), so a cancelled/
             // dropped outer future cannot publish a file written by a detached
             // blocking task. The `.await` itself is the cancellation point.
-            let (output_byte_len, spilled_temp) = tokio::task::spawn_blocking(move || {
+            let output_result = tokio::task::spawn_blocking(move || {
                 write_cloud_download(
                     body,
                     cse_info,
@@ -884,7 +939,34 @@ pub async fn download_single_file(
                 )
             })
             .await
-            .context(BlockingTaskSnafu)??;
+            .context(BlockingTaskSnafu)?;
+
+            // A cancelled streamed download surfaces as an Interrupted io error
+            // through write_cloud_download; classify it as CANCELLED rather than
+            // a generic write/decrypt failure.
+            let (output_byte_len, spilled_temp) = match output_result {
+                Ok(v) => v,
+                Err(e) if is_stream_cancelled_error(&e) => {
+                    return Err(GcsDownloadError::Cancelled {
+                        location: Location::new(file!(), line!(), 0),
+                    })
+                    .context(GcsDownloadSnafu);
+                }
+                Err(e) => return Err(e),
+            };
+
+            // Cancelled after the blocking write but before publish: abandon the
+            // artifact rather than publishing a completed file. The spilled temp
+            // auto-deletes on drop; only the `.part` path needs explicit removal.
+            if cancel.is_cancelled() {
+                if spilled_temp.is_none() {
+                    warn_remove_partial(&partial_path);
+                }
+                return Err(GcsDownloadError::Cancelled {
+                    location: Location::new(file!(), line!(), 0),
+                })
+                .context(GcsDownloadSnafu);
+            }
 
             // Atomic publish — runs after .await so a dropped future cannot publish.
             match spilled_temp {
@@ -952,6 +1034,7 @@ pub async fn download_single_file(
                 data.multipart,
                 &azure_retry_policy(policy),
                 spill_target,
+                cancel.clone(),
             )
             .await
             .context(AzureDownloadSnafu)?;
@@ -963,7 +1046,7 @@ pub async fn download_single_file(
             let partial_path2 = partial_path.clone();
             // Write to `<dst>.part` but do NOT rename inside spawn_blocking;
             // same cancellation-safety rationale as the GCS arm above.
-            let (output_byte_len, spilled_temp) = tokio::task::spawn_blocking(move || {
+            let output_result = tokio::task::spawn_blocking(move || {
                 write_cloud_download(
                     body,
                     cse_info,
@@ -974,7 +1057,34 @@ pub async fn download_single_file(
                 )
             })
             .await
-            .context(BlockingTaskSnafu)??;
+            .context(BlockingTaskSnafu)?;
+
+            // A cancelled streamed download surfaces as an Interrupted io error
+            // through write_cloud_download; classify it as CANCELLED rather than
+            // a generic write/decrypt failure.
+            let (output_byte_len, spilled_temp) = match output_result {
+                Ok(v) => v,
+                Err(e) if is_stream_cancelled_error(&e) => {
+                    return Err(AzureDownloadError::Cancelled {
+                        location: Location::new(file!(), line!(), 0),
+                    })
+                    .context(AzureDownloadSnafu);
+                }
+                Err(e) => return Err(e),
+            };
+
+            // Cancelled after the blocking write but before publish: abandon the
+            // artifact rather than publishing a completed file. The spilled temp
+            // auto-deletes on drop; only the `.part` path needs explicit removal.
+            if cancel.is_cancelled() {
+                if spilled_temp.is_none() {
+                    warn_remove_partial(&partial_path);
+                }
+                return Err(AzureDownloadError::Cancelled {
+                    location: Location::new(file!(), line!(), 0),
+                })
+                .context(AzureDownloadSnafu);
+            }
 
             // Atomic publish — runs after .await so a dropped future cannot publish.
             match spilled_temp {
@@ -1339,6 +1449,18 @@ impl FileManagerError {
                 ..
             }
         )
+    }
+
+    pub(crate) fn is_cancelled(&self) -> bool {
+        match self {
+            FileManagerError::GcsUpload { source, .. } => source.is_cancelled(),
+            FileManagerError::GcsDownload { source, .. } => source.is_cancelled(),
+            FileManagerError::AzureUpload { source, .. } => source.is_cancelled(),
+            FileManagerError::AzureDownload { source, .. } => source.is_cancelled(),
+            FileManagerError::S3Upload { source, .. } => source.is_cancelled(),
+            FileManagerError::S3Download { source, .. } => source.is_cancelled(),
+            _ => false,
+        }
     }
 }
 
@@ -2441,9 +2563,14 @@ mod tests {
         let policy = crate::config::retry::RetryPolicy::put_get(
             &crate::config::param_store::ParamStore::new(),
         );
-        upload_single_file(data, &policy, &mut refresher)
-            .await
-            .expect("upload_single_file should succeed against the mock")
+        upload_single_file(
+            data,
+            &policy,
+            &mut refresher,
+            tokio_util::sync::CancellationToken::new(),
+        )
+        .await
+        .expect("upload_single_file should succeed against the mock")
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -2566,9 +2693,14 @@ mod tests {
         let policy = crate::config::retry::RetryPolicy::put_get(
             &crate::config::param_store::ParamStore::new(),
         );
-        let result = upload_single_file(data, &policy, &mut refresher)
-            .await
-            .expect("S3 upload should succeed against the mock");
+        let result = upload_single_file(
+            data,
+            &policy,
+            &mut refresher,
+            tokio_util::sync::CancellationToken::new(),
+        )
+        .await
+        .expect("S3 upload should succeed against the mock");
         assert_eq!(result.status, "UPLOADED");
     }
 }

--- a/sf_core/src/file_manager/s3_transfer.rs
+++ b/sf_core/src/file_manager/s3_transfer.rs
@@ -32,6 +32,7 @@ use aws_sdk_s3::types::BucketAccelerateStatus;
 use aws_sdk_s3::types::{CompletedMultipartUpload, CompletedPart};
 use aws_sdk_s3::{Client as S3Client, primitives::ByteStream};
 use aws_smithy_types::body::SdkBody;
+use tokio_util::sync::CancellationToken;
 
 const SNOWFLAKE_UPLOAD_PROVIDER: &str = "snowflake-upload";
 const SNOWFLAKE_DOWNLOAD_PROVIDER: &str = "snowflake-download";
@@ -82,6 +83,7 @@ pub(super) async fn upload_to_s3_or_skip(
     base_policy: &RetryPolicy,
     multipart: MultipartParams,
     refresher: &mut Option<&mut dyn StageInfoRefresher>,
+    cancel: CancellationToken,
 ) -> Result<UploadStatus, UploadFileError> {
     let s3_key = format!("{}{filename}", stage_info.key_prefix);
     let policy = s3_retry_policy(base_policy);
@@ -103,13 +105,20 @@ pub(super) async fn upload_to_s3_or_skip(
         let stage_info = with_creds(stage_info, creds);
         let s3_key = s3_key.clone();
         let policy = policy.clone();
+        let cancel = cancel.clone();
         async move {
-            let s3_client = create_s3_client(&stage_info, SNOWFLAKE_UPLOAD_PROVIDER, &policy)
-                .await
-                .map_err(|e| S3AttemptError::Other(UploadFileError::from(e)))?;
+            let s3_client = tokio::select! {
+                biased;
+                _ = cancel.cancelled() => {
+                    return Err(S3AttemptError::Other(upload_file_error::CancelledSnafu.build()));
+                }
+                result = create_s3_client(&stage_info, SNOWFLAKE_UPLOAD_PROVIDER, &policy) => {
+                    result.map_err(|e| S3AttemptError::Other(UploadFileError::from(e)))?
+                }
+            };
 
             if !overwrite
-                && check_if_file_exists(&s3_client, &stage_info, &s3_key)
+                && check_if_file_exists(&s3_client, &stage_info, &s3_key, cancel.clone())
                     .await
                     .map_err(S3AttemptError::Other)?
             {
@@ -125,10 +134,11 @@ pub(super) async fn upload_to_s3_or_skip(
                     &s3_key,
                     body_len,
                     multipart.concurrency,
+                    cancel,
                 )
                 .await?;
             } else {
-                put_object(prepared, &s3_client, &stage_info, &s3_key).await?;
+                put_object(prepared, &s3_client, &stage_info, &s3_key, cancel).await?;
             }
             Ok(UploadStatus::Uploaded)
         }
@@ -143,6 +153,8 @@ pub(super) async fn upload_to_s3_or_skip(
         // any other S3 PUT error.
         |aws_err| upload_file_error::S3UploadSnafu.into_error(aws_err),
         attempt,
+        cancel.clone(),
+        || upload_file_error::CancelledSnafu.build(),
     )
     .await
 }
@@ -173,35 +185,43 @@ enum S3AttemptError<E> {
 /// actually rotate (refresher inside its coalescing window) reports
 /// `Ok(false)` and the helper propagates the original error rather than
 /// spinning.
-struct S3StsRefresher<'a, E, W> {
+struct S3StsRefresher<'a, E, W, C> {
     refresher: &'a mut dyn StageInfoRefresher,
     last_seen_key: Option<String>,
     map_refresh_err: W,
+    cancel: CancellationToken,
+    map_cancel_err: C,
     _marker: PhantomData<fn() -> E>,
 }
 
-impl<'a, E, W> S3StsRefresher<'a, E, W>
+impl<'a, E, W, C> S3StsRefresher<'a, E, W, C>
 where
     W: Fn(StageInfoRefreshError) -> E,
+    C: Fn() -> E,
 {
     fn new(
         refresher: &'a mut dyn StageInfoRefresher,
         initial: &CloudCredentials,
         map_refresh_err: W,
+        cancel: CancellationToken,
+        map_cancel_err: C,
     ) -> Self {
         Self {
             refresher,
             last_seen_key: aws_key_id(initial).map(str::to_string),
             map_refresh_err,
+            cancel,
+            map_cancel_err,
             _marker: PhantomData,
         }
     }
 }
 
-impl<'a, E, W> Refresher<CloudCredentials, S3AttemptError<E>> for S3StsRefresher<'a, E, W>
+impl<'a, E, W, C> Refresher<CloudCredentials, S3AttemptError<E>> for S3StsRefresher<'a, E, W, C>
 where
     E: Send,
     W: Fn(StageInfoRefreshError) -> E + Send,
+    C: Fn() -> E + Send,
 {
     fn current(
         &mut self,
@@ -218,10 +238,14 @@ where
     fn refresh(&mut self) -> crate::refresh::RefreshFuture<'_, Result<bool, S3AttemptError<E>>> {
         Box::pin(async move {
             tracing::info!("S3 hit ExpiredToken; refreshing stage credentials");
-            self.refresher
-                .refresh()
-                .await
-                .map_err(|e| S3AttemptError::Other((self.map_refresh_err)(e)))?;
+            let result = tokio::select! {
+                biased;
+                _ = self.cancel.cancelled() => {
+                    return Err(S3AttemptError::Other((self.map_cancel_err)()));
+                }
+                result = self.refresher.refresh() => result,
+            };
+            result.map_err(|e| S3AttemptError::Other((self.map_refresh_err)(e)))?;
             let new = self.refresher.cache().snapshot().creds;
             let new_key = aws_key_id(&new).map(str::to_string);
             if new_key == self.last_seen_key {
@@ -250,6 +274,8 @@ async fn run_s3_with_sts_refresh<F, Fut, T, E>(
     map_refresh_err: impl Fn(StageInfoRefreshError) -> E + Send,
     map_sts_err: impl FnOnce(aws_sdk_s3::Error) -> E,
     attempt: F,
+    cancel: CancellationToken,
+    map_cancel_err: impl Fn() -> E + Send,
 ) -> Result<T, E>
 where
     F: Fn(CloudCredentials) -> Fut,
@@ -258,7 +284,8 @@ where
 {
     let outcome = match refresher.as_deref_mut() {
         Some(r) => {
-            let mut sts_refresher = S3StsRefresher::new(r, initial_creds, map_refresh_err);
+            let mut sts_refresher =
+                S3StsRefresher::new(r, initial_creds, map_refresh_err, cancel, map_cancel_err);
             execute_with_refresh(&mut sts_refresher, attempt).await
         }
         None => attempt(initial_creds.clone()).await,
@@ -295,14 +322,18 @@ async fn check_if_file_exists(
     s3_client: &S3Client,
     stage_info: &StageInfo,
     s3_key: &str,
+    cancel: CancellationToken,
 ) -> Result<bool, UploadFileError> {
-    match s3_client
+    let result = tokio::select! {
+        biased;
+        _ = cancel.cancelled() => return upload_file_error::CancelledSnafu.fail(),
+        result = s3_client
         .head_object()
         .bucket(stage_info.bucket.clone())
         .key(s3_key)
-        .send()
-        .await
-    {
+        .send() => result,
+    };
+    match result {
         Ok(_) => Ok(true),
         Err(SdkError::ServiceError(err)) if err.err().is_not_found() => Ok(false),
         Err(SdkError::ServiceError(ref err)) if err.raw().status().as_u16() == 403 => {
@@ -396,6 +427,7 @@ async fn put_object(
     s3_client: &S3Client,
     stage_info: &StageInfo,
     s3_key: &str,
+    cancel: CancellationToken,
 ) -> Result<(), S3AttemptError<UploadFileError>> {
     // CSE params (cloud metadata + encryptor) are both present or both absent.
     let (encryption_metadata, encryptor) = prepared.cse.map(|c| (c.metadata, c.encryptor)).unzip();
@@ -411,10 +443,14 @@ async fn put_object(
         // can replay the body (re-encryption is deterministic).
         (source, Some(encryptor)) => encrypting_byte_stream(source, encryptor),
         // SSE Path: hand the SDK the file directly (FsBuilder is retryable).
-        (ByteSource::Path(ref path), None) => ByteStream::read_from()
+        (ByteSource::Path(ref path), None) => tokio::select! {
+            biased;
+            _ = cancel.cancelled() => {
+                return Err(S3AttemptError::Other(upload_file_error::CancelledSnafu.build()));
+            }
+            result = ByteStream::read_from()
             .path(path)
-            .build()
-            .await
+            .build() => result
             .map_err(|e| {
                 S3AttemptError::Other(
                     upload_file_error::SourceOpenSnafu {
@@ -422,7 +458,8 @@ async fn put_object(
                     }
                     .build(),
                 )
-            })?,
+            })?
+        },
         // SSE in-memory (small / passthrough payloads).
         (ByteSource::Bytes(bytes), None) => ByteStream::from(bytes),
     };
@@ -454,12 +491,18 @@ async fn put_object(
     // Log only safe metadata.
     tracing::trace!(bucket = %stage_info.bucket, key = ?s3_key, "Sending S3 PutObject request");
 
-    match put_object_request
+    let result = tokio::select! {
+        biased;
+        _ = cancel.cancelled() => {
+            return Err(S3AttemptError::Other(upload_file_error::CancelledSnafu.build()));
+        }
+        result = put_object_request
         .customize()
         .disable_payload_signing()
-        .send()
-        .await
-    {
+        .send() => result,
+    };
+
+    match result {
         Ok(res) => {
             tracing::debug!("S3 upload result: {:?}", res);
             Ok(())
@@ -496,12 +539,15 @@ async fn s3_multipart_upload(
     s3_key: &str,
     body_len: u64,
     concurrency: usize,
+    cancel: CancellationToken,
 ) -> Result<(), S3AttemptError<UploadFileError>> {
     let chunk_size = multipart::compute_part_size(body_len, &MultipartConfig::S3)
         .context(upload_file_error::FileTooLargeSnafu)
         .map_err(S3AttemptError::Other)?;
 
-    let upload_id = s3_create_multipart_upload(&prepared, s3_client, stage_info, s3_key).await?;
+    let upload_id =
+        s3_create_multipart_upload(&prepared, s3_client, stage_info, s3_key, cancel.clone())
+            .await?;
     tracing::debug!(
         "S3 multipart upload started: key={s3_key:?} upload_id={upload_id:?} \
          body_len={body_len} chunk_size={chunk_size} concurrency={concurrency}"
@@ -522,6 +568,7 @@ async fn s3_multipart_upload(
         &upload_id,
         parts_rx,
         concurrency,
+        cancel,
     )
     .await;
 
@@ -546,6 +593,7 @@ async fn s3_create_multipart_upload(
     s3_client: &S3Client,
     stage_info: &StageInfo,
     s3_key: &str,
+    cancel: CancellationToken,
 ) -> Result<String, S3AttemptError<UploadFileError>> {
     let mut request = s3_client
         .create_multipart_upload()
@@ -570,7 +618,14 @@ async fn s3_create_multipart_upload(
         key = ?s3_key,
         "S3 CreateMultipartUpload"
     );
-    match request.send().await {
+    let result = tokio::select! {
+        biased;
+        _ = cancel.cancelled() => {
+            return Err(S3AttemptError::Other(upload_file_error::CancelledSnafu.build()));
+        }
+        result = request.send() => result,
+    };
+    match result {
         Ok(out) => {
             tracing::debug!(bucket = %stage_info.bucket, key = ?s3_key, "S3 CreateMultipartUpload succeeded");
             out.upload_id().map(str::to_string).ok_or_else(|| {
@@ -611,22 +666,47 @@ async fn upload_parts_and_complete(
     upload_id: &str,
     parts_rx: tokio::sync::mpsc::Receiver<std::io::Result<multipart::UploadPart>>,
     concurrency: usize,
+    cancel: CancellationToken,
 ) -> Result<(), S3AttemptError<UploadFileError>> {
-    let mut completed: Vec<CompletedPart> = ReceiverStream::new(parts_rx)
-        .map(|part| async move {
-            let part = part.map_err(|e| {
-                S3AttemptError::Other(
-                    upload_file_error::SourceReadSnafu {
-                        detail: e.to_string(),
-                    }
-                    .build(),
+    let cancel_for_parts = cancel.clone();
+    let completed_parts = ReceiverStream::new(parts_rx)
+        .map(move |part| {
+            let cancel = cancel_for_parts.clone();
+            async move {
+                if cancel.is_cancelled() {
+                    return Err(S3AttemptError::Other(
+                        upload_file_error::CancelledSnafu.build(),
+                    ));
+                }
+                let part = part.map_err(|e| {
+                    S3AttemptError::Other(
+                        upload_file_error::SourceReadSnafu {
+                            detail: e.to_string(),
+                        }
+                        .build(),
+                    )
+                })?;
+                upload_one_part(
+                    s3_client,
+                    stage_info,
+                    s3_key,
+                    upload_id,
+                    part,
+                    cancel.clone(),
                 )
-            })?;
-            upload_one_part(s3_client, stage_info, s3_key, upload_id, part).await
+                .await
+            }
         })
         .buffer_unordered(concurrency)
-        .try_collect()
-        .await?;
+        .try_collect();
+
+    let mut completed: Vec<CompletedPart> = tokio::select! {
+        biased;
+        _ = cancel.cancelled() => {
+            return Err(S3AttemptError::Other(upload_file_error::CancelledSnafu.build()));
+        }
+        completed = completed_parts => completed?,
+    };
 
     // A multipart upload with zero parts makes S3 reject CompleteMultipartUpload
     // with an opaque `MalformedXML`; surface a clear error instead. Unreachable on
@@ -655,15 +735,20 @@ async fn upload_parts_and_complete(
         upload_id = ?upload_id,
         "S3 CompleteMultipartUpload"
     );
-    match s3_client
+    let result = tokio::select! {
+        biased;
+        _ = cancel.cancelled() => {
+            return Err(S3AttemptError::Other(upload_file_error::CancelledSnafu.build()));
+        }
+        result = s3_client
         .complete_multipart_upload()
         .bucket(stage_info.bucket.clone())
         .key(s3_key)
         .upload_id(upload_id)
         .multipart_upload(completed_upload)
-        .send()
-        .await
-    {
+        .send() => result,
+    };
+    match result {
         Ok(res) => {
             tracing::debug!("S3 CompleteMultipartUpload succeeded: {:?}", res);
             Ok(())
@@ -686,6 +771,7 @@ async fn upload_one_part(
     s3_key: &str,
     upload_id: &str,
     part: multipart::UploadPart,
+    cancel: CancellationToken,
 ) -> Result<CompletedPart, S3AttemptError<UploadFileError>> {
     let part_number = part.number;
     let content_length = part.body.len() as i64;
@@ -698,7 +784,12 @@ async fn upload_one_part(
         part_number,
         "S3 UploadPart"
     );
-    match s3_client
+    let result = tokio::select! {
+        biased;
+        _ = cancel.cancelled() => {
+            return Err(S3AttemptError::Other(upload_file_error::CancelledSnafu.build()));
+        }
+        result = s3_client
         .upload_part()
         .bucket(stage_info.bucket.clone())
         .key(s3_key)
@@ -708,9 +799,9 @@ async fn upload_one_part(
         .set_content_length(Some(content_length))
         .customize()
         .disable_payload_signing()
-        .send()
-        .await
-    {
+        .send() => result,
+    };
+    match result {
         Ok(out) => Ok(CompletedPart::builder()
             .set_e_tag(out.e_tag().map(str::to_string))
             .part_number(part_number)
@@ -881,6 +972,7 @@ pub(super) async fn download_from_s3(
     multipart: MultipartParams,
     refresher: &mut Option<&mut dyn StageInfoRefresher>,
     spill_target: SpillTarget<'_>,
+    cancel: CancellationToken,
 ) -> Result<S3Download, DownloadFileError> {
     let s3_key = format!("{}{filename}", stage_info.key_prefix);
     let policy = s3_retry_policy(base_policy);
@@ -889,11 +981,26 @@ pub(super) async fn download_from_s3(
         let stage_info = with_creds(stage_info, creds);
         let s3_key = s3_key.clone();
         let policy = policy.clone();
+        let cancel = cancel.clone();
         async move {
-            let s3_client = create_s3_client(&stage_info, SNOWFLAKE_DOWNLOAD_PROVIDER, &policy)
-                .await
-                .map_err(|e| S3AttemptError::Other(DownloadFileError::from(e)))?;
-            s3_download_attempt(&s3_client, &stage_info, &s3_key, multipart, spill_target).await
+            let s3_client = tokio::select! {
+                biased;
+                _ = cancel.cancelled() => {
+                    return Err(S3AttemptError::Other(download_file_error::CancelledSnafu.build()));
+                }
+                result = create_s3_client(&stage_info, SNOWFLAKE_DOWNLOAD_PROVIDER, &policy) => {
+                    result.map_err(|e| S3AttemptError::Other(DownloadFileError::from(e)))?
+                }
+            };
+            s3_download_attempt(
+                &s3_client,
+                &stage_info,
+                &s3_key,
+                multipart,
+                spill_target,
+                cancel,
+            )
+            .await
         }
     };
 
@@ -903,6 +1010,8 @@ pub(super) async fn download_from_s3(
         |e| download_file_error::StageInfoRefreshSnafu.into_error(e),
         |aws_err| download_file_error::S3DownloadSnafu.into_error(aws_err),
         attempt,
+        cancel.clone(),
+        || download_file_error::CancelledSnafu.build(),
     )
     .await
 }
@@ -917,8 +1026,9 @@ async fn s3_download_attempt(
     s3_key: &str,
     multipart: MultipartParams,
     spill_target: SpillTarget<'_>,
+    cancel: CancellationToken,
 ) -> Result<S3Download, S3AttemptError<DownloadFileError>> {
-    let head = s3_head_object(s3_client, stage_info, s3_key).await?;
+    let head = s3_head_object(s3_client, stage_info, s3_key, cancel.clone()).await?;
     let content_length = head.content_length().unwrap_or(0).max(0) as u64;
     let metadata_map = head.metadata().cloned().unwrap_or_default();
     let (digest, file_metadata) =
@@ -941,11 +1051,12 @@ async fn s3_download_attempt(
             chunk_size,
             multipart.concurrency,
             spill_target,
+            cancel,
         )
         .await?;
         S3DownloadBody::Spilled(spilled)
     } else {
-        S3DownloadBody::InMemory(s3_get_whole(s3_client, stage_info, s3_key).await?)
+        S3DownloadBody::InMemory(s3_get_whole(s3_client, stage_info, s3_key, cancel).await?)
     };
 
     Ok(S3Download {
@@ -996,6 +1107,7 @@ async fn s3_head_object(
     s3_client: &S3Client,
     stage_info: &StageInfo,
     s3_key: &str,
+    cancel: CancellationToken,
 ) -> Result<aws_sdk_s3::operation::head_object::HeadObjectOutput, S3AttemptError<DownloadFileError>>
 {
     tracing::info!(
@@ -1004,13 +1116,18 @@ async fn s3_head_object(
         key = ?s3_key,
         "S3 HeadObject"
     );
-    match s3_client
+    let result = tokio::select! {
+        biased;
+        _ = cancel.cancelled() => {
+            return Err(S3AttemptError::Other(download_file_error::CancelledSnafu.build()));
+        }
+        result = s3_client
         .head_object()
         .bucket(stage_info.bucket.clone())
         .key(s3_key)
-        .send()
-        .await
-    {
+        .send() => result,
+    };
+    match result {
         Ok(out) => Ok(out),
         Err(sdk_err) => {
             tracing::warn!(
@@ -1030,12 +1147,15 @@ async fn s3_head_object(
 /// `ByteStream` download error. Shared by the single-GET and ranged-GET paths.
 async fn collect_s3_body(
     out: aws_sdk_s3::operation::get_object::GetObjectOutput,
+    cancel: CancellationToken,
 ) -> Result<Bytes, S3AttemptError<DownloadFileError>> {
-    out.body
-        .collect()
-        .await
-        .map(|agg| agg.into_bytes())
-        .map_err(|e| S3AttemptError::Other(download_file_error::ByteStreamSnafu.into_error(e)))
+    tokio::select! {
+        biased;
+        _ = cancel.cancelled() => Err(S3AttemptError::Other(download_file_error::CancelledSnafu.build())),
+        result = out.body.collect() => result
+            .map(|agg| agg.into_bytes())
+            .map_err(|e| S3AttemptError::Other(download_file_error::ByteStreamSnafu.into_error(e))),
+    }
 }
 
 /// Single buffered GET of the whole object body. Folds `ExpiredToken` into
@@ -1044,6 +1164,7 @@ async fn s3_get_whole(
     s3_client: &S3Client,
     stage_info: &StageInfo,
     s3_key: &str,
+    cancel: CancellationToken,
 ) -> Result<Bytes, S3AttemptError<DownloadFileError>> {
     tracing::info!(
         method = "GET",
@@ -1051,13 +1172,18 @@ async fn s3_get_whole(
         key = ?s3_key,
         "S3 GetObject"
     );
-    let out = match s3_client
+    let result = tokio::select! {
+        biased;
+        _ = cancel.cancelled() => {
+            return Err(S3AttemptError::Other(download_file_error::CancelledSnafu.build()));
+        }
+        result = s3_client
         .get_object()
         .bucket(stage_info.bucket.clone())
         .key(s3_key)
-        .send()
-        .await
-    {
+        .send() => result,
+    };
+    let out = match result {
         Ok(out) => out,
         Err(sdk_err) => {
             tracing::warn!(
@@ -1071,7 +1197,7 @@ async fn s3_get_whole(
             }));
         }
     };
-    collect_s3_body(out).await
+    collect_s3_body(out, cancel).await
 }
 
 /// Downloads the object with parallel ranged GETs into a pre-allocated file,
@@ -1099,6 +1225,7 @@ async fn s3_range_download(
     chunk_size: u64,
     concurrency: usize,
     target: SpillTarget<'_>,
+    cancel: CancellationToken,
 ) -> Result<SpilledBody, S3AttemptError<DownloadFileError>> {
     let mk_temp_err = |detail: String| {
         S3AttemptError::Other(download_file_error::TempFileSnafu { detail }.build())
@@ -1157,8 +1284,15 @@ async fn s3_range_download(
     let results: Vec<Result<(), S3AttemptError<DownloadFileError>>> = futures::stream::iter(ranges)
         .map(|range| {
             let file = Arc::clone(&file);
+            let cancel = cancel.clone();
             async move {
-                let bytes = s3_get_range(s3_client, stage_info, s3_key, &range).await?;
+                if cancel.is_cancelled() {
+                    return Err(S3AttemptError::Other(
+                        download_file_error::CancelledSnafu.build(),
+                    ));
+                }
+                let bytes =
+                    s3_get_range(s3_client, stage_info, s3_key, &range, cancel.clone()).await?;
                 // Guard against endpoints that ignore Range and return the whole
                 // object (200 not 206): writing at range.start would corrupt the
                 // assembled file by overrunning the pre-allocated length.
@@ -1210,6 +1344,7 @@ async fn s3_get_range(
     stage_info: &StageInfo,
     s3_key: &str,
     range: &multipart::DownloadRange,
+    cancel: CancellationToken,
 ) -> Result<Bytes, S3AttemptError<DownloadFileError>> {
     let range_header = format!("bytes={}-{}", range.start, range.end);
     tracing::info!(
@@ -1219,14 +1354,19 @@ async fn s3_get_range(
         range = %range_header,
         "S3 GetObject (ranged)"
     );
-    let out = match s3_client
+    let result = tokio::select! {
+        biased;
+        _ = cancel.cancelled() => {
+            return Err(S3AttemptError::Other(download_file_error::CancelledSnafu.build()));
+        }
+        result = s3_client
         .get_object()
         .bucket(stage_info.bucket.clone())
         .key(s3_key)
         .range(range_header)
-        .send()
-        .await
-    {
+        .send() => result,
+    };
+    let out = match result {
         Ok(out) => out,
         Err(sdk_err) => {
             tracing::warn!(
@@ -1240,7 +1380,7 @@ async fn s3_get_range(
             }));
         }
     };
-    collect_s3_body(out).await
+    collect_s3_body(out, cancel).await
 }
 
 /// Returns a retry policy tuned for S3 file-transfer operations.
@@ -1566,6 +1706,17 @@ pub enum UploadFileError {
         #[snafu(implicit)]
         location: Location,
     },
+    #[snafu(display("Operation cancelled"))]
+    Cancelled {
+        #[snafu(implicit)]
+        location: Location,
+    },
+}
+
+impl UploadFileError {
+    pub(crate) fn is_cancelled(&self) -> bool {
+        matches!(self, UploadFileError::Cancelled { .. })
+    }
 }
 
 /// `pub` for the same reason as [`UploadFileError`] — a `source` field on the
@@ -1623,6 +1774,17 @@ pub enum DownloadFileError {
         #[snafu(implicit)]
         location: Location,
     },
+    #[snafu(display("Operation cancelled"))]
+    Cancelled {
+        #[snafu(implicit)]
+        location: Location,
+    },
+}
+
+impl DownloadFileError {
+    pub(crate) fn is_cancelled(&self) -> bool {
+        matches!(self, DownloadFileError::Cancelled { .. })
+    }
 }
 
 // --- Unit tests ---
@@ -2032,12 +2194,22 @@ mod tests {
         e
     }
 
+    fn unexpected_cancel() -> StageInfoRefreshError {
+        panic!("unexpected cancellation")
+    }
+
     #[tokio::test]
     async fn s3_sts_refresher_refresh_returns_true_when_creds_rotate() {
         let mut fake = FakeRefresher::new(s3_creds("AKIA1"));
         fake.arm(s3_creds("AKIA2"));
         let initial = s3_creds("AKIA1");
-        let mut sts_refresher = S3StsRefresher::new(&mut fake, &initial, identity_map);
+        let mut sts_refresher = S3StsRefresher::new(
+            &mut fake,
+            &initial,
+            identity_map,
+            CancellationToken::new(),
+            unexpected_cancel,
+        );
 
         let rotated = sts_refresher.refresh().await.unwrap();
 
@@ -2059,7 +2231,13 @@ mod tests {
         // spinning.
         let mut fake = FakeRefresher::new(s3_creds("AKIA1"));
         let initial = s3_creds("AKIA1");
-        let mut sts_refresher = S3StsRefresher::new(&mut fake, &initial, identity_map);
+        let mut sts_refresher = S3StsRefresher::new(
+            &mut fake,
+            &initial,
+            identity_map,
+            CancellationToken::new(),
+            unexpected_cancel,
+        );
 
         let rotated = sts_refresher.refresh().await.unwrap();
 
@@ -2078,7 +2256,13 @@ mod tests {
         let mut fake = FakeRefresher::new(s3_creds("AKIA1"));
         fake.arm(s3_creds("AKIA2"));
         let initial = s3_creds("AKIA1");
-        let mut sts_refresher = S3StsRefresher::new(&mut fake, &initial, identity_map);
+        let mut sts_refresher = S3StsRefresher::new(
+            &mut fake,
+            &initial,
+            identity_map,
+            CancellationToken::new(),
+            unexpected_cancel,
+        );
 
         assert!(sts_refresher.refresh().await.unwrap()); // AKIA1 -> AKIA2
         // Cache still holds AKIA2; arming nothing means refresh() leaves
@@ -2128,6 +2312,7 @@ mod tests {
             &base_policy(),
             MultipartParams::default(),
             &mut None,
+            tokio_util::sync::CancellationToken::new(),
         )
         .await
         .expect("upload should succeed against the mock");
@@ -2219,6 +2404,7 @@ mod tests {
                 &base_policy(),
                 MultipartParams::default(),
                 &mut None,
+                tokio_util::sync::CancellationToken::new(),
             ),
         )
         .await
@@ -2323,6 +2509,7 @@ mod tests {
             &base_policy(),
             MultipartParams::default(),
             &mut None,
+            tokio_util::sync::CancellationToken::new(),
         )
         .await
         .expect("encrypted S3 upload should succeed against the mock");
@@ -2536,6 +2723,7 @@ mod tests {
             &base_policy(),
             always_multipart(),
             &mut None,
+            tokio_util::sync::CancellationToken::new(),
         )
         .await
         .expect("multipart upload should succeed against the mock");
@@ -2595,6 +2783,7 @@ mod tests {
             &base_policy_with_attempts(1), // single attempt: fail fast, no SDK retry storm
             always_multipart(),
             &mut None,
+            tokio_util::sync::CancellationToken::new(),
         )
         .await;
 
@@ -2640,6 +2829,7 @@ mod tests {
             always_multipart(),
             &mut None,
             SpillTarget::Temp(spill.path()),
+            tokio_util::sync::CancellationToken::new(),
         )
         .await
         .expect("ranged download should succeed against the mock");
@@ -2689,6 +2879,7 @@ mod tests {
             always_multipart(),
             &mut None,
             SpillTarget::Part(&part_path),
+            tokio_util::sync::CancellationToken::new(),
         )
         .await
         .expect("ranged download should succeed against the mock");
@@ -2732,6 +2923,7 @@ mod tests {
             always_multipart(),
             &mut None,
             SpillTarget::Part(&part_path),
+            tokio_util::sync::CancellationToken::new(),
         )
         .await;
 

--- a/sf_core/src/http/retry.rs
+++ b/sf_core/src/http/retry.rs
@@ -77,6 +77,18 @@ pub enum HttpError {
         #[snafu(implicit)]
         location: Location,
     },
+    #[snafu(display("operation cancelled"))]
+    #[snafu(visibility(pub(crate)))]
+    Cancelled {
+        #[snafu(implicit)]
+        location: Location,
+    },
+}
+
+impl HttpError {
+    pub(crate) fn is_cancelled(&self) -> bool {
+        matches!(self, HttpError::Cancelled { .. })
+    }
 }
 
 /// Calculate effective timeout for a request attempt.
@@ -101,6 +113,7 @@ pub async fn execute_with_retry<T, B, F, H>(
     ctx: &HttpContext,
     policy: &RetryPolicy,
     on_response: H,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<T, HttpError>
 where
     B: Fn() -> reqwest::RequestBuilder,
@@ -157,17 +170,29 @@ where
             "outbound HTTP call"
         );
 
-        let result = req_builder.send().await;
+        let result = tokio::select! {
+            biased;
+            _ = cancel.cancelled() => return CancelledSnafu.fail(),
+            sent = req_builder.send() => sent,
+        };
 
         match result {
             Ok(resp) => {
                 if resp.status().is_success() {
-                    return on_response(resp).await;
+                    return tokio::select! {
+                        biased;
+                        _ = cancel.cancelled() => CancelledSnafu.fail(),
+                        res = on_response(resp) => res,
+                    };
                 }
                 if !should_retry_status(resp.status(), &policy.extra_retryable_statuses)
                     || !allow_retry(ctx, &policy.http)
                 {
-                    return on_response(resp).await;
+                    return tokio::select! {
+                        biased;
+                        _ = cancel.cancelled() => CancelledSnafu.fail(),
+                        res = on_response(resp) => res,
+                    };
                 }
 
                 if attempt >= max_attempts {
@@ -190,7 +215,11 @@ where
                     }
                     .fail();
                 }
-                tokio::time::sleep(delay).await;
+                tokio::select! {
+                    biased;
+                    _ = cancel.cancelled() => return CancelledSnafu.fail(),
+                    _ = tokio::time::sleep(delay) => {}
+                }
                 continue;
             }
             Err(e) => {
@@ -211,7 +240,11 @@ where
                     }
                     .fail();
                 }
-                tokio::time::sleep(delay).await;
+                tokio::select! {
+                    biased;
+                    _ = cancel.cancelled() => return CancelledSnafu.fail(),
+                    _ = tokio::time::sleep(delay) => {}
+                }
                 continue;
             }
         }
@@ -273,18 +306,27 @@ pub async fn execute_bytes_with_retry<B>(
     build: B,
     ctx: &HttpContext,
     policy: &RetryPolicy,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<Vec<u8>, HttpError>
 where
     B: Fn() -> reqwest::RequestBuilder,
 {
-    let resp = execute_with_retry(build, ctx, policy, |r| async move { Ok(r) }).await?;
-    match resp.error_for_status() {
-        Ok(ok) => {
-            let bytes = ok.bytes().await.context(TransportSnafu)?;
-            Ok(bytes.to_vec())
-        }
-        Err(e) => Err(TransportSnafu.into_error(e)),
-    }
+    execute_with_retry(
+        build,
+        ctx,
+        policy,
+        |r| async move {
+            match r.error_for_status() {
+                Ok(ok) => {
+                    let bytes = ok.bytes().await.context(TransportSnafu)?;
+                    Ok(bytes.to_vec())
+                }
+                Err(e) => Err(TransportSnafu.into_error(e)),
+            }
+        },
+        cancel,
+    )
+    .await
 }
 
 /// Like [`execute_bytes_with_retry`] but streams the response body and aborts
@@ -298,37 +340,44 @@ pub async fn execute_bytes_with_retry_capped<B>(
     ctx: &HttpContext,
     policy: &RetryPolicy,
     max_size: usize,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<Vec<u8>, HttpError>
 where
     B: Fn() -> reqwest::RequestBuilder,
 {
     use futures::StreamExt;
-    execute_with_retry(build, ctx, policy, |resp| async move {
-        let resp = resp.error_for_status().context(TransportSnafu)?;
-        if let Some(len) = resp.content_length()
-            && len > max_size as u64
-        {
-            return ResponseTooLargeSnafu {
-                size: len,
-                max_size,
-            }
-            .fail();
-        }
-        let mut stream = resp.bytes_stream();
-        let mut buf: Vec<u8> = Vec::new();
-        while let Some(chunk) = stream.next().await {
-            let chunk = chunk.context(TransportSnafu)?;
-            if buf.len() + chunk.len() > max_size {
+    execute_with_retry(
+        build,
+        ctx,
+        policy,
+        |resp| async move {
+            let resp = resp.error_for_status().context(TransportSnafu)?;
+            if let Some(len) = resp.content_length()
+                && len > max_size as u64
+            {
                 return ResponseTooLargeSnafu {
-                    size: (buf.len() + chunk.len()) as u64,
+                    size: len,
                     max_size,
                 }
                 .fail();
             }
-            buf.extend_from_slice(&chunk);
-        }
-        Ok(buf)
-    })
+            let mut stream = resp.bytes_stream();
+            let mut buf: Vec<u8> = Vec::new();
+            while let Some(chunk) = stream.next().await {
+                let chunk = chunk.context(TransportSnafu)?;
+                if buf.len() + chunk.len() > max_size {
+                    return ResponseTooLargeSnafu {
+                        size: (buf.len() + chunk.len()) as u64,
+                        max_size,
+                    }
+                    .fail();
+                }
+                buf.extend_from_slice(&chunk);
+            }
+            Ok(buf)
+        },
+        cancel,
+    )
     .await
 }
 
@@ -365,5 +414,73 @@ mod timeout_tests {
         let result =
             calculate_request_timeout(Some(Duration::from_secs(10)), Some(Duration::from_secs(3)));
         assert_eq!(result, Some(Duration::from_secs(3)));
+    }
+}
+
+#[cfg(test)]
+mod cancel_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn returns_cancelled_when_token_already_cancelled() {
+        let cancel = tokio_util::sync::CancellationToken::new();
+        cancel.cancel();
+        let client = reqwest::Client::new();
+        let ctx = HttpContext::new(Method::GET, "/cancel-test");
+        let policy = RetryPolicy::default();
+        let result: Result<(), HttpError> = execute_with_retry(
+            || client.get("http://127.0.0.1:9/"),
+            &ctx,
+            &policy,
+            |_resp| async move { Ok::<(), HttpError>(()) },
+            cancel,
+        )
+        .await;
+        assert!(matches!(result, Err(HttpError::Cancelled { .. })));
+    }
+
+    #[tokio::test]
+    async fn returns_cancelled_when_cancelled_while_reading_body() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            use tokio::io::AsyncWriteExt;
+            if let Ok((mut socket, _)) = listener.accept().await {
+                let _ = socket
+                    .write_all(b"HTTP/1.1 200 OK\r\ncontent-length: 0\r\n\r\n")
+                    .await;
+                tokio::time::sleep(Duration::from_secs(5)).await;
+            }
+        });
+
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let body_cancel = cancel.clone();
+        let client = reqwest::Client::new();
+        let ctx = HttpContext::new(Method::GET, "/slow-body");
+        let policy = RetryPolicy::default();
+        let url = format!("http://{addr}/");
+
+        let result: Result<(), HttpError> = execute_with_retry(
+            || client.get(url.clone()),
+            &ctx,
+            &policy,
+            move |_resp| {
+                let body_cancel = body_cancel.clone();
+                async move {
+                    // Cancellation lands mid-body: on_response must lose the race
+                    // and surface Cancelled instead of a slow success.
+                    body_cancel.cancel();
+                    tokio::time::sleep(Duration::from_secs(5)).await;
+                    Ok::<(), HttpError>(())
+                }
+            },
+            cancel,
+        )
+        .await;
+
+        assert!(
+            matches!(result, Err(HttpError::Cancelled { .. })),
+            "expected Cancelled, got {result:?}"
+        );
     }
 }

--- a/sf_core/src/protobuf/apis/database_driver_v1/converter.rs
+++ b/sf_core/src/protobuf/apis/database_driver_v1/converter.rs
@@ -592,6 +592,9 @@ pub(super) fn core_validation_issue_to_proto(issue: CoreValidationIssue) -> Vali
 
 fn to_driver_error(error: &ApiError) -> DriverError {
     match error {
+        ApiError::Cancelled { .. } => DriverError {
+            error_type: Some(driver_error::ErrorType::GenericError(GenericError {})),
+        },
         ApiError::GenericError { .. } => DriverError {
             error_type: Some(driver_error::ErrorType::GenericError(GenericError {})),
         },
@@ -889,127 +892,132 @@ fn extract_query_id(error: &ApiError) -> Option<String> {
 }
 
 fn to_driver_exception(error: ApiError) -> DriverException {
-    let status_code = match &error {
-        ApiError::GenericError { .. } => StatusCode::GenericError,
-        ApiError::RuntimeCreation { .. } => StatusCode::InternalError,
-        ApiError::Configuration {
-            source: ConfigError::InvalidParameterValue { .. },
-            ..
-        } => StatusCode::InvalidParameterValue,
-        ApiError::Configuration {
-            source: ConfigError::MissingParameter { .. },
-            ..
-        } => StatusCode::MissingParameter,
-        ApiError::Configuration {
-            source: ConfigError::ConflictingParameters { .. },
-            ..
-        } => StatusCode::InvalidParameterValue,
-        ApiError::Configuration {
-            source: ConfigError::ConfigFileRead { .. },
-            ..
-        } => StatusCode::InternalError,
-        ApiError::Configuration {
-            source: ConfigError::TomlParse { .. },
-            ..
-        } => StatusCode::InternalError,
-        ApiError::Configuration {
-            source: ConfigError::IniParse { .. },
-            ..
-        } => StatusCode::InternalError,
-        ApiError::Configuration {
-            source: ConfigError::IniAlreadyLoaded { .. },
-            ..
-        } => StatusCode::InternalError,
-        ApiError::Configuration {
-            source: ConfigError::InsecurePermissions { .. },
-            ..
-        } => StatusCode::InternalError,
-        ApiError::Configuration {
-            source: ConfigError::ConfigDirNotFound { .. },
-            ..
-        } => StatusCode::InternalError,
-        ApiError::Configuration {
-            source: ConfigError::ConnectionNotFound { .. },
-            ..
-        } => StatusCode::MissingParameter,
-        ApiError::Configuration {
-            source: ConfigError::Validation { issues, .. },
-            ..
-        } if issues
-            .iter()
-            .any(|i| i.code == CoreValidationCode::MissingRequired) =>
-        {
-            StatusCode::MissingParameter
-        }
-        ApiError::Configuration {
-            source: ConfigError::Validation { .. },
-            ..
-        } => StatusCode::InvalidParameterValue,
-        ApiError::InvalidArgument { .. } => StatusCode::InvalidArgument,
-        ApiError::Login { source, .. } => match source.as_ref() {
-            RestError::LoginError { .. } => StatusCode::LoginError,
-            _ => StatusCode::AuthenticationError,
-        },
-        ApiError::ConnectionLock { .. } => StatusCode::InternalError,
-        ApiError::StatementLocking { .. } => StatusCode::InternalError,
-        ApiError::DatabaseLocking { .. } => StatusCode::InternalError,
-        ApiError::QueryResponseProcess {
-            source: boxed_error,
-            ..
-        } => {
-            use crate::apis::database_driver_v1::error::QueryResponseProcessingError;
-            use crate::compression_types::CompressionTypeError;
-            use crate::file_manager::FileManagerError;
-
-            match boxed_error.as_ref() {
-                QueryResponseProcessingError::FileUpload { source, .. }
-                | QueryResponseProcessingError::FileDownload { source, .. } => match source {
-                    FileManagerError::NoFilesMatched { .. } => StatusCode::LocalFileNotFound,
-                    FileManagerError::CompressionType {
-                        source: CompressionTypeError::UnsupportedCompressionType { .. },
-                        ..
-                    } => StatusCode::UnsupportedCompression,
-                    // A too-large source file / stage object is an input
-                    // error, not a driver fault — surface it as
-                    // `InvalidArgument` rather than `InternalError`.
-                    s if s.is_file_too_large() => StatusCode::InvalidArgument,
-                    _ => StatusCode::InternalError,
-                },
-                QueryResponseProcessingError::RemoteFileNotFound { .. } => {
-                    StatusCode::RemoteFileNotFound
-                }
-                _ => StatusCode::InternalError,
+    let status_code = if error.is_cancelled() {
+        StatusCode::Cancelled
+    } else {
+        match &error {
+            ApiError::GenericError { .. } => StatusCode::GenericError,
+            ApiError::RuntimeCreation { .. } => StatusCode::InternalError,
+            ApiError::Configuration {
+                source: ConfigError::InvalidParameterValue { .. },
+                ..
+            } => StatusCode::InvalidParameterValue,
+            ApiError::Configuration {
+                source: ConfigError::MissingParameter { .. },
+                ..
+            } => StatusCode::MissingParameter,
+            ApiError::Configuration {
+                source: ConfigError::ConflictingParameters { .. },
+                ..
+            } => StatusCode::InvalidParameterValue,
+            ApiError::Configuration {
+                source: ConfigError::ConfigFileRead { .. },
+                ..
+            } => StatusCode::InternalError,
+            ApiError::Configuration {
+                source: ConfigError::TomlParse { .. },
+                ..
+            } => StatusCode::InternalError,
+            ApiError::Configuration {
+                source: ConfigError::IniParse { .. },
+                ..
+            } => StatusCode::InternalError,
+            ApiError::Configuration {
+                source: ConfigError::IniAlreadyLoaded { .. },
+                ..
+            } => StatusCode::InternalError,
+            ApiError::Configuration {
+                source: ConfigError::InsecurePermissions { .. },
+                ..
+            } => StatusCode::InternalError,
+            ApiError::Configuration {
+                source: ConfigError::ConfigDirNotFound { .. },
+                ..
+            } => StatusCode::InternalError,
+            ApiError::Configuration {
+                source: ConfigError::ConnectionNotFound { .. },
+                ..
+            } => StatusCode::MissingParameter,
+            ApiError::Configuration {
+                source: ConfigError::Validation { issues, .. },
+                ..
+            } if issues
+                .iter()
+                .any(|i| i.code == CoreValidationCode::MissingRequired) =>
+            {
+                StatusCode::MissingParameter
             }
+            ApiError::Configuration {
+                source: ConfigError::Validation { .. },
+                ..
+            } => StatusCode::InvalidParameterValue,
+            ApiError::InvalidArgument { .. } => StatusCode::InvalidArgument,
+            ApiError::Login { source, .. } => match source.as_ref() {
+                RestError::LoginError { .. } => StatusCode::LoginError,
+                _ => StatusCode::AuthenticationError,
+            },
+            ApiError::ConnectionLock { .. } => StatusCode::InternalError,
+            ApiError::StatementLocking { .. } => StatusCode::InternalError,
+            ApiError::DatabaseLocking { .. } => StatusCode::InternalError,
+            ApiError::QueryResponseProcess {
+                source: boxed_error,
+                ..
+            } => {
+                use crate::apis::database_driver_v1::error::QueryResponseProcessingError;
+                use crate::compression_types::CompressionTypeError;
+                use crate::file_manager::FileManagerError;
+
+                match boxed_error.as_ref() {
+                    QueryResponseProcessingError::FileUpload { source, .. }
+                    | QueryResponseProcessingError::FileDownload { source, .. } => match source {
+                        FileManagerError::NoFilesMatched { .. } => StatusCode::LocalFileNotFound,
+                        FileManagerError::CompressionType {
+                            source: CompressionTypeError::UnsupportedCompressionType { .. },
+                            ..
+                        } => StatusCode::UnsupportedCompression,
+                        // A too-large source file / stage object is an input
+                        // error, not a driver fault — surface it as
+                        // `InvalidArgument` rather than `InternalError`.
+                        s if s.is_file_too_large() => StatusCode::InvalidArgument,
+                        _ => StatusCode::InternalError,
+                    },
+                    QueryResponseProcessingError::RemoteFileNotFound { .. } => {
+                        StatusCode::RemoteFileNotFound
+                    }
+                    _ => StatusCode::InternalError,
+                }
+            }
+            ApiError::ConnectionNotInitialized { .. } => StatusCode::InternalError,
+            ApiError::TlsClientCreation { .. } => StatusCode::AuthenticationError,
+            ApiError::SessionRefresh { .. } => StatusCode::AuthenticationError,
+            ApiError::Statement { .. } => StatusCode::InternalError,
+            ApiError::Query { .. } => StatusCode::InternalError,
+            ApiError::MasterTokenExpired { .. } => StatusCode::AuthenticationError,
+            ApiError::InvalidRefreshState { .. } => StatusCode::InternalError,
+            ApiError::TokenCacheInitialization { .. } => StatusCode::AuthenticationError,
+            ApiError::ChunkFetch { .. } => StatusCode::InternalError,
+            ApiError::ArrowParse { .. } => StatusCode::InternalError,
+            ApiError::JsonChunkDecode { .. } => StatusCode::InternalError,
+            ApiError::BlockingTaskJoin { .. } => StatusCode::InternalError,
+            ApiError::InlineJsonEncode { .. } => StatusCode::InternalError,
+            ApiError::InvalidColumnMetadata { .. } => StatusCode::InvalidArgument,
+            ApiError::Base64Decode { .. } => StatusCode::InternalError,
+            ApiError::UnsupportedQueryResultFormat { .. } => StatusCode::InternalError,
+            ApiError::HttpRequest { .. } => StatusCode::GenericError,
+            ApiError::TokenRequest { .. } => StatusCode::AuthenticationError,
+            ApiError::ConnectionClosed { .. } => StatusCode::InvalidArgument,
+            ApiError::Logout { .. } => StatusCode::InternalError,
+            // Stage-binding failures are surfaced as a transport-layer
+            // generic error for now (no dedicated proto status code yet);
+            // the wrapper-side fallback work will add a dedicated variant and
+            // map to it. Until then, `GenericError` is the right bucket — the
+            // error trace carries enough detail for diagnostics.
+            ApiError::StageBinding { .. } => StatusCode::GenericError,
+            // TODO(SNOW-2872503): Add a dedicated proto StatusCode for query timeout so
+            // language wrappers can surface HYT00 / OperationalError correctly.
+            ApiError::QueryTimeout { .. } => StatusCode::GenericError,
+            ApiError::Cancelled { .. } => StatusCode::Cancelled,
         }
-        ApiError::ConnectionNotInitialized { .. } => StatusCode::InternalError,
-        ApiError::TlsClientCreation { .. } => StatusCode::AuthenticationError,
-        ApiError::SessionRefresh { .. } => StatusCode::AuthenticationError,
-        ApiError::Statement { .. } => StatusCode::InternalError,
-        ApiError::Query { .. } => StatusCode::InternalError,
-        ApiError::MasterTokenExpired { .. } => StatusCode::AuthenticationError,
-        ApiError::InvalidRefreshState { .. } => StatusCode::InternalError,
-        ApiError::TokenCacheInitialization { .. } => StatusCode::AuthenticationError,
-        ApiError::ChunkFetch { .. } => StatusCode::InternalError,
-        ApiError::ArrowParse { .. } => StatusCode::InternalError,
-        ApiError::JsonChunkDecode { .. } => StatusCode::InternalError,
-        ApiError::BlockingTaskJoin { .. } => StatusCode::InternalError,
-        ApiError::InlineJsonEncode { .. } => StatusCode::InternalError,
-        ApiError::InvalidColumnMetadata { .. } => StatusCode::InvalidArgument,
-        ApiError::Base64Decode { .. } => StatusCode::InternalError,
-        ApiError::UnsupportedQueryResultFormat { .. } => StatusCode::InternalError,
-        ApiError::HttpRequest { .. } => StatusCode::GenericError,
-        ApiError::TokenRequest { .. } => StatusCode::AuthenticationError,
-        ApiError::ConnectionClosed { .. } => StatusCode::InvalidArgument,
-        ApiError::Logout { .. } => StatusCode::InternalError,
-        // Stage-binding failures are surfaced as a transport-layer
-        // generic error for now (no dedicated proto status code yet);
-        // the wrapper-side fallback work will add a dedicated variant and
-        // map to it. Until then, `GenericError` is the right bucket — the
-        // error trace carries enough detail for diagnostics.
-        ApiError::StageBinding { .. } => StatusCode::GenericError,
-        // TODO(SNOW-2872503): Add a dedicated proto StatusCode for query timeout so
-        // language wrappers can surface HYT00 / OperationalError correctly.
-        ApiError::QueryTimeout { .. } => StatusCode::GenericError,
     };
 
     let (vendor_code, sql_state) = extract_vendor_info(&error);

--- a/sf_core/src/protobuf/apis/database_driver_v1/mod.rs
+++ b/sf_core/src/protobuf/apis/database_driver_v1/mod.rs
@@ -64,6 +64,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn database_new(
         &self,
         _input: DatabaseNewRequest,
+        _cancel: tokio_util::sync::CancellationToken,
     ) -> Result<DatabaseNewResponse, DriverException> {
         let handle = self.driver.database_new();
         Ok(DatabaseNewResponse {
@@ -75,6 +76,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn database_set_options(
         &self,
         input: DatabaseSetOptionsRequest,
+        _cancel: tokio_util::sync::CancellationToken,
     ) -> Result<DatabaseSetOptionsResponse, DriverException> {
         let db_handle = required(input.db_handle, "Database handle is required")?;
         let options = proto_options_to_hashmap(input.options);
@@ -97,6 +99,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn database_init(
         &self,
         input: DatabaseInitRequest,
+        _cancel: tokio_util::sync::CancellationToken,
     ) -> Result<DatabaseInitResponse, DriverException> {
         let db_handle = required(input.db_handle, "Database handle is required")?;
 
@@ -108,6 +111,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn database_release(
         &self,
         input: DatabaseReleaseRequest,
+        _cancel: tokio_util::sync::CancellationToken,
     ) -> Result<DatabaseReleaseResponse, DriverException> {
         let db_handle = required(input.db_handle, "Database handle is required")?;
 
@@ -121,6 +125,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn database_fetch_chunk(
         &self,
         input: DatabaseFetchChunkRequest,
+        cancel: tokio_util::sync::CancellationToken,
     ) -> Result<DatabaseFetchChunkResponse, DriverException> {
         let conn_handle = input.conn_handle.map(|h| h.into());
         let _ = required(input.chunks.first(), "At least one chunk is required")?;
@@ -161,6 +166,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
                 chunk_format,
                 &nullable_flags,
                 row_types,
+                cancel,
             )
             .await
             .to_protobuf()?;
@@ -175,6 +181,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn connection_new(
         &self,
         _input: ConnectionNewRequest,
+        _cancel: tokio_util::sync::CancellationToken,
     ) -> Result<ConnectionNewResponse, DriverException> {
         let handle = self.driver.connection_new();
         Ok(ConnectionNewResponse {
@@ -186,6 +193,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn connection_set_options(
         &self,
         input: ConnectionSetOptionsRequest,
+        _cancel: tokio_util::sync::CancellationToken,
     ) -> Result<ConnectionSetOptionsResponse, DriverException> {
         let conn_handle = required(input.conn_handle, "Connection handle is required")?;
         let options = proto_options_to_hashmap(input.options);
@@ -208,6 +216,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn connection_init(
         &self,
         input: ConnectionInitRequest,
+        cancel: tokio_util::sync::CancellationToken,
     ) -> Result<ConnectionInitResponse, DriverException> {
         let conn_handle = required(input.conn_handle, "Connection handle is required")?;
         let db_handle = required(input.db_handle, "Database handle is required")?;
@@ -241,7 +250,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
         }
 
         self.driver
-            .connection_init(conn_handle.into(), db_handle.into())
+            .connection_init(conn_handle.into(), db_handle.into(), cancel)
             .await
             .to_protobuf()?;
         Ok(ConnectionInitResponse {})
@@ -251,6 +260,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn connection_release(
         &self,
         input: ConnectionReleaseRequest,
+        _cancel: tokio_util::sync::CancellationToken,
     ) -> Result<ConnectionReleaseResponse, DriverException> {
         let conn_handle = required(input.conn_handle, "Connection handle is required")?;
 
@@ -264,11 +274,12 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn connection_close(
         &self,
         input: ConnectionCloseRequest,
+        cancel: tokio_util::sync::CancellationToken,
     ) -> Result<ConnectionCloseResponse, DriverException> {
         let conn_handle = required(input.conn_handle, "Connection handle is required")?;
 
         self.driver
-            .connection_close(conn_handle.into())
+            .connection_close(conn_handle.into(), cancel)
             .await
             .to_protobuf()?;
         Ok(ConnectionCloseResponse {})
@@ -278,6 +289,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn connection_is_closed(
         &self,
         input: ConnectionIsClosedRequest,
+        _cancel: tokio_util::sync::CancellationToken,
     ) -> Result<ConnectionIsClosedResponse, DriverException> {
         let conn_handle = required(input.conn_handle, "Connection handle is required")?;
 
@@ -293,6 +305,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn connection_is_expired(
         &self,
         input: ConnectionIsExpiredRequest,
+        _cancel: tokio_util::sync::CancellationToken,
     ) -> Result<ConnectionIsExpiredResponse, DriverException> {
         let conn_handle = required(input.conn_handle, "Connection handle is required")?;
 
@@ -308,6 +321,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn connection_get_info(
         &self,
         input: ConnectionGetInfoRequest,
+        _cancel: tokio_util::sync::CancellationToken,
     ) -> Result<ConnectionGetInfoResponse, DriverException> {
         let conn_handle = required(input.conn_handle, "Connection handle is required")?;
 
@@ -327,6 +341,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn connection_get_objects(
         &self,
         input: ConnectionGetObjectsRequest,
+        cancel: tokio_util::sync::CancellationToken,
     ) -> Result<ConnectionGetObjectsResponse, DriverException> {
         use crate::apis::database_driver_v1::GetObjectsRequest;
 
@@ -344,7 +359,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
 
         let info = self
             .driver
-            .connection_get_objects(req)
+            .connection_get_objects(req, cancel)
             .await
             .to_protobuf()?;
 
@@ -361,6 +376,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn connection_get_table_schema(
         &self,
         _input: ConnectionGetTableSchemaRequest,
+        _cancel: tokio_util::sync::CancellationToken,
     ) -> Result<ConnectionGetTableSchemaResponse, DriverException> {
         Err(not_implemented(
             "connection_get_table_schema is not yet implemented",
@@ -374,6 +390,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn connection_get_table_types(
         &self,
         _input: ConnectionGetTableTypesRequest,
+        _cancel: tokio_util::sync::CancellationToken,
     ) -> Result<ConnectionGetTableTypesResponse, DriverException> {
         Err(not_implemented(
             "connection_get_table_types is not yet implemented",
@@ -388,11 +405,12 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn connection_commit(
         &self,
         input: ConnectionCommitRequest,
+        cancel: tokio_util::sync::CancellationToken,
     ) -> Result<ConnectionCommitResponse, DriverException> {
         let conn_handle = required(input.conn_handle, "Connection handle is required")?;
         tracing::Span::current().record("conn_handle", tracing::field::debug(&conn_handle));
         self.driver
-            .connection_commit(conn_handle.into())
+            .connection_commit(conn_handle.into(), cancel)
             .await
             .to_protobuf()?;
         Ok(ConnectionCommitResponse {})
@@ -406,11 +424,12 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn connection_rollback(
         &self,
         input: ConnectionRollbackRequest,
+        cancel: tokio_util::sync::CancellationToken,
     ) -> Result<ConnectionRollbackResponse, DriverException> {
         let conn_handle = required(input.conn_handle, "Connection handle is required")?;
         tracing::Span::current().record("conn_handle", tracing::field::debug(&conn_handle));
         self.driver
-            .connection_rollback(conn_handle.into())
+            .connection_rollback(conn_handle.into(), cancel)
             .await
             .to_protobuf()?;
         Ok(ConnectionRollbackResponse {})
@@ -424,12 +443,13 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn connection_set_autocommit(
         &self,
         input: ConnectionSetAutocommitRequest,
+        cancel: tokio_util::sync::CancellationToken,
     ) -> Result<ConnectionSetAutocommitResponse, DriverException> {
         let conn_handle = required(input.conn_handle, "Connection handle is required")?;
         tracing::Span::current().record("conn_handle", tracing::field::debug(&conn_handle));
         tracing::Span::current().record("autocommit", input.autocommit);
         self.driver
-            .connection_set_autocommit(conn_handle.into(), input.autocommit)
+            .connection_set_autocommit(conn_handle.into(), input.autocommit, cancel)
             .await
             .to_protobuf()?;
         Ok(ConnectionSetAutocommitResponse {})
@@ -443,6 +463,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn connection_use_database(
         &self,
         input: ConnectionUseDatabaseRequest,
+        cancel: tokio_util::sync::CancellationToken,
     ) -> Result<ConnectionUseDatabaseResponse, DriverException> {
         let conn_handle = required(input.conn_handle, "Connection handle is required")?;
         // Record the trimmed form so the span matches what actually executes — the
@@ -450,7 +471,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
         tracing::Span::current().record("conn_handle", tracing::field::debug(&conn_handle));
         tracing::Span::current().record("database", input.database.trim());
         self.driver
-            .connection_use_database(conn_handle.into(), &input.database)
+            .connection_use_database(conn_handle.into(), &input.database, cancel)
             .await
             .to_protobuf()?;
         Ok(ConnectionUseDatabaseResponse {})
@@ -464,12 +485,13 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn connection_use_schema(
         &self,
         input: ConnectionUseSchemaRequest,
+        cancel: tokio_util::sync::CancellationToken,
     ) -> Result<ConnectionUseSchemaResponse, DriverException> {
         let conn_handle = required(input.conn_handle, "Connection handle is required")?;
         tracing::Span::current().record("conn_handle", tracing::field::debug(&conn_handle));
         tracing::Span::current().record("schema", input.schema.trim());
         self.driver
-            .connection_use_schema(conn_handle.into(), &input.schema)
+            .connection_use_schema(conn_handle.into(), &input.schema, cancel)
             .await
             .to_protobuf()?;
         Ok(ConnectionUseSchemaResponse {})
@@ -482,6 +504,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn connection_set_session_parameters(
         &self,
         input: ConnectionSetSessionParametersRequest,
+        _cancel: tokio_util::sync::CancellationToken,
     ) -> Result<ConnectionSetSessionParametersResponse, DriverException> {
         let conn_handle = required(input.conn_handle, "Connection handle is required")?;
 
@@ -497,6 +520,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn connection_get_parameter(
         &self,
         input: ConnectionGetParameterRequest,
+        _cancel: tokio_util::sync::CancellationToken,
     ) -> Result<ConnectionGetParameterResponse, DriverException> {
         let conn_handle = required(input.conn_handle, "Connection handle is required")?;
 
@@ -516,6 +540,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn connection_get_server_version(
         &self,
         input: ConnectionGetServerVersionRequest,
+        _cancel: tokio_util::sync::CancellationToken,
     ) -> Result<ConnectionGetServerVersionResponse, DriverException> {
         let conn_handle = required(input.conn_handle, "Connection handle is required")?;
 
@@ -535,6 +560,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn connection_get_all_parameters(
         &self,
         input: ConnectionGetAllParametersRequest,
+        _cancel: tokio_util::sync::CancellationToken,
     ) -> Result<ConnectionGetAllParametersResponse, DriverException> {
         let conn_handle = required(input.conn_handle, "Connection handle is required")?;
 
@@ -554,6 +580,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn connection_validate_options(
         &self,
         input: ConnectionValidateOptionsRequest,
+        _cancel: tokio_util::sync::CancellationToken,
     ) -> Result<ConnectionValidateOptionsResponse, DriverException> {
         let conn_handle = required(input.conn_handle, "Connection handle is required")?;
 
@@ -578,12 +605,13 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn connection_get_query_result(
         &self,
         input: ConnectionGetQueryResultRequest,
+        cancel: tokio_util::sync::CancellationToken,
     ) -> Result<ExecuteQueryResponse, DriverException> {
         let conn_handle = required(input.conn_handle, "Connection handle is required")?;
 
         let result = self
             .driver
-            .connection_get_query_result(conn_handle.into(), input.query_id)
+            .connection_get_query_result(conn_handle.into(), input.query_id, cancel)
             .await
             .to_protobuf()?;
 
@@ -597,12 +625,13 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn connection_get_result_set(
         &self,
         input: ConnectionGetResultSetRequest,
+        cancel: tokio_util::sync::CancellationToken,
     ) -> Result<ResultSetResponse, DriverException> {
         let conn_handle = required(input.conn_handle, "Connection handle is required")?;
 
         let result = self
             .driver
-            .create_result_set_from_sfqid(conn_handle.into(), input.query_id)
+            .create_result_set_from_sfqid(conn_handle.into(), input.query_id, cancel)
             .await
             .to_protobuf()?;
 
@@ -613,11 +642,12 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn connection_upload_stream(
         &self,
         input: ConnectionUploadStreamRequest,
+        cancel: tokio_util::sync::CancellationToken,
     ) -> Result<ConnectionUploadStreamResponse, DriverException> {
         let conn_handle = required(input.conn_handle, "Connection handle is required")?;
         let rs_info = self
             .driver
-            .connection_upload_stream(conn_handle.into(), input.sql, input.data)
+            .connection_upload_stream(conn_handle.into(), input.sql, input.data, cancel)
             .await
             .to_protobuf()?;
         Ok(ConnectionUploadStreamResponse {
@@ -633,6 +663,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn connection_download_stream(
         &self,
         input: ConnectionDownloadStreamRequest,
+        cancel: tokio_util::sync::CancellationToken,
     ) -> Result<ConnectionDownloadStreamResponse, DriverException> {
         let conn_handle = required(input.conn_handle, "Connection handle is required")?;
         let data = self
@@ -642,6 +673,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
                 &input.stage_name,
                 &input.source_filename,
                 input.decompress,
+                cancel,
             )
             .await
             .to_protobuf()?;
@@ -655,12 +687,13 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn connection_get_query_status(
         &self,
         input: ConnectionGetQueryStatusRequest,
+        cancel: tokio_util::sync::CancellationToken,
     ) -> Result<ConnectionGetQueryStatusResponse, DriverException> {
         let conn_handle = required(input.conn_handle, "Connection handle is required")?;
 
         let result = self
             .driver
-            .connection_get_query_status(conn_handle.into(), &input.query_id)
+            .connection_get_query_status(conn_handle.into(), &input.query_id, cancel)
             .await
             .to_protobuf()?;
 
@@ -671,6 +704,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn connection_abort_query(
         &self,
         input: ConnectionAbortQueryRequest,
+        _cancel: tokio_util::sync::CancellationToken,
     ) -> Result<ConnectionAbortQueryResponse, DriverException> {
         let conn_handle = required(input.conn_handle, "Connection handle is required")?;
 
@@ -690,6 +724,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn connection_send_http(
         &self,
         input: ConnectionSendHttpRequest,
+        _cancel: tokio_util::sync::CancellationToken,
     ) -> Result<ConnectionSendHttpResponse, DriverException> {
         let conn_handle = required(input.conn_handle, "Connection handle is required")?;
 
@@ -716,6 +751,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn connection_request_token(
         &self,
         input: ConnectionTokenRequest,
+        _cancel: tokio_util::sync::CancellationToken,
     ) -> Result<ConnectionTokenResponse, DriverException> {
         let conn_handle = required(input.conn_handle, "Connection handle is required")?;
 
@@ -747,6 +783,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn connection_heartbeat(
         &self,
         input: ConnectionHeartbeatRequest,
+        _cancel: tokio_util::sync::CancellationToken,
     ) -> Result<ConnectionHeartbeatResponse, DriverException> {
         let conn_handle = required(input.conn_handle, "Connection handle is required")?;
         let timeout = input
@@ -764,6 +801,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn statement_new(
         &self,
         input: StatementNewRequest,
+        _cancel: tokio_util::sync::CancellationToken,
     ) -> Result<StatementNewResponse, DriverException> {
         let conn_handle = required(input.conn_handle, "Connection handle is required")?;
 
@@ -780,6 +818,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn statement_release(
         &self,
         input: StatementReleaseRequest,
+        _cancel: tokio_util::sync::CancellationToken,
     ) -> Result<StatementReleaseResponse, DriverException> {
         let stmt_handle = required(input.stmt_handle, "Statement handle is required")?;
 
@@ -793,6 +832,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn statement_set_sql_query(
         &self,
         input: StatementSetSqlQueryRequest,
+        _cancel: tokio_util::sync::CancellationToken,
     ) -> Result<StatementSetSqlQueryResponse, DriverException> {
         let stmt_handle = required(input.stmt_handle, "Statement handle is required")?;
 
@@ -810,6 +850,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn statement_set_substrait_plan(
         &self,
         _input: StatementSetSubstraitPlanRequest,
+        _cancel: tokio_util::sync::CancellationToken,
     ) -> Result<StatementSetSubstraitPlanResponse, DriverException> {
         // TODO: Implement when corresponding API method is available
         Err(not_implemented(
@@ -821,11 +862,12 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn statement_prepare(
         &self,
         input: StatementPrepareRequest,
+        cancel: tokio_util::sync::CancellationToken,
     ) -> Result<StatementPrepareResponse, DriverException> {
         let stmt_handle = required(input.stmt_handle, "Statement handle is required")?;
         let result = self
             .driver
-            .statement_prepare(stmt_handle.into())
+            .statement_prepare(stmt_handle.into(), cancel)
             .await
             .to_protobuf()?;
         let result_ptr = reader_to_arrow_stream_ptr(result.stream);
@@ -847,6 +889,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn statement_set_options(
         &self,
         input: StatementSetOptionsRequest,
+        _cancel: tokio_util::sync::CancellationToken,
     ) -> Result<StatementSetOptionsResponse, DriverException> {
         let stmt_handle = required(input.stmt_handle, "Statement handle is required")?;
         let options = proto_options_to_hashmap(input.options);
@@ -872,6 +915,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn statement_get_parameter_schema(
         &self,
         _input: StatementGetParameterSchemaRequest,
+        _cancel: tokio_util::sync::CancellationToken,
     ) -> Result<StatementGetParameterSchemaResponse, DriverException> {
         Err(not_implemented(
             "statement_get_parameter_schema is not yet implemented",
@@ -882,6 +926,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn statement_execute_query(
         &self,
         input: StatementExecuteQueryRequest,
+        cancel: tokio_util::sync::CancellationToken,
     ) -> Result<ExecuteQueryResponse, DriverException> {
         let stmt_handle = required(input.stmt_handle, "Statement handle is required")?;
 
@@ -900,7 +945,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
 
         let result = self
             .driver
-            .statement_execute_query(stmt_handle.into(), bindings_opt, timeout_seconds)
+            .statement_execute_query(stmt_handle.into(), bindings_opt, timeout_seconds, cancel)
             .await
             .to_protobuf()?;
 
@@ -911,6 +956,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn statement_execute_async(
         &self,
         input: StatementExecuteAsyncRequest,
+        cancel: tokio_util::sync::CancellationToken,
     ) -> Result<StatementExecuteAsyncResponse, DriverException> {
         let stmt_handle = required(input.stmt_handle, "Statement handle is required")?;
 
@@ -927,7 +973,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
 
         let result = self
             .driver
-            .statement_execute_async(stmt_handle.into(), bindings_opt)
+            .statement_execute_async(stmt_handle.into(), bindings_opt, cancel)
             .await
             .to_protobuf()?;
 
@@ -943,6 +989,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn statement_execute_partitions(
         &self,
         _input: StatementExecutePartitionsRequest,
+        _cancel: tokio_util::sync::CancellationToken,
     ) -> Result<StatementExecutePartitionsResponse, DriverException> {
         Err(not_implemented(
             "statement_execute_partitions is not yet implemented",
@@ -956,6 +1003,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn statement_read_partition(
         &self,
         _input: StatementReadPartitionRequest,
+        _cancel: tokio_util::sync::CancellationToken,
     ) -> Result<StatementReadPartitionResponse, DriverException> {
         Err(not_implemented(
             "statement_read_partition is not yet implemented",
@@ -966,12 +1014,13 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn result_set_get_stream(
         &self,
         input: ResultSetGetStreamRequest,
+        cancel: tokio_util::sync::CancellationToken,
     ) -> Result<ResultSetGetStreamResponse, DriverException> {
         let handle = required(input.result_set_handle, "ResultSet handle is required")?;
 
         let result = self
             .driver
-            .result_set_get_stream(handle.into())
+            .result_set_get_stream(handle.into(), cancel)
             .await
             .to_protobuf()?;
 
@@ -982,6 +1031,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn result_set_get_chunks(
         &self,
         input: ResultSetGetChunksRequest,
+        _cancel: tokio_util::sync::CancellationToken,
     ) -> Result<ResultSetGetChunksResponse, DriverException> {
         let result_set_handle = required(input.result_set_handle, "ResultSet handle is required")?;
 
@@ -996,6 +1046,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn result_set_release(
         &self,
         input: ResultSetReleaseRequest,
+        _cancel: tokio_util::sync::CancellationToken,
     ) -> Result<ResultSetReleaseResponse, DriverException> {
         let handle = required(input.result_set_handle, "ResultSet handle is required")?;
 
@@ -1010,6 +1061,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn config_load_all_sections(
         &self,
         input: ConfigLoadAllSectionsRequest,
+        _cancel: tokio_util::sync::CancellationToken,
     ) -> Result<ConfigLoadAllSectionsResponse, DriverException> {
         let paths = if input.config_file.is_some() || input.connections_file.is_some() {
             path_resolver::ConfigPaths {
@@ -1045,6 +1097,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn config_get_paths(
         &self,
         _input: ConfigGetPathsRequest,
+        _cancel: tokio_util::sync::CancellationToken,
     ) -> Result<ConfigGetPathsResponse, DriverException> {
         let paths = path_resolver::get_config_paths()
             .context(ConfigurationSnafu)
@@ -1074,6 +1127,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn telemetry_send_api_usage(
         &self,
         input: TelemetrySendApiUsageRequest,
+        _cancel: tokio_util::sync::CancellationToken,
     ) -> Result<TelemetrySendResponse, DriverException> {
         let conn_handle = required(input.conn_handle, "Connection handle is required")?;
         let handle = Handle::from(conn_handle);
@@ -1097,6 +1151,7 @@ impl DatabaseDriver for DatabaseDriverImpl {
     async fn telemetry_send_wrapper_error(
         &self,
         input: TelemetrySendWrapperErrorRequest,
+        _cancel: tokio_util::sync::CancellationToken,
     ) -> Result<TelemetrySendResponse, DriverException> {
         let conn_handle = required(input.conn_handle, "Connection handle is required")?;
         let handle = Handle::from(conn_handle);
@@ -1287,188 +1342,234 @@ impl DatabaseDriverClientBlockingExt for DatabaseDriverClient {
         &self,
         input: DatabaseNewRequest,
     ) -> BlockingProtoResult<DatabaseNewResponse> {
-        block_on_client_call(self.database_new(input))
+        block_on_client_call(self.database_new(input, tokio_util::sync::CancellationToken::new()))
     }
 
     fn database_init_blocking(
         &self,
         input: DatabaseInitRequest,
     ) -> BlockingProtoResult<DatabaseInitResponse> {
-        block_on_client_call(self.database_init(input))
+        block_on_client_call(self.database_init(input, tokio_util::sync::CancellationToken::new()))
     }
 
     fn connection_new_blocking(
         &self,
         input: ConnectionNewRequest,
     ) -> BlockingProtoResult<ConnectionNewResponse> {
-        block_on_client_call(self.connection_new(input))
+        block_on_client_call(self.connection_new(input, tokio_util::sync::CancellationToken::new()))
     }
 
     fn connection_init_blocking(
         &self,
         input: ConnectionInitRequest,
     ) -> BlockingProtoResult<ConnectionInitResponse> {
-        block_on_client_call(self.connection_init(input))
+        block_on_client_call(
+            self.connection_init(input, tokio_util::sync::CancellationToken::new()),
+        )
     }
 
     fn connection_set_options_blocking(
         &self,
         input: ConnectionSetOptionsRequest,
     ) -> BlockingProtoResult<ConnectionSetOptionsResponse> {
-        block_on_client_call(self.connection_set_options(input))
+        block_on_client_call(
+            self.connection_set_options(input, tokio_util::sync::CancellationToken::new()),
+        )
     }
 
     fn statement_new_blocking(
         &self,
         input: StatementNewRequest,
     ) -> BlockingProtoResult<StatementNewResponse> {
-        block_on_client_call(self.statement_new(input))
+        block_on_client_call(self.statement_new(input, tokio_util::sync::CancellationToken::new()))
     }
 
     fn statement_execute_query_blocking(
         &self,
         input: StatementExecuteQueryRequest,
     ) -> BlockingProtoResult<ExecuteQueryResponse> {
-        block_on_client_call(self.statement_execute_query(input))
+        block_on_client_call(
+            self.statement_execute_query(input, tokio_util::sync::CancellationToken::new()),
+        )
     }
 
     fn statement_set_sql_query_blocking(
         &self,
         input: StatementSetSqlQueryRequest,
     ) -> BlockingProtoResult<StatementSetSqlQueryResponse> {
-        block_on_client_call(self.statement_set_sql_query(input))
+        block_on_client_call(
+            self.statement_set_sql_query(input, tokio_util::sync::CancellationToken::new()),
+        )
     }
 
     fn statement_set_options_blocking(
         &self,
         input: StatementSetOptionsRequest,
     ) -> BlockingProtoResult<StatementSetOptionsResponse> {
-        block_on_client_call(self.statement_set_options(input))
+        block_on_client_call(
+            self.statement_set_options(input, tokio_util::sync::CancellationToken::new()),
+        )
     }
 
     fn statement_release_blocking(
         &self,
         input: StatementReleaseRequest,
     ) -> BlockingProtoResult<StatementReleaseResponse> {
-        block_on_client_call(self.statement_release(input))
+        block_on_client_call(
+            self.statement_release(input, tokio_util::sync::CancellationToken::new()),
+        )
     }
 
     fn database_fetch_chunk_blocking(
         &self,
         input: DatabaseFetchChunkRequest,
     ) -> BlockingProtoResult<DatabaseFetchChunkResponse> {
-        block_on_client_call(self.database_fetch_chunk(input))
+        block_on_client_call(
+            self.database_fetch_chunk(input, tokio_util::sync::CancellationToken::new()),
+        )
     }
 
     fn connection_release_blocking(
         &self,
         input: ConnectionReleaseRequest,
     ) -> BlockingProtoResult<ConnectionReleaseResponse> {
-        block_on_client_call(self.connection_release(input))
+        block_on_client_call(
+            self.connection_release(input, tokio_util::sync::CancellationToken::new()),
+        )
     }
 
     fn database_release_blocking(
         &self,
         input: DatabaseReleaseRequest,
     ) -> BlockingProtoResult<DatabaseReleaseResponse> {
-        block_on_client_call(self.database_release(input))
+        block_on_client_call(
+            self.database_release(input, tokio_util::sync::CancellationToken::new()),
+        )
     }
 
     fn connection_close_blocking(
         &self,
         input: ConnectionCloseRequest,
     ) -> BlockingProtoResult<ConnectionCloseResponse> {
-        block_on_client_call(self.connection_close(input))
+        block_on_client_call(
+            self.connection_close(input, tokio_util::sync::CancellationToken::new()),
+        )
     }
 
     fn connection_is_closed_blocking(
         &self,
         input: ConnectionIsClosedRequest,
     ) -> BlockingProtoResult<ConnectionIsClosedResponse> {
-        block_on_client_call(self.connection_is_closed(input))
+        block_on_client_call(
+            self.connection_is_closed(input, tokio_util::sync::CancellationToken::new()),
+        )
     }
 
     fn connection_is_expired_blocking(
         &self,
         input: ConnectionIsExpiredRequest,
     ) -> BlockingProtoResult<ConnectionIsExpiredResponse> {
-        block_on_client_call(self.connection_is_expired(input))
+        block_on_client_call(
+            self.connection_is_expired(input, tokio_util::sync::CancellationToken::new()),
+        )
     }
 
     fn connection_get_info_blocking(
         &self,
         input: ConnectionGetInfoRequest,
     ) -> BlockingProtoResult<ConnectionGetInfoResponse> {
-        block_on_client_call(self.connection_get_info(input))
+        block_on_client_call(
+            self.connection_get_info(input, tokio_util::sync::CancellationToken::new()),
+        )
     }
 
     fn connection_get_server_version_blocking(
         &self,
         input: ConnectionGetServerVersionRequest,
     ) -> BlockingProtoResult<ConnectionGetServerVersionResponse> {
-        block_on_client_call(self.connection_get_server_version(input))
+        block_on_client_call(
+            self.connection_get_server_version(input, tokio_util::sync::CancellationToken::new()),
+        )
     }
 
     fn connection_get_result_set_blocking(
         &self,
         input: ConnectionGetResultSetRequest,
     ) -> Result<ResultSetResponse, proto_utils::ProtoError<DriverException>> {
-        BLOCKING_CLIENT_RUNTIME.block_on(self.connection_get_result_set(input))
+        BLOCKING_CLIENT_RUNTIME.block_on(
+            self.connection_get_result_set(input, tokio_util::sync::CancellationToken::new()),
+        )
     }
 
     fn result_set_get_stream_blocking(
         &self,
         input: ResultSetGetStreamRequest,
     ) -> BlockingProtoResult<ResultSetGetStreamResponse> {
-        block_on_client_call(self.result_set_get_stream(input))
+        block_on_client_call(
+            self.result_set_get_stream(input, tokio_util::sync::CancellationToken::new()),
+        )
     }
 
     fn result_set_get_chunks_blocking(
         &self,
         input: ResultSetGetChunksRequest,
     ) -> BlockingProtoResult<ResultSetGetChunksResponse> {
-        block_on_client_call(self.result_set_get_chunks(input))
+        block_on_client_call(
+            self.result_set_get_chunks(input, tokio_util::sync::CancellationToken::new()),
+        )
     }
 
     fn result_set_release_blocking(
         &self,
         input: ResultSetReleaseRequest,
     ) -> BlockingProtoResult<ResultSetReleaseResponse> {
-        block_on_client_call(self.result_set_release(input))
+        block_on_client_call(
+            self.result_set_release(input, tokio_util::sync::CancellationToken::new()),
+        )
     }
 
     fn telemetry_send_api_usage_blocking(
         &self,
         input: TelemetrySendApiUsageRequest,
     ) -> BlockingProtoResult<TelemetrySendResponse> {
-        block_on_client_call(self.telemetry_send_api_usage(input))
+        block_on_client_call(
+            self.telemetry_send_api_usage(input, tokio_util::sync::CancellationToken::new()),
+        )
     }
 
     fn telemetry_send_wrapper_error_blocking(
         &self,
         input: TelemetrySendWrapperErrorRequest,
     ) -> BlockingProtoResult<TelemetrySendResponse> {
-        block_on_client_call(self.telemetry_send_wrapper_error(input))
+        block_on_client_call(
+            self.telemetry_send_wrapper_error(input, tokio_util::sync::CancellationToken::new()),
+        )
     }
 
     fn connection_get_query_result_blocking(
         &self,
         input: ConnectionGetQueryResultRequest,
     ) -> BlockingProtoResult<ExecuteQueryResponse> {
-        block_on_client_call(self.connection_get_query_result(input))
+        block_on_client_call(
+            self.connection_get_query_result(input, tokio_util::sync::CancellationToken::new()),
+        )
     }
 
     fn connection_upload_stream_blocking(
         &self,
         input: ConnectionUploadStreamRequest,
     ) -> BlockingProtoResult<ConnectionUploadStreamResponse> {
-        block_on_client_call(self.connection_upload_stream(input))
+        block_on_client_call(
+            self.connection_upload_stream(input, tokio_util::sync::CancellationToken::new()),
+        )
     }
 
     fn connection_download_stream_blocking(
         &self,
         input: ConnectionDownloadStreamRequest,
     ) -> BlockingProtoResult<ConnectionDownloadStreamResponse> {
-        block_on_client_call(self.connection_download_stream(input))
+        block_on_client_call(
+            self.connection_download_stream(input, tokio_util::sync::CancellationToken::new()),
+        )
     }
 }

--- a/sf_core/src/protobuf/apis/mod.rs
+++ b/sf_core/src/protobuf/apis/mod.rs
@@ -32,9 +32,10 @@ impl Transport for RustTransport {
         service: &str,
         method: &str,
         message: Vec<u8>,
+        cancel: tokio_util::sync::CancellationToken,
     ) -> Result<Vec<u8>, ProtoError<Vec<u8>>> {
         match service {
-            "DatabaseDriver" => self.driver.handle_message(method, message).await,
+            "DatabaseDriver" => self.driver.handle_message(method, message, cancel).await,
             _ => Err(ProtoError::Transport(format!("Unknown API: {}", service))),
         }
     }

--- a/sf_core/src/protobuf/c_api.rs
+++ b/sf_core/src/protobuf/c_api.rs
@@ -128,11 +128,12 @@ pub unsafe extern "C" fn sf_core_api_call_proto(
         } else {
             std::slice::from_raw_parts(request, request_len)
         };
-        state.runtime.block_on(
-            state
-                .transport
-                .handle_message(&api, &method, message.to_vec()),
-        )
+        state.runtime.block_on(state.transport.handle_message(
+            &api,
+            &method,
+            message.to_vec(),
+            CancellationToken::new(),
+        ))
     });
 
     match result {
@@ -226,6 +227,7 @@ pub unsafe extern "C" fn sf_core_api_call_proto_async(
                 &api_str,
                 &method_str,
                 request_vec,
+                cancel_token_for_task.clone(),
             ))
             .catch_unwind() => Some(match result {
                 Ok(Ok(r)) => (0, r),

--- a/sf_core/src/rest/snowflake/async_exec.rs
+++ b/sf_core/src/rest/snowflake/async_exec.rs
@@ -193,6 +193,7 @@ pub async fn submit_statement_async<'a>(
     query_input: &QueryInput<'a>,
     request_id: uuid::Uuid,
     policy: &RetryPolicy,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<SubmitOk, SfError> {
     let server_url = &params.server_url;
     let client_info = &params.client_info;
@@ -218,11 +219,23 @@ pub async fn submit_statement_async<'a>(
     };
 
     let ctx = HttpContext::new(Method::POST, QUERY_REQUEST_PATH).allow_post_retry();
-    let response = execute_with_retry(submit_request, &ctx, policy, |r| async move { Ok(r) })
-        .await
-        .map_err(map_http_error)?;
+    let response = execute_with_retry(
+        submit_request,
+        &ctx,
+        policy,
+        |r| async move { Ok(r) },
+        cancel.clone(),
+    )
+    .await
+    .map_err(map_http_error)?;
 
-    parse_submit_response(server_url, response).await
+    tokio::select! {
+        biased;
+        _ = cancel.cancelled() => Err(SfError::Cancelled {
+            location: current_location(),
+        }),
+        parsed = parse_submit_response(server_url, response) => parsed,
+    }
 }
 
 pub(super) async fn poll_query_status(
@@ -231,22 +244,29 @@ pub(super) async fn poll_query_status(
     session_token: &str,
     get_result_url: &str,
     policy: &RetryPolicy,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<query_response::Response, SfError> {
     let result_url = get_result_url.to_string();
     let poll_request =
         move || apply_query_headers(client.get(result_url.clone()), client_info, session_token);
     let ctx = HttpContext::new(Method::GET, get_result_url.to_string());
-    let response = execute_with_retry(poll_request, &ctx, policy, |r| async move { Ok(r) })
-        .await
-        .map_err(map_http_error)?;
+    let response =
+        execute_with_retry(poll_request, &ctx, policy, |r| async move { Ok(r) }, cancel.clone())
+            .await
+            .map_err(map_http_error)?;
     let status = response.status();
     if !status.is_success() {
         return Err(http_status_error(status));
     }
-    let body_bytes = response
-        .bytes()
-        .await
-        .map_err(|source| transport_error(source))?;
+    let body_bytes = tokio::select! {
+        biased;
+        _ = cancel.cancelled() => {
+            return Err(SfError::Cancelled {
+                location: current_location(),
+            });
+        }
+        bytes = response.bytes() => bytes.map_err(|source| transport_error(source))?,
+    };
     let parsed: query_response::Response =
         serde_json::from_slice(&body_bytes).map_err(|source| body_parse_error(source))?;
     debug!(
@@ -273,6 +293,7 @@ pub(super) async fn execute_blocking_with_async<'a>(
     query_input: &QueryInput<'a>,
     request_id: uuid::Uuid,
     policy: &RetryPolicy,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<query_response::Response, SfError> {
     // query logging guarded with: log_query_text, log_query_parameters
     let (sql, bindings) = query_log_fields(params, query_input);
@@ -292,6 +313,7 @@ pub(super) async fn execute_blocking_with_async<'a>(
         query_input,
         request_id,
         policy,
+        cancel.clone(),
     )
     .await?;
     metrics.record_submit(submit_start.elapsed());
@@ -316,6 +338,7 @@ pub(super) async fn execute_blocking_with_async<'a>(
             result_url,
             policy,
             &mut metrics,
+            cancel,
         )
         .await?
     };
@@ -418,9 +441,17 @@ async fn inline_poll_for_completion(
     session_token: &str,
     result_url: &str,
     policy: &RetryPolicy,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<Option<query_response::Response>, SfError> {
-    let response =
-        poll_query_status(client, client_info, session_token, result_url, policy).await?;
+    let response = poll_query_status(
+        client,
+        client_info,
+        session_token,
+        result_url,
+        policy,
+        cancel,
+    )
+    .await?;
     handle_poll_response(response, true) // First poll
 }
 
@@ -438,6 +469,7 @@ async fn wait_for_completion(
     session_token: &str,
     result_url: &str,
     policy: &RetryPolicy,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<(query_response::Response, usize), SfError> {
     let start = Instant::now();
     let mut attempt: usize = 0;
@@ -445,6 +477,11 @@ async fn wait_for_completion(
     let mut polls: usize = 0;
 
     loop {
+        if cancel.is_cancelled() {
+            return Err(SfError::Cancelled {
+                location: current_location(),
+            });
+        }
         if let Some(deadline) = STATEMENT_POLL_DEADLINE {
             let elapsed = start.elapsed();
             if elapsed >= deadline {
@@ -475,11 +512,26 @@ async fn wait_for_completion(
                     });
                 }
             }
-            tokio::time::sleep(delay).await;
+            tokio::select! {
+                biased;
+                _ = cancel.cancelled() => {
+                    return Err(SfError::Cancelled {
+                        location: current_location(),
+                    });
+                }
+                _ = tokio::time::sleep(delay) => {}
+            }
         }
 
-        let response =
-            poll_query_status(client, client_info, session_token, result_url, policy).await?;
+        let response = poll_query_status(
+            client,
+            client_info,
+            session_token,
+            result_url,
+            policy,
+            cancel.clone(),
+        )
+        .await?;
         polls += 1;
 
         if let Some(done) = handle_poll_response(response, false)? {
@@ -500,10 +552,18 @@ async fn poll_for_result(
     result_url: &str,
     policy: &RetryPolicy,
     metrics: &mut AsyncExecutionMetrics,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<query_response::Response, SfError> {
     let inline_start = Instant::now();
-    let inline_result =
-        inline_poll_for_completion(client, client_info, session_token, result_url, policy).await?;
+    let inline_result = inline_poll_for_completion(
+        client,
+        client_info,
+        session_token,
+        result_url,
+        policy,
+        cancel.clone(),
+    )
+    .await?;
 
     match inline_result {
         Some(response) => {
@@ -513,8 +573,15 @@ async fn poll_for_result(
         None => {
             metrics.record_inline(inline_start.elapsed(), false);
             let wait_start = Instant::now();
-            let (response, polls) =
-                wait_for_completion(client, client_info, session_token, result_url, policy).await?;
+            let (response, polls) = wait_for_completion(
+                client,
+                client_info,
+                session_token,
+                result_url,
+                policy,
+                cancel,
+            )
+            .await?;
             metrics.record_wait(wait_start.elapsed(), polls);
             Ok(response)
         }
@@ -530,6 +597,7 @@ pub(super) async fn poll_detached_query(
     session_token: &str,
     response: &query_response::Response,
     policy: &RetryPolicy,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<query_response::Response, SfError> {
     let result_url = extract_result_url_from_response(&query_parameters.server_url, response)?
         .ok_or_else(|| SfError::MissingResultUrl {
@@ -544,6 +612,7 @@ pub(super) async fn poll_detached_query(
         &result_url,
         policy,
         &mut metrics,
+        cancel,
     )
     .await;
     metrics.emit("detached query poll timings");
@@ -629,6 +698,25 @@ fn handle_poll_response(
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[tokio::test]
+    async fn wait_for_completion_cancels_when_token_already_cancelled() {
+        let cancel = tokio_util::sync::CancellationToken::new();
+        cancel.cancel();
+        let client = reqwest::Client::new();
+        let client_info = crate::config::rest_parameters::test_fixtures::test_client_info();
+        let policy = crate::config::retry::RetryPolicy::default();
+        let result = wait_for_completion(
+            &client,
+            &client_info,
+            "session-token",
+            "http://127.0.0.1:9/result",
+            &policy,
+            cancel,
+        )
+        .await;
+        assert!(matches!(result, Err(SfError::Cancelled { .. })));
+    }
 
     fn response_from_json(value: serde_json::Value) -> query_response::Response {
         serde_json::from_value(value).expect("valid response JSON")

--- a/sf_core/src/rest/snowflake/error.rs
+++ b/sf_core/src/rest/snowflake/error.rs
@@ -100,6 +100,12 @@ pub enum SfError {
     },
 }
 
+impl SfError {
+    pub fn is_cancelled(&self) -> bool {
+        matches!(self, SfError::Cancelled { .. })
+    }
+}
+
 // Intentionally no From<reqwest::Error> to force explicit location on construction
 
 /// Capture the caller's source location for use in snafu error construction.
@@ -120,6 +126,7 @@ pub(crate) fn current_location() -> Location {
 pub(crate) fn map_http_error(err: HttpError) -> SfError {
     let location = current_location();
     match err {
+        HttpError::Cancelled { .. } => SfError::Cancelled { location },
         HttpError::Transport { source, .. } => SfError::Transport { source, location },
         HttpError::DeadlineExceeded {
             configured,

--- a/sf_core/src/rest/snowflake/external_browser.rs
+++ b/sf_core/src/rest/snowflake/external_browser.rs
@@ -121,6 +121,20 @@ pub enum ExternalBrowserError {
         #[snafu(implicit)]
         location: Location,
     },
+    #[snafu(display("External browser login cancelled"))]
+    Cancelled {
+        #[snafu(implicit)]
+        location: Location,
+    },
+}
+
+impl ExternalBrowserError {
+    pub(crate) fn is_cancelled(&self) -> bool {
+        matches!(
+            self,
+            ExternalBrowserError::Cancelled { .. }
+        ) || matches!(self, ExternalBrowserError::RetryExhausted { source, .. } if source.is_cancelled())
+    }
 }
 
 // ─── Main entry point ────────────────────────────────────────────────────────
@@ -142,6 +156,7 @@ pub(crate) async fn external_browser_authenticate(
     authentication_timeout_secs: u64,
     browser_opener: &dyn BrowserOpener,
     retry_policy: &RetryPolicy,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<ExternalBrowserAuthResult, ExternalBrowserError> {
     let budget = Duration::from_secs(authentication_timeout_secs);
     let start = Instant::now();
@@ -153,8 +168,15 @@ pub(crate) async fn external_browser_authenticate(
     let local_port = listener.local_addr().context(ListenerBindSnafu)?.port();
     tracing::debug!(port = local_port, "Local callback listener bound");
 
-    let idp_data =
-        request_authenticator(client, login_parameters, username, local_port, retry_policy).await?;
+    let idp_data = request_authenticator(
+        client,
+        login_parameters,
+        username,
+        local_port,
+        retry_policy,
+        cancel.clone(),
+    )
+    .await?;
     let proof_key = idp_data.proof_key;
     tracing::debug!("Received SSO URL and proof key from Snowflake");
 
@@ -193,12 +215,17 @@ pub(crate) async fn external_browser_authenticate(
     }
 
     let remaining = budget.saturating_sub(start.elapsed());
-    let callback = tokio::time::timeout(remaining, accept_token_from_callback(&listener))
-        .await
-        .map_err(|_| ExternalBrowserError::AuthenticationTimeout {
-            budget,
-            location: Location::new(file!(), line!(), column!()),
-        })??;
+    let callback = tokio::select! {
+        biased;
+        _ = cancel.cancelled() => return CancelledSnafu.fail(),
+        result = tokio::time::timeout(remaining, accept_token_from_callback(&listener)) => {
+            result
+                .map_err(|_| ExternalBrowserError::AuthenticationTimeout {
+                    budget,
+                    location: Location::new(file!(), line!(), column!()),
+                })??
+        }
+    };
 
     tracing::info!(
         elapsed_ms = start.elapsed().as_millis(),
@@ -237,6 +264,7 @@ async fn request_authenticator(
     username: &str,
     redirect_port: u16,
     retry_policy: &RetryPolicy,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<AuthenticatorRequestData, ExternalBrowserError> {
     let mut data: AuthRequestData = super::base_auth_request_data(login_parameters);
     data.login_name = Some(username.to_string());
@@ -264,6 +292,7 @@ async fn request_authenticator(
         },
         &ctx,
         retry_policy,
+        cancel,
     )
     .await
     .context(RetryExhaustedSnafu)?;

--- a/sf_core/src/rest/snowflake/logout.rs
+++ b/sf_core/src/rest/snowflake/logout.rs
@@ -45,6 +45,7 @@ pub async fn logout_session(
     session_token: &SensitiveString,
     client_info: &ClientInfo,
     retry_policy: &RetryPolicy,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<(), RestError> {
     tracing::info!("Initiating session logout");
 
@@ -91,9 +92,13 @@ pub async fn logout_session(
         // NO .timeout() - execute_with_retry applies it dynamically
     };
 
-    let response = execute_with_retry(&build_request, &ctx, retry_policy, |resp| async move {
-        Ok(resp)
-    })
+    let response = execute_with_retry(
+        &build_request,
+        &ctx,
+        retry_policy,
+        |resp| async move { Ok(resp) },
+        cancel.clone(),
+    )
     .await
     .map_err(map_http_error)
     .context(AsyncQuerySnafu {
@@ -103,7 +108,18 @@ pub async fn logout_session(
 
     // Read response body as text first (avoids crash on non-JSON responses)
     let status = response.status();
-    let body_text = response.text().await.ok().unwrap_or_default();
+    let body_text = tokio::select! {
+        biased;
+        _ = cancel.cancelled() => {
+            return Err(map_http_error(crate::http::retry::CancelledSnafu.build())).context(
+                AsyncQuerySnafu {
+                    request_id: Some(request_id),
+                    query_id: None,
+                },
+            );
+        }
+        text = response.text() => text.ok().unwrap_or_default(),
+    };
 
     // Try to parse as JSON
     let parsed: Option<LogoutResponse> = serde_json::from_str(&body_text).ok();

--- a/sf_core/src/rest/snowflake/mod.rs
+++ b/sf_core/src/rest/snowflake/mod.rs
@@ -68,12 +68,19 @@ async fn request_text_with_retry(
     build: impl Fn() -> reqwest::RequestBuilder,
     ctx: &HttpContext,
     policy: &RetryPolicy,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<(StatusCode, String), HttpError> {
-    execute_with_retry(build, ctx, policy, |resp| async move {
-        let status = resp.status();
-        let text = resp.text().await.context(TransportSnafu)?;
-        Ok((status, text))
-    })
+    execute_with_retry(
+        build,
+        ctx,
+        policy,
+        |resp| async move {
+            let status = resp.status();
+            let text = resp.text().await.context(TransportSnafu)?;
+            Ok((status, text))
+        },
+        cancel,
+    )
     .await
 }
 
@@ -503,6 +510,7 @@ pub async fn auth_request_data(
     token_cache: Option<&dyn TokenCache>,
     prompt_locks: Option<&std::sync::Arc<prompt_lock::PromptLockMap>>,
     retry_policy: &RetryPolicy,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<AuthRequestData, RestError> {
     let mut data = base_auth_request_data(login_parameters);
     data.spcs_token = login_parameters.spcs_token.clone();
@@ -517,10 +525,15 @@ pub async fn auth_request_data(
 
     match &login_parameters.login_method {
         LoginMethod::NativeOkta(okta_config) => {
-            let saml_html =
-                fetch_native_okta_saml(client, login_parameters, retry_policy, okta_config)
-                    .await
-                    .context(NativeOktaSnafu)?;
+            let saml_html = fetch_native_okta_saml(
+                client,
+                login_parameters,
+                retry_policy,
+                okta_config,
+                cancel.clone(),
+            )
+            .await
+            .context(NativeOktaSnafu)?;
 
             data.login_name = Some(okta_config.username.clone());
             data.authenticator = Some(okta_config.okta_url.to_string());
@@ -568,6 +581,7 @@ pub async fn auth_request_data(
                     *authentication_timeout_secs,
                     &DefaultBrowserOpener,
                     retry_policy,
+                    cancel.clone(),
                 )
                 .await
                 .context(ExternalBrowserSnafu)?;
@@ -730,6 +744,7 @@ async fn send_login_request(
     login_parameters: &LoginParameters,
     login_request: &AuthRequest,
     policy: &RetryPolicy,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<AuthResponse, RestError> {
     use crate::http::retry::{HttpContext, execute_with_retry};
 
@@ -799,15 +814,27 @@ async fn send_login_request(
 
     let ctx = HttpContext::new(Method::POST, "/session/v1/login-request").allow_post_retry();
 
-    let response = execute_with_retry(build_request, &ctx, policy, |r| async move { Ok(r) })
-        .await
-        .context(HttpRetrySnafu {
-            context: "login request",
-        })?;
+    let response = execute_with_retry(
+        build_request,
+        &ctx,
+        policy,
+        |r| async move { Ok(r) },
+        cancel.clone(),
+    )
+    .await
+    .context(HttpRetrySnafu {
+        context: "login request",
+    })?;
 
-    read_response_json::<auth::AuthResponseMain>(response)
-        .await
-        .context(InvalidSnowflakeResponseSnafu)
+    tokio::select! {
+        biased;
+        _ = cancel.cancelled() => Err(crate::http::retry::CancelledSnafu.build()).context(HttpRetrySnafu {
+            context: "login request",
+        }),
+        parsed = read_response_json::<auth::AuthResponseMain>(response) => {
+            parsed.context(InvalidSnowflakeResponseSnafu)
+        }
+    }
 }
 
 /// Drift C.5: per-request DPoP signing context for `send_login_request`.
@@ -827,6 +854,7 @@ pub async fn snowflake_login(
     login_parameters: &LoginParameters,
     session_parameters: Option<&HashMap<String, String>>,
     crl_worker: SharedCrlWorker,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<LoginResult, RestError> {
     let client = build_tls_http_client(&login_parameters.client_info, crl_worker)?;
     let policy = RetryPolicy::default();
@@ -837,6 +865,7 @@ pub async fn snowflake_login(
         None,
         None,
         &policy,
+        cancel,
     )
     .await
 }
@@ -858,6 +887,7 @@ pub async fn snowflake_login_with_client(
     token_cache: Option<&dyn TokenCache>,
     prompt_locks: Option<&std::sync::Arc<prompt_lock::PromptLockMap>>,
     retry_policy: &RetryPolicy,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<LoginResult, RestError> {
     tracing::info!("Starting Snowflake login process");
 
@@ -980,6 +1010,7 @@ pub async fn snowflake_login_with_client(
         token_cache,
         prompt_locks,
         retry_policy,
+        cancel.clone(),
     )
     .await?;
     tracing::Span::current().record("login_name", &login_request_data.login_name);
@@ -994,8 +1025,14 @@ pub async fn snowflake_login_with_client(
     );
 
     // Send the actual login request
-    let mut auth_response =
-        send_login_request(client, login_parameters, &login_request, retry_policy).await?;
+    let mut auth_response = send_login_request(
+        client,
+        login_parameters,
+        &login_request,
+        retry_policy,
+        cancel.clone(),
+    )
+    .await?;
 
     // Revoke cached token and retry if cached token caused failure
     if !auth_response.success {
@@ -1038,12 +1075,18 @@ pub async fn snowflake_login_with_client(
                     token_cache,
                     prompt_locks,
                     retry_policy,
+                    cancel.clone(),
                 )
                 .await?;
                 let retry_request = AuthRequest { data: retry_data };
-                auth_response =
-                    send_login_request(client, login_parameters, &retry_request, retry_policy)
-                        .await?;
+                auth_response = send_login_request(
+                    client,
+                    login_parameters,
+                    &retry_request,
+                    retry_policy,
+                    cancel.clone(),
+                )
+                .await?;
             }
         }
         // OAuth refresh-on-failure: when GS rejects the OAuth access token
@@ -1093,12 +1136,18 @@ pub async fn snowflake_login_with_client(
                     token_cache,
                     prompt_locks,
                     retry_policy,
+                    cancel.clone(),
                 )
                 .await?;
                 let retry_request = AuthRequest { data: retry_data };
-                auth_response =
-                    send_login_request(client, login_parameters, &retry_request, retry_policy)
-                        .await?;
+                auth_response = send_login_request(
+                    client,
+                    login_parameters,
+                    &retry_request,
+                    retry_policy,
+                    cancel.clone(),
+                )
+                .await?;
             }
         }
     }
@@ -1500,6 +1549,7 @@ pub async fn snowflake_query<'a>(
     query_input: QueryInput<'a>,
     execution_mode: QueryExecutionMode,
     crl_worker: SharedCrlWorker,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<query_response::Response, RestError> {
     let client = build_tls_http_client(&query_parameters.client_info, crl_worker)?;
     let policy = RetryPolicy::default();
@@ -1510,6 +1560,7 @@ pub async fn snowflake_query<'a>(
         query_input,
         &policy,
         execution_mode,
+        cancel,
     )
     .await
 }
@@ -1525,6 +1576,7 @@ pub async fn snowflake_query_with_client<'a>(
     query_input: QueryInput<'a>,
     retry_policy: &RetryPolicy,
     execution_mode: QueryExecutionMode,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<query_response::Response, RestError> {
     let session_token = session_token.as_ref();
 
@@ -1536,6 +1588,7 @@ pub async fn snowflake_query_with_client<'a>(
             session_token,
             query_input,
             retry_policy,
+            cancel,
         )
         .await;
     }
@@ -1547,6 +1600,7 @@ pub async fn snowflake_query_with_client<'a>(
         session_token,
         &query_input,
         retry_policy,
+        cancel,
     )
     .await
 }
@@ -1558,6 +1612,7 @@ async fn execute_async_with_fallback<'a>(
     session_token: &str,
     query_input: QueryInput<'a>,
     retry_policy: &RetryPolicy,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<query_response::Response, RestError> {
     match snowflake_query_async_style(
         client,
@@ -1565,6 +1620,7 @@ async fn execute_async_with_fallback<'a>(
         session_token,
         &query_input,
         retry_policy,
+        cancel.clone(),
     )
     .await
     {
@@ -1612,6 +1668,7 @@ async fn execute_async_with_fallback<'a>(
         session_token,
         &query_input,
         retry_policy,
+        cancel,
     )
     .await?;
 
@@ -1652,6 +1709,7 @@ async fn execute_sync_with_retry<'a>(
     session_token: &str,
     query_input: &QueryInput<'a>,
     retry_policy: &RetryPolicy,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<query_response::Response, RestError> {
     let request_id = uuid::Uuid::new_v4();
 
@@ -1662,6 +1720,7 @@ async fn execute_sync_with_retry<'a>(
         query_input,
         request_id,
         retry_policy,
+        cancel,
     )
     .await
 }
@@ -1707,6 +1766,7 @@ async fn execute_sync_query<'a>(
     query_input: &QueryInput<'a>,
     request_id: uuid::Uuid,
     retry_policy: &RetryPolicy,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<query_response::Response, RestError> {
     use crate::http::retry::{HttpContext, execute_with_retry};
 
@@ -1769,15 +1829,29 @@ async fn execute_sync_query<'a>(
 
     let ctx = HttpContext::new(Method::POST, QUERY_REQUEST_PATH).allow_post_retry();
 
-    let response = execute_with_retry(build_request, &ctx, retry_policy, |r| async move { Ok(r) })
-        .await
-        .context(HttpRetrySnafu {
-            context: "query request",
-        })?;
+    let response = execute_with_retry(
+        build_request,
+        &ctx,
+        retry_policy,
+        |r| async move { Ok(r) },
+        cancel.clone(),
+    )
+    .await
+    .context(HttpRetrySnafu {
+        context: "query request",
+    })?;
 
-    let query_response = read_response_json::<query_response::Data>(response)
-        .await
-        .context(InvalidSnowflakeResponseSnafu)?;
+    let query_response = tokio::select! {
+        biased;
+        _ = cancel.cancelled() => {
+            return Err(crate::http::retry::CancelledSnafu.build()).context(HttpRetrySnafu {
+                context: "query request",
+            });
+        }
+        parsed = read_response_json::<query_response::Data>(response) => {
+            parsed.context(InvalidSnowflakeResponseSnafu)?
+        }
+    };
 
     let elapsed_ms = send_start.elapsed().as_secs_f64() * 1000.0;
     tracing::debug!(
@@ -1795,6 +1869,7 @@ async fn execute_sync_query<'a>(
             session_token,
             &query_response,
             retry_policy,
+            cancel,
         )
         .await
         .context(AsyncQuerySnafu {
@@ -1823,6 +1898,7 @@ pub async fn snowflake_query_async_style<'a, S: AsRef<str>>(
     session_token: S,
     query_input: &QueryInput<'a>,
     retry_policy: &RetryPolicy,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<query_response::Response, RestError> {
     let request_id = uuid::Uuid::new_v4();
     crate::rest::snowflake::async_exec::execute_blocking_with_async(
@@ -1832,6 +1908,7 @@ pub async fn snowflake_query_async_style<'a, S: AsRef<str>>(
         query_input,
         request_id,
         retry_policy,
+        cancel,
     )
     .await
     .context(AsyncQuerySnafu {
@@ -1852,6 +1929,7 @@ pub async fn snowflake_get_query_result(
     session_token: &str,
     query_id: &str,
     retry_policy: &RetryPolicy,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<query_response::Response, RestError> {
     tracing::info!(query_id = query_id, "Fetching query result");
 
@@ -1866,6 +1944,7 @@ pub async fn snowflake_get_query_result(
         session_token,
         &result_url,
         retry_policy,
+        cancel,
     )
     .await
     .context(AsyncQuerySnafu {
@@ -1906,6 +1985,7 @@ pub async fn get_query_status(
     session_token: &SensitiveString,
     query_id: &str,
     retry_policy: &RetryPolicy,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<QueryStatusResult, RestError> {
     use crate::http::retry::{HttpContext, execute_with_retry};
 
@@ -1931,15 +2011,29 @@ pub async fn get_query_status(
     };
 
     let ctx = HttpContext::new(Method::GET, MONITORING_QUERIES_PATH);
-    let response = execute_with_retry(build_request, &ctx, retry_policy, |r| async move { Ok(r) })
-        .await
-        .context(HttpRetrySnafu {
-            context: "query status",
-        })?;
+    let response = execute_with_retry(
+        build_request,
+        &ctx,
+        retry_policy,
+        |r| async move { Ok(r) },
+        cancel.clone(),
+    )
+    .await
+    .context(HttpRetrySnafu {
+        context: "query status",
+    })?;
 
-    let body: QueryStatusResponse = read_response_json::<Option<QueryStatusResponseData>>(response)
-        .await
-        .context(InvalidSnowflakeResponseSnafu)?;
+    let body: QueryStatusResponse = tokio::select! {
+        biased;
+        _ = cancel.cancelled() => {
+            return Err(crate::http::retry::CancelledSnafu.build()).context(HttpRetrySnafu {
+                context: "query status",
+            });
+        }
+        parsed = read_response_json::<Option<QueryStatusResponseData>>(response) => {
+            parsed.context(InvalidSnowflakeResponseSnafu)?
+        }
+    };
 
     if !body.success {
         let message = body.message.unwrap_or_else(|| "Unknown error".to_owned());
@@ -2388,6 +2482,19 @@ pub enum RestError {
         location: Location,
     },
 }
+
+impl RestError {
+    pub(crate) fn is_cancelled(&self) -> bool {
+        match self {
+            RestError::AsyncQuery { source, .. } => source.is_cancelled(),
+            RestError::HttpRetry { source, .. } => source.is_cancelled(),
+            RestError::NativeOkta { source, .. } => source.is_cancelled(),
+            RestError::ExternalBrowser { source, .. } => source.is_cancelled(),
+            _ => false,
+        }
+    }
+}
+
 #[derive(Debug, Snafu, error_trace::ErrorTrace)]
 pub enum SnowflakeResponseError {
     #[snafu(display("Failed to parse Snowflake response {source}"))]
@@ -2842,6 +2949,7 @@ mod tests {
                 None,
                 None,
                 &RetryPolicy::default(),
+                tokio_util::sync::CancellationToken::new(),
             ))
             .unwrap();
 
@@ -2876,6 +2984,7 @@ mod tests {
                 None,
                 None,
                 &RetryPolicy::default(),
+                tokio_util::sync::CancellationToken::new(),
             ))
             .unwrap();
 
@@ -2902,6 +3011,7 @@ mod tests {
                 None,
                 None,
                 &RetryPolicy::default(),
+                tokio_util::sync::CancellationToken::new(),
             ))
             .unwrap();
 
@@ -2932,6 +3042,7 @@ mod tests {
                 None,
                 None,
                 &RetryPolicy::default(),
+                tokio_util::sync::CancellationToken::new(),
             ))
             .unwrap();
 
@@ -2994,8 +3105,14 @@ mod tests {
                 },
             };
 
-            let result =
-                send_login_request(&client, &params, &auth_req, &RetryPolicy::default()).await;
+            let result = send_login_request(
+                &client,
+                &params,
+                &auth_req,
+                &RetryPolicy::default(),
+                tokio_util::sync::CancellationToken::new(),
+            )
+            .await;
 
             assert!(result.is_ok(), "Expected retry to succeed, got: {result:?}");
             assert_eq!(
@@ -3249,6 +3366,7 @@ mod tests {
                 &query_input,
                 uuid::Uuid::new_v4(),
                 &retry_policy,
+                tokio_util::sync::CancellationToken::new(),
             )
             .await;
 

--- a/sf_core/src/rest/snowflake/native_okta.rs
+++ b/sf_core/src/rest/snowflake/native_okta.rs
@@ -102,6 +102,12 @@ pub enum NativeOktaError {
     },
 }
 
+impl NativeOktaError {
+    pub(crate) fn is_cancelled(&self) -> bool {
+        matches!(self, NativeOktaError::RetryExhausted { source, .. } if source.is_cancelled())
+    }
+}
+
 #[derive(Debug, Deserialize)]
 struct AuthenticatorRequestResponse {
     success: bool,
@@ -206,6 +212,7 @@ pub(crate) async fn fetch_native_okta_saml(
     login_parameters: &LoginParameters,
     base_policy: &RetryPolicy,
     config: &NativeOktaConfig,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<String, NativeOktaError> {
     tracing::info!("Starting native Okta authentication");
     let budget = Duration::from_secs(config.authentication_timeout_secs);
@@ -219,6 +226,7 @@ pub(crate) async fn fetch_native_okta_saml(
         config,
         start,
         budget,
+        cancel.clone(),
     )
     .await?;
 
@@ -235,6 +243,7 @@ pub(crate) async fn fetch_native_okta_saml(
         &token_url,
         &sso_url,
         start,
+        cancel,
     )
     .await
 }
@@ -247,6 +256,7 @@ async fn request_authenticator_endpoints(
     config: &NativeOktaConfig,
     start: Instant,
     budget: Duration,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<AuthenticatorRequestData, NativeOktaError> {
     let policy = remaining_policy(base_policy, start, budget)?;
     let mut data: AuthRequestData = super::base_auth_request_data(login_parameters);
@@ -274,6 +284,7 @@ async fn request_authenticator_endpoints(
         },
         &ctx,
         &policy,
+        cancel,
     )
     .await
     .context(RetryExhaustedSnafu)?;
@@ -374,6 +385,7 @@ async fn fetch_saml_with_retries(
     token_url: &Url,
     sso_url: &Url,
     start: Instant,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<String, NativeOktaError> {
     let budget = Duration::from_secs(config.authentication_timeout_secs);
     let idp_login = config.okta_username.as_deref().unwrap_or(&config.username);
@@ -396,6 +408,7 @@ async fn fetch_saml_with_retries(
             config.password.reveal(),
             &policy,
             start,
+            cancel.clone(),
         )
         .await?;
         tracing::debug!(attempt = saml_attempt, "Obtained one-time token from Okta");
@@ -415,6 +428,7 @@ async fn fetch_saml_with_retries(
             },
             &saml_ctx,
             &single_attempt_policy,
+            cancel.clone(),
         )
         .await;
 
@@ -495,6 +509,7 @@ async fn request_okta_token(
     password: &str,
     policy: &RetryPolicy,
     start: Instant,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<(String, String), NativeOktaError> {
     let token_ctx = HttpContext::new(Method::POST, "okta:token").allow_post_retry();
     let token_body = serde_json::json!({
@@ -512,6 +527,7 @@ async fn request_okta_token(
         },
         &token_ctx,
         policy,
+        cancel,
     )
     .await
     .context(RetryExhaustedSnafu)?;

--- a/sf_core/src/stage_binding.rs
+++ b/sf_core/src/stage_binding.rs
@@ -113,6 +113,17 @@ pub enum StageBindingError {
     },
 }
 
+impl StageBindingError {
+    pub(crate) fn is_cancelled(&self) -> bool {
+        match self {
+            StageBindingError::CreateStage { source, .. }
+            | StageBindingError::PutQuery { source, .. } => source.is_cancelled(),
+            StageBindingError::Upload { source, .. } => source.is_cancelled(),
+            _ => false,
+        }
+    }
+}
+
 pub struct StageBindingContext<'a> {
     pub client: &'a reqwest::Client,
     pub query_parameters: &'a QueryParameters,
@@ -132,14 +143,15 @@ pub async fn upload_csv_bindings(
     flags: &StageBindingFlags,
     request_id: Uuid,
     csv_bytes: &[u8],
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<String, StageBindingError> {
     if flags.stage_state.load(Ordering::Relaxed) == StageState::Disabled {
         return DisabledSnafu.fail();
     }
 
-    ensure_stage(ctx, flags).await?;
-    let put_response = issue_put_query(ctx, request_id).await?;
-    upload_blob(ctx, csv_bytes, &put_response.data).await?;
+    ensure_stage(ctx, flags, cancel.clone()).await?;
+    let put_response = issue_put_query(ctx, request_id, cancel.clone()).await?;
+    upload_blob(ctx, csv_bytes, &put_response.data, cancel).await?;
 
     Ok(format!("@{BIND_STAGE_NAME}/{request_id}"))
 }
@@ -147,6 +159,7 @@ pub async fn upload_csv_bindings(
 async fn ensure_stage(
     ctx: &StageBindingContext<'_>,
     flags: &StageBindingFlags,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<(), StageBindingError> {
     if flags.stage_state.load(Ordering::Relaxed) == StageState::Created {
         return Ok(());
@@ -167,6 +180,7 @@ async fn ensure_stage(
         query_input,
         ctx.retry_policy,
         QueryExecutionMode::Blocking,
+        cancel,
     )
     .await;
 
@@ -178,9 +192,12 @@ async fn ensure_stage(
             Ok(())
         }
         Err(e) => {
-            flags
-                .stage_state
-                .store(StageState::Disabled, Ordering::Relaxed);
+            let next_state = if e.is_cancelled() {
+                StageState::Unknown
+            } else {
+                StageState::Disabled
+            };
+            flags.stage_state.store(next_state, Ordering::Relaxed);
             Err(e).context(CreateStageSnafu)
         }
     }
@@ -189,6 +206,7 @@ async fn ensure_stage(
 async fn issue_put_query(
     ctx: &StageBindingContext<'_>,
     request_id: Uuid,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<Response, StageBindingError> {
     let put_sql = format!(
         "PUT 'file:///tmp/placeholder/0' '@{BIND_STAGE_NAME}/{request_id}' overwrite=true",
@@ -209,6 +227,7 @@ async fn issue_put_query(
         query_input,
         ctx.retry_policy,
         QueryExecutionMode::Blocking,
+        cancel,
     )
     .await
     .context(PutQuerySnafu)
@@ -218,6 +237,7 @@ async fn upload_blob(
     ctx: &StageBindingContext<'_>,
     csv_bytes: &[u8],
     data: &Data,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Result<(), StageBindingError> {
     let single = data
         .to_bind_stage_upload_data(ctx.use_s3_regional_url_session_param)
@@ -233,9 +253,15 @@ async fn upload_blob(
     // `perform_put_get_transfer`, so the storage client uses the default TLS
     // version window rather than the connection's narrowed one (see
     // adr/tls_version_enforcement_implementation_notes.md, "Known gaps").
-    upload_in_memory_file(csv_bytes.to_vec(), single, ctx.put_get_policy, &mut None)
-        .await
-        .context(UploadSnafu)?;
+    upload_in_memory_file(
+        csv_bytes.to_vec(),
+        single,
+        ctx.put_get_policy,
+        &mut None,
+        cancel,
+    )
+    .await
+    .context(UploadSnafu)?;
     Ok(())
 }
 

--- a/sf_core/tests/byte_source_roundtrip.rs
+++ b/sf_core/tests/byte_source_roundtrip.rs
@@ -254,6 +254,7 @@ async fn download_single_file_tampered_digest_leaves_no_output() {
         &RetryPolicy::put_get(&ParamStore::new()),
         0,
         &mut None,
+        tokio_util::sync::CancellationToken::new(),
     )
     .await;
 
@@ -410,6 +411,7 @@ async fn streaming_roundtrip_for(cloud: Cloud) {
                 ),
                 0,
                 &mut None,
+                tokio_util::sync::CancellationToken::new(),
             )
             .await
             .expect("GCS streaming download must succeed")
@@ -447,6 +449,7 @@ async fn streaming_roundtrip_for(cloud: Cloud) {
                 sf_core::file_manager::internal::CloudSpillTarget::Temp(
                     std::env::temp_dir().as_path(),
                 ),
+                tokio_util::sync::CancellationToken::new(),
             )
             .await
             .expect("Azure streaming download must succeed")
@@ -577,6 +580,7 @@ async fn gcs_streaming_mid_body_disconnect_surfaces_error() {
             ),
             0,
             &mut None,
+            tokio_util::sync::CancellationToken::new(),
         ),
     )
     .await

--- a/sf_core/tests/e2e/session/session_refresh.rs
+++ b/sf_core/tests/e2e/session/session_refresh.rs
@@ -113,10 +113,17 @@ fn should_refresh_session_proactively() {
 
         // When we login and immediately call refresh
         let policy = sf_core::config::retry::RetryPolicy::default();
-        let login_result =
-            snowflake_login_with_client(&http_client, &login_parameters, None, None, None, &policy)
-                .await
-                .expect("Login should succeed");
+        let login_result = snowflake_login_with_client(
+            &http_client,
+            &login_parameters,
+            None,
+            None,
+            None,
+            &policy,
+            tokio_util::sync::CancellationToken::new(),
+        )
+        .await
+        .expect("Login should succeed");
 
         let original_session_token = login_result.tokens.session_token.clone();
 

--- a/sf_core/tests/integration/http/azure_multipart.rs
+++ b/sf_core/tests/integration/http/azure_multipart.rs
@@ -207,10 +207,14 @@ async fn should_upload_and_download_via_azure_multipart_roundtrip() {
         skip_upload_on_content_match: false,
         multipart,
     };
-    let upload_result =
-        upload_single_file(upload, &RetryPolicy::put_get(&ParamStore::new()), &mut None)
-            .await
-            .expect("upload should succeed");
+    let upload_result = upload_single_file(
+        upload,
+        &RetryPolicy::put_get(&ParamStore::new()),
+        &mut None,
+        tokio_util::sync::CancellationToken::new(),
+    )
+    .await
+    .expect("upload should succeed");
     assert_eq!(upload_result.status, "UPLOADED");
 
     assert_eq!(
@@ -299,6 +303,7 @@ async fn should_upload_and_download_via_azure_multipart_roundtrip() {
         &RetryPolicy::put_get(&ParamStore::new()),
         0,
         &mut None,
+        tokio_util::sync::CancellationToken::new(),
     )
     .await
     .expect("download should succeed");

--- a/sf_core/tests/integration/http/azure_retry.rs
+++ b/sf_core/tests/integration/http/azure_retry.rs
@@ -80,6 +80,7 @@ async fn azure_download_success_returns_data_and_metadata() {
         &stage,
         "file.csv",
         &test_policy(DEFAULT_PUT_GET_MAX_ATTEMPTS),
+        tokio_util::sync::CancellationToken::new(),
     )
     .await;
 
@@ -128,6 +129,7 @@ async fn azure_download_403_is_retried_then_succeeds() {
         &stage,
         "file.csv",
         &test_policy(DEFAULT_PUT_GET_MAX_ATTEMPTS),
+        tokio_util::sync::CancellationToken::new(),
     )
     .await;
 
@@ -162,6 +164,7 @@ async fn azure_download_404_is_not_retried() {
         &stage,
         "file.csv",
         &test_policy(DEFAULT_PUT_GET_MAX_ATTEMPTS),
+        tokio_util::sync::CancellationToken::new(),
     )
     .await;
 
@@ -197,6 +200,7 @@ async fn azure_download_503_is_retried_then_succeeds() {
         &stage,
         "file.csv",
         &test_policy(DEFAULT_PUT_GET_MAX_ATTEMPTS),
+        tokio_util::sync::CancellationToken::new(),
     )
     .await;
 
@@ -231,6 +235,7 @@ async fn azure_error_response_redacts_sas_token() {
         &stage,
         "file.csv",
         &test_policy(DEFAULT_PUT_GET_MAX_ATTEMPTS),
+        tokio_util::sync::CancellationToken::new(),
     )
     .await;
 
@@ -281,6 +286,7 @@ async fn azure_transport_error_does_not_leak_sas_token() {
         &stage,
         "file.csv",
         &test_policy(DEFAULT_PUT_GET_MAX_ATTEMPTS),
+        tokio_util::sync::CancellationToken::new(),
     )
     .await;
 
@@ -314,6 +320,7 @@ async fn azure_download_with_wrong_creds_type_fails() {
         &stage,
         "file.csv",
         &test_policy(DEFAULT_PUT_GET_MAX_ATTEMPTS),
+        tokio_util::sync::CancellationToken::new(),
     )
     .await;
 
@@ -337,6 +344,7 @@ async fn azure_download_with_missing_storage_account_fails() {
         &stage,
         "file.csv",
         &test_policy(DEFAULT_PUT_GET_MAX_ATTEMPTS),
+        tokio_util::sync::CancellationToken::new(),
     )
     .await;
 
@@ -416,9 +424,14 @@ async fn azure_git_stage_download_succeeds_without_sfcdigest() {
         unsafe_file_write: false,
     };
 
-    let results = download_files(data, &RetryPolicy::put_get(&ParamStore::new()), None)
-        .await
-        .expect("git stage download should succeed even without sfcdigest");
+    let results = download_files(
+        data,
+        &RetryPolicy::put_get(&ParamStore::new()),
+        None,
+        tokio_util::sync::CancellationToken::new(),
+    )
+    .await
+    .expect("git stage download should succeed even without sfcdigest");
 
     assert_eq!(results.len(), 1);
     let written = std::fs::read(std::path::Path::new(&local_location).join("file.txt"))

--- a/sf_core/tests/integration/http/gcs_retry.rs
+++ b/sf_core/tests/integration/http/gcs_retry.rs
@@ -112,6 +112,7 @@ async fn gcs_download_401_returns_token_expired() {
         &test_policy(true, DEFAULT_PUT_GET_MAX_ATTEMPTS),
         0,
         &mut None,
+        tokio_util::sync::CancellationToken::new(),
     )
     .await;
 
@@ -154,6 +155,7 @@ async fn gcs_download_403_is_retried_then_succeeds() {
         &test_policy(true, DEFAULT_PUT_GET_MAX_ATTEMPTS),
         0,
         &mut None,
+        tokio_util::sync::CancellationToken::new(),
     )
     .await;
 
@@ -197,6 +199,7 @@ async fn gcs_download_400_with_presigned_url_is_retried() {
         &test_policy(true, DEFAULT_PUT_GET_MAX_ATTEMPTS),
         0,
         &mut None,
+        tokio_util::sync::CancellationToken::new(),
     )
     .await;
 
@@ -230,6 +233,7 @@ async fn gcs_download_400_without_presigned_url_is_not_retried() {
         &test_policy(false, DEFAULT_PUT_GET_MAX_ATTEMPTS),
         0,
         &mut None,
+        tokio_util::sync::CancellationToken::new(),
     )
     .await;
 
@@ -271,6 +275,7 @@ async fn gcs_download_404_is_not_retried() {
         &test_policy(true, DEFAULT_PUT_GET_MAX_ATTEMPTS),
         0,
         &mut None,
+        tokio_util::sync::CancellationToken::new(),
     )
     .await;
 
@@ -310,6 +315,7 @@ async fn gcs_download_503_is_retried_then_succeeds() {
         &test_policy(true, DEFAULT_PUT_GET_MAX_ATTEMPTS),
         0,
         &mut None,
+        tokio_util::sync::CancellationToken::new(),
     )
     .await;
 
@@ -374,6 +380,7 @@ async fn gcs_download_content_encoding_gzip_with_non_gzip_body_is_returned_verba
         &test_policy(true, 0),
         0,
         &mut None,
+        tokio_util::sync::CancellationToken::new(),
     )
     .await;
 
@@ -428,6 +435,7 @@ async fn gcs_download_content_encoding_gzip_with_gzip_body_is_not_decoded() {
         &test_policy(true, 0),
         0,
         &mut None,
+        tokio_util::sync::CancellationToken::new(),
     )
     .await
     .expect("download must succeed");
@@ -468,6 +476,7 @@ async fn gcs_download_without_content_encoding_header_is_unchanged() {
         &test_policy(true, 0),
         0,
         &mut None,
+        tokio_util::sync::CancellationToken::new(),
     )
     .await
     .expect("happy-path download must still succeed");
@@ -507,6 +516,7 @@ async fn gcs_download_content_length_match_succeeds() {
         &test_policy(true, 0),
         0,
         &mut None,
+        tokio_util::sync::CancellationToken::new(),
     )
     .await
     .expect("matching Content-Length must succeed");
@@ -548,6 +558,7 @@ async fn gcs_download_content_length_mismatch_truncated_body_is_http_error() {
         &test_policy(true, 0),
         0,
         &mut None,
+        tokio_util::sync::CancellationToken::new(),
     )
     .await;
 
@@ -581,6 +592,7 @@ async fn gcs_download_no_content_length_header_succeeds() {
         &test_policy(true, 0),
         0,
         &mut None,
+        tokio_util::sync::CancellationToken::new(),
     )
     .await;
 
@@ -620,6 +632,7 @@ async fn gcs_download_content_encoding_present_skips_length_check() {
         &test_policy(true, 0),
         0,
         &mut None,
+        tokio_util::sync::CancellationToken::new(),
     )
     .await;
 
@@ -654,6 +667,7 @@ async fn gcs_download_zero_byte_file_succeeds() {
         &test_policy(true, 0),
         0,
         &mut None,
+        tokio_util::sync::CancellationToken::new(),
     )
     .await
     .expect("zero-byte file must succeed");
@@ -692,6 +706,7 @@ async fn gcs_download_malformed_content_length_rejected_by_http_layer() {
         &test_policy(true, 0),
         0,
         &mut None,
+        tokio_util::sync::CancellationToken::new(),
     )
     .await;
 
@@ -732,6 +747,7 @@ async fn gcs_download_does_not_advertise_gzip_accept_encoding() {
         &test_policy(true, 0),
         0,
         &mut None,
+        tokio_util::sync::CancellationToken::new(),
     )
     .await
     .expect("download must succeed");
@@ -826,9 +842,14 @@ async fn gcs_download_files_routes_each_file_to_its_per_file_presigned_url() {
         unsafe_file_write: false,
     };
 
-    let results = download_files(data, &RetryPolicy::put_get(&ParamStore::new()), None)
-        .await
-        .expect("multi-file presigned GET should succeed");
+    let results = download_files(
+        data,
+        &RetryPolicy::put_get(&ParamStore::new()),
+        None,
+        tokio_util::sync::CancellationToken::new(),
+    )
+    .await
+    .expect("multi-file presigned GET should succeed");
 
     assert_eq!(results.len(), 2);
     let dir = std::path::Path::new(&local_location);
@@ -862,9 +883,14 @@ async fn gcs_download_files_fails_with_missing_credentials_when_no_url_and_no_to
         unsafe_file_write: false,
     };
 
-    let err = download_files(data, &RetryPolicy::put_get(&ParamStore::new()), None)
-        .await
-        .expect_err("download must fail when neither URL nor token is available");
+    let err = download_files(
+        data,
+        &RetryPolicy::put_get(&ParamStore::new()),
+        None,
+        tokio_util::sync::CancellationToken::new(),
+    )
+    .await
+    .expect_err("download must fail when neither URL nor token is available");
     // Walk the error chain (snafu wraps the leaf `MissingGcsCredentials`
     // through `GcsDownloadError` → `FileManagerError`).
     let chain: Vec<String> =
@@ -1018,6 +1044,7 @@ async fn gcs_download_400_triggers_url_refresh_and_succeeds() {
         &test_policy(true, 0),
         0,
         &mut refresher_opt,
+        tokio_util::sync::CancellationToken::new(),
     )
     .await;
 
@@ -1099,6 +1126,7 @@ async fn gcs_download_400_after_url_refresh_returns_presigned_url_expired() {
         &test_policy(true, 0),
         0,
         &mut refresher_opt,
+        tokio_util::sync::CancellationToken::new(),
     )
     .await
     .expect_err("two consecutive 400s must fail fast");
@@ -1182,6 +1210,7 @@ async fn gcs_download_401_triggers_token_refresh_and_succeeds() {
         &test_policy(false, 0),
         0,
         &mut refresher_opt,
+        tokio_util::sync::CancellationToken::new(),
     )
     .await;
 
@@ -1245,6 +1274,7 @@ async fn gcs_download_401_with_unchanged_token_returns_token_expired() {
         &test_policy(false, 0),
         0,
         &mut refresher_opt,
+        tokio_util::sync::CancellationToken::new(),
     )
     .await
     .expect_err("unchanged token must surface TokenExpired");
@@ -1338,6 +1368,7 @@ async fn gcs_upload_401_then_refresh_then_200() {
         true,
         &test_policy(false, DEFAULT_PUT_GET_MAX_ATTEMPTS),
         &mut refresher_opt,
+        tokio_util::sync::CancellationToken::new(),
     )
     .await;
 
@@ -1426,6 +1457,7 @@ async fn gcs_upload_400_triggers_url_refresh_and_succeeds() {
         true,
         &test_policy(true, DEFAULT_PUT_GET_MAX_ATTEMPTS),
         &mut refresher_opt,
+        tokio_util::sync::CancellationToken::new(),
     )
     .await;
 
@@ -1505,6 +1537,7 @@ async fn gcs_upload_notifies_dst_file_name_before_url_refresh() {
         true,
         &test_policy(true, DEFAULT_PUT_GET_MAX_ATTEMPTS),
         &mut refresher_opt,
+        tokio_util::sync::CancellationToken::new(),
     )
     .await;
 
@@ -1578,6 +1611,7 @@ async fn gcs_upload_400_after_url_refresh_returns_presigned_url_expired() {
         true,
         &test_policy(true, DEFAULT_PUT_GET_MAX_ATTEMPTS),
         &mut refresher_opt,
+        tokio_util::sync::CancellationToken::new(),
     )
     .await
     .expect_err("two consecutive 400s on PUT must fail fast");
@@ -1681,6 +1715,7 @@ async fn gcs_per_file_url_refresh_is_not_debounced() {
         &test_policy(true, 0),
         0,
         &mut refresher_opt,
+        tokio_util::sync::CancellationToken::new(),
     )
     .await;
     assert!(
@@ -1695,6 +1730,7 @@ async fn gcs_per_file_url_refresh_is_not_debounced() {
         &test_policy(true, 0),
         0,
         &mut refresher_opt,
+        tokio_util::sync::CancellationToken::new(),
     )
     .await;
     assert!(
@@ -1798,6 +1834,7 @@ async fn gcs_download_files_batch_rotates_presigned_urls_across_files() {
         data,
         &RetryPolicy::put_get(&ParamStore::new()),
         refresher_opt,
+        tokio_util::sync::CancellationToken::new(),
     )
     .await
     .expect("batch download should succeed after per-file URL refresh");
@@ -1891,6 +1928,7 @@ async fn gcs_cse_upload_sets_exact_content_length_and_is_not_chunked() {
         true,
         &test_policy(false, DEFAULT_PUT_GET_MAX_ATTEMPTS),
         &mut refresher_opt,
+        tokio_util::sync::CancellationToken::new(),
     )
     .await;
 
@@ -1966,9 +2004,14 @@ async fn gcs_git_stage_download_succeeds_without_sfc_digest() {
         unsafe_file_write: false,
     };
 
-    let results = download_files(data, &RetryPolicy::put_get(&ParamStore::new()), None)
-        .await
-        .expect("git stage download should succeed even without sfc-digest");
+    let results = download_files(
+        data,
+        &RetryPolicy::put_get(&ParamStore::new()),
+        None,
+        tokio_util::sync::CancellationToken::new(),
+    )
+    .await
+    .expect("git stage download should succeed even without sfc-digest");
 
     assert_eq!(results.len(), 1);
     let written = std::fs::read(std::path::Path::new(&local_location).join("git-file.txt"))

--- a/sf_core/tests/integration/http/retry.rs
+++ b/sf_core/tests/integration/http/retry.rs
@@ -29,9 +29,14 @@ async fn should_retry_get_after_transient_failure() {
     let ctx = HttpContext::new(Method::GET, url.clone());
 
     // When the helper executes the request
-    let body = execute_bytes_with_retry(|| client.get(&url), &ctx, &RetryPolicy::default())
-        .await
-        .expect("retry to succeed");
+    let body = execute_bytes_with_retry(
+        || client.get(&url),
+        &ctx,
+        &RetryPolicy::default(),
+        tokio_util::sync::CancellationToken::new(),
+    )
+    .await
+    .expect("retry to succeed");
 
     // Then it should have retried once and returned the successful body
     assert_eq!(body, b"ok");
@@ -72,9 +77,14 @@ async fn should_fail_when_retry_after_exceeds_deadline() {
     };
 
     // When the helper executes the request
-    let err = execute_bytes_with_retry(|| client.get(&url), &ctx, &policy)
-        .await
-        .expect_err("should exceed retry-after budget");
+    let err = execute_bytes_with_retry(
+        || client.get(&url),
+        &ctx,
+        &policy,
+        tokio_util::sync::CancellationToken::new(),
+    )
+    .await
+    .expect_err("should exceed retry-after budget");
 
     // Then it should return a Retry-After exceeded error
     match err {
@@ -106,6 +116,7 @@ async fn should_retry_idempotent_put_after_transient_failure() {
         || client.put(&url).body("payload"),
         &ctx,
         &RetryPolicy::default(),
+        tokio_util::sync::CancellationToken::new(),
     )
     .await
     .expect("retry to succeed");
@@ -147,9 +158,14 @@ async fn should_fail_after_reaching_max_attempts() {
     };
 
     // When the helper executes the request
-    let err = execute_bytes_with_retry(|| client.get(&url), &ctx, &policy)
-        .await
-        .expect_err("should stop after max attempts");
+    let err = execute_bytes_with_retry(
+        || client.get(&url),
+        &ctx,
+        &policy,
+        tokio_util::sync::CancellationToken::new(),
+    )
+    .await
+    .expect_err("should stop after max attempts");
 
     // Then it should return a max attempts error
     match err {
@@ -212,9 +228,14 @@ async fn async_style_retries_transient_error() {
     let ctx = HttpContext::new(Method::GET, url.clone());
 
     // When using execute_with_retry (async-style)
-    let body = execute_bytes_with_retry(|| client.get(&url), &ctx, &RetryPolicy::default())
-        .await
-        .expect("retry to succeed");
+    let body = execute_bytes_with_retry(
+        || client.get(&url),
+        &ctx,
+        &RetryPolicy::default(),
+        tokio_util::sync::CancellationToken::new(),
+    )
+    .await
+    .expect("retry to succeed");
 
     // Then it retries and succeeds
     assert_eq!(body, b"ok");
@@ -256,9 +277,14 @@ async fn should_retry_after_connection_reset() {
     let ctx = HttpContext::new(Method::GET, url.clone());
 
     // When the helper executes the request
-    let body = execute_bytes_with_retry(|| client.get(&url), &ctx, &RetryPolicy::default())
-        .await
-        .expect("should retry after connection reset");
+    let body = execute_bytes_with_retry(
+        || client.get(&url),
+        &ctx,
+        &RetryPolicy::default(),
+        tokio_util::sync::CancellationToken::new(),
+    )
+    .await
+    .expect("should retry after connection reset");
 
     // Then it should have retried and succeeded
     assert_eq!(body, b"ok");
@@ -279,7 +305,13 @@ async fn should_not_retry_401_unauthorized() {
     let ctx = HttpContext::new(Method::GET, url.clone());
 
     // When the helper executes the request
-    let result = execute_bytes_with_retry(|| client.get(&url), &ctx, &RetryPolicy::default()).await;
+    let result = execute_bytes_with_retry(
+        || client.get(&url),
+        &ctx,
+        &RetryPolicy::default(),
+        tokio_util::sync::CancellationToken::new(),
+    )
+    .await;
 
     // Then it should NOT retry (401 is not retryable) and return the response
     // The caller is responsible for handling 401 as session expired

--- a/sf_core/tests/integration/http/s3_multipart.rs
+++ b/sf_core/tests/integration/http/s3_multipart.rs
@@ -204,10 +204,14 @@ async fn should_upload_and_download_via_s3_multipart_roundtrip() {
         skip_upload_on_content_match: false,
         multipart,
     };
-    let upload_result =
-        upload_single_file(upload, &RetryPolicy::put_get(&ParamStore::new()), &mut None)
-            .await
-            .expect("upload should succeed");
+    let upload_result = upload_single_file(
+        upload,
+        &RetryPolicy::put_get(&ParamStore::new()),
+        &mut None,
+        tokio_util::sync::CancellationToken::new(),
+    )
+    .await
+    .expect("upload should succeed");
     assert_eq!(upload_result.status, "UPLOADED");
 
     assert_eq!(
@@ -248,6 +252,7 @@ async fn should_upload_and_download_via_s3_multipart_roundtrip() {
         &RetryPolicy::put_get(&ParamStore::new()),
         0,
         &mut None,
+        tokio_util::sync::CancellationToken::new(),
     )
     .await
     .expect("download should succeed");

--- a/sf_core/tests/integration/http/sync_retry.rs
+++ b/sf_core/tests/integration/http/sync_retry.rs
@@ -40,6 +40,7 @@ async fn should_include_request_id_in_query_parameters() {
         QueryInput::new("SELECT 1"),
         &RetryPolicy::default(),
         QueryExecutionMode::Blocking,
+        tokio_util::sync::CancellationToken::new(),
     )
     .await;
 
@@ -112,6 +113,7 @@ async fn should_retry_sync_query_on_connection_reset() {
         QueryInput::new("SELECT 1"),
         &RetryPolicy::default(),
         QueryExecutionMode::Blocking,
+        tokio_util::sync::CancellationToken::new(),
     )
     .await;
 
@@ -167,6 +169,7 @@ async fn should_use_sync_mode_by_default() {
         QueryInput::new("SELECT 1"),
         &RetryPolicy::default(),
         QueryExecutionMode::Blocking,
+        tokio_util::sync::CancellationToken::new(),
     )
     .await;
 
@@ -231,6 +234,7 @@ async fn should_include_statement_timeout_in_parameters_when_set() {
         },
         &RetryPolicy::default(),
         QueryExecutionMode::Blocking,
+        tokio_util::sync::CancellationToken::new(),
     )
     .await;
 
@@ -287,6 +291,7 @@ async fn should_not_include_parameters_when_timeout_not_set() {
         QueryInput::new("SELECT 1"),
         &RetryPolicy::default(),
         QueryExecutionMode::Blocking,
+        tokio_util::sync::CancellationToken::new(),
     )
     .await;
 

--- a/sf_core/tests/integration/logging/query_logging.rs
+++ b/sf_core/tests/integration/logging/query_logging.rs
@@ -81,6 +81,7 @@ async fn sync_query_emits_info_log_without_sql_when_flag_off() {
         QueryInput::new(SQL_LONG),
         &RetryPolicy::default(),
         QueryExecutionMode::Blocking,
+        tokio_util::sync::CancellationToken::new(),
     )
     .await;
 
@@ -122,6 +123,7 @@ async fn sync_query_emits_info_log_with_sql_when_text_flag_on() {
         QueryInput::new(SQL_LONG),
         &RetryPolicy::default(),
         QueryExecutionMode::Blocking,
+        tokio_util::sync::CancellationToken::new(),
     )
     .await;
 
@@ -167,6 +169,7 @@ async fn sync_query_emits_info_log_with_sql_and_bindings_when_both_flags_on() {
         input,
         &RetryPolicy::default(),
         QueryExecutionMode::Blocking,
+        tokio_util::sync::CancellationToken::new(),
     )
     .await;
 
@@ -310,6 +313,7 @@ async fn async_submit_emits_info_log_with_sql_when_text_flag_on() {
         QueryInput::new(SQL_LONG),
         &RetryPolicy::default(),
         QueryExecutionMode::Async,
+        tokio_util::sync::CancellationToken::new(),
     )
     .await;
 

--- a/sf_core/tests/integration/session/logout.rs
+++ b/sf_core/tests/integration/session/logout.rs
@@ -471,6 +471,7 @@ async fn should_cancel_individual_request_when_per_request_socket_timeout_exceed
         &SensitiveString::from("test_token"),
         &client_info,
         &retry_policy,
+        tokio_util::sync::CancellationToken::new(),
     )
     .await;
     let elapsed = start.elapsed();
@@ -533,6 +534,7 @@ async fn should_respect_total_retry_budget_timeout_across_all_attempts() {
         &SensitiveString::from("test_token"),
         &client_info,
         &retry_policy,
+        tokio_util::sync::CancellationToken::new(),
     )
     .await;
     let elapsed = start.elapsed();
@@ -611,6 +613,7 @@ async fn should_ignore_session_gone_390111_for_each_strategy_type() {
             &SensitiveString::from("test_token"),
             &client_info,
             &RetryPolicy::default(),
+            tokio_util::sync::CancellationToken::new(),
         )
         .await;
 
@@ -692,6 +695,7 @@ async fn should_retry_logout_on_retryable_error_type_for_each_strategy_type() {
                 &SensitiveString::from("test_token"),
                 &client_info,
                 &RetryPolicy::default(),
+                tokio_util::sync::CancellationToken::new(),
             )
             .await;
 
@@ -761,6 +765,7 @@ async fn should_retry_logout_on_retryable_error_type_for_each_strategy_type() {
                 &SensitiveString::from("test_token"),
                 &client_info,
                 &RetryPolicy::default(),
+                tokio_util::sync::CancellationToken::new(),
             )
             .await;
 
@@ -1096,6 +1101,7 @@ async fn should_honor_provided_retry_config_and_succeed_for_each_strategy_type()
             &SensitiveString::from("test_token"),
             &client_info,
             &retry_policy,
+            tokio_util::sync::CancellationToken::new(),
         )
         .await;
 
@@ -1165,6 +1171,7 @@ async fn should_honor_provided_timeout_config_and_succeed_for_each_strategy_type
             &SensitiveString::from("test_token"),
             &client_info,
             &retry_policy,
+            tokio_util::sync::CancellationToken::new(),
         )
         .await;
         let elapsed = start.elapsed();
@@ -1665,6 +1672,7 @@ async fn should_throw_on_timeout_with_strict_strategy() {
         &SensitiveString::from("test_token"),
         &client_info,
         &retry_policy,
+        tokio_util::sync::CancellationToken::new(),
     )
     .await;
     let elapsed = start.elapsed();
@@ -1740,6 +1748,7 @@ async fn should_log_warn_and_succeed_on_timeout_with_best_effort_strategy() {
         &SensitiveString::from("test_token"),
         &client_info,
         &retry_policy,
+        tokio_util::sync::CancellationToken::new(),
     )
     .await;
     let elapsed = start.elapsed();


### PR DESCRIPTION
## Summary

Threads async cancellation (`tokio_util::sync::CancellationToken`) end-to-end through the driver stack so a caller-initiated cancel — including ODBC `SQLCancel` — reliably interrupts in-flight work and surfaces as `CANCELLED` / `HY008` instead of a generic error.

## What changed

**Core threading**
- Generated `Transport` / `DatabaseDriverClient` methods take a `CancellationToken`, threaded through the `DatabaseDriverV1` core ops, REST/chunk retry helpers, and the multi-chunk fetch path (`fetch_chunks_reader` → prefetch/initial-chunk readers → `get_chunk_data`) down to the leaf awaits.
- `execute_with_retry` and the async-query poll loop race the token via `tokio::select!`, returning `HttpError::Cancelled` / `SfError::Cancelled`.
- `ApiError::is_cancelled` propagates cancellation to `StatusCode::CANCELLED`; ODBC maps core `CANCELLED` to `OperationCanceled` (`HY008`).

**Coverage**
- SHOW / reader-drain paths surface cancellation (including successful drains).
- HTTP retry `on_response` + body reads, REST response-body reads, and Azure/GCS/S3 file-transfer body reads race the token.
- `logout` preserves cancellation (bypasses BestEffort suppression).
- Native Okta and external-browser login (including the callback wait) are cancellable; result-set handles are released on stream-fetch error.
- ODBC: the `SQLCancel` armed token is threaded through catalog RPCs, the SHOW path, `SQLMoreResults`, execute finalization, and the numeric-settings refresh; the async-spawn path publishes the token before spawning to close a TOCTOU race.

## Known follow-ups (tracked separately)

- OAuth Authorization Code / OAuth Client Credentials / Workload Identity login flows are not yet threaded.
- GCS credential-refresh cancellation (shared `StageInfoRefresher` / `StageInfoRefreshError`) is not yet cancellation-aware.

## Testing

- Added cancellation unit tests (HTTP retry, reader drain, ODBC).
- `cargo check --package sf_core --package odbc --all-targets` is clean.
- Cancellation-focused test suites pass (sf_core + odbc).
