### PR TITLE
SNOW-4008939 sf_core: keep the telemetry raw-log message a JSON object so message:data stays readable

### DIFF
--- a/sf_core/src/telemetry/session_telemetry.rs
+++ b/sf_core/src/telemetry/session_telemetry.rs
@@ -6,7 +6,7 @@
 //! - the **span lane** ([`super::snowflake_processor`]): a driver-instrumented
 //!   `SpanData` → [`span_to_log_entries`] (message built from scalar attributes);
 //! - the **raw-log lane** (caller JSON forwarded by wrappers, e.g. Snowpark): a
-//!   `message_json` string → parsed and embedded verbatim.
+//!   `message_json` string → parsed and embedded as an object.
 //!
 //! Everything after that is identical — both build the same `{message, timestamp}`
 //! shape via [`log_entry`]/[`logs_payload`] and POST through the same
@@ -15,7 +15,7 @@
 //! time, so the span-end hot path only enqueues the `SpanData`.
 
 use opentelemetry_sdk::trace::SpanData;
-use serde_json::Value;
+use serde_json::{Value, json};
 
 use super::serialization::{log_entry, logs_payload, span_to_log_entries};
 use super::session_batch::{SessionBuffer, flush_bounded, spawn_best_effort};
@@ -36,13 +36,31 @@ pub(crate) struct RawLogEntry {
 }
 
 impl RawLogEntry {
-    /// Parse the caller's `message_json` and wrap it as a single log entry. A
-    /// malformed entry falls back to sending the raw string as the message —
-    /// one bad entry must never sink the whole batch, but it also shouldn't
-    /// silently vanish.
+    /// Parse the caller's `message_json` and wrap it as a single log entry.
+    ///
+    /// The `message` is always a JSON **object**. Consumers read payload fields
+    /// as `message:data:<field>` against a VARIANT, and against a scalar or an
+    /// array that yields NULL rather than an error — so a caller sending the
+    /// wrong shape would produce rows that look present but carry no readable
+    /// payload, with nothing reported on either side.
+    ///
+    /// Anything that is not an object is therefore nested under `message`
+    /// rather than dropped, whether it parsed as valid JSON of the wrong shape
+    /// or failed to parse at all: one bad entry must never sink the whole
+    /// batch, but it also shouldn't silently vanish.
     fn into_log_entries(self) -> Vec<Value> {
-        let message = serde_json::from_str::<Value>(&self.message_json)
-            .unwrap_or(Value::String(self.message_json));
+        let parsed = serde_json::from_str::<Value>(&self.message_json);
+        let message = match parsed {
+            Ok(Value::Object(fields)) => Value::Object(fields),
+            Ok(other) => {
+                tracing::debug!("Raw log message is not a JSON object; nesting it under `message`");
+                json!({ "message": other })
+            }
+            Err(_) => {
+                tracing::debug!("Raw log message is not valid JSON; nesting it under `message`");
+                json!({ "message": self.message_json })
+            }
+        };
         vec![log_entry(message, self.timestamp_ms)]
     }
 }
@@ -358,14 +376,62 @@ mod tests {
     }
 
     #[test]
-    fn raw_log_entry_falls_back_to_string_for_malformed_json() {
+    fn raw_log_entry_nests_malformed_json_under_message() {
         let entry = RawLogEntry {
             message_json: "not valid json".to_string(),
             timestamp_ms: 1700000000000,
         };
         let logs = entry.into_log_entries();
         assert_eq!(logs.len(), 1);
-        assert_eq!(logs[0]["message"], "not valid json");
+        // Retained rather than dropped, but nested so `message` stays an object.
+        assert!(logs[0]["message"].is_object());
+        assert_eq!(logs[0]["message"]["message"], "not valid json");
         assert_eq!(logs[0]["timestamp"], "1700000000000");
+    }
+
+    /// Valid JSON of the wrong shape is the case that used to slip through:
+    /// it parsed, so it was embedded as-is, and `message:data:<field>` then
+    /// read NULL downstream instead of failing.
+    #[test]
+    fn raw_log_entry_nests_non_object_json_under_message() {
+        for (input, expected) in [
+            ("42", json!(42)),
+            ("[1,2,3]", json!([1, 2, 3])),
+            (r#""text""#, json!("text")),
+            ("true", json!(true)),
+            ("null", json!(null)),
+        ] {
+            let entry = RawLogEntry {
+                message_json: input.to_string(),
+                timestamp_ms: 1700000000123,
+            };
+            let logs = entry.into_log_entries();
+            assert_eq!(logs.len(), 1);
+            let msg = &logs[0]["message"];
+            assert!(
+                msg.is_object(),
+                "message must be an object for input {input}"
+            );
+            assert_eq!(
+                msg["message"], expected,
+                "payload preserved for input {input}"
+            );
+            assert_eq!(logs[0]["timestamp"], "1700000000123");
+        }
+    }
+
+    /// An object is passed through untouched — no extra nesting level, so the
+    /// well-behaved caller's field paths are unchanged.
+    #[test]
+    fn raw_log_entry_does_not_nest_an_object_message() {
+        let entry = RawLogEntry {
+            message_json: r#"{"type":"ct","data":{"k":1}}"#.to_string(),
+            timestamp_ms: 1700000000123,
+        };
+        let logs = entry.into_log_entries();
+        let msg = &logs[0]["message"];
+        assert_eq!(msg["type"], "ct");
+        assert_eq!(msg["data"]["k"], 1);
+        assert!(msg.get("message").is_none());
     }
 }


### PR DESCRIPTION
This changes the raw-log lane in `sf_core/src/telemetry/session_telemetry.rs` so that the `message` field of a `/telemetry/send` log entry is always a JSON object. `RawLogEntry::into_log_entries` previously parsed the caller's `message_json` into any `serde_json::Value` and embedded whatever came out; it now passes objects through untouched and nests anything else under a `message` key. No API, wire-envelope or proto change is involved, and for every caller that already sends an object — which is all of them today — the emitted payload is byte-identical.

The motivation is [SNOW-4008939](https://snowflakecomputing.atlassian.net/browse/SNOW-4008939). `TelemetrySendLog` accepts `message_json` as a `string`, and nothing required the parsed value to be an object, so a caller sending a scalar or an array parsed successfully and produced an envelope with a non-object `message`. That matters because downstream consumers read payload fields as `message:data:<field>` against a VARIANT: against a scalar or an array, that expression yields NULL rather than an error. A misbehaving producer therefore creates rows that look present but carry no readable payload, and nothing on either side reports a problem. The severity is low — it takes a misbehaving caller, and the damage is confined to that caller's own rows — but the failure is silent in both directions, which makes it far cheaper to close now than to diagnose from a dashboard later.

Of the two fixes the ticket suggested, rejecting the entry or wrapping it, this takes the wrapping route. This lane already has a stated rule for bad input, in the doc comment on the function being changed: one bad entry must never sink the whole batch, but it also should not silently vanish. Rejecting would satisfy the first half and violate the second, and it would do so without any way to tell the caller, since `telemetry_send_log` has no error channel back to the wrapper — it returns an empty `TelemetrySendResponse` unconditionally. Wrapping keeps the payload, makes the envelope shape predictable, and leaves the well-behaved path allocation-for-allocation identical. Worth flagging for review: the malformed-JSON case, which the ticket treated as already handled, produced `Value::String(raw)` and so was affected by exactly the same problem — a JSON string is not an object either. It now takes the same wrapping path, and that is the one behaviour change an existing caller could observe. The two cases are logged distinguishably at debug level so a misbehaving producer can still be identified.

The risk is small and concentrated in that one behaviour change. There is no Java or JDBC caller of this RPC today; the wired consumers are the Rust core and Python, and neither sends a non-object message, so nothing shipping changes shape. Objects gain no extra nesting level, so existing field paths are untouched. Anyone who was relying on a malformed entry arriving as a bare string would now find it at `message.message`, which is a deliberate trade: that reading was already unusable through the documented `message:data` access path. The change adds no allocation on the object path and no new dependency.

Testing is at the unit level, alongside the existing cases in the same module. `raw_log_entry_nests_non_object_json_under_message` covers a number, an array, a string, a boolean and `null`, asserting both that `message` is an object and that the original value survives at `message.message`. `raw_log_entry_does_not_nest_an_object_message` pins the no-regression case, asserting that an object gains no wrapper key. The pre-existing malformed-JSON test was updated to the new expectation rather than deleted, so the fallback stays covered. All 12 unit tests in `telemetry::session_telemetry` pass, as do all 35 tests in the `telemetry` integration module, which exercise the real wire body through wiremock and would have caught an envelope-shape regression. `cargo fmt` and `cargo clippy -p sf_core --lib` are both clean, the only clippy output being a pre-existing deprecation warning elsewhere in the crate.

One note for the reviewer on provenance: the ticket cites `origin/main` at `4846f3466`, which is not an ancestor of `main` and could not be resolved in this clone, so this work is based on `aac98014b` instead. The code in question is unchanged in substance between the two descriptions. Separately, the ticket records two adjacent behaviours that were investigated and deliberately not changed here — key reordering from `serde_json`'s `BTreeMap` backing, which is harmless because VARIANT field access is order-insensitive, and integer precision, where an earlier claim of degradation above 2^53 was measured and found to be wrong. A related but independent issue in this lane, the absence of any per-call flush, is tracked separately as [SNOW-4008940](https://snowflakecomputing.atlassian.net/browse/SNOW-4008940) and is not touched by this PR.

Made with [Cursor](https://cursor.com)

[SNOW-4008939]: https://snowflakecomputing.atlassian.net/browse/SNOW-4008939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SNOW-4008940]: https://snowflakecomputing.atlassian.net/browse/SNOW-4008940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ