### PR TITLE
feat(sf_core): atomically take result streams

### DIFF
--- a/sf_core/src/apis/database_driver_v1/result_set.rs
+++ b/sf_core/src/apis/database_driver_v1/result_set.rs
@@ -390,16 +390,35 @@ async fn snapshot_reader_inputs(
 // --- DatabaseDriverV1 impl ---
 
 impl DatabaseDriverV1 {
-    /// Builds a fresh Arrow [`RecordBatchReader`] for this result set, lazily
-    /// from the stored `RowsetData`, so it can be requested multiple times. The
-    /// protobuf layer wraps it in an `FFI_ArrowArrayStream` at the C boundary.
+    // Build a reader from a retained or atomically consumed result set.
+    async fn build_result_set_stream(
+        &self,
+        rs_ptr: Arc<Mutex<ResultSet>>,
+    ) -> Result<Box<dyn RecordBatchReader + Send>, ApiError> {
+        let (data, http_client, prefetch_config, columns) = snapshot_reader_inputs(&rs_ptr).await;
+
+        let nullable_flags: Vec<bool> = columns.iter().map(|c| c.nullable).collect();
+        let flags = if nullable_flags.is_empty() {
+            None
+        } else {
+            Some(nullable_flags.as_slice())
+        };
+        build_reader_from_rowset_data(
+            &data,
+            http_client,
+            &prefetch_config,
+            &self.wrapper_presets,
+            flags,
+        )
+        .await
+        .context(QueryResponseProcessSnafu)
+    }
+
+    /// Builds a fresh Arrow [`RecordBatchReader`] while leaving the result-set
+    /// handle registered, so callers may request the stream again.
     ///
-    /// Awaiting this only builds the reader and never blocks. Iterating it,
-    /// however, must happen in a synchronous context: chunked result sets pull
-    /// chunks via a blocking channel receiver, so draining from within an async
-    /// runtime would call `blocking_recv` and panic. Drain after returning from
-    /// `block_on` (keeping the runtime alive), on a dedicated `std::thread`, or
-    /// via `tokio::task::spawn_blocking`.
+    /// Awaiting this only builds the reader. Drain chunked readers outside an
+    /// async runtime, on a dedicated thread, or with `spawn_blocking`.
     pub async fn result_set_get_stream(
         &self,
         result_handle: Handle,
@@ -410,24 +429,27 @@ impl DatabaseDriverV1 {
             .with_context(|| InvalidArgumentSnafu {
                 argument: "result_handle: ResultSet handle not found".to_string(),
             })?;
-        let (data, http_client, prefetch_config, columns) = snapshot_reader_inputs(&rs_ptr).await;
+        self.build_result_set_stream(rs_ptr).await
+    }
 
-        let nullable_flags: Vec<bool> = columns.iter().map(|c| c.nullable).collect();
-        let flags = if nullable_flags.is_empty() {
-            None
-        } else {
-            Some(nullable_flags.as_slice())
-        };
-        let reader = build_reader_from_rowset_data(
-            &data,
-            http_client,
-            &prefetch_config,
-            &self.wrapper_presets,
-            flags,
-        )
-        .await
-        .context(QueryResponseProcessSnafu)?;
-        Ok(reader)
+    /// Atomically consumes a result-set handle and builds its Arrow stream.
+    ///
+    /// The handle is deregistered before stream construction, and remains
+    /// released whether construction succeeds or fails. Use this for one-shot
+    /// consumers to avoid pairing [`Self::result_set_get_stream`] with
+    /// [`Self::result_set_release`] and duplicating cleanup logic. As with
+    /// `result_set_get_stream`, drain chunked readers outside an async runtime.
+    pub async fn result_set_take_stream(
+        &self,
+        result_handle: Handle,
+    ) -> Result<Box<dyn RecordBatchReader + Send>, ApiError> {
+        let rs_ptr =
+            self.results
+                .take_obj(result_handle)
+                .with_context(|| InvalidArgumentSnafu {
+                    argument: "result_handle: ResultSet handle not found".to_string(),
+                })?;
+        self.build_result_set_stream(rs_ptr).await
     }
 
     /// Returns chunk metadata (inline data + remote chunk URLs) for this result set.
@@ -672,6 +694,65 @@ mod tests {
 
         assert_id_name_reader(reader);
         drop(runtime);
+    }
+
+    #[test]
+    fn result_set_take_stream_returns_reader_and_consumes_handle() {
+        let driver = DatabaseDriverV1::new();
+        let data: Data = serde_json::from_str(JSON_ROWSET)
+            .expect("fixture must deserialize into query_response::Data");
+        let descriptor = response_to_descriptor(&data, &WrapperPresets::default());
+        let reader_ctx = ReaderContext {
+            http_client: reqwest::Client::new(),
+            prefetch_config: PrefetchConfig::default(),
+        };
+        let handle = driver.create_result_set(descriptor, data.into_rowset_data(), reader_ctx);
+
+        let runtime = tokio::runtime::Runtime::new().expect("failed to build tokio runtime");
+        let reader = runtime
+            .block_on(driver.result_set_take_stream(handle))
+            .expect("taking an inline JSON result stream should succeed");
+
+        assert!(
+            runtime
+                .block_on(driver.result_set_take_stream(handle))
+                .is_err(),
+            "a consumed handle must not be reusable"
+        );
+        assert!(
+            driver.result_set_release(handle).is_err(),
+            "a consumed handle must already be released"
+        );
+        assert_id_name_reader(reader);
+        drop(runtime);
+    }
+
+    #[test]
+    fn result_set_take_stream_consumes_handle_when_stream_build_fails() {
+        let driver = DatabaseDriverV1::new();
+        let data: Data = serde_json::from_str(ARROW_DATA)
+            .expect("fixture must deserialize into query_response::Data");
+        let descriptor = response_to_descriptor(&data, &WrapperPresets::default());
+        let reader_ctx = ReaderContext {
+            http_client: reqwest::Client::new(),
+            prefetch_config: PrefetchConfig::default(),
+        };
+        let malformed = RowsetData::ArrowSingleChunk {
+            chunk_base64: "not valid base64".to_string(),
+        };
+        let handle = driver.create_result_set(descriptor, malformed, reader_ctx);
+
+        let runtime = tokio::runtime::Runtime::new().expect("failed to build tokio runtime");
+        assert!(
+            runtime
+                .block_on(driver.result_set_take_stream(handle))
+                .is_err(),
+            "malformed Arrow data must fail stream construction"
+        );
+        assert!(
+            driver.result_set_release(handle).is_err(),
+            "the handle must remain released after construction fails"
+        );
     }
 
     #[test]

--- a/sf_core/src/apis/database_driver_v1/statement.rs
+++ b/sf_core/src/apis/database_driver_v1/statement.rs
@@ -227,8 +227,7 @@ impl DatabaseDriverV1 {
                 }
                 .fail();
             };
-            let stream = self.result_set_get_stream(rs_info.handle).await?;
-            self.result_set_release(rs_info.handle)?;
+            let stream = self.result_set_take_stream(rs_info.handle).await?;
 
             let stmt_ptr =
                 self.statements

--- a/sf_core/src/handle_manager.rs
+++ b/sf_core/src/handle_manager.rs
@@ -83,7 +83,7 @@ impl<T> HandleManager<T> {
     /// Atomically deregisters and returns the value for `handle`. Only one caller
     /// can take a live handle; later lookups and takes fail.
     pub(crate) fn take_obj(&self, handle: Handle) -> Option<Arc<T>> {
-        let span = span!(target: "handle_manager", Level::INFO, "Taking handle", handle_id = handle.id, handle_magic = handle.magic);
+        let span = span!(target: "handle_manager", Level::INFO, "HandleManager::take_obj", handle_id = handle.id, handle_magic = handle.magic);
         let _enter = span.enter();
         let index = handle.id as usize;
         let mut handles = self.handles.write_recover();

--- a/sf_core/src/handle_manager.rs
+++ b/sf_core/src/handle_manager.rs
@@ -80,35 +80,39 @@ impl<T> HandleManager<T> {
         }
     }
 
-    pub fn delete_handle(&self, handle: Handle) -> bool {
-        let span = span!(target: "handle_manager", Level::INFO, "Deleting handle", handle_id = handle.id, handle_magic = handle.magic);
+    /// Atomically deregisters and returns the value for `handle`. Only one caller
+    /// can take a live handle; later lookups and takes fail.
+    pub(crate) fn take_obj(&self, handle: Handle) -> Option<Arc<T>> {
+        let span = span!(target: "handle_manager", Level::INFO, "Taking handle", handle_id = handle.id, handle_magic = handle.magic);
         let _enter = span.enter();
         let index = handle.id as usize;
         let mut handles = self.handles.write_recover();
 
         if index >= handles.len() {
-            tracing::error!("Handle index out of bounds, cannot delete handle");
-            return false;
+            tracing::error!("Handle index out of bounds, cannot take object");
+            return None;
         }
 
         let handle_value = &mut handles[index];
-        let magic = handle_value.magic;
-
-        if magic != handle.magic {
-            tracing::error!("Handle magic mismatch, cannot delete handle");
-            return false;
+        if handle_value.magic != handle.magic {
+            tracing::error!("Handle magic mismatch, cannot take object");
+            return None;
         }
 
         match handle_value.value.take() {
-            Some(_) => {
-                tracing::trace!(target: "handle_manager", "Handle deleted successfully");
-                true
+            Some(value) => {
+                tracing::trace!(target: "handle_manager", "Handle taken successfully");
+                Some(value)
             }
             None => {
-                tracing::error!("Handle not found, cannot delete handle");
-                false
+                tracing::error!("Handle not found, cannot take object");
+                None
             }
         }
+    }
+
+    pub fn delete_handle(&self, handle: Handle) -> bool {
+        self.take_obj(handle).is_some()
     }
 
     /// Deregisters and returns every currently-live value matching `pred`,


### PR DESCRIPTION
## Summary

- add `DatabaseDriverV1::result_set_take_stream`, a one-shot API that atomically deregisters a result-set handle before constructing its Arrow reader
- guarantee the handle stays released when reader construction fails
- add an internal `HandleManager::take_obj` primitive so concurrent consumers are first-caller-wins under one write lock
- share stream construction between retained `result_set_get_stream` and consuming `result_set_take_stream`
- migrate `statement_prepare` to the one-shot lifecycle

## Motivation

In-process wrappers currently repeat this lifecycle in execution, metadata, and ingestion paths:

1. call `result_set_get_stream`
2. call `result_set_release` on success
3. remember to release separately on acquisition failure
4. decide which error wins when both operations fail

The new method centralizes that ownership transition in sf_core. The Rust ADBC driver can replace its shared acquire/release helper with one `result_set_take_stream` call, while protobuf clients retain the existing independent get/release methods.

## Semantics

- the handle is consumed before stream construction starts
- only one caller can take a live handle
- a successful take returns the same reader as `result_set_get_stream`
- construction failure does not restore or leak the handle
- `result_set_get_stream` remains reusable and backward compatible

## Testing

- `cargo test -p sf_core --lib -- --test-threads=1` — 1700 passed, 1 ignored
- targeted success, duplicate-take, release-after-take, and construction-failure cleanup tests
- `cargo check -p sf_core --all-targets`
- `cargo check -p sf_core --no-default-features`
- `cargo clippy -p sf_core --lib`
- `cargo doc -p sf_core --no-deps`
- `cargo fmt --all -- --check`
- `git diff --check`

The full suite was run serially because existing resolver tests mutate process environment and can race under the default parallel test runner.
